### PR TITLE
docs(v0): add product plan, component specs, and architecture notes

### DIFF
--- a/.agents/docs/init/xmtp-broker.md
+++ b/.agents/docs/init/xmtp-broker.md
@@ -1,0 +1,1379 @@
+# XMTP Agent Broker PRD
+
+**Version:** 0.2.1
+**Status:** Draft
+**Updated:** 2026-03-12
+
+## Summary
+
+This document proposes an **agent broker** architecture for XMTP-based applications and agents.
+
+The core idea is simple:
+
+- A **broker** is the real XMTP client.
+- The broker owns the raw XMTP signer, installation continuity, local encrypted database, and message sync.
+- An **agent harness** never touches the raw XMTP client directly.
+- Instead, the harness connects to the broker over a controlled interface and receives a filtered **view** of one or more conversations and a scoped **grant** of allowed actions.
+- The permissions and scope of the view and grant are represented by group-visible **attestations**.
+
+This model is designed to support agents in XMTP and Convos without pretending that a standard group member can somehow be cryptographically blind to ordinary group messages. It creates a practical, harness-agnostic security boundary that works with local brokers, self-hosted brokers, and managed broker deployments.
+
+The proposal also outlines candidate XIP directions that could improve interoperability and richer client experiences over time, and describes a trust chain model that moves agent participation from opaque trust to inspectable trust.
+
+## Motivation
+
+There is growing interest in agents that participate in XMTP group chats, especially in apps such as Convos.
+
+That interest is well-founded:
+
+- Agents are a natural fit for group coordination, summarization, memory, retrieval, automation, and tool use.
+- Group chat is a powerful environment for collaborative workflows and multi-party context.
+- XMTP offers strong identity, messaging, and group primitives that make agent participation possible in a decentralized setting.
+
+At the same time, the current agent shape is too blunt.
+
+A typical setup today looks like this:
+
+- An agent harness spins up a new account or inbox.
+- It stores wallet material and database encryption keys locally.
+- It runs the XMTP client directly.
+- It joins a group as a normal member.
+
+That pattern is convenient, but it has major problems:
+
+- The harness effectively becomes the XMTP client.
+- Any “read-only” or “limited” tool permissions are mostly advisory if the harness holds raw credentials.
+- The blast radius is too large if keys, storage, logs, or tool integrations are compromised.
+- There is little group-visible provenance around what an agent can actually do.
+- There is no durable, shared language for agent capability posture inside a conversation.
+
+We need a better boundary.
+
+## From Opaque Trust to Inspectable Trust
+
+Today, nobody should trust an XMTP agent just because it exists in a chat. An agent is basically just another XMTP inbox. XMTP gives you strong cryptographic identity primitives around inboxes and linked identities, signatures, and group-role permissions, but it does not currently tell other participants what software stack is behind that inbox, whether a broker is involved, or what capability boundary is actually being enforced.
+
+The current state:
+
+- An agent joins a group.
+- You know it is some inbox.
+- You do not know what code is running behind it.
+- You do not know whether it has raw credentials.
+- You do not know whether its claimed limits are real.
+
+This proposal does not solve trust by decree. It moves us from **opaque trust** to **inspectable trust**.
+
+Concretely, that means a brokered agent can publish signed, group-visible attestations describing its current permissions, hosting mode, and scope, and agent-authored messages can reference the attestation they were produced under.
+
+That still does not prove the operator is honest. But it gives the group something cryptographic and inspectable to verify, which is strictly better than the current state where agents can make claims and nobody can tell what is actually behind them.
+
+The important honesty clause: a broker does not magically make an agent trustworthy. It makes the system **auditable and constrainable** in a way today’s pattern is not. That is the difference.
+
+## Ground Setting
+
+### What we are proposing
+
+We are proposing an **application-layer brokered model** for agent access to XMTP conversations.
+
+In this model:
+
+- The broker is the real XMTP participant runtime.
+- The agent consumes a derived and policy-filtered interface.
+- Permissions are enforced at the broker boundary.
+- Group-visible attestation messages communicate the current capability state of an agent.
+- The same conceptual model works across local, self-hosted, and managed deployments.
+
+### What we are not proposing
+
+We are **not** proposing that a standard XMTP group member can be given a weaker token and thereby become selectively unable to decrypt ordinary group messages.
+
+We are **not** proposing a centralized authority that all agent permissions must flow through.
+
+We are **not** claiming that a hosted broker preserves the same trust boundary as a local broker.
+
+We are **not** trying to fully solve cross-session or cross-group memory leakage inside the agent model itself. The immediate goal is to create a better boundary for raw message access and action authority.
+
+### MLS and the cryptographic reality
+
+XMTP v3 uses the Messaging Layer Security (MLS) protocol for group encryption. The broker, as the real XMTP client, is a full MLS group member. It holds the complete epoch key schedule and can decrypt all group messages it receives. The view model described in this proposal is purely application-layer filtering on top of MLS. The broker always has access to the full ciphertext-to-plaintext path for its groups.
+
+This is by design. The security boundary this proposal creates is between the broker and the agent harness, not between the broker and the MLS group. The broker is trusted to enforce policy on the derived view; MLS is not being extended or modified.
+
+### Design truth statements
+
+Several truths should remain explicit throughout the design:
+
+- If the harness holds the raw XMTP signer and raw DB access, token-based restrictions are largely cosmetic.
+- If the broker is remote, plaintext exists at the remote broker boundary for anything the broker is allowed to process.
+- If an agent is allowed to send content to an external LLM provider, privacy guarantees are weaker than pure end-to-end delivery between human clients.
+- A clean user experience should not rely on magical hidden guarantees that the system does not actually provide.
+- An inbox alone can prove identity association and signatures. It cannot prove “I am definitely running behind a real broker with these exact internal controls.”
+
+## Product Goals
+
+### Primary goals
+
+- Enable safe and ergonomic agent participation in XMTP and Convos conversations.
+- Make permissions meaningful by enforcing them below the harness layer.
+- Keep the capabilities model agnostic to the agent framework or harness.
+- Create group-visible provenance for agent permissions and permission changes.
+- Support both local and hosted deployment topologies.
+- Preserve a clean path toward standardization through future XIPs.
+
+### Secondary goals
+
+- Allow flexible message visibility modes, including reveal-oriented flows.
+- Support multiple transport surfaces such as WebSocket, MCP, HTTP, CLI, and SDK adapters.
+- Make it easy for users to self-host or one-click deploy their own broker.
+- Give apps like Convos rich UX affordances without requiring immediate protocol changes.
+- Provide a near-term deployable verification path for broker trust.
+
+## Non-Goals
+
+- Full protocol-level selective message visibility for standard group members.
+- Hiding metadata from infrastructure operators beyond what XMTP already protects.
+- Preventing an agent from storing or inferring information it has already been shown.
+- Solving every governance question about group approval and social policy in v1.
+
+## Core Concepts
+
+### Broker
+
+The **broker** is the trusted runtime boundary that owns the real XMTP client.
+
+Responsibilities:
+
+- Hold the XMTP signer or equivalent identity material for one or more agent inboxes.
+- Maintain installation continuity.
+- Persist the raw XMTP database and its encryption keys.
+- Sync, receive, and store the real conversation state.
+- Enforce policy for views, grants, and message projection.
+- Issue sessions to agent harnesses.
+- Publish group-visible capability attestations.
+- Manage per-agent isolation when serving multiple agents.
+
+The term “broker” is preferred over “gateway” to avoid confusion with XMTP Gateway Service and other gateway terminology in the ecosystem.
+
+### Identity Model
+
+Each agent has its own XMTP inbox. The broker holds the signer for that inbox and operates its MLS state, but from the protocol’s perspective, the agent is the group member.
+
+This means:
+
+- The group sees each agent as a distinct participant with its own inbox identity.
+- Attestations are about a specific agent, not about the broker as a whole.
+- One broker can manage multiple agent inboxes, each joining different groups independently.
+- There is no “ventriloquist” problem where one broker identity speaks as multiple agents.
+- The broker is infrastructure, not a participant. It does not appear in group membership.
+
+When a single broker serves multiple agents in the same group, each agent has its own inbox, its own attestation, its own view, and its own grant. The broker maintains strict isolation between agents internally — Agent A’s view must not leak into Agent B’s derived state.
+
+### View
+
+A **view** is a policy-filtered description of what an agent can see across one or more conversations.
+
+A view may specify:
+
+- Full visibility over a conversation or thread.
+- Redacted visibility.
+- Reveal-only visibility.
+- Thread-scoped visibility.
+- Summary-only visibility.
+
+A view also specifies allowed **content types** via an explicit allowlist. Content types not in the allowlist are held at the broker and not forwarded to the agent.
+
+Content type allowlists follow three tiers:
+
+- **Baseline allowlist:** Content types that have passed through the XIP process and are part of the accepted XMTP spec. These are allowed by default.
+- **Broker-level configuration:** The broker operator can expand or restrict beyond the baseline across all agents the broker manages.
+- **Per-agent view configuration:** The owner can further scope what a specific agent sees within what the broker allows.
+
+The effective allowlist for any given agent is the intersection of what the broker permits and what the agent’s view config includes.
+
+**Default-deny for unknown content types.** If a content type is not in the effective allowlist, it does not reach the agent. When a new XIP content type is accepted and the baseline list updates, existing agents do not automatically start seeing it. The broker updates its baseline, but each agent’s view must explicitly include the new type.
+
+A view is not the real XMTP message state. It is a derived projection enforced by the broker.
+
+### Grant
+
+A **grant** is a structured description of what actions an agent is allowed to perform.
+
+Grant categories:
+
+#### Messaging capabilities
+
+- Send messages.
+- Reply in thread.
+- React.
+- Draft only.
+- Post only with confirmation.
+
+#### Group management capabilities
+
+- Add members.
+- Remove members.
+- Update metadata.
+- Invite users.
+- Change agent policy.
+
+#### Tool capabilities
+
+- Calendar access.
+- Payment actions.
+- External HTTP access.
+- Search/retrieval.
+- Custom application tools.
+
+#### Retention and egress capabilities
+
+- Store message excerpts.
+- Use content for memory.
+- Forward to model providers.
+- Quote revealed content.
+- Summarize hidden or revealed content.
+
+A view and a grant are independently composable. An agent can have a `reveal-only` view paired with `send + react` capabilities, or a `full` view paired with `draft-only` capabilities, without needing named modes for every combination.
+
+### View Modes
+
+Suggested initial view modes as convenience labels:
+
+- `full`
+- `thread-only`
+- `redacted`
+- `reveal-only`
+- `summary-only`
+
+A view mode is only a convenience label. The underlying view object (including the content type allowlist) and grant object should remain explicit and authoritative.
+
+### Attestation
+
+An **attestation** is a signed assertion about an agent’s current permissions, scope, and operating posture.
+
+Attestations are meant to be visible to the group and updated whenever permissions change materially.
+
+Attestations establish shared understanding of:
+
+- Who owns the agent.
+- Which inbox the agent uses.
+- What the agent can see (view).
+- What the agent can do (grant).
+- How the agent handles egress and inference.
+- Whether content is reveal-only or broader.
+- The hosting mode and trust posture.
+- What changed since the previous state.
+
+#### Attestation noise and materiality
+
+Not every internal state change should produce a group-visible attestation. The system should distinguish **material changes** from **routine operations**.
+
+Material changes that produce group-visible attestations:
+
+- View mode or scope changes.
+- Grant additions or removals.
+- Egress or inference policy changes.
+- Agent addition or revocation.
+- Ownership or hosting mode changes.
+- Verifier statement updates.
+
+Routine operations that remain silent:
+
+- Session rotation within the same view and grant.
+- Heartbeat / liveness signals.
+- Internal broker housekeeping.
+
+This prevents the conversation timeline from becoming a compliance log while ensuring that meaningful permission changes are always visible.
+
+### Session
+
+A **session** is the ephemeral authorization context between an agent harness and the broker.
+
+A session is how the harness receives its active view and grant.
+
+Sessions should be:
+
+- Short-lived.
+- Rotatable.
+- Scoped.
+- Revocable.
+- Bound to a specific view and grant.
+
+#### Session and view/grant binding
+
+View and grant updates that do not change the security boundary can be applied within an existing session without requiring reconnection. Examples: adjusting a thread scope, adding a new content type to the allowlist, or enabling a reaction capability.
+
+Changes that materially expand the security boundary require session reauthorization. Examples: upgrading from `reveal-only` to `full` visibility, adding egress permissions, or granting group management capabilities. The broker should terminate the current session and require the harness to establish a new one under the updated policy.
+
+This prevents excessive reconnection churn while ensuring that privilege escalation always involves a clean authorization step.
+
+## Users and Stakeholders
+
+### End users
+
+People who want to add agents to their private or group conversations without surrendering raw account access to the agent harness.
+
+### Group members
+
+People sharing a conversation with an agent who need visibility into what that agent can currently do.
+
+### App developers
+
+Teams building XMTP or Convos clients that want first-class agent support with clear permission UX.
+
+### Agent developers
+
+People building harnesses, tools, and integrations who need a stable, framework-agnostic interface.
+
+### Infrastructure operators
+
+People who want to self-host or provide managed broker services.
+
+## Problem Statement
+
+Today, the easiest way to run an XMTP agent is to let the harness run the XMTP client directly.
+
+That creates several structural problems:
+
+- The harness can often bypass app-level permissions by calling the SDK or CLI directly.
+- There is no clean separation between the real client and the agent’s policy view.
+- Hosted deployments become hard to reason about because the host is effectively the agent endpoint anyway.
+- Users and group members do not have a durable, shared language for understanding current capability state.
+- Different apps and agent frameworks are likely to reinvent incompatible patterns.
+
+The system needs a boundary that is real, visible, and portable.
+
+## Proposed Solution
+
+### High-level architecture
+
+The proposed architecture separates the system into three layers:
+
+#### Raw plane
+
+The raw plane contains the real XMTP client and raw conversation state.
+
+Owned by the broker:
+
+- Signer material for agent inboxes.
+- Installation continuity.
+- Raw message retrieval and sync.
+- Raw local database.
+- DB encryption keys.
+
+#### Policy plane
+
+The policy plane determines what an agent is allowed to see and do.
+
+It includes:
+
+- View definitions (visibility scope and content type allowlists).
+- Grant definitions (action permissions).
+- Reveal state.
+- Group policy state.
+- Attestations.
+- Revocations.
+
+#### Derived plane
+
+The derived plane is what the agent actually consumes.
+
+This may be:
+
+- A filtered event stream.
+- A derived encrypted cache.
+- A session-bound local store.
+- A transformed API surface.
+- A combination of the above.
+
+### Core rule
+
+The harness never touches the raw plane.
+
+The broker is the only component allowed to operate the real XMTP client.
+
+### Harness-agnostic interface
+
+The broker should expose a canonical interface that can be adapted to:
+
+- WebSocket
+- HTTP
+- MCP
+- CLI bindings
+- OpenClaw channel adapters
+- AI SDK adapters
+- Claude Agent SDK adapters
+- OpenAI agent adapters
+
+The system should define one capability model and multiple connection adapters, rather than one permission system per harness.
+
+## Egress and Inference Disclosure
+
+When an agent sends conversation content to an external LLM provider, the privacy story changes fundamentally. This is arguably the single most consequential thing a group member would want to know about an agent.
+
+Egress and inference posture must be declared as structured, first-class fields in the attestation — not buried in a generic policy blob.
+
+### Required egress fields
+
+- `inferenceMode` — `local` | `external` | `hybrid`
+- `inferenceProviders` — A list of providers the agent may use, e.g. `["anthropic", "openai"]`. Empty for purely local inference.
+- `contentEgressScope` — What content leaves the broker boundary: `full-messages` | `summaries-only` | `tool-calls-only` | `none`
+- `retentionAtProvider` — `none` | `session` | `persistent` | `unknown`
+
+These fields are **required** in every attestation. If the value cannot be determined, the field must be set to `unknown` rather than omitted. Silent omission is not allowed. Every attestation takes an explicit position, even if that position is “I don’t know.”
+
+### Envelope declaration
+
+For agent frameworks that dynamically switch inference providers (such as OpenClaw), the attestation should declare the **envelope** of possible providers, not the instantaneous state. If the agent may route to Anthropic, OpenAI, or a local model depending on the query, the attestation declares all three and sets `inferenceMode` to `hybrid`.
+
+Overstating the envelope is acceptable. Understating it is not.
+
+### Verification and honesty
+
+In v1, these fields are self-reported by the broker. An unverified broker claiming `inferenceMode: local` gets treated with the same skepticism as any other unverified claim. A source-verified or runtime-attested broker making that claim is more credible. The schema does not solve trust — it gives trust something structured to attach to.
+
+## Attestation Model
+
+### Why attestations matter
+
+Attestations make agent posture legible to the conversation itself.
+
+Without attestations, permissions live only in the owner’s client or broker config. That is not enough for a multi-party environment.
+
+### Attestation signing in v1
+
+In v1, the broker signs attestations using the agent’s inbox key (which the broker holds). The attestation includes the `ownerInboxId` field, which creates a social accountability link — the group can see who is responsible for the agent — even though the owner is not cryptographically co-signing every update.
+
+Clients verify the signature against the agent’s inbox, confirming the attestation came from the entity that controls that agent.
+
+In future versions, optional owner co-signing could be added for high-stakes permission changes (such as upgrading from `reveal-only` to `full` visibility), while keeping routine attestations broker-signed only.
+
+### Attestation lifecycle
+
+An attestation should be published when a material change occurs:
+
+- An agent is added.
+- Permissions are first granted.
+- View or grant changes.
+- Egress or inference policy changes.
+- The agent is revoked.
+- The ownership or hosting mode changes.
+- A verifier statement is updated.
+
+### Suggested attestation fields
+
+- `attestationId`
+- `previousAttestationId`
+- `agentInboxId`
+- `ownerInboxId`
+- `groupId`
+- `threadScope`
+- `viewMode`
+- `contentTypes`
+- `grantedOps`
+- `toolScopes`
+- `inferenceMode`
+- `inferenceProviders`
+- `contentEgressScope`
+- `retentionAtProvider`
+- `hostingMode`
+- `trustTier`
+- `buildProvenanceRef` (optional, populated when available)
+- `verifierStatementRef` (optional, populated when available)
+- `sessionKeyFingerprint`
+- `policyHash`
+- `heartbeatInterval`
+- `issuedAt`
+- `expiresAt`
+- `revocationRules`
+- `issuer`
+
+### Message provenance
+
+Agent-authored messages should reference the attestation under which they were produced.
+
+This gives clients the ability to render:
+
+- The current capability posture.
+- Whether a message was generated under different permissions than the current state.
+- Whether permissions changed mid-conversation.
+
+### Trust model for attestations
+
+The system should not rely on self-attestation from the agent alone.
+
+The more trustworthy path is:
+
+- The broker signs the attestation with the agent’s inbox key.
+- The attestation is posted into the group.
+- Agent messages reference the current attestation.
+- Clients compare references over time.
+- Verifier statements (when available) add external validation.
+
+## Trust Chain Model
+
+The trust model for brokers is built as a chain of four independent layers. Each layer adds assurance, but none alone is sufficient.
+
+### Layer 1: XMTP Identity
+
+What XMTP already provides. Proves which inbox is speaking, with cryptographic identity association and signatures. This tells you **who**, but not what software or controls are behind that identity.
+
+### Layer 2: Build Provenance
+
+What the broker project publishes. Establishes that a specific artifact was built from a specific source by a specific pipeline. Relevant evidence includes: repo, commit SHA, build workflow, artifact digest, SBOM, signing identity, and transparency log entries.
+
+Tools in this layer include SLSA provenance, Sigstore signing and transparency logs, and GitHub artifact attestations.
+
+Open source plus build provenance gets you to: “this artifact likely came from that source/build pipeline.”
+
+### Layer 3: Runtime Attestation
+
+What the live broker instance proves. Establishes that a specific measured workload is actually running in the deployment environment. This is where enclave-style attestation (such as AWS Nitro Enclaves or other TEE platforms) fits for hosted deployments.
+
+Runtime attestation gets you to: “this live hosted broker is likely running the artifact it claims to be running.”
+
+The design should be **TEE-agnostic and verifier-agnostic** — AWS Nitro today, other attested runtimes tomorrow, or purely source/build-verified self-hosting for users who do not want enclave dependencies.
+
+### Layer 4: Capability Attestation
+
+What gets posted into the group. Describes what this broker claims the agent can do right now. This is the app/XIP layer — the view, the grant, the hosting mode, the egress posture.
+
+This layer becomes far more credible when it chains back to the first three layers.
+
+### Trust Tiers
+
+The trust chain maps to three practical tiers that clients can render:
+
+#### Tier 1 — Source-verified
+
+- Open source broker implementation.
+- Signed release.
+- Build provenance available and verifiable.
+
+#### Tier 2 — Reproducibly verified
+
+- All of Tier 1.
+- Independent parties can reproduce the artifact bit-for-bit from source.
+
+#### Tier 3 — Runtime-attested
+
+- All of Tier 2.
+- Hosted runtime proves measurement via remote attestation.
+- Secrets are released only to approved measurements.
+
+The group-visible attestation includes a `trustTier` field reflecting the highest tier the broker can currently demonstrate.
+
+## Broker Verification
+
+### Near-term: Reference Verifier
+
+To provide a fast path to verification without waiting for the full trust chain to mature, the system should ship an open source **reference verifier** — a lightweight service deployable to Cloudflare Workers, Railway, or similar platforms.
+
+The reference verifier:
+
+- Accepts a verification request containing the broker inbox ID, artifact digest, and build provenance bundle.
+- Checks the provenance against a known set of published releases (GitHub artifact attestations, Sigstore transparency log entries).
+- Returns a signed verification statement bound to the broker’s inbox, artifact digest, and an expiry.
+
+The verifier identity is just an XMTP inbox. The verification statement is a signed message (or structured content type). This means the protocol surface is the same whether the verifier is a reference instance, a community-run deployment, or eventually a node operator sidecar. The decentralization path is baked in from day one because there is no privileged API endpoint — just inboxes that issue statements and clients that decide which issuers to trust.
+
+### Verifier-over-XMTP flow
+
+1. Broker inbox opens a DM with verifier inbox.
+1. Broker sends a verification request containing: broker inbox identity, challenge nonce, artifact digest, build provenance bundle, optional runtime attestation evidence, requested verification class.
+1. Verifier checks policy and evidence.
+1. Verifier replies over XMTP with a signed verification statement.
+1. Broker references that statement in its group-visible capability attestation via the `verifierStatementRef` field.
+1. Clients validate: the verifier issuer, the signature, expiry, evidence class, and whether subsequent agent messages still point to a current statement.
+
+### Multiple issuers
+
+The system should support multiple verifier issuers. Apps, auditors, node operators, XMTP Labs, third parties, and self-run verifiers can all participate. Clients and groups choose which issuers they trust. There should be no single central authority blessing all brokers.
+
+### XMTP node operators
+
+XMTP node operators could run verifier services alongside their nodes in the future, but the node software itself should not be required to become the verifier layer. This preserves decentralization of issuers without bloating the network’s base responsibilities. A later XIP could explore whether the node layer should participate more directly.
+
+## Reveal and Selective Visibility
+
+### Important distinction
+
+This proposal does not assume protocol-level selective decryptability for normal XMTP group messages.
+
+Instead, it uses **broker-enforced selective disclosure**.
+
+### Practical reveal model
+
+The broker receives and stores the real conversation state.
+
+For each incoming message, the broker decides what to project into the view:
+
+- Full plaintext.
+- Redacted content.
+- Hidden placeholder.
+- Summary.
+- Nothing.
+
+### Reveal behaviors
+
+Suggested reveal patterns:
+
+- Reveal per message.
+- Reveal per thread.
+- Temporary reveal mode for a time window.
+- Reveal by content type.
+- Reveal by sender or role.
+
+### Group-visible policy
+
+Reveal behavior should be understandable in the client UX.
+
+For example, Convos could render:
+
+- Hidden from assistant.
+- Revealed to assistant.
+- Reveal this message.
+- Reveal this thread.
+- Pause assistant visibility.
+
+### Why this matters
+
+This preserves a meaningful distinction between:
+
+- The real XMTP message state.
+- The materialized agent view.
+
+That distinction is what makes broker-enforced permissions real.
+
+## Liveness and Graceful Degradation
+
+The broker-mediated model adds a mandatory dependency: if the broker goes down, the agent goes completely silent. From the group’s perspective, a crashed broker is indistinguishable from a healthy agent that is choosing not to respond. The system should address this.
+
+### Heartbeat and staleness
+
+The attestation includes a `heartbeatInterval` field indicating the expected liveness cadence. Clients should render an “agent unreachable” or “last active N minutes ago” indicator when the interval is exceeded. This does not require noisy group-visible messages — it can be inferred from session keepalives or lightweight structured signals.
+
+### Broker recovery: inbound messages
+
+Messages sent by the group while the broker was down should still be delivered to the agent on recovery. The agent needs that context to understand what happened during the outage. However, the broker must tag these messages as **historical** — they carry their original timestamps, but the broker signals to the agent that they are not fresh messages to act on. The agent gets context, not action triggers.
+
+### Broker recovery: outbound messages
+
+Outbound agent actions that were queued or implied during downtime should be subject to a **configurable expiry window**. If the broker recovers within that window, queued actions can proceed. Beyond the window, they expire silently. This prevents stale responses to questions asked hours earlier.
+
+### Client-side rendering
+
+When the broker recovers, the client can show a notice such as “agent back online, caught up through [timestamp]” to indicate that the agent has resynced but may have missed real-time participation during the outage.
+
+## Revocation
+
+Revocation should be **immediate, visible, and fail-closed**. If there is any ambiguity about whether an agent is still authorized, the answer is no.
+
+### Normal revocation
+
+The owner instructs the broker to revoke the agent. The broker immediately terminates the agent’s session, posts a revocation attestation to the group, and stops projecting any view to that agent.
+
+### Owner loses access
+
+If the owner’s device is lost or the owner leaves the group, two safety valves apply:
+
+- **Mandatory expiration:** Attestations must have an `expiresAt` field. A broker with no owner contact eventually stops being authorized.
+- **Group admin override:** Group admins can remove the agent’s inbox from the group at the XMTP group permissions level, which effectively kills access regardless of what the broker thinks.
+
+### Session expiry without rotation
+
+If a session expires and the harness does not re-authenticate, the broker automatically stops projecting the view. No silent continuation on stale credentials. The broker posts a session-expired attestation so the group knows the agent is no longer active under valid authorization.
+
+### In-flight messages during revocation
+
+If the agent has a message in transit when revocation hits, the broker drops it. A message that arrives at the broker after the revocation attestation was posted should never reach the group. Better to lose a message than to have an agent act after its permissions were pulled.
+
+## Threat Model
+
+The broker architecture concentrates trust in the broker and its host. The following threat profiles map attacker types to what they gain across deployment modes.
+
+### Compromised harness
+
+What they gain: nothing beyond the current view and grant. The harness has no raw signer, no DB encryption key, no direct XMTP SDK access. The attacker can abuse the agent’s currently granted actions and read whatever the current view exposes, but cannot escalate beyond the session’s permissions.
+
+This is the scenario the architecture is specifically designed to contain, and represents a major improvement over the current model where a compromised harness has full client access.
+
+### Compromised broker host (local)
+
+What they gain: access to operational keys and the raw DB, but not the root signing key if it is stored in the Secure Enclave. The attacker can read raw messages and abuse the operational key for routine signing, but cannot perform privilege escalation (which requires biometric authentication on the root key) and cannot extract the root key from hardware.
+
+On platforms without hardware-backed key storage, a compromised local machine means full access to the raw plane including all key material.
+
+Mitigation includes hardware-backed key storage (Secure Enclave, TPM), standard local security hygiene, and biometric gating on privilege escalation. The broker does not make a compromised machine safer — but hardware-bound keys significantly limit what an attacker can do even with process-level access.
+
+### Compromised broker host (self-hosted / managed)
+
+What they gain: full raw message access for all agents the broker manages, all signer material, and the ability to forge attestations. The hosted environment is the real client boundary, and compromise of it is equivalent to owning every agent on that broker.
+
+Mitigations: short-lived sessions limit exposure window, mandatory attestation expiry forces periodic renewal, runtime attestation (Tier 3) can detect environment tampering, and the broker’s attestation history creates a forensic trail.
+
+### Malicious operator (managed deployment)
+
+What they gain: the same access as a compromised host, but with the added ability to operate covertly over time. A malicious managed broker operator can silently exfiltrate messages, forge attestations, and impersonate agents.
+
+Mitigations: the `hostingMode` field in attestations discloses managed deployment, allowing clients to render appropriate trust indicators. Runtime attestation (Tier 3) with TEE-backed key release is the strongest counter. Verifier statements from independent issuers provide a cross-check. But fundamentally, a managed broker requires trust in the operator — the system should be honest about that.
+
+### Network adversary
+
+What they gain: limited value. XMTP messages are encrypted in transit via MLS. The attacker cannot read message contents. They may observe metadata (who is communicating, when, message sizes) to the extent XMTP’s transport layer exposes it, but the broker architecture does not change this posture relative to the current model.
+
+## Governance and Group Policy
+
+### Initial ownership model (v1)
+
+For v1, an agent is owned and configured by one group member.
+
+That owner can:
+
+- Add the agent.
+- Configure the view and grant.
+- Rotate permissions.
+- Revoke access.
+
+### Group visibility
+
+Even in the owner-driven model, the resulting permissions are visible to the group via attestations. Group members can inspect what an agent can see and do at any time.
+
+### Power asymmetry in v1
+
+The v1 model creates a known power asymmetry. If Alice adds an agent with `full` visibility, Bob can see that via the attestation, but he has no direct mechanism to override or restrict the agent’s permissions — his recourse is limited to leaving the group or asking Alice to change the configuration.
+
+This is an accepted limitation of v1. The attestation model makes the situation transparent, which is a meaningful improvement over the current state where Bob has no visibility at all.
+
+### Future group governance
+
+Over time, clients and standards could support richer governance patterns that address this asymmetry:
+
+- Group-level caps on maximum permissions (e.g. “no agent in this group may exceed reveal-only visibility”).
+- Approval thresholds for risky capabilities.
+- Admin-only control of agent policy.
+- Automatic revocation if owner leaves or is removed.
+- Per-member objection mechanisms.
+
+## Client Experience
+
+### Convos as a rich reference client
+
+Convos is especially well-positioned to make this model understandable because it already leans into per-conversation identity, privacy-forward UX, and explicit assistant behavior.
+
+Possible Convos additions:
+
+- Agent creation and connection flow from within a conversation.
+- Visual view mode and grant badges.
+- Trust tier indicators.
+- Permission editing UI.
+- Reveal toggles on messages and threads.
+- Timeline cards for attestation changes (material changes only).
+- Agent ownership labeling.
+- Hosting mode labeling.
+- Inference and egress disclosure (e.g. “processes locally” or “sends to Anthropic, session only”).
+- Confirmation flows for risky actions.
+- Explainability UI for why an agent did or did not see a message.
+- Agent offline / staleness indicators.
+
+### UX principles
+
+- Make capability posture visible without being noisy.
+- Default to understandable safety labels.
+- Keep message timelines coherent.
+- Avoid creating excessive side-chat tax unless the user explicitly chooses that mode.
+- Show provenance on agent actions.
+- Distinguish material permission changes from routine operations in the timeline.
+
+### Trust tier rendering
+
+Clients should render trust posture in a way that is accurate but not alarmist:
+
+- **Unverified** — no verifier statement, self-asserted only.
+- **Source-verified** — build provenance verified by a recognized issuer.
+- **Reproducibly verified** — independent reproduction confirmed.
+- **Runtime-attested** — live environment measurement verified.
+
+Additionally:
+
+- **Local** — broker runs on the user’s machine.
+- **Self-hosted** — broker runs on user-controlled infrastructure.
+- **Managed** — broker hosted by a third party.
+
+These two dimensions (trust tier and hosting mode) should be shown together so users can make informed decisions.
+
+### Side-chat and side-room support
+
+Even if reveal-in-place is the main UX, clients should still support side-room patterns for higher-risk or higher-privacy tasks.
+
+Useful variants:
+
+- Task-specific side rooms.
+- Temporary assistant workrooms.
+- Private reveal rooms for selected participants.
+
+## Deployment Model
+
+### Local broker
+
+A local broker runs on the user’s machine.
+
+Benefits:
+
+- Strongest practical trust boundary.
+- Lowest third-party exposure.
+- Natural fit for users already running local agents.
+
+Trade-offs:
+
+- Requires an always-on machine for long-lived agents.
+- More setup friction.
+- Local networking and process management complexity.
+
+### Self-hosted broker
+
+A self-hosted broker runs on a machine or service the user controls.
+
+Examples: home server, private VM, personal cloud deployment.
+
+Benefits:
+
+- Persistent uptime.
+- Better privacy posture than a fully managed service.
+- Operational flexibility.
+
+Trade-offs:
+
+- More operational burden.
+- Trust still moves to the hosted environment.
+
+### Managed broker
+
+A managed broker is hosted by a third party.
+
+Benefits:
+
+- Lowest setup friction.
+- Makes the model accessible to users without an always-on machine.
+- Good default for agents that need continuous operation.
+
+Trade-offs:
+
+- The managed broker becomes the real client boundary.
+- Plaintext exists where the broker processes it.
+- The trust boundary is weaker than local or self-hosted deployments.
+
+### Product truth
+
+All deployment modes share:
+
+- The same broker protocol.
+- The same view and grant model.
+- The same attestation model.
+- The same client UX semantics.
+
+They do not share the same trust boundary.
+
+That difference should be clearly disclosed.
+
+Managed broker deployments have real operational costs — compute, storage, bandwidth. The protocol should support lightweight and hibernatable broker modes to keep deployment sustainable.
+
+## Hosting and Deployment Strategy
+
+### Spec-first approach
+
+The system should be defined as an open specification first, with multiple reference deployments.
+
+Recommended outputs:
+
+- Broker protocol spec.
+- View, grant, and session spec.
+- Attestation schema.
+- Reference verifier implementation (deployable to Cloudflare Workers or Railway).
+- Broker reference implementations.
+- One-click deployment templates.
+
+### Recommended deployment profiles
+
+#### Desktop local profile
+
+- Runs as a local service.
+- Connects over localhost WebSocket, Unix socket, or local MCP.
+- Best for privacy-sensitive users and local agent workflows.
+
+#### Self-hosted container profile
+
+- Runs in a stateful Linux container or VM.
+- Uses persistent disk.
+- Good fit for Fly, Railway, VPS, or home-server deployment.
+
+#### Cloudflare hybrid profile
+
+- Cloudflare handles control-plane tasks.
+- A stateful raw broker runs elsewhere.
+- Good fit for global session management, fanout, and attestation coordination.
+
+### Platform considerations
+
+#### Fly.io
+
+A strong candidate for stateful self-hosted or semi-managed broker deployment because it maps well to persistent container workloads.
+
+#### Railway
+
+Also a strong candidate for persistent broker deployment with good ergonomics for rapid setup.
+
+#### Cloudflare
+
+Best suited to control-plane roles, hybrid deployment patterns, and hosting the reference verifier.
+
+### One-click deployment
+
+A one-click deployment experience should:
+
+- Generate broker secrets inside the target environment.
+- Avoid showing long-lived secrets back to the user in plaintext when possible.
+- Support user-controlled recovery and rotation.
+- Publish broker identity and attestation fingerprints.
+- Make the hosting mode visible to the client.
+
+### Honest security posture for hosted deployment
+
+A hosted deployment may keep secrets from leaving the environment in plaintext to the user, but that is not equivalent to a cryptographic guarantee that the hosting platform or deployer can never access them.
+
+The product language should reflect that honestly.
+
+## Transport and Interface Design
+
+### Primary transport
+
+WebSocket is the most natural primary transport for live agent interaction.
+
+Reasons:
+
+- Real-time event streaming.
+- Bi-directional messaging.
+- Natural fit for session-oriented connections.
+- Good substrate for harness adapters.
+
+### Additional adapters
+
+The broker should also support:
+
+- MCP adapter
+- HTTP API
+- CLI client
+- SDK helper libraries
+- OpenClaw channel adapter
+
+### Canonical broker events
+
+Suggested event types:
+
+- `session.started`
+- `session.expired`
+- `session.reauthorization_required`
+- `attestation.updated`
+- `view.updated`
+- `grant.updated`
+- `message.visible`
+- `message.visible.historical`
+- `message.hidden`
+- `message.revealed`
+- `tool.allowed`
+- `tool.denied`
+- `action.confirmation_required`
+- `agent.revoked`
+- `broker.recovery.complete`
+
+## Security and Privacy Model
+
+### Trusted computing base
+
+In this architecture, the broker and its host form the trusted computing base for the raw XMTP view.
+
+That is true whether the broker is local or hosted.
+
+### Security goals
+
+- Keep raw XMTP credentials out of the harness.
+- Make permissions meaningful through enforced mediation.
+- Minimize blast radius through short-lived sessions and explicit scopes.
+- Make agent posture visible to conversation participants.
+- Reduce accidental overexposure to tools and models.
+- Ensure revocation is immediate, visible, and fail-closed.
+
+### Security limitations
+
+- A compromised broker can expose raw content.
+- A malicious host or operator may still exfiltrate data in hosted environments.
+- An agent can still remember or infer content it has already seen.
+- Egress to an LLM provider weakens privacy relative to pure client-to-client messaging.
+- Attestation fields beyond the trust chain are self-reported in v1.
+
+### Hard requirements
+
+- No direct harness access to raw keys.
+- No direct harness access to raw DB files.
+- No unsupported side-channel access to the raw plane.
+- Signing keys stored in hardware-backed storage where available (Secure Enclave, TEE).
+- Privilege escalation requires root key authorization (biometric or equivalent).
+- Clear session expiration and rotation.
+- Clear revocation flow with fail-closed behavior.
+- Mandatory `expiresAt` on all attestations.
+
+## Key Management and Hardware Binding
+
+The PRD states that the broker “holds the signer” for agent inboxes. This section specifies *how* that signer material should be managed, with a strong preference for hardware-backed key storage that prevents extraction even by the broker process itself.
+
+### Design principle
+
+The broker should be able to **invoke** signing operations without being able to **extract** the signing key. This is the difference between “the broker holds the key” and “the broker can use the key through hardware-enforced mediation.” The latter is materially stronger.
+
+### Inspiration
+
+Projects such as keypo-cli demonstrate that Mac Secure Enclave-backed P-256 key management for AI agents is practical and shippable today. The architectural pattern — keys generated inside hardware, never exportable, with policy-gated access (open, passcode, biometric) and a vault system for encrypted secret storage — is directly applicable to the broker’s key management needs.
+
+However, for supply chain integrity, the broker should implement its own purpose-built key management layer rather than taking a dependency on a third-party tool. The core security boundary of the broker should not depend on external packages whose maintenance, auditability, or future direction is outside the project’s control. The keypo-cli architecture should be treated as a reference design, not a runtime dependency.
+
+### Recommended key hierarchy
+
+The broker should maintain a three-tier derived key hierarchy:
+
+#### Root key
+
+- Generated inside the Secure Enclave (local) or TEE (hosted).
+- Protected by biometric authentication (Touch ID) or equivalent strong authentication.
+- Non-exportable by hardware design.
+- Used for: initial agent inbox creation, privilege escalation authorization, key rotation, and recovery flows.
+- This is the agent’s true identity anchor.
+
+#### Operational key
+
+- Derived from the root key.
+- Protected by `passcode` or `open` policy depending on deployment mode.
+- Used for: routine message signing, attestation publishing, session issuance, and day-to-day broker operations.
+- Does not require biometric authentication per operation, allowing the broker to function autonomously for routine tasks.
+
+#### Session keys
+
+- Ephemeral, scoped to a specific session and grant.
+- Issued to the agent harness.
+- Short-lived and revocable.
+- Cannot escalate to operational-level or root-level operations.
+- This is what the harness actually holds.
+
+### Privilege escalation and biometric gating
+
+Routine broker operations — sending messages, publishing routine attestations, managing sessions — should flow through the operational key without requiring per-operation authentication. This allows agents to function autonomously within their granted permissions.
+
+Operations that cross a privilege threshold should require root key authorization, which means biometric (or equivalent) authentication:
+
+- Upgrading a view from `reveal-only` to `full` visibility.
+- Adding egress permissions or new inference providers.
+- Granting group management capabilities.
+- Creating new agent inboxes.
+- Performing key rotation.
+- Any grant escalation beyond the current session’s scope.
+
+This maps directly to the session reauthorization boundary defined in the Session section: non-material operations flow through the session, material privilege escalations require a clean authorization step backed by the root key.
+
+### Coordinating agent pattern
+
+A broker with root key access can act as a key authority for its managed agents. A coordinating agent — itself operating under a specific view and grant — could be authorized to create new agent inboxes on the fly, each with their own derived operational key, each scoped to specific grants.
+
+Those downstream agents can operate autonomously within their scoped permissions, but they can never reach back up to the root key without a biometric check from the human owner. This enables patterns like:
+
+- A coordinating agent that spins up task-specific agents for a conversation.
+- Each task agent gets a scoped grant and derived key.
+- If any task agent needs to exceed its granted scope, the request bubbles up to the coordinating agent, which in turn requires root key authorization from the owner.
+
+### Encrypted secret storage
+
+Beyond signing keys, brokers need to manage other secrets: database encryption keys, API credentials for inference providers, webhook tokens, and configuration secrets.
+
+These should be stored in an encrypted vault backed by the same hardware key hierarchy. Secrets are encrypted at rest using enclave-backed keys and injected into processes as environment variables at runtime — never written to disk in plaintext, never stored in `.env` files, and never visible in shell history or process listings.
+
+### Local broker key management
+
+For local brokers on macOS with Apple Silicon:
+
+- Root key lives in the Secure Enclave, protected by biometric policy.
+- Operational and session keys are derived and managed in memory or in the encrypted vault.
+- The user can set up a broker with a single biometric authentication.
+- Day-to-day operation does not require repeated biometric prompts.
+- The key literally cannot be extracted — not by the agent, not by the harness, not by malware, and not by the broker process itself.
+
+For local brokers on other platforms, the implementation should use the best available hardware-backed key storage (TPM, platform keychain with hardware binding, etc.) and degrade gracefully with clear labeling of the actual security posture.
+
+### Hosted broker key management
+
+For hosted brokers, the Secure Enclave is not available. The equivalent pattern is TEE-backed key storage:
+
+- Root key generated inside the enclave/TEE.
+- Signing operations invoked through the TEE interface without key extraction.
+- Key release conditioned on runtime attestation measurements.
+- The architectural boundary is the same — the broker can use the key but never see it — just implemented with different hardware.
+
+The attestation’s `trustTier` and `hostingMode` fields should reflect whether hardware-backed key storage is in use.
+
+## Key Rotation
+
+Key rotation is essential for operational continuity — machines change, hardware fails, and security hygiene requires periodic rotation.
+
+### Machine migration
+
+Secure Enclave keys are non-exportable and device-bound by hardware design. Moving to a new machine means:
+
+1. Authenticate on the new machine (biometric enrollment).
+1. The broker creates new enclave-backed keys on the new hardware.
+1. The broker performs an XMTP installation rotation — the agent’s inbox identity persists, but the signing key material rotates.
+1. The broker publishes an updated attestation reflecting the new key material and any updated verifier statements.
+1. The old machine’s keys are revoked.
+
+This is cleaner than a “recovery key” approach because it avoids ever having exportable root material. There are no seed phrases or recovery keys to secure, leak, or lose. The agent’s identity continuity is maintained through XMTP’s installation management, not through key portability.
+
+### Periodic rotation
+
+Even without a machine change, operational keys should support periodic rotation as a security hygiene measure. The broker should be able to rotate operational keys without disrupting active sessions — new sessions use the new key, existing sessions continue until their natural expiry, and the attestation is updated to reflect the rotation.
+
+### Rotation attestation
+
+Any key rotation event is a material change and should produce a group-visible attestation update. The group should be able to see that key material changed, when it changed, and that the new material chains back to a valid root.
+
+## Candidate XIP Directions
+
+This proposal is intentionally app-layer first, but several pieces are candidates for future XIPs.
+
+### Capability Attestation XIP (recommended first)
+
+Standardize a portable, signed attestation format for agent capabilities.
+
+Potential scope:
+
+- Required attestation fields (including structured egress/inference fields).
+- View and grant semantics.
+- Update semantics and materiality thresholds.
+- Revocation semantics.
+- Ownership and issuer model.
+- Attestation references in agent-authored messages.
+
+This is recommended as the first XIP because it is the foundation everything else references.
+
+### Broker Verification Statement XIP
+
+Standardize the verification request and verification statement content types.
+
+Potential scope:
+
+- Verification request format.
+- Verification statement format.
+- Issuer / expiry / revocation semantics.
+- Standard verification classes (self-asserted, source-verified, build-provenance-verified, runtime-attested).
+- Standard way for attestations to reference verifier statements.
+
+### Agent Message Provenance XIP
+
+Standardize how agent-authored messages indicate:
+
+- Which attestation they were produced under.
+- Whether the agent was acting with full, reveal-only, or other view modes.
+- Whether tool use or external actions were involved.
+
+### Group-Scoped Delegation XIP
+
+Explore a first-class group-scoped delegated principal model.
+
+This would be richer than inbox-level delegation and better aligned with group agent use cases.
+
+Possible semantics:
+
+- Delegate bound to one group.
+- Scoped capabilities.
+- Auto-revocation if delegator is removed.
+- Optional multi-admin approval.
+
+### Reveal Policy XIP
+
+Define portable message or thread-level policy objects for assistant visibility and reveal intent.
+
+This could give apps a shared language for:
+
+- Hidden from assistant.
+- Revealed to assistant.
+- Reveal thread.
+- Revoke future reveal.
+
+### Hosting and Trust Disclosure XIP
+
+Standardize a lightweight representation of hosting mode and trust posture.
+
+For example: local, self-hosted, managed, hybrid.
+
+This would help clients surface the real trust boundary to users.
+
+## Why XIPs matter here
+
+Without standardization, each app may invent different agent policy semantics, provenance formats, and UX expectations.
+
+A small number of targeted XIPs could:
+
+- Improve interoperability.
+- Make clients more consistent.
+- Reduce ambiguity around agent posture.
+- Encourage healthier defaults across the ecosystem.
+
+## Convos-Specific Opportunities
+
+Convos can add flavor to this model without waiting for protocol-level changes.
+
+### Identity and presentation
+
+- Present agents as first-class conversation participants with visible capability posture.
+- Highlight owner relationship and hosting mode.
+- Show trust tier alongside hosting mode.
+- Show when an agent is scoped to one convo versus broadly reused.
+
+### Message UX
+
+- Reveal-to-assistant controls inline.
+- Thread-level visibility toggles.
+- Agent-only summaries.
+- Hidden content placeholders.
+- Timeline notices when capabilities change (material changes only).
+
+### Trust and safety UX
+
+- Explain what the assistant can currently access.
+- Show inference and egress posture clearly.
+- Show when content may leave the device or local broker boundary.
+- Require confirmations for send, tool use, or risky actions.
+- Make revocation easy and legible.
+- Show agent offline/staleness state.
+
+### Developer and power-user UX
+
+- Attach to local broker.
+- Attach to self-hosted broker.
+- Inspect active session details.
+- Inspect attestation history.
+- Export broker fingerprints and configuration.
+
+## Rollout Strategy
+
+### Phase 1
+
+- Define broker, view, grant, attestation, and session concepts.
+- Ship local broker reference implementation with Secure Enclave-backed key management.
+- Implement derived key hierarchy (root → operational → session).
+- Ship open source reference verifier (Cloudflare Workers / Railway).
+- Expose WebSocket interface.
+- Support basic view modes (full, reveal-only) and grant configurations.
+- Ship Convos experimental client integration.
+- Define structured egress/inference disclosure fields.
+
+### Phase 2
+
+- Add self-hosted deployment templates.
+- Add MCP and SDK adapters.
+- Add permission editing UX.
+- Add attestation timeline UX (material changes only).
+- Add action confirmations and richer tool scopes.
+- Verifier-over-XMTP flow operational.
+- Draft Capability Attestation XIP based on implementation learnings.
+
+### Phase 3
+
+- Add managed broker product surface.
+- Add hybrid control-plane support.
+- Add key rotation and machine migration flows.
+- Add coordinating agent pattern for dynamic agent creation.
+- Add reproducible build verification support.
+- Draft Broker Verification Statement XIP.
+- Explore runtime attestation integration (TEE-agnostic) with TEE-backed key storage for hosted brokers.
+
+## Open Questions
+
+- What is the exact minimum viable attestation schema?
+- How should clients render stale or expired attestations?
+- How should reveal history be represented in UX?
+- Should session issuance be tied to explicit per-thread scopes by default?
+- How much policy should be in-group versus off-chain broker config?
+- What is the cleanest recovery story for one-click hosted deployments?
+- Which verification classes should the reference verifier support at launch?
+- What is the appropriate default heartbeat interval?
+- How should content type allowlist updates be surfaced in client UX?
+
+## Success Criteria
+
+The proposal is successful if it achieves the following:
+
+- Agents no longer need raw XMTP credentials in the harness to participate in a useful way.
+- Users can run local or hosted agents through the same conceptual model.
+- Group members can understand what an agent can do right now.
+- Permission changes become visible and attributable.
+- Egress and inference posture is explicitly disclosed, not hidden.
+- A reference verifier is available for early trust verification.
+- Apps such as Convos can create a rich, understandable UX without waiting on large protocol changes.
+- The model produces enough clarity and adoption pressure to justify one or more focused XIPs.
+
+## Risks
+
+### Technical risks
+
+- Broker complexity grows too quickly.
+- Too much app-layer behavior creates interop fragmentation.
+- Reveal semantics become inconsistent across clients.
+- Hosted deployment is oversold relative to its trust boundary.
+- Multi-agent isolation within a single broker proves harder than expected.
+
+### Product risks
+
+- Users misunderstand the difference between local and hosted modes.
+- The view and grant model feels too complex.
+- Too much UX ceremony discourages agent usage.
+- Attestations become noisy despite the materiality threshold.
+- Group members feel powerless under the v1 owner-only governance model.
+
+### Mitigations
+
+- Keep v1 narrow.
+- Start with simple view modes and basic grants.
+- Make hosting mode and trust tier explicit.
+- Focus first on clear provenance and meaningful enforcement.
+- Ship the reference verifier early for fast trust bootstrapping.
+- Standardize only after implementation learning.
+- Name the v1 governance asymmetry explicitly so expectations are set.
+
+## Recommendation
+
+Proceed with an app-layer broker architecture as the primary design direction.
+
+Start with:
+
+- A local broker reference implementation with Secure Enclave-backed key management.
+- A purpose-built key management layer (inspired by keypo-cli’s architecture, built in-house for supply chain integrity).
+- Derived key hierarchy with biometric-gated privilege escalation.
+- WebSocket as the primary live interface.
+- Structured view and grant model.
+- Group-visible capability attestations with structured egress disclosure.
+- An open source reference verifier deployable to Cloudflare Workers or Railway.
+- Convos as a rich UX proving ground.
+- Self-hosted templates for Fly and Railway.
+- A Cloudflare-friendly hybrid control-plane design.
+
+Use implementation learnings to identify which parts should become formal XIPs, starting with Capability Attestation.
+
+## Appendix: Crisp Framing
+
+The simplest way to explain the proposal is:
+
+- The **broker** is the real XMTP client.
+- The **view** is what the agent is allowed to see.
+- The **grant** is what the agent is allowed to do.
+- The **attestation** is what the group is told about that view and grant.
+- The **session** is how the harness connects to it.
+- The **verifier** is how the group can check whether the broker is what it claims.
+
+Or more simply:
+
+**The group trusts the attestation. The broker enforces the view and grant. The agent never touches the raw client. The verifier keeps the broker honest.**

--- a/.agents/notes/outfitter-patterns/agents-md-and-conventions.md
+++ b/.agents/notes/outfitter-patterns/agents-md-and-conventions.md
@@ -1,0 +1,123 @@
+# AGENTS.md Structure and Development Conventions
+
+Extracted from `outfitter/stack` as reference for xmtp-broker's agent-facing documentation.
+
+## CLAUDE.md vs AGENTS.md
+
+In outfitter/stack, CLAUDE.md is a thin wrapper:
+
+```markdown
+# CLAUDE.md
+## Claude-Specific Instruction
+- Unless otherwise specified, updates to this file should be made directly in `./AGENTS.md`.
+## Agent Instructions
+<!-- Do not edit below this line -->
+@AGENTS.md
+```
+
+All substance lives in AGENTS.md. No `.claude/rules/` directory — single file is the source of truth. This keeps things simple and avoids fragmentation.
+
+## AGENTS.md Structure (466 lines)
+
+The file follows a clear progression:
+
+1. **One-line summary** — "Bun-first TypeScript monorepo. Tests before code. Result types, not exceptions."
+2. **Project overview** — what the project does, core idea, Linear team key
+3. **Project structure** — where things live (apps/, packages/, docs/)
+4. **Commands** — every build/test/lint/release command, copy-pasteable
+5. **CI jobs** — table of all CI pipeline jobs and what they validate
+6. **Architecture** — package tiers, handler contract, action registry, CommandBuilder API, streaming, output envelopes, error taxonomy
+7. **Environment configuration** — profiles, env vars, precedence chain
+8. **Development principles** — non-negotiable (TDD, Result types) vs strong preferences (Bun-first)
+9. **Blessed dependencies** — canonical package for each concern
+10. **Code style** — TypeScript strictness, formatting tool
+11. **Testing** — runner, file patterns, snapshots
+12. **Git workflow** — branch naming, commits, PRs, hooks, changesets
+13. **Key files** — links to deeper docs
+
+## Key Patterns Worth Adopting
+
+### Lead with the non-negotiables
+
+The "Development Principles" section is explicit about what's mandatory vs. preferred:
+
+> **Non-Negotiable**
+> - **TDD-First** — Write the test before the code. Always.
+> - **Result Types** — Handlers return `Result<T, E>`, not exceptions.
+>
+> **Strong Preferences**
+> - **Bun-First** — Use Bun-native APIs before npm packages.
+
+This makes it unambiguous for both humans and agents.
+
+### Blessed dependencies table
+
+Explicit list of which package to use for each concern. Prevents agents from pulling in alternatives:
+
+| Concern           | Package                     |
+| ----------------- | --------------------------- |
+| Result type       | `better-result`             |
+| Schema validation | `zod`                       |
+| CLI parsing       | `commander`                 |
+| Logging           | `@logtape/logtape`          |
+| MCP protocol      | `@modelcontextprotocol/sdk` |
+| Prompts           | `@clack/prompts`            |
+
+### Package tiers with dependency direction
+
+Foundation -> Runtime -> Tooling, with the rule that dependencies flow one direction. This prevents circular deps and keeps the architecture layered.
+
+### Copy-pasteable commands
+
+Every command block is ready to run — no "replace X with Y" placeholders. Agents can execute directly.
+
+### Environment precedence chain
+
+Explicit resolution order prevents confusion:
+```
+env var override > explicit option > environment profile > package default
+```
+
+### CI job table
+
+Agents know exactly what CI checks and can predict what will fail.
+
+## Adaptation Notes for xmtp-broker
+
+**Adopt:**
+- Single AGENTS.md as source of truth (symlink CLAUDE.md to it, already done)
+- Lead with one-line summary and core idea
+- Non-negotiable vs. strong preference distinction
+- Blessed dependencies table
+- Copy-pasteable commands section
+- Package tier / dependency direction rules
+- Environment precedence chain pattern
+
+**Adapt:**
+- xmtp-broker is much simpler initially — AGENTS.md can be shorter
+- CI section can wait until CI exists
+- Package tiers will be different (broker core, transports, key management)
+
+**Development principles for xmtp-broker (draft):**
+
+### Non-Negotiable
+- **TDD-First** — Write the test before the code. Always.
+- **Result Types** — Functions that can fail return `Result<T, E>`, not exceptions.
+- **Schema-First** — Zod schemas are the single source of truth for types and validation.
+- **No Raw Credentials in Harness** — The core security invariant of the entire project.
+
+### Strong Preferences
+- **Bun-First** — Use Bun-native APIs before npm packages.
+- **Small Files** — < 200 LOC healthy, 200-400 find seams, > 400 refactor first.
+- **Transport-Agnostic Handlers** — Domain logic knows nothing about WebSocket, MCP, or CLI.
+- **Validate at Boundaries** — Parse external data at the edge, trust types internally.
+
+### Blessed Dependencies (starter)
+| Concern           | Package           |
+| ----------------- | ----------------- |
+| Result type       | `better-result`   |
+| Schema validation | `zod`             |
+| Testing           | `bun:test`        |
+| Logging           | TBD               |
+| WebSocket         | TBD (Bun native?) |
+| XMTP SDK          | `@xmtp/node-sdk`  |

--- a/.agents/notes/outfitter-patterns/error-handling-and-result.md
+++ b/.agents/notes/outfitter-patterns/error-handling-and-result.md
@@ -1,0 +1,108 @@
+# Error Handling and Result Pattern
+
+Extracted from `outfitter/stack` as reference for xmtp-broker error handling.
+
+## Core Principle: No Throw
+
+Handlers never throw. All error paths return `Result.err(error)`. This is enforced by:
+- An oxlint rule (`no-throw-in-handler`) that flags `throw` in handler code
+- Convention: only test assertions and explicit `expect()` utilities may throw
+
+## Result Type
+
+Uses the `better-result` library:
+
+```typescript
+Result<T, E>             // Success value T or error E
+Result.ok(value)         // Construct Ok
+Result.err(error)        // Construct Err
+result.isOk()            // Type guard
+result.isErr()           // Type guard
+result.value             // Access T when Ok
+result.error             // Access E when Err
+```
+
+Extended with custom combinators:
+- `unwrapOrElse(result, fn)` — lazy default on error
+- `orElse(result1, result2)` — alternative result on error
+- `combine2(r1, r2)` — combine multiple results into tuple
+- `expect(result, message)` — unwrap or throw with context (for boundaries only)
+
+## Error Taxonomy
+
+10 categories, each with dedicated error class, numeric code range, and cross-transport mappings:
+
+| Category | Class(es) | Exit | HTTP | JSON-RPC | Retryable |
+|----------|-----------|------|------|----------|-----------|
+| validation | ValidationError | 1 | 400 | -32602 | no |
+| not_found | NotFoundError | 2 | 404 | -32007 | no |
+| conflict | AlreadyExistsError, ConflictError | 3 | 409 | -32002 | no |
+| permission | PermissionError | 4 | 403 | -32003 | no |
+| timeout | TimeoutError | 5 | 504 | -32001 | yes |
+| rate_limit | RateLimitError | 6 | 429 | -32004 | yes |
+| network | NetworkError | 7 | 502 | -32005 | yes |
+| internal | InternalError, AssertionError | 8 | 500 | -32603 | no |
+| auth | AuthError | 9 | 401 | -32000 | no |
+| cancelled | CancelledError | 130 | 499 | -32006 | no |
+
+Numeric error code ranges (1000-10999) provide fine-grained identification within categories.
+
+## Error Class Shape
+
+All errors inherit from a `TaggedError` base:
+
+```typescript
+interface OutfitterError extends Error {
+  _tag: string;                          // class name for discrimination
+  code: number;                          // specific numeric code
+  category: ErrorCategory;               // taxonomy bucket
+  context?: Record<string, unknown>;     // structured data
+}
+```
+
+Each class has static factory methods:
+- `ValidationError.create(field, reason, context?)`
+- `NotFoundError.create(resourceType, resourceId, context?)`
+- `TimeoutError.create(operation, timeoutMs)`
+- etc.
+
+## Cross-Transport Error Flow
+
+```
+Handler returns Result.err(error)
+    │
+    ├── CLI: error.exitCode() → process.exit(N), stderr output
+    ├── MCP: error serialized → { isError: true, content: [...] }
+    ├── HTTP: error.statusCode() → HTTP status, JSON body
+    └── WebSocket: error serialized → structured error frame
+```
+
+Unified lookup: `errorCategoryMeta(category)` returns `{ exitCode, statusCode, jsonRpcCode, retryable }`.
+
+## Retryability
+
+Only transient errors are retryable: `timeout`, `rate_limit`, `network`. Permanent errors (validation, not_found, permission, auth, internal) require human intervention.
+
+## Adaptation Notes for xmtp-broker
+
+**Adopt:**
+- Result type for all handler returns (use `better-result` or similar)
+- Error taxonomy with categories mapping to transport-specific codes
+- Static factory methods on error classes for consistent construction
+- `_tag` discriminant for type-safe error matching
+- Retryability classification (important for session reconnection logic)
+- Structured `context` field on errors for debugging
+
+**Adapt for broker domain:**
+- Add broker-specific error categories or classes:
+  - `SessionExpiredError` (maps to auth)
+  - `GrantDeniedError` (maps to permission)
+  - `AttestationError` (maps to validation or conflict)
+  - `ViewFilterError` (maps to internal)
+  - `RevocationError` (maps to permission)
+- WebSocket transport needs error frame format (not HTTP status codes)
+- Consider whether the full 10-category taxonomy is needed initially — start with what the broker actually produces
+
+**Start with:**
+- validation, not_found, permission, auth, internal, timeout, cancelled
+- Add conflict, rate_limit, network as transports mature

--- a/.agents/notes/outfitter-patterns/schema-first-architecture.md
+++ b/.agents/notes/outfitter-patterns/schema-first-architecture.md
@@ -1,0 +1,135 @@
+# Schema-First Architecture
+
+Extracted from `outfitter/stack` as reference for xmtp-broker's type and validation strategy.
+
+## Core Idea
+
+Schemas are the single source of truth. A Zod schema defines the shape of data once, and everything else derives from it:
+
+- **TypeScript types** — inferred via `z.infer<typeof Schema>`
+- **Runtime validation** — `Schema.parse(input)` at boundaries
+- **CLI arg parsing** — Zod schema validates parsed CLI options
+- **MCP tool definitions** — `zodToJsonSchema(schema)` auto-generates JSON Schema for MCP protocol
+- **Documentation** — schema descriptions flow into help text and tool listings
+
+No manual type duplication. No type/validation drift.
+
+## How It Works in Practice
+
+### 1. Define the schema once
+
+```typescript
+// In a shared contracts/schemas location
+const GetNoteInput = z.object({
+  id: z.string().describe("Note ID"),
+  workspace: z.string().describe("Workspace root path"),
+});
+
+type GetNoteInput = z.infer<typeof GetNoteInput>;
+```
+
+### 2. Handler receives typed, validated input
+
+```typescript
+const getNoteHandler: Handler<GetNoteInput, Note, NotFoundError> = async (input, ctx) => {
+  // input is already validated and typed — no need to check fields
+  const note = await loadNote(input.id, input.workspace);
+  if (!note) return Result.err(NotFoundError.create("note", input.id));
+  return Result.ok(note);
+};
+```
+
+### 3. CLI adapter parses args against schema
+
+```typescript
+command("note:get")
+  .input(GetNoteInput)                    // Zod schema drives validation
+  .option("--id <id>", "Note ID")
+  .option("--workspace <path>", "Root")
+  .action(getNoteHandler)
+  .build();
+```
+
+### 4. MCP adapter derives JSON Schema
+
+```typescript
+registerTool({
+  name: "notes/get",
+  inputSchema: GetNoteInput,              // zodToJsonSchema() called internally
+  handler: getNoteHandler,
+});
+```
+
+The MCP protocol receives a JSON Schema representation of the Zod schema, which LLM clients use to construct valid tool calls.
+
+## Content Type Allowlists
+
+In outfitter/stack, schemas also drive content type handling. Content type registries use schemas to validate message payloads.
+
+This pattern maps directly to the broker's **content type allowlist** concept:
+
+```typescript
+// Each content type has a schema
+const TextContentSchema = z.object({ text: z.string() });
+const ReactionContentSchema = z.object({ reference: z.string(), action: z.enum(["added", "removed"]), content: z.string() });
+
+// The view's allowlist references content type IDs
+// The broker validates incoming content against the schema before projecting to the agent
+```
+
+## Attestation Schema
+
+The broker's attestation model is a natural fit for schema-first design:
+
+```typescript
+const AttestationSchema = z.object({
+  attestationId: z.string(),
+  previousAttestationId: z.string().nullable(),
+  agentInboxId: z.string(),
+  ownerInboxId: z.string(),
+  groupId: z.string(),
+  viewMode: z.enum(["full", "thread-only", "redacted", "reveal-only", "summary-only"]),
+  contentTypes: z.array(z.string()),
+  grantedOps: z.array(z.string()),
+  inferenceMode: z.enum(["local", "external", "hybrid", "unknown"]),
+  inferenceProviders: z.array(z.string()),
+  contentEgressScope: z.enum(["full-messages", "summaries-only", "tool-calls-only", "none", "unknown"]),
+  retentionAtProvider: z.enum(["none", "session", "persistent", "unknown"]),
+  hostingMode: z.enum(["local", "self-hosted", "managed"]),
+  trustTier: z.enum(["unverified", "source-verified", "reproducibly-verified", "runtime-attested"]),
+  issuedAt: z.string().datetime(),
+  expiresAt: z.string().datetime(),
+  // ...
+});
+
+type Attestation = z.infer<typeof AttestationSchema>;
+```
+
+This schema:
+- Validates attestations at the broker boundary
+- Types all internal attestation handling
+- Auto-generates JSON Schema for MCP tool definitions
+- Self-documents the attestation format
+- Can be versioned as the attestation spec evolves
+
+## Adaptation Notes for xmtp-broker
+
+**Adopt from day one:**
+- Zod as the schema library (lightweight, composable, excellent TS inference)
+- Schema-first for all broker domain types: views, grants, attestations, sessions, events
+- `z.infer<>` for all TypeScript types — no manual interfaces
+- Validate at boundaries (incoming harness requests, config, env vars), trust types internally
+- `zodToJsonSchema()` when MCP transport is added later
+
+**Key schemas to define early:**
+- `ViewSchema` — view mode, content type allowlist, thread scope
+- `GrantSchema` — messaging caps, group management caps, tool caps, egress caps
+- `AttestationSchema` — full attestation structure
+- `SessionSchema` — session config, expiry, binding
+- `BrokerEventSchema` — union of all canonical event types
+- `HarnessRequestSchema` — union of all harness -> broker requests
+
+**Why this matters for xmtp-broker specifically:**
+- The attestation format will eventually become a XIP — having it schema-defined from day one means the spec is always in sync with the code
+- Multiple transports (WebSocket, MCP, CLI) will all need the same validation — one schema serves all
+- Agent harnesses in different languages can consume the JSON Schema version

--- a/.agents/notes/outfitter-patterns/transport-agnostic-handlers.md
+++ b/.agents/notes/outfitter-patterns/transport-agnostic-handlers.md
@@ -1,0 +1,148 @@
+# Transport-Agnostic Handler Patterns
+
+Extracted from `outfitter/stack` as reference for xmtp-broker's broker interface design.
+
+## Core Idea
+
+All domain logic lives in a single handler function. The handler is transport-agnostic — it doesn't know whether it's being called from CLI, MCP, HTTP, or anything else. Transport adapters handle protocol-specific concerns (arg parsing, output formatting, error codes).
+
+## The Handler Contract
+
+```typescript
+type Handler<TInput, TOutput, TError extends OutfitterError> = (
+  input: TInput,
+  ctx: HandlerContext
+) => Promise<Result<TOutput, TError>>;
+```
+
+- **input**: Pre-validated, typed data matching a Zod schema
+- **ctx**: Cross-cutting concerns (config, logger, cwd, env, signal, requestId, progress callback)
+- **returns**: `Result<TOutput, TError>` — never throws
+
+## HandlerContext
+
+```typescript
+interface HandlerContext {
+  config: Config;
+  cwd: string;
+  env: Record<string, string | undefined>;
+  logger: Logger;
+  progress?: ProgressCallback;  // streaming updates for long ops
+  requestId: string;             // tracing
+  signal: AbortSignal;           // cancellation
+  workspaceRoot: string;
+}
+```
+
+## ActionSpec: One Definition, Many Surfaces
+
+An `ActionSpec` bundles a handler with its schema and surface-specific metadata:
+
+```typescript
+interface ActionSpec<TInput, TOutput, TError extends OutfitterError> {
+  readonly id: string;
+  readonly handler: Handler<TInput, TOutput, TError>;
+  readonly input: z.ZodType<TInput>;
+  readonly output?: z.ZodType<TOutput>;
+  readonly cli?: ActionCliSpec<TInput>;    // CLI-specific: options, aliases, mapInput
+  readonly mcp?: ActionMcpSpec<TInput>;    // MCP-specific: readOnly, destructive, deferLoading
+  readonly api?: ActionApiSpec;            // HTTP-specific
+  readonly surfaces?: readonly ActionSurface[];
+}
+```
+
+Each surface adapter (CLI, MCP, HTTP) reads its specific config from the ActionSpec and wires up the shared handler.
+
+## CLI Surface
+
+CLI commands are built with a fluent builder on top of Commander.js:
+
+```typescript
+command("note:get")
+  .description("Fetch a note by ID")
+  .input(GetNoteInput)              // Zod schema
+  .option("--id <id>", "Note ID")
+  .action(handler)                   // the shared handler
+  .build();
+```
+
+The builder handles:
+1. Parsing CLI args into raw object
+2. Validating against Zod schema
+3. Constructing HandlerContext
+4. Calling handler
+5. Formatting output for terminal (or JSON with `--output=json`)
+6. Mapping errors to exit codes
+
+## MCP Surface
+
+MCP tools are registered with the same handler:
+
+```typescript
+registerTool({
+  name: "notes/get",
+  description: "Fetch a note by ID",
+  inputSchema: GetNoteInput,         // same Zod schema → auto-converted to JSON Schema
+  handler: handler,                   // same handler
+  readOnly: true,
+});
+```
+
+The MCP transport:
+1. Receives `CallToolRequest`
+2. Validates args against Zod schema
+3. Constructs HandlerContext
+4. Calls handler
+5. Wraps result in MCP protocol envelope (content array with text/structured)
+6. Maps errors to `isError: true` responses
+
+## Output Envelope
+
+All responses follow a consistent envelope:
+
+```typescript
+{
+  ok: boolean;
+  data?: T;            // on success
+  error?: {            // on failure
+    _tag: string;
+    category: string;
+    message: string;
+    context?: Record<string, unknown>;
+  };
+  meta: {
+    requestId: string;
+    timestamp: string;
+    durationMs: number;
+  };
+  pagination?: {
+    count: number;
+    hasMore: boolean;
+    nextCursor?: string;
+    total?: number;
+  };
+}
+```
+
+## Adaptation Notes for xmtp-broker
+
+**Key insight**: The broker's "derived plane" interface is essentially another transport surface. The same pattern applies:
+
+- **Broker core handlers** contain the domain logic (view filtering, grant enforcement, attestation management)
+- **WebSocket transport** adapts handlers for the primary live interface
+- **MCP transport** can expose the same handlers as MCP tools (later)
+- **CLI transport** can expose them as commands (later)
+- **HTTP transport** for REST API (later)
+
+**Adopt:**
+- Handler contract pattern (input + context -> Result)
+- Zod schemas for all inputs, auto-derived JSON Schema for MCP
+- HandlerContext with logger, signal, requestId
+- Result return type (never throw)
+- ActionSpec-like registration that bundles handler + schema + surface metadata
+
+**Simplify for v1:**
+- Start with WebSocket as sole transport
+- Don't need the full ActionSpec builder — a simpler registration will do
+- Add CLI/MCP/HTTP adapters incrementally as the interface stabilizes
+- Keep the schema-first principle from day one so adding transports later is mechanical

--- a/.agents/notes/outfitter-patterns/workspace-and-tooling.md
+++ b/.agents/notes/outfitter-patterns/workspace-and-tooling.md
@@ -1,0 +1,112 @@
+# Workspace and Tooling Patterns
+
+Extracted from `outfitter/stack` as reference for xmtp-broker scaffolding.
+
+## Bun Workspace
+
+- Root `package.json` with `"type": "module"` (ESM-only)
+- Workspaces: `packages/*`, `apps/*`, `plugins/*`, `examples/*`
+- Bun version pinned in `.bun-version` (e.g., `1.3.10`) — CI reads from this file
+- `packageManager` field in root package.json for toolchain enforcement
+- **Bun catalogs** for centralized dependency versions — workspace packages use `catalog:` instead of specific versions
+- Internal packages use `workspace:*` for cross-references
+
+## TypeScript
+
+Shared base config (`tsconfig.base.json`) extended by all packages.
+
+Key strictness settings:
+- `strict: true`
+- `noUncheckedIndexedAccess: true`
+- `exactOptionalPropertyTypes: true`
+- `noPropertyAccessFromIndexSignature: true`
+- `noImplicitReturns: true`
+- `noFallthroughCasesInSwitch: true`
+- `noUnusedLocals: true` / `noUnusedParameters: true`
+- `isolatedModules: true` / `isolatedDeclarations: true`
+- `verbatimModuleSyntax: true`
+
+Module settings:
+- `target: "ESNext"`
+- `moduleResolution: "bundler"`
+- `declaration: true` with source maps
+
+Per-package configs extend base with `outDir: "./dist"`, `rootDir: "./src"`, exclude `node_modules`, `dist`, `src/__tests__`.
+
+## Linting: oxlint
+
+Config in `.oxlintrc.json`:
+- `correctness` and `suspicious` categories set to `error`
+- Custom plugin (`@outfitter/oxlint-plugin`) for org-specific rules:
+  - `max-file-lines`: warn at 200, error at 400
+  - `handler-must-return-result`: error
+  - `no-console-in-packages`: error
+  - `no-cross-tier-import`: error (architecture enforcement)
+  - `no-deep-relative-import`: warn
+  - `no-throw-in-handler`: warn
+  - `prefer-bun-api`: warn
+- Ignores: `node_modules/**`, `dist/**`, `.turbo/**`, `*.gen.ts`, `__snapshots__/**`, `fixtures/**`
+
+## Formatting: oxfmt
+
+Config in `.oxfmtrc.jsonc`:
+- Print width: 80
+- Indent: 2 spaces
+- Double quotes
+- Trailing commas: ES5
+- Semicolons: always
+- Import sorting: ASC order with newline separators
+
+## Build System: Turbo
+
+Config in `turbo.json`:
+- Remote cache enabled (signed)
+- Global deps: `.bun-version`, `.oxlintrc.json` invalidate all caches
+- `build` depends on upstack builds; inputs `src/**`, `scripts/**`, `tsconfig.json`; outputs `dist/**`
+- `test` depends on build; **cache disabled** (always runs)
+- `typecheck` depends on upstack builds
+- `lint` depends on upstack builds + oxlint-plugin build
+
+Build tool: **bunup** (Bun's native bundler) with a lock script to serialize builds and prevent package.json race conditions under parallel Turbo.
+
+## Testing: bun:test
+
+- Test files: `src/__tests__/*.test.ts`
+- Snapshots: `src/__snapshots__/*.snap`
+- Run via `bun test` (per-package) or `bun run test` (root, via Turbo)
+- Test cache disabled in Turbo — always reruns
+
+## Git Hooks: Lefthook
+
+`.lefthook.yml`:
+- **Pre-commit**: runs linter/formatter on staged files with `stage_fixed: true`
+- **Pre-push**: full verification including schema drift, block drift, docs sentinel
+
+## Package Conventions
+
+- Scope: `@outfitter/*`
+- `publishConfig.access: "public"`
+- Explicit, granular exports (e.g., `@outfitter/contracts/result`, `@outfitter/contracts/errors`)
+- Entry points: `./dist/index.js` with types at `./dist/index.d.ts`
+- Three-tier hierarchy: Foundation (contracts, types) -> Runtime (cli, mcp, config, logging) -> Tooling (outfitter CLI, presets, docs)
+
+## Adaptation Notes for xmtp-broker
+
+**Adopt directly:**
+- Bun workspace with `.bun-version` pin
+- ESM-only with `"type": "module"`
+- Max-strict tsconfig base config
+- oxlint + oxfmt (but without the custom plugin initially)
+- Turbo for build orchestration
+- Lefthook for git hooks
+- bun:test as test runner
+
+**Adapt:**
+- No need for Bun catalogs until there are multiple packages
+- Custom oxlint rules can come later once patterns stabilize
+- bunup lock script only needed with parallel package builds
+- Start simpler — single package, grow into workspace as needed
+
+**Skip:**
+- @outfitter/* packages themselves (goal is zero dependency on them)
+- Changesets (not publishing to npm initially)

--- a/.agents/plans/v0/01-repo-scaffolding.md
+++ b/.agents/plans/v0/01-repo-scaffolding.md
@@ -1,0 +1,511 @@
+# 01 — Repo Scaffolding
+
+## Overview
+
+This spec defines the workspace structure, build tooling, and developer conventions for xmtp-broker. It is the foundation every other spec depends on — nothing compiles, tests, or lints until this is in place.
+
+The broker is a Bun-first TypeScript monorepo using workspaces from day one. The monorepo structure enforces the three-tier architecture (Foundation, Runtime, Transport) through package boundaries rather than convention alone. Each tier maps to a set of packages with explicit dependency rules: dependencies flow downward only.
+
+Monorepo from day one is the right call. The tier boundaries are load-bearing for security (raw plane vs. derived plane isolation), and enforcing them through package imports is cheaper than enforcing them through lint rules. The cost is minimal — Bun workspaces + Turbo handle the orchestration, and each package starts as a single `src/index.ts` file.
+
+## Dependencies
+
+This spec has no code dependencies. It produces the workspace root and per-package scaffolding that all other specs build on.
+
+**Produces:**
+- Root `package.json`, `tsconfig.base.json`, `turbo.json`, `.lefthook.yml`
+- Per-package `package.json` and `tsconfig.json` stubs
+- Linting and formatting configs
+- CI pipeline
+
+**Consumed by:** Every other spec (02 through 09).
+
+## Public Interfaces
+
+N/A — this spec produces configuration, not code.
+
+## Zod Schemas
+
+N/A.
+
+## Behaviors
+
+### Workspace Layout
+
+```
+xmtp-broker/
+├── .agents/                    # Plans, notes, agent docs (existing)
+├── .bun-version                # Bun version pin (read by CI)
+├── .github/
+│   └── workflows/
+│       └── ci.yml              # Lint, typecheck, test on PR
+├── .lefthook.yml               # Git hooks
+├── .oxfmtrc.jsonc              # Formatter config
+├── .oxlintrc.json              # Linter config
+├── .reference/                 # Read-only reference codebases (gitignored)
+├── apps/                          # Runnable entrypoints (empty for now)
+├── packages/
+│   ├── schemas/                # @xmtp-broker/schemas
+│   ├── contracts/              # @xmtp-broker/contracts
+│   ├── core/                   # @xmtp-broker/core
+│   ├── policy/                 # @xmtp-broker/policy
+│   ├── sessions/               # @xmtp-broker/sessions
+│   ├── attestations/           # @xmtp-broker/attestations
+│   ├── keys/                   # @xmtp-broker/keys
+│   ├── ws/                     # @xmtp-broker/ws
+│   └── verifier/               # @xmtp-broker/verifier
+├── package.json                # Workspace root
+├── tsconfig.base.json          # Shared TypeScript config
+├── turbo.json                  # Build orchestration
+├── AGENTS.md
+├── CLAUDE.md
+└── README.md
+```
+
+Each package follows the same internal structure:
+
+```
+packages/<name>/
+├── package.json
+├── tsconfig.json
+├── src/
+│   ├── index.ts                # Public exports
+│   └── __tests__/
+│       └── *.test.ts
+```
+
+### Root package.json
+
+```jsonc
+{
+  "name": "xmtp-broker",
+  "private": true,
+  "type": "module",
+  "workspaces": ["packages/*", "apps/*"],
+  "packageManager": "bun@1.2.9",
+  "scripts": {
+    "build": "turbo run build",
+    "test": "turbo run test",
+    "typecheck": "turbo run typecheck",
+    "lint": "turbo run lint",
+    "format:check": "oxfmt --check .",
+    "format:fix": "oxfmt .",
+    "check": "turbo run lint typecheck test"
+  },
+  "devDependencies": {
+    "@biomejs/js-api": "catalog:",
+    "lefthook": "catalog:",
+    "oxlint": "catalog:",
+    "turbo": "catalog:",
+    "typescript": "catalog:"
+  }
+}
+```
+
+**Note on Bun catalogs:** Use the `[catalog]` field in root `package.json` to centralize shared dependency versions. Workspace packages reference them with `"catalog:"` instead of pinned versions. This avoids version drift across packages.
+
+```jsonc
+// Root package.json (additional field)
+{
+  "catalog": {
+    "better-result": "^1.1.0",
+    "zod": "^3.24.0",
+    "typescript": "^5.8.0",
+    "oxlint": "^0.18.0",
+    "turbo": "^2.5.0",
+    "lefthook": "^1.11.0"
+  }
+}
+```
+
+### .bun-version
+
+```
+1.2.9
+```
+
+Pin the Bun version. CI reads this file. Developers use `bun upgrade` to match.
+
+### Per-Package package.json Template
+
+```jsonc
+{
+  "name": "@xmtp-broker/<name>",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "bun build ./src/index.ts --outdir ./dist --target bun",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint .",
+    "test": "bun test"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "catalog:"
+  }
+}
+```
+
+**Package-specific dependencies** (added per spec, not all at once):
+
+| Package | Runtime deps | Workspace deps |
+|---------|-------------|----------------|
+| `schemas` | `zod`, `better-result` | — |
+| `contracts` | `better-result` | `@xmtp-broker/schemas` |
+| `core` | `@xmtp/node-sdk`, `better-result` | `@xmtp-broker/schemas`, `@xmtp-broker/contracts` |
+| `policy` | `better-result` | `@xmtp-broker/schemas`, `@xmtp-broker/contracts` |
+| `sessions` | `better-result` | `@xmtp-broker/schemas`, `@xmtp-broker/contracts` |
+| `attestations` | `better-result` | `@xmtp-broker/schemas`, `@xmtp-broker/contracts` |
+| `keys` | `better-result` | `@xmtp-broker/schemas`, `@xmtp-broker/contracts` |
+| `ws` | `better-result` | `@xmtp-broker/schemas`, `@xmtp-broker/contracts`, `@xmtp-broker/core`, `@xmtp-broker/policy`, `@xmtp-broker/sessions` |
+| `verifier` | `better-result`, `zod` | `@xmtp-broker/schemas` |
+
+Workspace deps use `"workspace:*"` in the `dependencies` field.
+
+### TypeScript Configuration
+
+**tsconfig.base.json:**
+
+```jsonc
+{
+  "compilerOptions": {
+    // Strictness
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+
+    // Modules
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "isolatedDeclarations": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": false,
+
+    // Output
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "skipLibCheck": true
+  }
+}
+```
+
+**Per-package tsconfig.json:**
+
+```jsonc
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "src/__tests__"]
+}
+```
+
+### Linting: oxlint
+
+**.oxlintrc.json:**
+
+```jsonc
+{
+  "rules": {
+    "correctness": "error",
+    "suspicious": "error"
+  },
+  "ignorePatterns": [
+    "node_modules/**",
+    "dist/**",
+    ".turbo/**",
+    ".reference/**",
+    "*.gen.ts"
+  ]
+}
+```
+
+No custom plugin for v0. The built-in `correctness` and `suspicious` categories catch real bugs without noise. Custom rules (max-file-lines, no-throw-in-handler, no-cross-tier-import) are a post-v0 concern once patterns stabilize.
+
+### Formatting: oxfmt
+
+**.oxfmtrc.jsonc:**
+
+```jsonc
+{
+  "printWidth": 80,
+  "indentWidth": 2,
+  "useTabs": false,
+  "quoteStyle": "double",
+  "trailingCommas": "es5",
+  "semicolons": "always"
+}
+```
+
+### Build System: Turbo
+
+**turbo.json:**
+
+```jsonc
+{
+  "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": [".bun-version", ".oxlintrc.json"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**", "tsconfig.json", "package.json"],
+      "outputs": ["dist/**"]
+    },
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**", "tsconfig.json", "package.json"],
+      "outputs": []
+    },
+    "lint": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**", ".oxlintrc.json"],
+      "outputs": []
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "cache": false,
+      "inputs": ["src/**"],
+      "outputs": []
+    }
+  }
+}
+```
+
+Test caching is disabled — tests always run. This is deliberate: tests are cheap in Bun and stale test results are dangerous.
+
+### Git Hooks: Lefthook
+
+**.lefthook.yml:**
+
+```yaml
+pre-commit:
+  parallel: true
+  commands:
+    format:
+      glob: "*.{ts,tsx,js,json,jsonc}"
+      run: bunx oxfmt {staged_files}
+      stage_fixed: true
+    lint:
+      glob: "*.{ts,tsx,js}"
+      run: bunx oxlint {staged_files}
+
+pre-push:
+  commands:
+    typecheck:
+      run: bun run typecheck
+    test:
+      run: bun run test
+    lint:
+      run: bun run lint
+```
+
+Pre-commit is fast (format + lint on staged files only). Pre-push runs the full verification suite. This catches issues before they hit CI without slowing down commits.
+
+### CI Pipeline
+
+**.github/workflows/ci.yml:**
+
+```yaml
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    name: Lint, Typecheck, Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read Bun version
+        id: bun-version
+        run: echo "version=$(cat .bun-version)" >> "$GITHUB_OUTPUT"
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ steps.bun-version.version }}
+
+      - run: bun install --frozen-lockfile
+
+      - name: Format check
+        run: bun run format:check
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun run test
+```
+
+Single job for v0. Split into parallel jobs when the build time justifies it. Format check runs first because it is the cheapest gate.
+
+### Blessed Dependencies
+
+Complete table of what to use for each concern. Do not add dependencies outside this list without explicit discussion.
+
+| Concern | Package | Notes |
+|---------|---------|-------|
+| Result type | `better-result` | All fallible functions return `Result<T, E>` |
+| Schema validation | `zod` | Single source of truth for types via `z.infer<>` |
+| Testing | `bun:test` | Built-in, zero-config |
+| XMTP SDK | `@xmtp/node-sdk` | The broker wraps this; only `core` package imports it |
+| WebSocket server | `Bun.serve()` | Built-in WebSocket support; no external package |
+| SQLite | `bun:sqlite` | For session/key storage if needed |
+| Hashing | `Bun.hash()` / `Bun.CryptoHasher` | Built-in; no `crypto` import needed |
+| File I/O | `Bun.file()` / `Bun.write()` | Built-in |
+| Linting | `oxlint` | Dev dependency, root only |
+| Formatting | `oxfmt` | Dev dependency, root only |
+| Build orchestration | `turbo` | Dev dependency, root only |
+| Git hooks | `lefthook` | Dev dependency, root only |
+| TypeScript | `typescript` | Dev dependency, type checking only (Bun runs TS directly) |
+
+**Explicitly not used:**
+- No `express`, `fastify`, `hono` — `Bun.serve()` handles HTTP/WS
+- No `jest`, `vitest` — `bun:test` is the runner
+- No `eslint`, `prettier` — `oxlint` and `oxfmt` replace them
+- No `esbuild`, `tsup`, `unbuild` — `bun build` is sufficient
+- No `@outfitter/*` — zero dependency on external frameworks
+
+### Package Stub Content
+
+Each package starts with a minimal `src/index.ts` that exports nothing meaningful:
+
+```typescript
+// src/index.ts
+// Placeholder — see spec 0X for real exports.
+export {};
+```
+
+This ensures `bun build`, `tsc --noEmit`, and `bun test` all pass on the empty workspace before any real code is written.
+
+## Error Cases
+
+N/A — configuration spec.
+
+## Open Questions Resolved
+
+| Question | Resolution | Rationale |
+|----------|-----------|-----------|
+| Mono-package vs monorepo? | Monorepo from day one with Bun workspaces. | The tier boundaries (Foundation/Runtime/Transport) are security-critical. Package boundaries enforce them through the module system. The overhead is minimal — each package is a `package.json`, `tsconfig.json`, and `src/index.ts`. Turbo handles build ordering. |
+| Bun catalogs? | Yes, use `catalog:` for shared dependency versions. | Prevents version drift across 8 packages. One place to update `zod`, `better-result`, etc. |
+| Custom oxlint plugin? | Not for v0. | Patterns haven't stabilized. Built-in `correctness` + `suspicious` categories are sufficient. Custom rules (max-file-lines, no-cross-tier-import) are a post-v0 concern. |
+| Build tool (bunup vs bun build)? | `bun build` directly. No bunup lock script. | The broker is not published to npm, so advanced bundling is unnecessary. `bun build` produces ESM output. If parallel build races surface, add a lock script then. |
+| Remote Turbo cache? | Not for v0. | No shared CI infra yet. Add when build times justify it. |
+
+## Deferred
+
+- **Custom oxlint plugin** — rules like `no-cross-tier-import`, `max-file-lines`, `no-throw-in-handler`. Add once patterns are stable.
+- **Changesets / versioning** — not publishing to npm; versions stay at `0.0.0`.
+- **Remote Turbo cache** — no shared build infra yet.
+- **`apps/` directory** — workspace glob included (`apps/*`), but no runnable application until the broker CLI exists (post-v0).
+- **Bun bunup** — `bun build` is sufficient for non-published packages.
+- **Import sorting** — oxfmt handles this; no additional tooling.
+
+## Testing Strategy
+
+The scaffolding itself is verified by running the full toolchain on the empty workspace:
+
+1. `bun install` — workspace resolution succeeds
+2. `bun run build` — all packages build (empty exports)
+3. `bun run typecheck` — all packages pass type checking
+4. `bun run lint` — no lint errors on empty stubs
+5. `bun run format:check` — all files formatted
+6. `bun run test` — test runner executes (no tests yet, zero failures)
+
+These are manual verification steps, not automated tests. The scaffolding spec's "test" is that the toolchain works end to end.
+
+### Smoke Test File
+
+Add one test file to `packages/schemas/` to verify the test runner works:
+
+```typescript
+// packages/schemas/src/__tests__/smoke.test.ts
+import { describe, expect, it } from "bun:test";
+
+describe("workspace", () => {
+  it("test runner works", () => {
+    expect(true).toBe(true);
+  });
+});
+```
+
+## File Layout
+
+Exact files to create, with brief descriptions:
+
+```
+.bun-version                                    # "1.2.9"
+.github/workflows/ci.yml                        # CI pipeline
+.lefthook.yml                                   # Git hooks config
+.oxfmtrc.jsonc                                  # Formatter config
+.oxlintrc.json                                  # Linter config
+package.json                                    # Workspace root
+tsconfig.base.json                              # Shared TS config
+turbo.json                                      # Build orchestration
+
+packages/schemas/package.json                   # @xmtp-broker/schemas
+packages/schemas/tsconfig.json                  # Extends base
+packages/schemas/src/index.ts                   # Export stub
+packages/schemas/src/__tests__/smoke.test.ts    # Smoke test
+
+packages/contracts/package.json                 # @xmtp-broker/contracts
+packages/contracts/tsconfig.json
+packages/contracts/src/index.ts
+
+packages/core/package.json                      # @xmtp-broker/core
+packages/core/tsconfig.json
+packages/core/src/index.ts
+
+packages/policy/package.json                    # @xmtp-broker/policy
+packages/policy/tsconfig.json
+packages/policy/src/index.ts
+
+packages/sessions/package.json                  # @xmtp-broker/sessions
+packages/sessions/tsconfig.json
+packages/sessions/src/index.ts
+
+packages/attestations/package.json              # @xmtp-broker/attestations
+packages/attestations/tsconfig.json
+packages/attestations/src/index.ts
+
+packages/keys/package.json                      # @xmtp-broker/keys
+packages/keys/tsconfig.json
+packages/keys/src/index.ts
+
+packages/ws/package.json                        # @xmtp-broker/ws
+packages/ws/tsconfig.json
+packages/ws/src/index.ts
+
+packages/verifier/package.json                  # @xmtp-broker/verifier
+packages/verifier/tsconfig.json
+packages/verifier/src/index.ts
+```
+
+Total: 31 files. All are configuration or stubs — no domain logic.

--- a/.agents/plans/v0/02-schemas.md
+++ b/.agents/plans/v0/02-schemas.md
@@ -1,0 +1,1066 @@
+# 02-schemas
+
+**Package:** `@xmtp-broker/schemas`
+**Spec version:** 0.1.0
+
+## Overview
+
+The schemas package is the foundation of the entire broker system. It defines every Zod schema, inferred TypeScript type, and error class used across all other packages. No runtime logic lives here -- only shapes, validation, and error taxonomy.
+
+Cross-package interfaces (service contracts, provider interfaces, event types) live in `@xmtp-broker/contracts`, not here. The split principle: **schemas** = "what shape is the data?" while **contracts** = "what can components do to each other?" See [02b-contracts](02b-contracts.md) for the contracts package spec.
+
+Every other package in the broker monorepo imports from `@xmtp-broker/schemas`. Nothing imports into it except `@xmtp-broker/contracts`. This zero-dependency position means changes here cascade everywhere, so the schemas must be stable, well-described, and complete from day one.
+
+All schemas carry `.describe()` annotations so they can be converted to JSON Schema for MCP tool definitions, documentation generation, and cross-language harness consumption. All TypeScript types are derived via `z.infer<>` -- no manual interfaces, no type duplication.
+
+Fields that are conceptually optional use `.nullable()` with an explicit `null` value, never `.optional()`. This ensures every attestation, event, and request has a predictable shape regardless of which fields are populated.
+
+## Dependencies
+
+**Imports:** `zod` (sole runtime dependency)
+
+**Imported by:** `@xmtp-broker/contracts` (directly), and transitively by every other `@xmtp-broker/*` package
+
+## Public Interfaces
+
+The package exports schemas, inferred types, error classes, and utility constants. All exports are named -- no default exports.
+
+### Content Type Identifiers
+
+```typescript
+/**
+ * XMTP content type identifier following the authority/type:version convention.
+ * Examples: "xmtp.org/text:1.0", "xmtp.org/reaction:1.0"
+ */
+const ContentTypeId = z
+  .string()
+  .regex(/^[a-z0-9.-]+\/[a-zA-Z0-9]+:\d+\.\d+$/)
+  .describe("XMTP content type identifier (authority/type:version)");
+
+type ContentTypeId = z.infer<typeof ContentTypeId>;
+```
+
+### Baseline Content Types
+
+```typescript
+/** Standard XMTP content types accepted by default. */
+const BASELINE_CONTENT_TYPES = [
+  "xmtp.org/text:1.0",
+  "xmtp.org/reaction:1.0",
+  "xmtp.org/reply:1.0",
+  "xmtp.org/readReceipt:1.0",
+  "xmtp.org/groupUpdated:1.0",
+] as const satisfies readonly ContentTypeId[];
+
+type BaselineContentType = (typeof BASELINE_CONTENT_TYPES)[number];
+```
+
+### Content Type Payload Schemas
+
+Each baseline content type has a corresponding payload schema for validation at the broker boundary.
+
+```typescript
+const TextPayload = z.object({
+  text: z.string().min(1).describe("Message text content"),
+}).describe("Text message payload");
+
+const ReactionPayload = z.object({
+  reference: z.string().describe("Message ID being reacted to"),
+  action: z.enum(["added", "removed"]).describe("Whether reaction is added or removed"),
+  content: z.string().describe("Reaction content (emoji or text)"),
+  schema: z.enum(["unicode", "shortcode", "custom"]).describe("Reaction schema type"),
+}).describe("Reaction payload");
+
+const ReplyPayload = z.object({
+  reference: z.string().describe("Message ID being replied to"),
+  content: z.object({
+    type: ContentTypeId.describe("Content type of the reply body"),
+    payload: z.unknown().describe("Encoded reply content"),
+  }).describe("Reply body"),
+}).describe("Reply payload");
+
+const ReadReceiptPayload = z.object({}).describe("Read receipt payload (empty body)");
+
+const GroupUpdatedPayload = z.object({
+  initiatedByInboxId: z.string().describe("Inbox ID of the member who initiated the update"),
+  addedInboxes: z.array(z.string()).describe("Inbox IDs added to the group"),
+  removedInboxes: z.array(z.string()).describe("Inbox IDs removed from the group"),
+  metadataFieldsChanged: z.array(z.object({
+    fieldName: z.string().describe("Name of the changed metadata field"),
+    oldValue: z.string().nullable().describe("Previous value"),
+    newValue: z.string().nullable().describe("New value"),
+  })).describe("Metadata fields that changed"),
+}).describe("Group membership/metadata update payload");
+```
+
+Content type registry for extensibility:
+
+```typescript
+/** Map from content type ID to its payload schema. Extensible at runtime. */
+const CONTENT_TYPE_SCHEMAS: Record<string, z.ZodType> = {
+  "xmtp.org/text:1.0": TextPayload,
+  "xmtp.org/reaction:1.0": ReactionPayload,
+  "xmtp.org/reply:1.0": ReplyPayload,
+  "xmtp.org/readReceipt:1.0": ReadReceiptPayload,
+  "xmtp.org/groupUpdated:1.0": GroupUpdatedPayload,
+};
+```
+
+### View Schemas
+
+```typescript
+const ViewMode = z.enum([
+  "full",
+  "thread-only",
+  "redacted",
+  "reveal-only",
+  "summary-only",
+]).describe("Visibility mode for the agent's view of conversations");
+
+type ViewMode = z.infer<typeof ViewMode>;
+
+const ContentTypeAllowlist = z
+  .array(ContentTypeId)
+  .min(1)
+  .describe("Content types the agent is allowed to see");
+
+type ContentTypeAllowlist = z.infer<typeof ContentTypeAllowlist>;
+
+const ThreadScope = z.object({
+  groupId: z.string().describe("Group the thread belongs to"),
+  threadId: z.string().nullable().describe("Specific thread ID, or null for entire group"),
+}).describe("Scopes a view to a specific group and optional thread");
+
+type ThreadScope = z.infer<typeof ThreadScope>;
+
+const ViewConfig = z.object({
+  mode: ViewMode.describe("Base visibility mode"),
+  threadScopes: z.array(ThreadScope).min(1).describe("Groups and threads this view covers"),
+  contentTypes: ContentTypeAllowlist.describe("Allowed content types for this view"),
+}).describe("Complete view configuration for an agent session");
+
+type ViewConfig = z.infer<typeof ViewConfig>;
+```
+
+### Grant Schemas
+
+```typescript
+const MessagingGrant = z.object({
+  send: z.boolean().describe("Can send messages"),
+  reply: z.boolean().describe("Can reply in threads"),
+  react: z.boolean().describe("Can add/remove reactions"),
+  draftOnly: z.boolean().describe("Messages require owner confirmation before sending"),
+}).describe("Messaging action permissions");
+
+type MessagingGrant = z.infer<typeof MessagingGrant>;
+
+const GroupManagementGrant = z.object({
+  addMembers: z.boolean().describe("Can add members to the group"),
+  removeMembers: z.boolean().describe("Can remove members from the group"),
+  updateMetadata: z.boolean().describe("Can update group metadata"),
+  inviteUsers: z.boolean().describe("Can issue invitations"),
+}).describe("Group management permissions");
+
+type GroupManagementGrant = z.infer<typeof GroupManagementGrant>;
+
+const ToolScope = z.object({
+  toolId: z.string().describe("Identifier for the tool"),
+  allowed: z.boolean().describe("Whether this tool is currently allowed"),
+  parameters: z.record(z.string(), z.unknown()).nullable()
+    .describe("Permitted parameter constraints, null for unconstrained"),
+}).describe("Permission scope for a single tool");
+
+type ToolScope = z.infer<typeof ToolScope>;
+
+const ToolGrant = z.object({
+  scopes: z.array(ToolScope).describe("Per-tool permission scopes"),
+}).describe("Tool capability permissions");
+
+type ToolGrant = z.infer<typeof ToolGrant>;
+
+const EgressGrant = z.object({
+  storeExcerpts: z.boolean().describe("Can store message excerpts"),
+  useForMemory: z.boolean().describe("Can use content for persistent memory"),
+  forwardToProviders: z.boolean().describe("Can forward content to inference providers"),
+  quoteRevealed: z.boolean().describe("Can quote revealed content in messages"),
+  summarize: z.boolean().describe("Can summarize hidden or revealed content"),
+}).describe("Retention and egress permissions");
+
+type EgressGrant = z.infer<typeof EgressGrant>;
+
+const GrantConfig = z.object({
+  messaging: MessagingGrant.describe("Messaging action permissions"),
+  groupManagement: GroupManagementGrant.describe("Group management permissions"),
+  tools: ToolGrant.describe("Tool capability permissions"),
+  egress: EgressGrant.describe("Retention and egress permissions"),
+}).describe("Complete grant configuration for an agent session");
+
+type GrantConfig = z.infer<typeof GrantConfig>;
+```
+
+### Attestation Schema
+
+The full attestation schema. All fields are present; optional fields use `null`. This is the shape posted to the group as a structured content type.
+
+```typescript
+const InferenceMode = z.enum([
+  "local",
+  "external",
+  "hybrid",
+  "unknown",
+]).describe("How the agent performs inference");
+
+type InferenceMode = z.infer<typeof InferenceMode>;
+
+const ContentEgressScope = z.enum([
+  "full-messages",
+  "summaries-only",
+  "tool-calls-only",
+  "none",
+  "unknown",
+]).describe("What content leaves the broker boundary");
+
+type ContentEgressScope = z.infer<typeof ContentEgressScope>;
+
+const RetentionAtProvider = z.enum([
+  "none",
+  "session",
+  "persistent",
+  "unknown",
+]).describe("How long the inference provider retains content");
+
+type RetentionAtProvider = z.infer<typeof RetentionAtProvider>;
+
+const HostingMode = z.enum([
+  "local",
+  "self-hosted",
+  "managed",
+]).describe("Where the broker runs");
+
+type HostingMode = z.infer<typeof HostingMode>;
+
+const TrustTier = z.enum([
+  "unverified",
+  "source-verified",
+  "reproducibly-verified",
+  "runtime-attested",
+]).describe("Highest trust tier the broker can demonstrate");
+
+type TrustTier = z.infer<typeof TrustTier>;
+
+const RevocationRules = z.object({
+  maxTtlSeconds: z.number().int().positive()
+    .describe("Maximum attestation lifetime in seconds"),
+  requireHeartbeat: z.boolean()
+    .describe("Whether missed heartbeats trigger auto-revocation"),
+  ownerCanRevoke: z.boolean()
+    .describe("Whether the owner can revoke at any time"),
+  adminCanRemove: z.boolean()
+    .describe("Whether group admins can remove the agent"),
+}).describe("Rules governing how this attestation can be revoked");
+
+type RevocationRules = z.infer<typeof RevocationRules>;
+
+const AttestationSchema = z.object({
+  attestationId: z.string().describe("Unique identifier for this attestation"),
+  previousAttestationId: z.string().nullable()
+    .describe("ID of the attestation this supersedes, null for initial"),
+  agentInboxId: z.string().describe("XMTP inbox ID of the agent"),
+  ownerInboxId: z.string().describe("XMTP inbox ID of the agent's owner"),
+  groupId: z.string().describe("Group this attestation applies to"),
+  threadScope: z.string().nullable()
+    .describe("Thread scope if narrower than full group, null for group-wide"),
+  viewMode: ViewMode.describe("Current view mode"),
+  contentTypes: z.array(ContentTypeId)
+    .describe("Content types the agent can see"),
+  grantedOps: z.array(z.string())
+    .describe("Granted operation identifiers"),
+  toolScopes: z.array(z.string())
+    .describe("Tool scope identifiers the agent may use"),
+  inferenceMode: InferenceMode.describe("How the agent performs inference"),
+  inferenceProviders: z.array(z.string())
+    .describe("Envelope of inference providers the agent may use"),
+  contentEgressScope: ContentEgressScope
+    .describe("What content leaves the broker boundary"),
+  retentionAtProvider: RetentionAtProvider
+    .describe("Provider-side retention policy"),
+  hostingMode: HostingMode.describe("Where the broker runs"),
+  trustTier: TrustTier
+    .describe("Highest demonstrated trust tier"),
+  buildProvenanceRef: z.string().nullable()
+    .describe("Reference to build provenance bundle, null if unavailable"),
+  verifierStatementRef: z.string().nullable()
+    .describe("Reference to verifier statement, null if unavailable"),
+  sessionKeyFingerprint: z.string().nullable()
+    .describe("Fingerprint of the current session key, null if not bound"),
+  policyHash: z.string()
+    .describe("Hash of the full policy config for integrity checking"),
+  heartbeatInterval: z.number().int().positive().default(30)
+    .describe("Expected heartbeat cadence in seconds"),
+  issuedAt: z.string().datetime()
+    .describe("ISO 8601 timestamp when this attestation was issued"),
+  expiresAt: z.string().datetime()
+    .describe("ISO 8601 timestamp when this attestation expires"),
+  revocationRules: RevocationRules
+    .describe("Rules governing revocation of this attestation"),
+  issuer: z.string()
+    .describe("Identity of the attestation issuer (broker's signing identity)"),
+}).describe("Group-visible capability attestation for an agent");
+
+type Attestation = z.infer<typeof AttestationSchema>;
+```
+
+### Session Schemas
+
+```typescript
+const SessionConfig = z.object({
+  agentInboxId: z.string().describe("Agent this session is for"),
+  view: ViewConfig.describe("View configuration for this session"),
+  grant: GrantConfig.describe("Grant configuration for this session"),
+  ttlSeconds: z.number().int().positive().default(3600)
+    .describe("Session time-to-live in seconds"),
+  heartbeatInterval: z.number().int().positive().default(30)
+    .describe("Expected heartbeat cadence in seconds"),
+}).describe("Configuration for issuing a new session");
+
+type SessionConfig = z.infer<typeof SessionConfig>;
+
+const SessionToken = z.object({
+  sessionId: z.string().describe("Unique session identifier"),
+  agentInboxId: z.string().describe("Agent this session belongs to"),
+  sessionKeyFingerprint: z.string()
+    .describe("Fingerprint of the session key"),
+  issuedAt: z.string().datetime().describe("When the session was issued"),
+  expiresAt: z.string().datetime().describe("When the session expires"),
+}).describe("Opaque session token issued to the harness");
+
+type SessionToken = z.infer<typeof SessionToken>;
+
+const SessionState = z.enum([
+  "active",
+  "expired",
+  "revoked",
+  "reauthorization-required",
+]).describe("Current lifecycle state of a session");
+
+type SessionState = z.infer<typeof SessionState>;
+```
+
+### Reveal Schemas
+
+```typescript
+const RevealScope = z.enum([
+  "message",
+  "thread",
+  "time-window",
+  "content-type",
+  "sender",
+]).describe("Granularity of a reveal operation");
+
+type RevealScope = z.infer<typeof RevealScope>;
+
+const RevealRequest = z.object({
+  revealId: z.string().describe("Unique reveal request identifier"),
+  groupId: z.string().describe("Group containing the content"),
+  scope: RevealScope.describe("What granularity to reveal"),
+  targetId: z.string().describe("ID of the message, thread, content type, or sender"),
+  requestedBy: z.string().describe("Inbox ID of the member requesting the reveal"),
+  expiresAt: z.string().datetime().nullable()
+    .describe("When this reveal expires, null for permanent"),
+}).describe("Request to reveal content to an agent");
+
+type RevealRequest = z.infer<typeof RevealRequest>;
+
+const RevealGrant = z.object({
+  revealId: z.string().describe("Matches the RevealRequest.revealId"),
+  grantedAt: z.string().datetime().describe("When the reveal was granted"),
+  grantedBy: z.string().describe("Inbox ID of the granting member"),
+  expiresAt: z.string().datetime().nullable()
+    .describe("When this grant expires, null for permanent"),
+}).describe("Granted reveal making content visible to the agent");
+
+type RevealGrant = z.infer<typeof RevealGrant>;
+
+const RevealState = z.object({
+  activeReveals: z.array(RevealGrant)
+    .describe("Currently active reveal grants"),
+}).describe("Aggregate reveal state for a session");
+
+type RevealState = z.infer<typeof RevealState>;
+```
+
+### Revocation Schemas
+
+```typescript
+const AgentRevocationReason = z.enum([
+  "owner-initiated",
+  "session-expired",
+  "admin-removed",
+  "heartbeat-timeout",
+  "policy-violation",
+]).describe("Why the agent was revoked from a group");
+
+type AgentRevocationReason = z.infer<typeof AgentRevocationReason>;
+
+const SessionRevocationReason = z.enum([
+  "owner-initiated",
+  "session-expired",
+  "heartbeat-timeout",
+  "policy-violation",
+  "reauthorization-required",
+]).describe("Why a session was revoked");
+
+type SessionRevocationReason = z.infer<typeof SessionRevocationReason>;
+
+const RevocationAttestation = z.object({
+  attestationId: z.string().describe("ID of this revocation attestation"),
+  previousAttestationId: z.string()
+    .describe("ID of the attestation being revoked"),
+  agentInboxId: z.string().describe("Agent being revoked"),
+  groupId: z.string().describe("Group the revocation applies to"),
+  reason: AgentRevocationReason.describe("Why the agent was revoked"),
+  revokedAt: z.string().datetime().describe("When the revocation took effect"),
+  issuer: z.string().describe("Identity of the revocation issuer"),
+}).describe("Group-visible revocation of an agent's attestation");
+
+type RevocationAttestation = z.infer<typeof RevocationAttestation>;
+```
+
+### Event Schemas (broker to harness)
+
+Events use a discriminated union on the `type` field. Each event carries enough context for the harness to act without additional lookups.
+
+```typescript
+const MessageVisibility = z.enum([
+  "visible",
+  "historical",
+  "hidden",
+  "revealed",
+  "redacted",
+]).describe("How the message is being projected to the agent");
+
+type MessageVisibility = z.infer<typeof MessageVisibility>;
+
+const MessageEvent = z.object({
+  type: z.literal("message.visible").describe("Event type discriminator"),
+  messageId: z.string().describe("XMTP message ID"),
+  groupId: z.string().describe("Group the message belongs to"),
+  senderInboxId: z.string().describe("Inbox ID of the sender"),
+  contentType: ContentTypeId.describe("Content type of the message"),
+  content: z.unknown().describe("Decoded message payload"),
+  visibility: MessageVisibility.describe("How this message is projected"),
+  sentAt: z.string().datetime().describe("When the message was sent"),
+  attestationId: z.string().nullable()
+    .describe("Attestation ID if sent by a brokered agent, null otherwise"),
+}).describe("A message projected to the agent according to its view");
+
+const AttestationEvent = z.object({
+  type: z.literal("attestation.updated").describe("Event type discriminator"),
+  attestation: AttestationSchema.describe("The updated attestation"),
+}).describe("Attestation was published or updated");
+
+const SessionStartedEvent = z.object({
+  type: z.literal("session.started").describe("Event type discriminator"),
+  session: SessionToken.describe("The issued session token"),
+  view: ViewConfig.describe("Active view for this session"),
+  grant: GrantConfig.describe("Active grant for this session"),
+}).describe("Session successfully established");
+
+const SessionExpiredEvent = z.object({
+  type: z.literal("session.expired").describe("Event type discriminator"),
+  sessionId: z.string().describe("Expired session ID"),
+  reason: z.string().describe("Why the session expired"),
+}).describe("Session has expired");
+
+const SessionReauthRequiredEvent = z.object({
+  type: z.literal("session.reauthorization_required")
+    .describe("Event type discriminator"),
+  sessionId: z.string().describe("Session requiring reauthorization"),
+  reason: z.string().describe("What policy change triggered reauthorization"),
+}).describe("Session must be reauthorized due to material policy change");
+
+const HeartbeatEvent = z.object({
+  type: z.literal("heartbeat").describe("Event type discriminator"),
+  sessionId: z.string().describe("Session this heartbeat is for"),
+  timestamp: z.string().datetime().describe("Heartbeat timestamp"),
+}).describe("Liveness signal from the broker");
+
+const RevealEvent = z.object({
+  type: z.literal("message.revealed").describe("Event type discriminator"),
+  messageId: z.string().describe("Message being revealed"),
+  groupId: z.string().describe("Group the message belongs to"),
+  contentType: ContentTypeId.describe("Content type of the revealed message"),
+  content: z.unknown().describe("Decoded message payload"),
+  revealId: z.string().describe("Reveal grant that authorized this"),
+}).describe("Previously hidden content revealed to the agent");
+
+const ViewUpdatedEvent = z.object({
+  type: z.literal("view.updated").describe("Event type discriminator"),
+  view: ViewConfig.describe("Updated view configuration"),
+}).describe("View configuration changed within the current session");
+
+const GrantUpdatedEvent = z.object({
+  type: z.literal("grant.updated").describe("Event type discriminator"),
+  grant: GrantConfig.describe("Updated grant configuration"),
+}).describe("Grant configuration changed within the current session");
+
+const AgentRevokedEvent = z.object({
+  type: z.literal("agent.revoked").describe("Event type discriminator"),
+  revocation: RevocationAttestation.describe("The revocation details"),
+}).describe("Agent has been revoked from the group");
+
+const ActionConfirmationEvent = z.object({
+  type: z.literal("action.confirmation_required")
+    .describe("Event type discriminator"),
+  actionId: z.string().describe("ID of the pending action"),
+  actionType: z.string().describe("Type of action awaiting confirmation"),
+  preview: z.unknown().describe("Preview of the action for owner review"),
+}).describe("An action requires owner confirmation before execution");
+
+const BrokerRecoveryEvent = z.object({
+  type: z.literal("broker.recovery.complete")
+    .describe("Event type discriminator"),
+  caughtUpThrough: z.string().datetime()
+    .describe("Timestamp through which the broker has resynced"),
+}).describe("Broker has recovered and resynced");
+
+/** Discriminated union of all broker-to-harness events. */
+const BrokerEvent = z.discriminatedUnion("type", [
+  MessageEvent,
+  AttestationEvent,
+  SessionStartedEvent,
+  SessionExpiredEvent,
+  SessionReauthRequiredEvent,
+  HeartbeatEvent,
+  RevealEvent,
+  ViewUpdatedEvent,
+  GrantUpdatedEvent,
+  AgentRevokedEvent,
+  ActionConfirmationEvent,
+  BrokerRecoveryEvent,
+]).describe("Any event the broker may send to a harness");
+
+type BrokerEvent = z.infer<typeof BrokerEvent>;
+```
+
+### Request Schemas (harness to broker)
+
+```typescript
+const SendMessageRequest = z.object({
+  type: z.literal("send_message").describe("Request type discriminator"),
+  requestId: z.string().describe("Client-generated request ID for correlation"),
+  groupId: z.string().describe("Target group"),
+  contentType: ContentTypeId.describe("Content type of the message"),
+  content: z.unknown().describe("Encoded message payload"),
+}).describe("Send a message to a group");
+
+const SendReactionRequest = z.object({
+  type: z.literal("send_reaction").describe("Request type discriminator"),
+  requestId: z.string().describe("Client-generated request ID"),
+  groupId: z.string().describe("Target group"),
+  messageId: z.string().describe("Message to react to"),
+  action: z.enum(["added", "removed"]).describe("Add or remove reaction"),
+  content: z.string().describe("Reaction content"),
+}).describe("React to a message");
+
+const SendReplyRequest = z.object({
+  type: z.literal("send_reply").describe("Request type discriminator"),
+  requestId: z.string().describe("Client-generated request ID"),
+  groupId: z.string().describe("Target group"),
+  messageId: z.string().describe("Message to reply to"),
+  contentType: ContentTypeId.describe("Content type of the reply body"),
+  content: z.unknown().describe("Encoded reply payload"),
+}).describe("Reply to a message in a thread");
+
+const UpdateViewRequest = z.object({
+  type: z.literal("update_view").describe("Request type discriminator"),
+  requestId: z.string().describe("Client-generated request ID"),
+  view: ViewConfig.describe("Requested view update"),
+}).describe("Request a view update (broker may reject if material escalation)");
+
+const RevealContentRequest = z.object({
+  type: z.literal("reveal_content").describe("Request type discriminator"),
+  requestId: z.string().describe("Client-generated request ID"),
+  reveal: RevealRequest.describe("Reveal details"),
+}).describe("Request content be revealed to the agent");
+
+const ConfirmActionRequest = z.object({
+  type: z.literal("confirm_action").describe("Request type discriminator"),
+  requestId: z.string().describe("Client-generated request ID"),
+  actionId: z.string().describe("Action being confirmed or denied"),
+  confirmed: z.boolean().describe("Whether the action is approved"),
+}).describe("Confirm or deny a pending action");
+
+const HeartbeatRequest = z.object({
+  type: z.literal("heartbeat").describe("Request type discriminator"),
+  requestId: z.string().describe("Client-generated request ID"),
+  sessionId: z.string().describe("Session sending the heartbeat"),
+}).describe("Heartbeat from the harness to keep the session alive");
+
+/** Discriminated union of all harness-to-broker requests. */
+const HarnessRequest = z.discriminatedUnion("type", [
+  SendMessageRequest,
+  SendReactionRequest,
+  SendReplyRequest,
+  UpdateViewRequest,
+  RevealContentRequest,
+  ConfirmActionRequest,
+  HeartbeatRequest,
+]).describe("Any request a harness may send to the broker");
+
+type HarnessRequest = z.infer<typeof HarnessRequest>;
+```
+
+### Response Envelope
+
+```typescript
+const RequestSuccess = z.object({
+  ok: z.literal(true).describe("Success indicator"),
+  requestId: z.string().describe("Correlates with the original request"),
+  data: z.unknown().describe("Response payload, type depends on request"),
+}).describe("Successful response to a harness request");
+
+const RequestFailure = z.object({
+  ok: z.literal(false).describe("Failure indicator"),
+  requestId: z.string().describe("Correlates with the original request"),
+  error: z.object({
+    code: z.number().int().describe("Numeric error code"),
+    category: z.string().describe("Error category from taxonomy"),
+    message: z.string().describe("Human-readable error description"),
+    context: z.record(z.string(), z.unknown()).nullable()
+      .describe("Structured error context for debugging"),
+  }).describe("Error details"),
+}).describe("Failed response to a harness request");
+
+const RequestResponse = z.discriminatedUnion("ok", [
+  RequestSuccess,
+  RequestFailure,
+]).describe("Response envelope for harness requests");
+
+type RequestResponse = z.infer<typeof RequestResponse>;
+```
+
+## Error Taxonomy
+
+### Error Categories
+
+```typescript
+const ErrorCategory = z.enum([
+  "validation",
+  "not_found",
+  "permission",
+  "auth",
+  "internal",
+  "timeout",
+  "cancelled",
+]).describe("Error category for cross-transport mapping");
+
+type ErrorCategory = z.infer<typeof ErrorCategory>;
+```
+
+### Cross-Transport Mappings
+
+| Category    | Exit Code | HTTP | JSON-RPC | Retryable |
+|-------------|-----------|------|----------|-----------|
+| validation  | 1         | 400  | -32602   | no        |
+| not_found   | 2         | 404  | -32007   | no        |
+| permission  | 4         | 403  | -32003   | no        |
+| auth        | 9         | 401  | -32000   | no        |
+| internal    | 8         | 500  | -32603   | no        |
+| timeout     | 5         | 504  | -32001   | yes       |
+| cancelled   | 130       | 499  | -32006   | no        |
+
+```typescript
+interface ErrorCategoryMeta {
+  readonly exitCode: number;
+  readonly statusCode: number;
+  readonly jsonRpcCode: number;
+  readonly retryable: boolean;
+}
+
+/** Lookup table for category metadata. */
+const ERROR_CATEGORY_META: Record<ErrorCategory, ErrorCategoryMeta> = {
+  validation:  { exitCode: 1,   statusCode: 400, jsonRpcCode: -32602, retryable: false },
+  not_found:   { exitCode: 2,   statusCode: 404, jsonRpcCode: -32007, retryable: false },
+  permission:  { exitCode: 4,   statusCode: 403, jsonRpcCode: -32003, retryable: false },
+  auth:        { exitCode: 9,   statusCode: 401, jsonRpcCode: -32000, retryable: false },
+  internal:    { exitCode: 8,   statusCode: 500, jsonRpcCode: -32603, retryable: false },
+  timeout:     { exitCode: 5,   statusCode: 504, jsonRpcCode: -32001, retryable: true  },
+  cancelled:   { exitCode: 130, statusCode: 499, jsonRpcCode: -32006, retryable: false },
+};
+
+function errorCategoryMeta(category: ErrorCategory): ErrorCategoryMeta {
+  return ERROR_CATEGORY_META[category];
+}
+```
+
+### TaggedError Base
+
+```typescript
+/**
+ * Base interface for all broker errors. Discriminated by `_tag`.
+ * Never constructed directly -- use the static factory on each subclass.
+ */
+interface BrokerError extends Error {
+  readonly _tag: string;
+  readonly code: number;
+  readonly category: ErrorCategory;
+  readonly context: Record<string, unknown> | null;
+}
+```
+
+### Error Classes
+
+Each class has a static `create()` factory, a numeric code, and maps to one category.
+
+```typescript
+// -- validation (code range 1000-1099) --
+
+class ValidationError extends Error implements BrokerError {
+  readonly _tag = "ValidationError";
+  readonly code = 1000;
+  readonly category = "validation" as const;
+  constructor(
+    message: string,
+    readonly context: { field: string; reason: string } & Record<string, unknown>,
+  ) { super(message); }
+
+  static create(field: string, reason: string, extra?: Record<string, unknown>): ValidationError {
+    return new ValidationError(
+      `Validation failed on '${field}': ${reason}`,
+      { field, reason, ...extra },
+    );
+  }
+}
+
+// -- not_found (1100-1199) --
+
+class NotFoundError extends Error implements BrokerError {
+  readonly _tag = "NotFoundError";
+  readonly code = 1100;
+  readonly category = "not_found" as const;
+  constructor(
+    message: string,
+    readonly context: { resourceType: string; resourceId: string } & Record<string, unknown>,
+  ) { super(message); }
+
+  static create(resourceType: string, resourceId: string): NotFoundError {
+    return new NotFoundError(
+      `${resourceType} '${resourceId}' not found`,
+      { resourceType, resourceId },
+    );
+  }
+}
+
+// -- permission (1200-1299) --
+
+class PermissionError extends Error implements BrokerError {
+  readonly _tag = "PermissionError";
+  readonly code = 1200;
+  readonly category = "permission" as const;
+  constructor(
+    message: string,
+    readonly context: Record<string, unknown> | null,
+  ) { super(message); }
+
+  static create(message: string, context?: Record<string, unknown>): PermissionError {
+    return new PermissionError(message, context ?? null);
+  }
+}
+
+class GrantDeniedError extends Error implements BrokerError {
+  readonly _tag = "GrantDeniedError";
+  readonly code = 1210;
+  readonly category = "permission" as const;
+  constructor(
+    message: string,
+    readonly context: { operation: string; grantType: string } & Record<string, unknown>,
+  ) { super(message); }
+
+  static create(operation: string, grantType: string): GrantDeniedError {
+    return new GrantDeniedError(
+      `Operation '${operation}' denied: missing ${grantType} grant`,
+      { operation, grantType },
+    );
+  }
+}
+
+// -- auth (1300-1399) --
+
+class AuthError extends Error implements BrokerError {
+  readonly _tag = "AuthError";
+  readonly code = 1300;
+  readonly category = "auth" as const;
+  constructor(
+    message: string,
+    readonly context: Record<string, unknown> | null,
+  ) { super(message); }
+
+  static create(message: string, context?: Record<string, unknown>): AuthError {
+    return new AuthError(message, context ?? null);
+  }
+}
+
+class SessionExpiredError extends Error implements BrokerError {
+  readonly _tag = "SessionExpiredError";
+  readonly code = 1310;
+  readonly category = "auth" as const;
+  constructor(
+    message: string,
+    readonly context: { sessionId: string } & Record<string, unknown>,
+  ) { super(message); }
+
+  static create(sessionId: string): SessionExpiredError {
+    return new SessionExpiredError(
+      `Session '${sessionId}' has expired`,
+      { sessionId },
+    );
+  }
+}
+
+// -- internal (1400-1499) --
+
+class InternalError extends Error implements BrokerError {
+  readonly _tag = "InternalError";
+  readonly code = 1400;
+  readonly category = "internal" as const;
+  constructor(
+    message: string,
+    readonly context: Record<string, unknown> | null,
+  ) { super(message); }
+
+  static create(message: string, context?: Record<string, unknown>): InternalError {
+    return new InternalError(message, context ?? null);
+  }
+}
+
+// -- timeout (1500-1599) --
+
+class TimeoutError extends Error implements BrokerError {
+  readonly _tag = "TimeoutError";
+  readonly code = 1500;
+  readonly category = "timeout" as const;
+  constructor(
+    message: string,
+    readonly context: { operation: string; timeoutMs: number } & Record<string, unknown>,
+  ) { super(message); }
+
+  static create(operation: string, timeoutMs: number): TimeoutError {
+    return new TimeoutError(
+      `Operation '${operation}' timed out after ${timeoutMs}ms`,
+      { operation, timeoutMs },
+    );
+  }
+}
+
+// -- cancelled (1600-1699) --
+
+class CancelledError extends Error implements BrokerError {
+  readonly _tag = "CancelledError";
+  readonly code = 1600;
+  readonly category = "cancelled" as const;
+  constructor(
+    message: string,
+    readonly context: Record<string, unknown> | null,
+  ) { super(message); }
+
+  static create(message: string): CancelledError {
+    return new CancelledError(message, null);
+  }
+}
+
+// -- domain-specific --
+
+class AttestationError extends Error implements BrokerError {
+  readonly _tag = "AttestationError";
+  readonly code = 1010;
+  readonly category = "validation" as const;
+  constructor(
+    message: string,
+    readonly context: { attestationId: string } & Record<string, unknown>,
+  ) { super(message); }
+
+  static create(attestationId: string, reason: string): AttestationError {
+    return new AttestationError(
+      `Attestation '${attestationId}': ${reason}`,
+      { attestationId, reason },
+    );
+  }
+}
+```
+
+### Discriminated Error Matching
+
+```typescript
+type AnyBrokerError =
+  | ValidationError
+  | NotFoundError
+  | PermissionError
+  | GrantDeniedError
+  | AuthError
+  | SessionExpiredError
+  | InternalError
+  | TimeoutError
+  | CancelledError
+  | AttestationError;
+
+/** Type-safe error matching by _tag discriminant. */
+function matchError<T>(
+  error: AnyBrokerError,
+  handlers: { [K in AnyBrokerError["_tag"]]: (e: Extract<AnyBrokerError, { _tag: K }>) => T },
+): T {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (handlers as any)[error._tag](error);
+}
+```
+
+## Behaviors
+
+This package has no runtime behavior beyond validation. All schemas are pure declarations. Error classes are simple value objects with factory constructors.
+
+### Schema Composition Rules
+
+1. `ViewConfig` and `GrantConfig` are independently composable -- any view mode can pair with any grant configuration.
+2. The effective content type allowlist for an agent is `intersection(broker.allowlist, agent.view.contentTypes)`. The schemas define the agent's requested list; the policy engine computes the effective list at runtime.
+3. Attestation `grantedOps` is a string array derived from the `GrantConfig` at attestation time. The mapping from structured grants to string identifiers is defined in the attestation package, not here.
+
+### Nullable vs Optional Convention
+
+Every field is either required or `.nullable()`. No `.optional()` anywhere. This means:
+- Serialized attestations always have every key.
+- Harnesses can rely on a stable shape without defensive `in` checks.
+- Schema evolution adds new nullable fields rather than making existing fields optional.
+
+## Error Cases
+
+This package defines errors but does not produce them at runtime. Error production happens in consumer packages. The key design constraints:
+
+- Each error has exactly one `category` -- no multi-category errors.
+- Only `timeout` is retryable. `cancelled` is terminal (the caller chose to stop).
+- `GrantDeniedError` and `SessionExpiredError` are domain-specific subclasses that share categories with their parent (`permission` and `auth` respectively) but have distinct `_tag` values for precise matching.
+- Error `context` is structured data, not stringified. Transports serialize it as-is.
+
+## Open Questions Resolved
+
+**Q: What is the exact minimum viable attestation schema?** (PRD Open Questions)
+**A:** Full schema from day one with all 24 fields. Fields that may not be populated use `null`. Rationale: prevents schema drift, clients always know the shape, and the attestation format is a candidate XIP -- better to define it completely now than to add fields later and break consumers.
+
+**Q: Should session issuance be tied to explicit per-thread scopes by default?** (PRD Open Questions)
+**A:** No. Sessions scope to agent + groups via `ViewConfig.threadScopes`. Thread filtering is a view concern within a session, not a session-level binding. Rationale: simpler session model; thread scoping changes are non-material view updates that don't require session reauthorization.
+
+**Q: What is the appropriate default heartbeat interval?** (PRD Open Questions)
+**A:** 30 seconds, configurable per-agent via `SessionConfig.heartbeatInterval` and reflected in the attestation's `heartbeatInterval` field. Rationale: balances liveness visibility with noise; 30s is fast enough to detect outages within a minute, slow enough to avoid overhead.
+
+**Q: How should content type allowlist updates be surfaced?** (PRD Open Questions)
+**A:** Adding content types to the allowlist is a material change that produces a new attestation. The attestation's `contentTypes` array reflects the current effective list, and `previousAttestationId` creates a diff chain. The broker logs the delta internally. Rationale: consistent with the materiality rules -- any change to what an agent can see is material.
+
+## Deferred
+
+- **Conflict and rate_limit error categories**: The v0 taxonomy covers 7 categories. `conflict` (AlreadyExistsError) and `rate_limit` (RateLimitError) will be added when transports mature and produce those conditions. Adding them now would create dead code.
+- **Network error category**: Deferred until the broker has external service dependencies that produce transient network failures distinct from timeouts.
+- **Custom content type registration API**: The `CONTENT_TYPE_SCHEMAS` record is extensible at the code level. A runtime registration API (e.g., `registerContentType(id, schema)`) is deferred to Phase 2 when plugin architecture is designed.
+- **Attestation signature schema**: The attestation schema defines the payload shape. The signed envelope schemas (`SignedAttestationEnvelope`, `SignedRevocationEnvelope`) live in `@xmtp-broker/contracts` as protocol wire formats.
+- **Zod-to-JSON-Schema utility**: The `zodToJsonSchema()` conversion for MCP is a transport concern. This package provides the Zod schemas; the MCP adapter converts them.
+
+## Testing Strategy
+
+### What to Test
+
+1. **Schema validation** -- Every schema accepts valid input and rejects invalid input. Test boundary conditions (empty arrays, null vs missing, datetime format).
+2. **Type inference** -- Compile-time tests that `z.infer<typeof Schema>` produces the expected shape. Use `expectTypeOf` from `bun:test`.
+3. **Error factories** -- Each `create()` factory produces an error with the correct `_tag`, `code`, `category`, and `context`.
+4. **Cross-transport metadata** -- `errorCategoryMeta()` returns correct codes for each category.
+5. **Discriminated unions** -- `BrokerEvent` and `HarnessRequest` correctly discriminate on `type`. `RequestResponse` discriminates on `ok`.
+6. **Content type regex** -- `ContentTypeId` accepts valid XMTP content type strings and rejects malformed ones.
+
+### Key Test Scenarios
+
+```typescript
+// Schema validation
+expect(ViewMode.safeParse("full").success).toBe(true);
+expect(ViewMode.safeParse("invalid").success).toBe(false);
+
+// Nullable fields require explicit null
+expect(AttestationSchema.safeParse({ ...validAttestation, buildProvenanceRef: undefined }).success)
+  .toBe(false);
+expect(AttestationSchema.safeParse({ ...validAttestation, buildProvenanceRef: null }).success)
+  .toBe(true);
+
+// Error factory
+const err = GrantDeniedError.create("send", "messaging");
+expect(err._tag).toBe("GrantDeniedError");
+expect(err.category).toBe("permission");
+expect(err.code).toBe(1210);
+
+// Content type ID validation
+expect(ContentTypeId.safeParse("xmtp.org/text:1.0").success).toBe(true);
+expect(ContentTypeId.safeParse("invalid").success).toBe(false);
+expect(ContentTypeId.safeParse("xmtp.org/text").success).toBe(false);
+```
+
+### Test Utilities
+
+Export test fixtures for use by downstream packages:
+
+```typescript
+/** Valid attestation fixture for testing. */
+function createTestAttestation(overrides?: Partial<Attestation>): Attestation;
+
+/** Valid view config fixture. */
+function createTestViewConfig(overrides?: Partial<ViewConfig>): ViewConfig;
+
+/** Valid grant config fixture. */
+function createTestGrantConfig(overrides?: Partial<GrantConfig>): GrantConfig;
+
+/** Valid session token fixture. */
+function createTestSessionToken(overrides?: Partial<SessionToken>): SessionToken;
+```
+
+These live in `src/__tests__/fixtures.ts` and are exported from a `test-utils` subpath export so downstream packages can import them without pulling in test runner dependencies.
+
+## File Layout
+
+```
+packages/schemas/
+  package.json
+  tsconfig.json
+  src/
+    index.ts                    # Re-exports all public API
+    content-types.ts            # ContentTypeId, payloads, BASELINE_CONTENT_TYPES, registry
+    view.ts                     # ViewMode, ThreadScope, ContentTypeAllowlist, ViewConfig
+    grant.ts                    # MessagingGrant, GroupManagementGrant, ToolGrant, EgressGrant, GrantConfig
+    attestation.ts              # InferenceMode, ContentEgressScope, RetentionAtProvider,
+                                # HostingMode, TrustTier, RevocationRules, AttestationSchema
+    session.ts                  # SessionConfig, SessionToken, SessionState
+    reveal.ts                   # RevealScope, RevealRequest, RevealGrant, RevealState
+    revocation.ts               # AgentRevocationReason, SessionRevocationReason, RevocationAttestation
+    events.ts                   # All event schemas, BrokerEvent union
+    requests.ts                 # All request schemas, HarnessRequest union
+    response.ts                 # RequestSuccess, RequestFailure, RequestResponse
+    errors/
+      index.ts                  # Re-exports all error types
+      category.ts               # ErrorCategory, ErrorCategoryMeta, errorCategoryMeta()
+      base.ts                   # BrokerError interface, AnyBrokerError union, matchError()
+      validation.ts             # ValidationError, AttestationError
+      not-found.ts              # NotFoundError
+      permission.ts             # PermissionError, GrantDeniedError
+      auth.ts                   # AuthError, SessionExpiredError
+      internal.ts               # InternalError
+      timeout.ts                # TimeoutError
+      cancelled.ts              # CancelledError
+    __tests__/
+      content-types.test.ts
+      view.test.ts
+      grant.test.ts
+      attestation.test.ts
+      session.test.ts
+      reveal.test.ts
+      revocation.test.ts
+      events.test.ts
+      requests.test.ts
+      response.test.ts
+      errors.test.ts
+      fixtures.ts               # Test fixtures, exported via subpath
+```
+
+Each source file stays well under 200 LOC. The `errors/` directory splits error classes by category for clear ownership and small diffs.

--- a/.agents/plans/v0/02b-contracts.md
+++ b/.agents/plans/v0/02b-contracts.md
@@ -1,0 +1,255 @@
+# 02b — Contracts
+
+**Package:** `@xmtp-broker/contracts`
+**Spec version:** 0.1.0
+
+## Overview
+
+The contracts package defines cross-package interfaces that runtime packages implement and consume. It sits between `@xmtp-broker/schemas` (data shapes) and the runtime tier, providing a stable interface layer that decouples packages from each other's implementations.
+
+**Split principle:** Schemas answer "what shape is the data?" while contracts answer "what can components do to each other?" This keeps `schemas` zero-dep beyond Zod, and gives runtime packages a single place to find the interfaces they implement or depend on.
+
+This package contains no runtime logic -- only TypeScript interfaces, type aliases, and the signed envelope schemas that define protocol wire formats.
+
+## Dependencies
+
+**Imports:** `@xmtp-broker/schemas` (sole workspace dependency), `better-result` (for `Result` type in interface signatures)
+
+**Imported by:** All runtime packages (`core`, `policy`, `sessions`, `attestations`, `keys`), transport packages (`ws`)
+
+## Contract Catalog
+
+### Service Interfaces
+
+Interfaces implemented by runtime packages to provide their core functionality. These define the "manager" APIs that transport adapters orchestrate.
+
+| Interface | Source spec | Description |
+|-----------|-----------|-------------|
+| `BrokerCore` | 03 | Top-level broker lifecycle: initialize, shutdown, state transitions |
+| `SessionManager` | 05 | Session issuance, lookup, revocation, heartbeat processing |
+| `AttestationManager` | 06 | Attestation lifecycle: issue, refresh, revoke, query |
+
+```typescript
+interface BrokerCore {
+  readonly state: CoreState;
+  initialize(): Promise<Result<void, BrokerError>>;
+  shutdown(): Promise<Result<void, BrokerError>>;
+  getGroupInfo(groupId: string): Promise<Result<GroupInfo, BrokerError>>;
+}
+
+interface SessionManager {
+  issue(config: SessionConfig): Promise<Result<SessionToken, BrokerError>>;
+  lookup(sessionId: string): Promise<Result<SessionRecord, BrokerError>>;
+  revoke(sessionId: string, reason: SessionRevocationReason): Promise<Result<void, BrokerError>>;
+  heartbeat(sessionId: string): Promise<Result<void, BrokerError>>;
+  isActive(sessionId: string): Promise<Result<boolean, BrokerError>>;
+}
+
+interface AttestationManager {
+  issue(sessionId: string, groupId: string): Promise<Result<SignedAttestation, BrokerError>>;
+  refresh(attestationId: string): Promise<Result<SignedAttestation, BrokerError>>;
+  revoke(attestationId: string, reason: AgentRevocationReason): Promise<Result<void, BrokerError>>;
+  current(agentInboxId: string, groupId: string): Promise<Result<SignedAttestation | null, BrokerError>>;
+}
+```
+
+### Provider Interfaces
+
+Interfaces that abstract external dependencies. Runtime packages depend on these abstractions; concrete implementations live in the implementing package.
+
+| Interface | Source spec | Description |
+|-----------|-----------|-------------|
+| `SignerProvider` | 03/07 | Abstracts key material for signing operations |
+| `AttestationSigner` | 06 | Signs attestation payloads |
+| `AttestationPublisher` | 06 | Publishes signed attestations to groups |
+| `RevealStateStore` | 04 | Persists and queries reveal grant state |
+
+```typescript
+interface SignerProvider {
+  sign(data: Uint8Array): Promise<Result<Uint8Array, BrokerError>>;
+  getPublicKey(): Promise<Result<Uint8Array, BrokerError>>;
+  getFingerprint(): Promise<Result<string, BrokerError>>;
+}
+
+interface AttestationSigner {
+  sign(payload: Attestation): Promise<Result<SignedAttestation, BrokerError>>;
+  signRevocation(payload: RevocationAttestation): Promise<Result<SignedRevocationEnvelope, BrokerError>>;
+}
+
+interface AttestationPublisher {
+  publish(groupId: string, attestation: SignedAttestation): Promise<Result<void, BrokerError>>;
+  publishRevocation(groupId: string, revocation: SignedRevocationEnvelope): Promise<Result<void, BrokerError>>;
+}
+
+interface RevealStateStore {
+  grant(revealGrant: RevealGrant): Promise<Result<void, BrokerError>>;
+  revoke(revealId: string): Promise<Result<void, BrokerError>>;
+  activeReveals(sessionId: string): Promise<Result<RevealState, BrokerError>>;
+  isRevealed(sessionId: string, messageId: string): Promise<Result<boolean, BrokerError>>;
+}
+```
+
+### Core Types
+
+Types and interfaces that multiple runtime packages reference but that aren't Zod schemas. These define runtime concepts that don't need validation at boundaries.
+
+| Type | Source spec | Description |
+|------|-----------|-------------|
+| `CoreState` | 03 | Union of broker lifecycle states |
+| `CoreContext` | 03 | Context object passed to handlers during broker operations |
+| `GroupInfo` | 03 | Broker-internal representation of a group's state |
+| `RawMessage` | 04 | Unfiltered message from the XMTP client |
+| `RawEvent` | 03 | Union of raw XMTP events before view filtering |
+| `SessionRecord` | 05 | Internal session state (superset of `SessionToken`) |
+| `MaterialityCheck` | 05 | Result of checking whether a policy change is material |
+| `PolicyDelta` | 04/06 | Describes a change between two policy configurations |
+| `MessageProvenanceMetadata` | 06 | Provenance info attached to outbound messages |
+| `GrantError` | 04 | Type alias for grant enforcement error results |
+
+```typescript
+type CoreState = "uninitialized" | "initializing" | "ready" | "shutting-down" | "stopped" | "error";
+
+interface CoreContext {
+  readonly brokerId: string;
+  readonly signerProvider: SignerProvider;
+}
+
+interface GroupInfo {
+  readonly groupId: string;
+  readonly identityKeyFingerprint: string;
+  readonly memberInboxIds: readonly string[];
+  readonly createdAt: string;
+}
+
+interface RawMessage {
+  readonly messageId: string;
+  readonly groupId: string;
+  readonly senderInboxId: string;
+  readonly contentType: ContentTypeId;
+  readonly content: unknown;
+  readonly sentAt: string;
+}
+
+type RawEvent =
+  | { readonly type: "message"; readonly message: RawMessage }
+  | { readonly type: "group.member_added"; readonly groupId: string; readonly inboxId: string }
+  | { readonly type: "group.member_removed"; readonly groupId: string; readonly inboxId: string }
+  | { readonly type: "group.metadata_updated"; readonly groupId: string; readonly fields: Record<string, string> };
+
+interface SessionRecord {
+  readonly sessionId: string;
+  readonly agentInboxId: string;
+  readonly sessionKeyFingerprint: string;
+  readonly view: ViewConfig;
+  readonly grant: GrantConfig;
+  readonly state: SessionState;
+  readonly issuedAt: string;
+  readonly expiresAt: string;
+  readonly lastHeartbeat: string;
+}
+
+interface MaterialityCheck {
+  readonly isMaterial: boolean;
+  readonly reason: string | null;
+  readonly delta: PolicyDelta | null;
+}
+
+interface PolicyDelta {
+  readonly viewChanges: ReadonlyArray<{ field: string; from: unknown; to: unknown }>;
+  readonly grantChanges: ReadonlyArray<{ field: string; from: unknown; to: unknown }>;
+  readonly contentTypeChanges: {
+    readonly added: readonly ContentTypeId[];
+    readonly removed: readonly ContentTypeId[];
+  };
+}
+
+interface MessageProvenanceMetadata {
+  readonly attestationId: string;
+  readonly sessionKeyFingerprint: string;
+  readonly policyHash: string;
+}
+
+type GrantError = GrantDeniedError | PermissionError;
+```
+
+### Protocol Wire Formats
+
+Signed envelope schemas for attestations published to groups. These are Zod schemas (not plain interfaces) because they define wire formats that must be validated at boundaries. They live in contracts rather than schemas because they compose schemas with signing metadata that only makes sense in the context of the attestation/signing contracts.
+
+```typescript
+const SignedAttestationEnvelope = z.object({
+  attestation: AttestationSchema.describe("The attestation payload"),
+  signature: z.string().describe("Base64-encoded signature over the canonical attestation bytes"),
+  signingAlgorithm: z.string().describe("Algorithm used to produce the signature"),
+  signingKeyRef: z.string().describe("Reference to the key that produced the signature"),
+}).describe("Signed attestation ready for group publication");
+
+type SignedAttestation = z.infer<typeof SignedAttestationEnvelope>;
+
+const SignedRevocationEnvelope = z.object({
+  revocation: RevocationAttestation.describe("The revocation payload"),
+  signature: z.string().describe("Base64-encoded signature over the canonical revocation bytes"),
+  signingAlgorithm: z.string().describe("Algorithm used to produce the signature"),
+  signingKeyRef: z.string().describe("Reference to the key that produced the signature"),
+}).describe("Signed revocation ready for group publication");
+
+type SignedRevocationEnvelope = z.infer<typeof SignedRevocationEnvelope>;
+```
+
+## File Layout
+
+```
+packages/contracts/
+  package.json
+  tsconfig.json
+  src/
+    index.ts                    # Re-exports all public API
+    services.ts                 # BrokerCore, SessionManager, AttestationManager
+    providers.ts                # SignerProvider, AttestationSigner, AttestationPublisher, RevealStateStore
+    core-types.ts               # CoreState, CoreContext, GroupInfo, RawMessage, RawEvent
+    session-types.ts            # SessionRecord, MaterialityCheck
+    policy-types.ts             # PolicyDelta, GrantError
+    attestation-types.ts        # MessageProvenanceMetadata, SignedAttestationEnvelope, SignedRevocationEnvelope
+    __tests__/
+      envelope.test.ts          # Signed envelope schema validation
+```
+
+Each source file stays well under 200 LOC. Interfaces are pure declarations with no runtime logic, so test coverage focuses on the signed envelope schemas (the only Zod schemas in this package).
+
+## Package Configuration
+
+```jsonc
+{
+  "name": "@xmtp-broker/contracts",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "bun build ./src/index.ts --outdir ./dist --target bun",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint .",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@xmtp-broker/schemas": "workspace:*",
+    "better-result": "catalog:",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "typescript": "catalog:"
+  }
+}
+```
+
+## Notes
+
+- **Minimize re-exports.** Each item has one canonical home. Runtime packages import interfaces from `@xmtp-broker/contracts`, data shapes from `@xmtp-broker/schemas`. Neither re-exports from the other.
+- **No circular deps.** `contracts` imports from `schemas` only. Runtime packages import from both `schemas` and `contracts` but never from each other's internals.
+- **Interface evolution.** Adding a new optional method to a service interface is non-breaking. Adding a required method requires coordinating across implementing packages -- treat it as a material change.
+- **`zod` in contracts.** The signed envelope schemas are the only Zod usage in this package. They exist here (not in `schemas`) because they compose attestation schemas with signing metadata that is part of the contract, not the data shape.

--- a/.agents/plans/v0/03-broker-core.md
+++ b/.agents/plans/v0/03-broker-core.md
@@ -1,0 +1,534 @@
+# 03-broker-core
+
+**Package:** `@xmtp-broker/core`
+**Spec version:** 0.1.0
+
+## Overview
+
+The broker core owns the raw plane: the XMTP client, message sync, per-group identity keys, database management, and signer material. It is the only component that touches the real XMTP SDK. Everything above it -- policy engine, session manager, transports -- consumes a filtered event stream that the core emits.
+
+The core's primary job is lifecycle management. It starts XMTP clients (one per agent identity), streams messages from the network, and emits typed raw events for downstream consumption. It never makes policy decisions about what an agent should see or do; that is the policy engine's job. The core is infrastructure: reliable, sealed, and observable.
+
+Per-group identity is default-on. Following the convos-node-sdk pattern (ADR 002), each group conversation gets its own wallet key, database encryption key, and XMTP client instance. This provides maximum isolation: compromising one identity reveals nothing about others, and group membership lists never cross-contaminate. The feature is configurable -- simpler deployments can disable it and use a single identity across groups.
+
+The core exposes a `BrokerCore` service with a start/stop lifecycle, an `EventEmitter`-style interface for raw events, and a context object that downstream consumers use to send messages or query state through the core's sealed boundary.
+
+## Dependencies
+
+**Imports:**
+- `@xmtp/node-sdk` -- XMTP Client, Conversations, Group, Signer types
+- `@xmtp-broker/contracts` -- `SignerProvider`, `RawEvent`, `CoreContext`, `BrokerCore`, `CoreState`, `GroupInfo` (canonical interface definitions)
+- `@xmtp-broker/schemas` -- event schemas, error types, content type definitions
+- `better-result` -- Result type for fallible operations
+- `zod` -- runtime validation at the XMTP boundary
+
+**Imported by:**
+- `@xmtp-broker/policy` -- subscribes to raw events, uses core context for actions
+- `@xmtp-broker/sessions` -- queries core for agent identity info
+- `@xmtp-broker/attestations` -- uses core context to publish attestation messages
+- `@xmtp-broker/ws` -- indirectly, through the policy/session layer
+
+## Public Interfaces
+
+> **Note:** The following interfaces are canonically defined in `@xmtp-broker/contracts`: `SignerProvider`, `RawEvent` (union), `CoreContext`, `GroupInfo`, `BrokerCore`, `CoreState`. This package implements them. The descriptions below document behavior and usage; the contracts package is the source of truth for the type signatures.
+
+### Configuration
+
+```typescript
+import { z } from "zod";
+
+const XmtpEnvSchema = z.enum([
+  "local",
+  "dev",
+  "production",
+]).describe("XMTP network environment");
+
+const IdentityModeSchema = z.enum([
+  "per-group",
+  "shared",
+]).describe("Whether each group gets a unique identity or shares one");
+
+const BrokerCoreConfigSchema = z.object({
+  dataDir: z.string().describe("Base directory for all broker data"),
+  env: XmtpEnvSchema.default("dev")
+    .describe("XMTP network environment"),
+  identityMode: IdentityModeSchema.default("per-group")
+    .describe("Identity isolation strategy"),
+  heartbeatIntervalMs: z.number().int().positive().default(30_000)
+    .describe("Heartbeat emission interval in milliseconds"),
+  syncTimeoutMs: z.number().int().positive().default(30_000)
+    .describe("Maximum time to wait for initial sync"),
+  appVersion: z.string().default("xmtp-broker/0.1.0")
+    .describe("App version string sent to XMTP network"),
+}).describe("Broker core configuration");
+
+type BrokerCoreConfig = z.infer<typeof BrokerCoreConfigSchema>;
+```
+
+### Identity Store
+
+```typescript
+/** Represents a single agent identity managed by the broker. */
+interface AgentIdentity {
+  /** Unique identifier for this identity (hex, 32 bytes). */
+  readonly id: string;
+  /** XMTP inbox ID, set after first client registration. */
+  readonly inboxId: string | null;
+  /** Group ID this identity is bound to, null if shared mode. */
+  readonly groupId: string | null;
+  /** Creation timestamp. */
+  readonly createdAt: string;
+}
+
+/** Persistent store for agent identity material. */
+interface IdentityStore {
+  /** Create a new identity with fresh key material. */
+  create(groupId: string | null): Promise<Result<AgentIdentity, InternalError>>;
+
+  /** Look up the identity for a given group. */
+  getByGroupId(groupId: string): Promise<AgentIdentity | null>;
+
+  /** Look up an identity by its ID. */
+  getById(id: string): Promise<AgentIdentity | null>;
+
+  /** List all identities. */
+  list(): Promise<readonly AgentIdentity[]>;
+
+  /** Update the inboxId after XMTP registration. */
+  setInboxId(
+    id: string,
+    inboxId: string,
+  ): Promise<Result<AgentIdentity, NotFoundError>>;
+
+  /** Remove an identity and its associated data. */
+  remove(id: string): Promise<Result<void, NotFoundError>>;
+}
+```
+
+### Signer Adapter
+
+The core does not manage raw key bytes directly. It delegates signing to a `SignerProvider` injected at construction. This allows the key management package (`@xmtp-broker/keys`) to provide hardware-backed signers while the core remains key-agnostic.
+
+```typescript
+import type { Signer } from "@xmtp/node-sdk";
+
+/** Provides XMTP-compatible signers for agent identities. */
+interface SignerProvider {
+  /** Get or create a signer for the given identity. */
+  getSigner(identityId: string): Promise<Result<Signer, InternalError>>;
+
+  /** Get the database encryption key for the given identity (32 bytes). */
+  getDbEncryptionKey(identityId: string): Promise<Result<Uint8Array, InternalError>>;
+}
+```
+
+### Raw Events
+
+Raw events are the core's output. They carry unfiltered XMTP data with enough metadata for the policy engine to apply views and grants. These are internal types, not the `BrokerEvent` schemas from `02-schemas` (those are the harness-facing events emitted by the policy engine after filtering).
+
+```typescript
+/** Raw message received from XMTP, before any policy filtering. */
+interface RawMessageEvent {
+  readonly type: "raw.message";
+  readonly messageId: string;
+  readonly groupId: string;
+  readonly senderInboxId: string;
+  readonly contentType: string;
+  readonly content: unknown;
+  readonly sentAt: string;
+  /** True if this message was received during recovery sync. */
+  readonly isHistorical: boolean;
+}
+
+/** A new group was discovered (joined or created). */
+interface RawGroupJoinedEvent {
+  readonly type: "raw.group.joined";
+  readonly groupId: string;
+  readonly groupName: string;
+}
+
+/** Group membership changed. */
+interface RawGroupUpdatedEvent {
+  readonly type: "raw.group.updated";
+  readonly groupId: string;
+  readonly update: unknown;
+}
+
+/** Core lifecycle events. */
+interface RawCoreStartedEvent {
+  readonly type: "raw.core.started";
+  readonly identityCount: number;
+  readonly syncedThrough: string;
+}
+
+interface RawCoreStoppedEvent {
+  readonly type: "raw.core.stopped";
+  readonly reason: string;
+}
+
+interface RawHeartbeatEvent {
+  readonly type: "raw.heartbeat";
+  readonly timestamp: string;
+}
+
+type RawEvent =
+  | RawMessageEvent
+  | RawGroupJoinedEvent
+  | RawGroupUpdatedEvent
+  | RawCoreStartedEvent
+  | RawCoreStoppedEvent
+  | RawHeartbeatEvent;
+```
+
+### Core Context
+
+The core context is the sealed interface that downstream components use to perform actions through the XMTP client. It never exposes the raw client, conversations, or signer.
+
+```typescript
+/** Sealed interface for performing actions through the broker core. */
+interface CoreContext {
+  /** Send a message to a group. */
+  sendMessage(
+    groupId: string,
+    contentType: string,
+    content: unknown,
+  ): Promise<Result<{ messageId: string }, BrokerError>>;
+
+  /** Get group metadata. */
+  getGroupInfo(
+    groupId: string,
+  ): Promise<Result<GroupInfo, NotFoundError>>;
+
+  /** List all groups the broker is a member of. */
+  listGroups(): Promise<Result<readonly GroupInfo[], InternalError>>;
+
+  /** Add members to a group by inbox ID. */
+  addMembers(
+    groupId: string,
+    inboxIds: readonly string[],
+  ): Promise<Result<void, BrokerError>>;
+
+  /** Remove members from a group. */
+  removeMembers(
+    groupId: string,
+    inboxIds: readonly string[],
+  ): Promise<Result<void, BrokerError>>;
+
+  /** Get the inbox ID for a given group's identity. */
+  getInboxId(groupId: string): Promise<Result<string, NotFoundError>>;
+
+  /** Force a sync for a specific group. */
+  syncGroup(groupId: string): Promise<Result<void, BrokerError>>;
+}
+
+interface GroupInfo {
+  readonly groupId: string;
+  readonly name: string;
+  readonly description: string;
+  readonly memberInboxIds: readonly string[];
+  readonly createdAt: string;
+}
+```
+
+### BrokerCore Service
+
+```typescript
+type RawEventHandler = (event: RawEvent) => void;
+
+/** The core service managing the raw XMTP plane. */
+interface BrokerCore {
+  /** Start the core: initialize clients, begin streaming. */
+  start(): Promise<Result<void, BrokerError>>;
+
+  /** Stop the core: close streams, disconnect clients. */
+  stop(): Promise<Result<void, BrokerError>>;
+
+  /** Subscribe to raw events. Returns an unsubscribe function. */
+  on(handler: RawEventHandler): () => void;
+
+  /** Get the sealed context for performing actions. */
+  readonly context: CoreContext;
+
+  /** Current lifecycle state. */
+  readonly state: CoreState;
+}
+
+type CoreState = "idle" | "starting" | "running" | "stopping" | "stopped" | "error";
+```
+
+## Zod Schemas
+
+Core-specific schemas are defined above (`BrokerCoreConfigSchema`, `XmtpEnvSchema`, `IdentityModeSchema`). All other schemas (events, errors, content types) are imported from `@xmtp-broker/schemas` as defined in `02-schemas.md`.
+
+Raw event types are plain TypeScript interfaces, not Zod schemas, because they are internal to the runtime tier and never cross a serialization boundary.
+
+## Behaviors
+
+### Lifecycle State Machine
+
+```
+  ┌──────┐   start()   ┌──────────┐   clients ready   ┌─────────┐
+  │ idle │ ──────────>  │ starting │ ────────────────>  │ running │
+  └──────┘              └──────────┘                    └─────────┘
+                            │                              │
+                            │ error                        │ stop()
+                            v                              v
+                        ┌───────┐                     ┌──────────┐
+                        │ error │                     │ stopping │
+                        └───────┘                     └──────────┘
+                                                          │
+                                                          v
+                                                      ┌─────────┐
+                                                      │ stopped │
+                                                      └─────────┘
+```
+
+State transitions are synchronous and guarded: `start()` only works from `idle`, `stop()` only from `running`. Calling `start()` on a `stopped` core returns an error -- create a new instance instead.
+
+### Startup Sequence
+
+1. Validate `BrokerCoreConfig` with Zod.
+2. Initialize `IdentityStore` from `dataDir`.
+3. Load all existing identities.
+4. For each identity, obtain a `Signer` and `dbEncryptionKey` from the `SignerProvider`.
+5. Create an XMTP `Client` for each identity via `Client.create(signer, options)`.
+   - `dbPath`: `{dataDir}/db/{env}/{identityId}.db3`
+   - `dbEncryptionKey`: from `SignerProvider`
+   - `disableDeviceSync`: `true` (per-group identity means no cross-device sync)
+   - `env`: from config
+6. Call `conversations.syncAll()` on each client to catch up.
+7. Start the message stream via `conversations.streamAllMessages()`.
+8. Start the group stream via `conversations.streamGroups()`.
+9. Start the heartbeat timer.
+10. Emit `raw.core.started`.
+11. Transition to `running`.
+
+### Per-Group Identity Flow
+
+When a new group is encountered (either through invitation or explicit creation):
+
+```
+  New group discovered
+        │
+        v
+  ┌─────────────────────┐
+  │ identityMode check  │
+  └─────────────────────┘
+       │            │
+  per-group       shared
+       │            │
+       v            v
+  Create new    Use existing
+  identity      shared identity
+       │            │
+       v            v
+  Generate keys   Already
+  via SignerProvider  registered
+       │
+       v
+  Create XMTP Client
+       │
+       v
+  Register with network
+       │
+       v
+  Store identity -> group mapping
+       │
+       v
+  Join group with new client
+       │
+       v
+  Begin streaming for this client
+```
+
+Each identity gets:
+- Its own wallet key (via `SignerProvider`)
+- Its own database encryption key (via `SignerProvider`)
+- Its own SQLite database file
+- Its own XMTP `Client` instance
+- Its own message stream
+
+In `shared` mode, a single identity is used for all groups. The startup path is simpler but provides no isolation.
+
+### Message Flow
+
+```
+  XMTP Network
+       │
+       │  streamAllMessages()
+       v
+  ┌──────────────┐
+  │  Raw decode   │  Content validated against CONTENT_TYPE_SCHEMAS
+  │  + validate   │  Unknown types still forwarded with raw bytes
+  └──────────────┘
+       │
+       v
+  ┌──────────────┐
+  │  Determine    │  Was this received during sync (isHistorical)
+  │  freshness    │  or from the live stream?
+  └──────────────┘
+       │
+       v
+  ┌──────────────┐
+  │  Emit         │  RawMessageEvent to all subscribers
+  │  raw.message  │
+  └──────────────┘
+       │
+       v
+  Policy Engine (04-policy-engine) handles filtering
+```
+
+The core tracks a "caught up" watermark per client. Messages received during the initial `syncAll()` call are marked `isHistorical: true`. Messages from the live stream after sync completes are `isHistorical: false`. This distinction allows the policy engine to tag historical messages appropriately for the harness, as specified in the PRD's recovery section.
+
+### Heartbeat Generation
+
+A `setInterval` timer emits `raw.heartbeat` events at the configured interval (default: 30s). The heartbeat is a core-level signal that the broker process is alive. The policy engine translates these into session-scoped `HeartbeatEvent`s for each active harness.
+
+On `stop()`, the heartbeat timer is cleared.
+
+### Client Registry
+
+The core maintains an internal `Map<string, ManagedClient>` keyed by identity ID:
+
+```typescript
+interface ManagedClient {
+  readonly identityId: string;
+  readonly inboxId: string;
+  readonly client: Client;
+  readonly stream: AsyncIterable<DecodedMessage>;
+  readonly groupIds: Set<string>;
+}
+```
+
+This registry is ephemeral -- it is rebuilt from the `IdentityStore` and XMTP network state on every startup. The `IdentityStore` is the durable source of truth for which identities exist; the `ManagedClient` registry is the runtime source of truth for active connections.
+
+### Graceful Shutdown
+
+1. Transition to `stopping`.
+2. Clear heartbeat timer.
+3. Close all message streams (the XMTP SDK stream `return()` method).
+4. Emit `raw.core.stopped`.
+5. Allow in-flight `sendMessage` calls to complete (5s grace period).
+6. Transition to `stopped`.
+
+XMTP `Client` instances are not explicitly closed -- the SDK manages its own connection lifecycle. The core only manages the streams and timers it creates.
+
+## Error Cases
+
+| Scenario | Error Type | Category | Recovery |
+|---|---|---|---|
+| Config validation fails | `ValidationError` | validation | Fix config, restart |
+| XMTP client creation fails | `InternalError` | internal | Retry with backoff |
+| Message stream drops | `InternalError` | internal | Auto-reconnect stream |
+| Sync times out | `TimeoutError` | timeout | Retry (retryable) |
+| Identity not found for group | `NotFoundError` | not_found | Create identity if per-group mode |
+| SignerProvider fails | `InternalError` | internal | Cannot proceed without keys |
+| Send message fails | `InternalError` | internal | Bubble to caller |
+| Group not found | `NotFoundError` | not_found | Sync and retry once |
+
+### Stream Reconnection
+
+When a message stream drops (the XMTP SDK calls `onFail`), the core:
+1. Waits 1 second.
+2. Calls `syncAll()` to catch up on missed messages.
+3. Restarts the stream.
+4. Marks messages from the sync as `isHistorical: true`.
+
+This loop continues indefinitely while the core is in `running` state. If three consecutive reconnection attempts fail within 60 seconds, the core transitions to `error` state and emits `raw.core.stopped` with reason `"stream_reconnection_exhausted"`.
+
+## Open Questions Resolved
+
+**Q: Per-group identity -- default-on or opt-in?** (PLAN.md Key Decisions)
+**A:** Default-on. The `identityMode` config defaults to `"per-group"`. Rationale: matches the convos-node-sdk ADR 002 pattern, provides strongest isolation, and prevents accidental group membership cross-contamination. Operators who want simplicity can set `"shared"` explicitly.
+
+**Q: How does per-group identity interact with XMTP's inbox model?**
+**A:** Each identity gets its own XMTP inbox. From the network's perspective, these are independent participants. The broker is the only entity that knows they share an owner. This means each identity registers separately, maintains its own MLS state, and appears as a distinct member in each group. `disableDeviceSync: true` is set on all per-group clients since cross-device sync is meaningless when each identity is purpose-bound to one group.
+
+**Q: What state is ephemeral vs durable?**
+**A:** Durable: identity records (id, wallet key reference, db encryption key reference, group binding, inbox ID) stored in the `IdentityStore`. The XMTP SQLite databases are also durable (managed by the SDK). Ephemeral: `ManagedClient` registry, stream handles, heartbeat timer, caught-up watermarks. On crash recovery, all ephemeral state is reconstructed from durable state + XMTP sync.
+
+**Q: How does the broker handle crash recovery?**
+**A:** The core's startup sequence is its recovery sequence. On restart after a crash, the core loads identities from the store, creates XMTP clients (which reuse existing SQLite databases), calls `syncAll()` to catch up, and resumes streaming. Messages received during sync are tagged as historical. The policy engine emits a `broker.recovery.complete` event with the `caughtUpThrough` timestamp once all clients have synced.
+
+## Deferred
+
+- **Multi-agent isolation within a single broker process**: v0 assumes one "owner" operating the broker. Multiple independent owners sharing a broker process is a post-v0 concern. The per-group identity model provides group-level isolation, but tenant-level isolation (separate owners) is not designed here.
+- **Client connection pooling**: Each identity gets its own client. Connection pooling or multiplexing across identities is a performance optimization for post-v0.
+- **Custom content type codecs**: v0 uses baseline content types. Runtime codec registration is deferred to Phase 2.
+- **Database compaction/cleanup**: Old XMTP databases for removed identities are cleaned up by `IdentityStore.remove()`, but no automatic compaction or retention policy is implemented.
+- **Metrics and observability**: The core emits events, but structured metrics (message count, sync latency, stream reconnections) are deferred.
+- **Hosted broker adaptations**: TEE-backed key storage, hibernation, and multi-tenant isolation are post-v0 per the PLAN.md phase boundaries.
+
+## Testing Strategy
+
+### What to Test
+
+1. **Lifecycle state machine** -- Verify state transitions: idle -> starting -> running -> stopping -> stopped. Verify guards (start from stopped fails, stop from idle fails).
+2. **Identity store CRUD** -- Create, read, update, list, remove identities. Verify group binding lookup.
+3. **Per-group identity creation** -- When a new group is encountered in per-group mode, verify a new identity is created and bound.
+4. **Shared mode bypass** -- When identity mode is shared, verify no new identity is created for new groups.
+5. **Raw event emission** -- Verify that messages from XMTP streams are converted to `RawMessageEvent`s with correct fields.
+6. **Historical tagging** -- Messages from `syncAll()` are tagged `isHistorical: true`; live stream messages are `false`.
+7. **Heartbeat timer** -- Verify heartbeats are emitted at the configured interval and stop on shutdown.
+8. **Stream reconnection** -- Simulate stream failure and verify reconnection with sync.
+9. **Core context sealing** -- Verify that `CoreContext` methods work without exposing the raw client.
+10. **Config validation** -- Invalid configs are rejected with `ValidationError`.
+
+### How to Test
+
+**Unit tests** (most tests): Mock the XMTP SDK. The `Client`, `Conversations`, and `Group` classes are injected via a factory function, allowing complete isolation from the network. The `SignerProvider` is also mocked.
+
+**Integration tests** (few, slow): Use the XMTP local environment (`env: "local"`) with `yarn test:setup` to run a local XMTP node. These tests verify that real XMTP client creation, registration, and message streaming work end-to-end through the core.
+
+### Test Utilities
+
+```typescript
+/** Create a mock SignerProvider for testing. */
+function createMockSignerProvider(): SignerProvider;
+
+/** Create a mock XMTP Client for testing. */
+function createMockXmtpClient(options?: {
+  inboxId?: string;
+  messages?: RawMessageEvent[];
+}): Client;
+
+/** Create a BrokerCore with all dependencies mocked. */
+function createTestBrokerCore(
+  overrides?: Partial<BrokerCoreConfig>,
+): { core: BrokerCore; mocks: TestMocks };
+
+interface TestMocks {
+  signerProvider: SignerProvider;
+  identityStore: IdentityStore;
+  emitMessage: (event: RawMessageEvent) => void;
+  emitStreamDrop: () => void;
+}
+```
+
+## File Layout
+
+```
+packages/core/
+  package.json
+  tsconfig.json
+  src/
+    index.ts                    # Re-exports public API
+    config.ts                   # BrokerCoreConfigSchema, XmtpEnvSchema, IdentityModeSchema
+    broker-core.ts              # BrokerCore implementation (start/stop lifecycle)
+    core-context.ts             # CoreContext implementation (sealed action interface)
+    identity-store.ts           # IdentityStore implementation (file-based, under dataDir)
+    client-registry.ts          # ManagedClient map, stream management
+    event-emitter.ts            # Typed event emitter for RawEvent
+    raw-events.ts               # RawEvent type definitions
+    xmtp-client-factory.ts      # Wraps XMTP Client.create with broker conventions
+    __tests__/
+      config.test.ts
+      broker-core.test.ts
+      core-context.test.ts
+      identity-store.test.ts
+      client-registry.test.ts
+      event-emitter.test.ts
+      fixtures.ts               # Test utilities and mocks
+```
+
+Each file stays under 200 LOC. The `broker-core.ts` file orchestrates the lifecycle but delegates client management to `client-registry.ts`, identity persistence to `identity-store.ts`, and event distribution to `event-emitter.ts`.

--- a/.agents/plans/v0/04-policy-engine.md
+++ b/.agents/plans/v0/04-policy-engine.md
@@ -1,0 +1,640 @@
+# 04-policy-engine
+
+**Package:** `@xmtp-broker/policy`
+**Spec version:** 0.1.0
+
+## Overview
+
+The policy engine is the enforcement layer between the raw XMTP plane and the derived agent-facing plane. It has two jobs: filter what agents see (view projection) and validate what agents do (grant enforcement). Every message flowing from the network to an agent passes through the view projection pipeline. Every request flowing from an agent harness to the broker passes through the grant validation pipeline.
+
+The engine is stateless per-invocation. Each pipeline stage is a pure function that takes input and configuration, returning a result. The only mutable state the engine owns is the reveal grant store, which tracks which content has been selectively disclosed to which agents. All other configuration (views, grants, content type allowlists) is owned by the session manager and passed in as arguments.
+
+The policy engine does not know about WebSocket, MCP, or any transport. It does not know about XMTP message decoding. It receives already-decoded messages and typed harness requests, and returns typed results or errors.
+
+## Dependencies
+
+**Imports:**
+- `@xmtp-broker/contracts` -- `PolicyDelta`, `RawMessage`, `RevealStateStore`, `GrantError` (canonical interface definitions)
+- `@xmtp-broker/schemas` -- `ViewConfig`, `ViewMode`, `GrantConfig`, `ContentTypeId`, `BASELINE_CONTENT_TYPES`, `RevealRequest`, `RevealGrant`, `RevealState`, `MessageEvent`, `MessageVisibility`, `BrokerError`, `GrantDeniedError`, `ValidationError`, `PermissionError`
+- `better-result` -- `Result`, `ok`, `err`
+
+**Imported by:**
+- `@xmtp-broker/ws` (transport adapter calls pipeline functions, orchestration)
+- `@xmtp-broker/attestations` (imports `isMaterialChange` -- this package is the canonical owner of materiality logic)
+
+## Public Interfaces
+
+> **Note:** The following interfaces are canonically defined in `@xmtp-broker/contracts`: `PolicyDelta`, `RawMessage`, `RevealStateStore`, `GrantError`. This package implements them. This package is also the **canonical owner** of the `isMaterialChange` logic -- `@xmtp-broker/attestations` imports materiality from here rather than defining its own.
+
+### View Projection Pipeline
+
+```typescript
+/** A raw message as received from the XMTP client, already decoded. */
+interface RawMessage {
+  readonly messageId: string;
+  readonly groupId: string;
+  readonly senderInboxId: string;
+  readonly contentType: ContentTypeId;
+  readonly content: unknown;
+  readonly sentAt: string; // ISO 8601
+  readonly threadId: string | null;
+  readonly attestationId: string | null;
+}
+
+/** Result of projecting a raw message through the view pipeline. */
+type ProjectionResult =
+  | { readonly action: "emit"; readonly event: MessageEvent }
+  | { readonly action: "drop" };
+
+/**
+ * Projects a raw message through the view filter, content type filter,
+ * redaction logic, and reveal state to produce a derived event or drop.
+ *
+ * Pure function. No side effects.
+ */
+function projectMessage(
+  message: RawMessage,
+  view: ViewConfig,
+  effectiveAllowlist: ReadonlySet<ContentTypeId>,
+  revealState: RevealState,
+): ProjectionResult;
+```
+
+### Individual Pipeline Stages
+
+Each stage is exported for unit testing and composability.
+
+```typescript
+/**
+ * Stage 1: Scope filter. Returns true if the message falls within
+ * the view's thread scopes.
+ */
+function isInScope(
+  message: Pick<RawMessage, "groupId" | "threadId">,
+  scopes: readonly ThreadScope[],
+): boolean;
+
+/**
+ * Stage 2: Content type filter. Returns true if the message's content
+ * type is in the effective allowlist.
+ */
+function isContentTypeAllowed(
+  contentType: ContentTypeId,
+  allowlist: ReadonlySet<ContentTypeId>,
+): boolean;
+
+/**
+ * Stage 3: Visibility resolver. Determines the MessageVisibility
+ * for this message given the view mode and reveal state.
+ */
+function resolveVisibility(
+  message: Pick<RawMessage, "messageId" | "groupId" | "threadId" | "senderInboxId" | "contentType">,
+  mode: ViewMode,
+  revealState: RevealState,
+): MessageVisibility;
+
+/**
+ * Stage 4: Content projector. Applies redaction or summary
+ * based on the resolved visibility. Returns the content to emit.
+ */
+function projectContent(
+  content: unknown,
+  contentType: ContentTypeId,
+  visibility: MessageVisibility,
+): unknown;
+```
+
+### Content Type Allowlist Resolution
+
+```typescript
+/** Broker-level content type configuration. */
+interface BrokerContentTypeConfig {
+  readonly allowlist: ReadonlySet<ContentTypeId>;
+}
+
+/**
+ * Computes the effective allowlist as the intersection of
+ * baseline, broker-level, and agent view-level allowlists.
+ *
+ * effectiveAllowlist = baseline ∩ broker ∩ agent
+ *
+ * If the broker expands beyond baseline, the intersection still
+ * holds -- only types present in all three tiers pass.
+ */
+function resolveEffectiveAllowlist(
+  baseline: readonly ContentTypeId[],
+  brokerConfig: BrokerContentTypeConfig,
+  agentAllowlist: readonly ContentTypeId[],
+): ReadonlySet<ContentTypeId>;
+```
+
+### Grant Validation Pipeline
+
+```typescript
+/** The set of policy errors the grant enforcer can produce. */
+type GrantError = GrantDeniedError | ValidationError | PermissionError;
+
+/**
+ * Validates a send_message request against the active grant.
+ */
+function validateSendMessage(
+  request: { groupId: string; contentType: ContentTypeId },
+  grant: GrantConfig,
+  view: ViewConfig,
+): Result<{ draftOnly: boolean }, GrantError>;
+
+/**
+ * Validates a send_reaction request against the active grant.
+ */
+function validateSendReaction(
+  request: { groupId: string; messageId: string },
+  grant: GrantConfig,
+  view: ViewConfig,
+): Result<void, GrantError>;
+
+/**
+ * Validates a send_reply request against the active grant.
+ */
+function validateSendReply(
+  request: { groupId: string; messageId: string; contentType: ContentTypeId },
+  grant: GrantConfig,
+  view: ViewConfig,
+): Result<{ draftOnly: boolean }, GrantError>;
+
+/**
+ * Validates a group management action against the active grant.
+ */
+function validateGroupManagement(
+  action: "addMembers" | "removeMembers" | "updateMetadata" | "inviteUsers",
+  request: { groupId: string },
+  grant: GrantConfig,
+  view: ViewConfig,
+): Result<void, GrantError>;
+
+/**
+ * Validates a tool invocation against the active grant.
+ */
+function validateToolUse(
+  toolId: string,
+  parameters: Record<string, unknown> | null,
+  grant: GrantConfig,
+): Result<void, GrantError>;
+
+/**
+ * Validates an egress action against the active grant.
+ */
+function validateEgress(
+  action: "storeExcerpts" | "useForMemory" | "forwardToProviders" | "quoteRevealed" | "summarize",
+  grant: GrantConfig,
+): Result<void, GrantError>;
+```
+
+### Reveal State Manager
+
+```typescript
+/**
+ * In-memory reveal state store scoped to an agent session.
+ * Persisted by the session manager; the policy engine owns the logic.
+ */
+interface RevealStateStore {
+  /** Add a reveal grant. */
+  grant(reveal: RevealGrant, request: RevealRequest): void;
+
+  /** Check if a specific message is revealed. */
+  isRevealed(
+    messageId: string,
+    groupId: string,
+    threadId: string | null,
+    senderInboxId: string,
+    contentType: ContentTypeId,
+  ): boolean;
+
+  /** Remove expired reveals. Returns count of removed grants. */
+  expireStale(now: Date): number;
+
+  /** Snapshot the current state for serialization. */
+  snapshot(): RevealState;
+
+  /** Restore from a serialized snapshot. */
+  restore(state: RevealState): void;
+}
+
+/**
+ * Creates a new reveal state store.
+ */
+function createRevealStateStore(): RevealStateStore;
+```
+
+### Materiality Classifier
+
+```typescript
+/** Description of a policy change for materiality classification. */
+interface PolicyDelta {
+  readonly field: string;
+  readonly oldValue: unknown;
+  readonly newValue: unknown;
+}
+
+/**
+ * Classifies whether a set of policy changes is material
+ * (triggers attestation) or routine (silent).
+ */
+function isMaterialChange(deltas: readonly PolicyDelta[]): boolean;
+
+/**
+ * Classifies whether a policy change requires session
+ * reauthorization (privilege escalation).
+ */
+function requiresReauthorization(deltas: readonly PolicyDelta[]): boolean;
+```
+
+## Zod Schemas
+
+This package defines no new Zod schemas. All schemas are imported from `@xmtp-broker/schemas` (see [02-schemas.md](02-schemas.md)). The `RawMessage` and `PolicyDelta` interfaces are internal TypeScript types, not schema-validated boundaries -- they flow between trusted internal components.
+
+## Behaviors
+
+### View Projection Pipeline
+
+Each raw message passes through four stages. A drop at any stage stops the pipeline.
+
+```
+Raw Message
+    │
+    ▼
+┌──────────────┐
+│ 1. Scope     │──── out of scope ──── DROP
+│    Filter    │
+└──────┬───────┘
+       │ in scope
+       ▼
+┌──────────────┐
+│ 2. Content   │──── type not allowed ── DROP
+│    Type      │
+└──────┬───────┘
+       │ type allowed
+       ▼
+┌──────────────┐
+│ 3. Visibility│──── resolves to "hidden" with no reveal ── DROP
+│    Resolver  │
+└──────┬───────┘
+       │ visibility determined
+       ▼
+┌──────────────┐
+│ 4. Content   │──── applies redaction/summary if needed
+│    Projector │
+└──────┬───────┘
+       │
+       ▼
+  MessageEvent (emit)
+```
+
+#### Stage 1: Scope Filter
+
+Checks whether the message's `groupId` (and optionally `threadId`) falls within any of the view's `threadScopes`. A `ThreadScope` with `threadId: null` matches all threads in that group. A `ThreadScope` with a specific `threadId` matches only messages in that thread.
+
+#### Stage 2: Content Type Filter
+
+Checks whether the message's `contentType` is in the effective allowlist. The effective allowlist is pre-computed via `resolveEffectiveAllowlist` when the session is established or the view is updated. Unknown content types are dropped silently -- this is the default-deny behavior.
+
+#### Stage 3: Visibility Resolver
+
+Determines `MessageVisibility` based on view mode and reveal state:
+
+| View Mode      | Default Visibility | With Active Reveal |
+|----------------|--------------------|--------------------|
+| `full`         | `visible`          | `visible`          |
+| `thread-only`  | `visible`*         | `visible`          |
+| `redacted`     | `redacted`         | `revealed`         |
+| `reveal-only`  | `hidden`           | `revealed`         |
+| `summary-only` | `redacted`**       | `revealed`         |
+
+\* `thread-only` messages already passed the scope filter, so they are visible.
+
+\** `summary-only` uses `redacted` visibility with summarized content in stage 4.
+
+If visibility resolves to `hidden` and no reveal grant covers the message, the pipeline returns `DROP`.
+
+#### Stage 4: Content Projector
+
+Transforms content based on resolved visibility:
+
+- `visible` / `historical` / `revealed`: content passes through unchanged.
+- `redacted`: content is replaced with `null`. The `contentType` and metadata (sender, timestamp) are preserved.
+- `hidden`: unreachable (dropped in stage 3).
+
+**`summary-only` mode is Phase 2 behavior.** The mode exists in the schema for forward compatibility, but in v0 the broker returns a `ValidationError` if a harness attempts to create a session or update a view with `mode: "summary-only"`. This prevents harnesses from relying on placeholder behavior that will change semantically in Phase 2.
+
+### Grant Validation Pipeline
+
+Every harness request is validated before execution:
+
+```
+Harness Request
+    │
+    ▼
+┌──────────────────┐
+│ 1. Scope Check   │──── group not in view ──── PermissionError
+│    (group in      │
+│     view scopes?) │
+└──────┬───────────┘
+       │ in scope
+       ▼
+┌──────────────────┐
+│ 2. Grant Check   │──── grant denied ──── GrantDeniedError
+│    (operation     │
+│     permitted?)   │
+└──────┬───────────┘
+       │ permitted
+       ▼
+┌──────────────────┐
+│ 3. Draft Check   │──── draftOnly=true ──── return { draftOnly: true }
+│    (requires      │
+│     confirmation?)│
+└──────┬───────────┘
+       │
+       ▼
+  Result<void | { draftOnly: boolean }>
+```
+
+#### Scope Check
+
+The request's `groupId` must appear in at least one of the view's `threadScopes`. An agent cannot send messages to groups it cannot see. This is a hard boundary -- even if the grant says `send: true`, the agent cannot target a group outside its view.
+
+#### Grant Check Details
+
+**Messaging grants:**
+- `send_message`: requires `grant.messaging.send === true`
+- `send_reply`: requires `grant.messaging.reply === true`
+- `send_reaction`: requires `grant.messaging.react === true`
+
+**Group management grants:** each action maps directly to its boolean field:
+- `addMembers` -> `grant.groupManagement.addMembers`
+- `removeMembers` -> `grant.groupManagement.removeMembers`
+- `updateMetadata` -> `grant.groupManagement.updateMetadata`
+- `inviteUsers` -> `grant.groupManagement.inviteUsers`
+
+**Tool grants:** the `toolId` must appear in `grant.tools.scopes` with `allowed: true`. If the tool scope has non-null `parameters`, the request parameters must be a subset of the permitted constraints.
+
+**Egress grants:** each egress action maps directly to its boolean field on `grant.egress`.
+
+#### Draft-Only Enforcement
+
+When `grant.messaging.draftOnly === true`, send and reply operations succeed at the grant check but return `{ draftOnly: true }`. The transport layer holds the message and emits an `action.confirmation_required` event to the owner. The message is only sent to the group after owner confirmation via `confirm_action`.
+
+### Content Type Allowlist Resolution
+
+The three-tier intersection ensures conservative defaults:
+
+```
+  BASELINE_CONTENT_TYPES (XIP-accepted, hardcoded)
+           ∩
+  Broker config allowlist (operator-scoped)
+           ∩
+  Agent view.contentTypes (owner-scoped)
+           =
+  Effective allowlist
+```
+
+Key behaviors:
+- If the broker config is a superset of baseline, baseline still constrains.
+- If the agent view requests types the broker doesn't allow, those are silently excluded.
+- When `BASELINE_CONTENT_TYPES` is updated (new XIP type accepted), existing agents do not automatically see it. The broker updates its allowlist, but each agent's `view.contentTypes` must be explicitly updated by the owner.
+- An empty intersection is a `ValidationError` at session creation time -- the session cannot start if the agent would see nothing.
+
+### Reveal State Management
+
+#### Reveal Flow
+
+```
+Group member ──reveal_content request──▶ Broker
+                                           │
+                                           ▼
+                                   ┌───────────────┐
+                                   │ Authorization  │
+                                   │ (is requestor  │
+                                   │  group owner?) │
+                                   └───────┬───────┘
+                                           │ yes
+                                           ▼
+                                   ┌───────────────┐
+                                   │ Create         │
+                                   │ RevealGrant    │
+                                   └───────┬───────┘
+                                           │
+                                           ▼
+                                   ┌───────────────┐
+                                   │ Store in       │
+                                   │ RevealState    │
+                                   └───────┬───────┘
+                                           │
+                                           ▼
+                              Replay affected messages
+                              through projection pipeline
+                                    with new state
+                                           │
+                                           ▼
+                              Emit RevealEvent(s) to harness
+```
+
+#### Who Can Reveal
+
+In v0, only the agent's owner (the member identified by `ownerInboxId` in the attestation) can grant reveals. This matches the single-owner governance model.
+
+#### Reveal Scope Resolution
+
+When `isRevealed()` is called, the store checks active grants in order of specificity:
+
+1. **message** scope: `targetId` matches the `messageId` exactly.
+2. **thread** scope: `targetId` matches the message's `threadId`.
+3. **sender** scope: `targetId` matches the message's `senderInboxId`.
+4. **content-type** scope: `targetId` matches the message's `contentType`.
+5. **time-window** scope: `targetId` is a start timestamp; the grant's `expiresAt` defines the end. The message's `sentAt` must fall within the window.
+
+A message is revealed if any active (non-expired) grant covers it.
+
+#### Persistence
+
+The reveal state store is in-memory during a session. On session creation, the store is empty. The session manager serializes the store's snapshot when persisting session state and restores it on reconnection within the same session. Reveal grants do not survive session expiration -- a new session starts with no reveals.
+
+### Materiality Classification
+
+The classifier examines each `PolicyDelta` and returns `true` if any delta is material.
+
+**Material fields** (trigger attestation):
+- `view.mode`
+- `view.threadScopes` (adding or removing scopes)
+- `view.contentTypes` (adding types -- removing is also material since it changes what the agent sees)
+- `grant.messaging.*` (any change)
+- `grant.groupManagement.*` (any change)
+- `grant.tools.scopes` (any change)
+- `grant.egress.*` (any change)
+
+**Routine fields** (silent):
+- Session rotation (same view + grant)
+- Heartbeat interval adjustment
+- Internal broker state
+
+**Reauthorization-required fields** (material + session termination):
+- `view.mode` changing to a broader mode (e.g., `redacted` -> `full`, `reveal-only` -> `full`)
+- `grant.egress.*` changing from `false` to `true`
+- `grant.groupManagement.*` changing from `false` to `true`
+
+The `requiresReauthorization` function checks a stricter subset: only privilege escalations (expanding from `false` to `true` or from a narrower to a broader mode). Privilege reductions are material (new attestation) but do not require reauthorization.
+
+#### View Mode Ordering (narrow to broad)
+
+```
+reveal-only < summary-only < redacted < thread-only < full
+```
+
+A mode change is an escalation if the new mode is broader than the old mode in this ordering.
+
+## Error Cases
+
+| Scenario | Error | Category |
+|----------|-------|----------|
+| Message targets group not in view | `PermissionError` | permission |
+| Send without `messaging.send` grant | `GrantDeniedError` | permission |
+| Reply without `messaging.reply` grant | `GrantDeniedError` | permission |
+| React without `messaging.react` grant | `GrantDeniedError` | permission |
+| Group mgmt action without matching grant | `GrantDeniedError` | permission |
+| Tool not in allowed scopes | `GrantDeniedError` | permission |
+| Tool parameters exceed constraints | `ValidationError` | validation |
+| Egress action without matching grant | `GrantDeniedError` | permission |
+| Empty effective content type allowlist | `ValidationError` | validation |
+| Reveal requested by non-owner | `PermissionError` | permission |
+| Content type not in effective allowlist (send) | `ValidationError` | validation |
+| View mode set to `summary-only` in v0 | `ValidationError` | validation |
+
+All functions return `Result<T, E>`. No exceptions are thrown.
+
+## Open Questions Resolved
+
+**Q: How should content type allowlist updates be surfaced?** (PRD Open Questions)
+**A:** Adding or removing content types from the effective allowlist is a material change that triggers a new attestation. The `resolveEffectiveAllowlist` function recomputes the intersection on every view update. If the result differs from the previous effective list, `isMaterialChange` returns `true`. The attestation's `contentTypes` field reflects the new effective list.
+
+**Q: Should non-material view/grant changes be applied within an existing session?** (PRD Session section)
+**A:** Yes. Non-material changes (e.g., adjusting a thread scope within the same groups, or minor grant tweaks that don't escalate privileges) are applied in-place and emit a `view.updated` or `grant.updated` event. Only escalations require session reauthorization. This is enforced by `requiresReauthorization` returning `false` for non-escalation changes.
+
+**Q: How does summary-only mode work in v0?** (PRD View Modes)
+**A:** In v0, `summary-only` is kept in the schema for forward compatibility but is not usable. If a harness attempts to create a session or update a view with `mode: "summary-only"`, the broker returns a `ValidationError`. Actual summarization (LLM-generated summaries) is deferred to Phase 2. The schema includes the value so the wire format is stable across versions.
+
+## Deferred
+
+- **LLM-powered summarization**: `summary-only` mode emits placeholders. Actual summary generation requires an inference pipeline, deferred to Phase 2.
+- **Tool parameter constraint validation**: v0 checks that the `toolId` is allowed and that `parameters` is non-null if constrained. Deep parameter validation (e.g., "this integer must be < 100") is deferred.
+- **Group governance beyond owner**: v0 only allows the owner to grant reveals and modify policy. Multi-member governance (approval thresholds, admin caps) is deferred.
+- **Reveal history API**: The engine tracks active reveals but does not expose a history of past reveals. Forensic history is deferred.
+- **Rate limiting on grant checks**: No per-agent rate limiting on request validation. Deferred until transport layer maturity.
+- **Content type version negotiation**: The allowlist matches exact content type IDs including version. Version negotiation (e.g., accepting `text:1.1` when `text:1.0` is listed) is deferred.
+
+## Testing Strategy
+
+### What to Test
+
+**Unit tests** for each pipeline stage in isolation, plus integration tests for the full pipeline.
+
+### Key Test Scenarios
+
+#### View Projection Pipeline
+
+1. **Scope filter**: message in scope -> passes; message out of scope -> drops.
+2. **Scope filter with null threadId**: `ThreadScope { groupId: "g1", threadId: null }` matches all threads in g1.
+3. **Content type filter**: allowed type -> passes; unknown type -> drops (default-deny).
+4. **Visibility resolver per mode**: each view mode produces correct visibility.
+5. **Reveal overrides hidden**: `reveal-only` mode + active reveal grant -> `revealed`.
+6. **Redaction replaces content**: `redacted` visibility -> content becomes `null`.
+7. **Full pipeline integration**: raw message with various configs -> correct `ProjectionResult`.
+
+#### Grant Validation Pipeline
+
+8. **Send granted**: `messaging.send: true` -> success.
+9. **Send denied**: `messaging.send: false` -> `GrantDeniedError`.
+10. **Draft-only**: `messaging.draftOnly: true` -> success with `{ draftOnly: true }`.
+11. **Group out of scope**: send to group not in view -> `PermissionError`.
+12. **Group management**: each of 4 actions with grant true/false.
+13. **Tool allowed**: toolId in scopes with `allowed: true` -> success.
+14. **Tool denied**: toolId not in scopes -> `GrantDeniedError`.
+15. **Egress**: each of 5 egress flags with true/false.
+
+#### Content Type Allowlist
+
+16. **Intersection**: baseline has 5, broker has 4, agent has 3 -> effective is intersection.
+17. **Empty intersection**: -> `ValidationError`.
+18. **Broker superset of baseline**: effective still bounded by baseline.
+
+#### Reveal State
+
+19. **Grant and query**: grant a message reveal -> `isRevealed` returns true.
+20. **Thread reveal**: grant covers all messages in thread.
+21. **Expiration**: expired reveal -> `isRevealed` returns false after `expireStale`.
+22. **Snapshot/restore**: round-trip through `snapshot()` and `restore()`.
+
+#### Materiality Classifier
+
+23. **View mode change**: material = true, reauth depends on direction.
+24. **Grant escalation**: `send: false -> true` is material + reauth.
+25. **Grant reduction**: `send: true -> false` is material, no reauth.
+26. **Session rotation**: same view+grant -> not material.
+27. **Mode ordering**: verify `reveal-only < summary-only < redacted < thread-only < full`.
+
+### Test Utilities
+
+```typescript
+/** Creates a RawMessage fixture. */
+function createTestRawMessage(overrides?: Partial<RawMessage>): RawMessage;
+
+/** Creates a minimal ViewConfig that passes all messages. */
+function createPassthroughView(groupId: string): ViewConfig;
+
+/** Creates a GrantConfig with all permissions enabled. */
+function createFullGrant(): GrantConfig;
+
+/** Creates a GrantConfig with all permissions denied. */
+function createDenyAllGrant(): GrantConfig;
+```
+
+## File Layout
+
+```
+packages/policy/
+  package.json
+  tsconfig.json
+  src/
+    index.ts                        # Re-exports public API
+    pipeline/
+      project-message.ts            # projectMessage() orchestrator
+      scope-filter.ts               # isInScope()
+      content-type-filter.ts        # isContentTypeAllowed()
+      visibility-resolver.ts        # resolveVisibility()
+      content-projector.ts          # projectContent()
+    grant/
+      validate-send.ts              # validateSendMessage(), validateSendReply()
+      validate-reaction.ts          # validateSendReaction()
+      validate-group-management.ts  # validateGroupManagement()
+      validate-tool.ts              # validateToolUse()
+      validate-egress.ts            # validateEgress()
+      scope-check.ts                # shared group-in-view check
+    allowlist.ts                    # resolveEffectiveAllowlist()
+    reveal-state.ts                 # RevealStateStore, createRevealStateStore()
+    materiality.ts                  # isMaterialChange(), requiresReauthorization()
+    types.ts                        # RawMessage, ProjectionResult, PolicyDelta, etc.
+    __tests__/
+      scope-filter.test.ts
+      content-type-filter.test.ts
+      visibility-resolver.test.ts
+      content-projector.test.ts
+      project-message.test.ts
+      validate-send.test.ts
+      validate-reaction.test.ts
+      validate-group-management.test.ts
+      validate-tool.test.ts
+      validate-egress.test.ts
+      allowlist.test.ts
+      reveal-state.test.ts
+      materiality.test.ts
+      fixtures.ts                   # Test utilities
+```
+
+Each source file stays well under 200 LOC. The `pipeline/` and `grant/` directories separate the two main flows for clear ownership.

--- a/.agents/plans/v0/05-sessions.md
+++ b/.agents/plans/v0/05-sessions.md
@@ -1,0 +1,508 @@
+# 05-sessions
+
+**Package:** `@xmtp-broker/sessions`
+**Spec version:** 0.1.0
+
+## Overview
+
+The sessions package manages ephemeral authorization contexts between agent harnesses and the broker. A session is the mechanism by which a harness receives its active view and grant -- it binds a specific agent to a set of groups with a defined visibility mode and action permissions for a limited time.
+
+Sessions are opaque bearer tokens validated entirely broker-side. The broker maintains a session store mapping tokens to session records that track state, policy binding, and expiry. This avoids the complexity of JWTs (key distribution, revocation lists, clock skew) while keeping the security model simple: possession of a valid token grants exactly the permissions the broker recorded at issuance.
+
+The session manager enforces the materiality boundary from the PRD. Non-material policy changes (thread scope adjustment, adding a content type, enabling reactions) apply in-place to the active session. Material changes (view mode escalation, egress permission grants, group management capabilities) terminate the session and require the harness to reauthorize under the new policy. This prevents excessive reconnection churn while ensuring privilege escalation always involves a clean authorization step.
+
+Sessions are scoped to agent + groups, not per-thread. Thread filtering is a view concern handled by the policy engine within a session's group scope. This matches the PLAN.md decision and keeps the session model simple.
+
+## Dependencies
+
+**Imports:**
+- `@xmtp-broker/contracts` — `SessionRecord`, `MaterialityCheck`, `SessionManager` (canonical interface definitions)
+- `@xmtp-broker/schemas` — `SessionConfig`, `SessionToken`, `SessionState`, `SessionRevocationReason`, `ViewConfig`, `GrantConfig`, error classes (`AuthError`, `SessionExpiredError`, `ValidationError`, `NotFoundError`, `InternalError`)
+- `better-result` — `Result`, `Ok`, `Err`
+
+**Imported by:**
+- `@xmtp-broker/ws` — transport layer creates sessions on harness connect
+- `@xmtp-broker/policy` — policy engine checks session validity before enforcing grants
+- `@xmtp-broker/attestations` — attestation manager reads session key fingerprint
+- `@xmtp-broker/keys` — key manager issues session keys bound to sessions
+
+## Public Interfaces
+
+> **Note:** The following interfaces are canonically defined in `@xmtp-broker/contracts`: `SessionRecord`, `MaterialityCheck`, `SessionManager`. This package implements the `SessionManager` interface from contracts. The `SessionRevocationReason` enum has moved to `@xmtp-broker/schemas`.
+
+### SessionRecord
+
+The broker-side record for an active session. Not exported to harnesses -- they only see `SessionToken`.
+
+```typescript
+interface SessionRecord {
+  readonly sessionId: string;
+  readonly token: string;
+  readonly agentInboxId: string;
+  readonly view: ViewConfig;
+  readonly grant: GrantConfig;
+  readonly policyHash: string;
+  readonly sessionKeyFingerprint: string;
+  readonly state: SessionState;
+  readonly heartbeatInterval: number;
+  readonly lastHeartbeatAt: string;
+  readonly createdAt: string;
+  readonly expiresAt: string;
+  readonly revokedAt: string | null;
+  readonly revocationReason: SessionRevocationReason | null;
+}
+```
+
+### SessionRevocationReason
+
+```typescript
+const SessionRevocationReason = z.enum([
+  "expired",
+  "policy-change",
+  "explicit-revoke",
+  "harness-disconnect",
+  "heartbeat-timeout",
+  "max-sessions-exceeded",
+]).describe("Why a session was revoked");
+
+type SessionRevocationReason = z.infer<typeof SessionRevocationReason>;
+```
+
+### MaterialityBoundary
+
+Fields whose changes constitute a material escalation.
+
+```typescript
+interface MaterialityCheck {
+  readonly isMaterial: boolean;
+  readonly reason: string | null;
+  readonly changedFields: readonly string[];
+}
+```
+
+### SessionManager
+
+```typescript
+interface SessionManagerConfig {
+  readonly defaultTtlSeconds: number;       // default: 3600
+  readonly maxConcurrentPerAgent: number;    // default: 3
+  readonly tokenByteLength: number;          // default: 32
+  readonly renewalWindowSeconds: number;     // default: 300 (5 min before expiry)
+  readonly heartbeatGracePeriod: number;     // default: 3 (missed beats before timeout)
+}
+
+interface SessionManager {
+  /** Create a new session for an agent with the given config. */
+  createSession(
+    config: SessionConfig,
+    sessionKeyFingerprint: string,
+  ): Promise<Result<SessionRecord, ValidationError | InternalError>>;
+
+  /** Look up a session by its bearer token. */
+  getSessionByToken(
+    token: string,
+  ): Result<SessionRecord, SessionExpiredError | NotFoundError>;
+
+  /** Look up a session by its ID. */
+  getSessionById(
+    sessionId: string,
+  ): Result<SessionRecord, NotFoundError>;
+
+  /** List active sessions for an agent. */
+  getActiveSessions(
+    agentInboxId: string,
+  ): readonly SessionRecord[];
+
+  /** Record a heartbeat for a session. */
+  recordHeartbeat(
+    sessionId: string,
+  ): Result<void, SessionExpiredError | NotFoundError>;
+
+  /** Renew a session before it expires. Returns a new session record. */
+  renewSession(
+    sessionId: string,
+  ): Promise<Result<SessionRecord, SessionExpiredError | NotFoundError | AuthError>>;
+
+  /** Apply a non-material policy update to an active session. */
+  updateSessionPolicy(
+    sessionId: string,
+    view: ViewConfig,
+    grant: GrantConfig,
+  ): Result<SessionRecord, SessionExpiredError | NotFoundError>;
+
+  /** Revoke a session immediately. */
+  revokeSession(
+    sessionId: string,
+    reason: SessionRevocationReason,
+  ): Result<SessionRecord, NotFoundError>;
+
+  /** Revoke all sessions for an agent. */
+  revokeAllSessions(
+    agentInboxId: string,
+    reason: SessionRevocationReason,
+  ): readonly SessionRecord[];
+
+  /** Check whether a policy change is material relative to the current session. */
+  checkMateriality(
+    sessionId: string,
+    newView: ViewConfig,
+    newGrant: GrantConfig,
+  ): Result<MaterialityCheck, NotFoundError>;
+
+  /** Run expiry sweep. Called periodically by the broker. */
+  sweepExpired(): readonly SessionRecord[];
+}
+```
+
+### Factory
+
+```typescript
+function createSessionManager(
+  config?: Partial<SessionManagerConfig>,
+): SessionManager;
+```
+
+## Zod Schemas
+
+Session schemas are defined in `@xmtp-broker/schemas` (see 02-schemas.md):
+- `SessionConfig` — input for creating a session
+- `SessionToken` — the token shape returned to the harness
+- `SessionState` — `"active" | "expired" | "revoked" | "reauthorization-required"`
+
+This package adds one schema:
+- `SessionRevocationReason` — defined above
+
+## Behaviors
+
+### Session Creation Flow
+
+```
+Harness connects
+    |
+    v
+Transport calls createSession(config, keyFingerprint)
+    |
+    +--> Validate config via SessionConfig.parse()
+    |
+    +--> Check concurrent session count for agent
+    |    |
+    |    +--> If at max: revoke oldest session (reason: max-sessions-exceeded)
+    |
+    +--> Check for dedup: same agent + same view + same grant
+    |    |
+    |    +--> If match found and active: return existing session
+    |
+    +--> Generate token: 32 random bytes, base64url-encoded
+    |
+    +--> Generate sessionId: "ses_" + 16 random bytes, hex-encoded
+    |
+    +--> Compute policyHash: Bun.hash(canonicalize(view + grant))
+    |
+    +--> Create SessionRecord with state = "active"
+    |
+    +--> Store: token -> record, sessionId -> record, agent -> [sessions]
+    |
+    +--> Return SessionRecord
+```
+
+The transport layer converts the `SessionRecord` to a `SessionToken` (the harness-visible subset) and emits a `session.started` event.
+
+### Token Format
+
+- **32 bytes** of cryptographically random data via `crypto.getRandomValues()`
+- Encoded as **base64url** (no padding) for transport safety
+- Total encoded length: 43 characters
+- Prefix: none (opaque to the harness)
+- The token is a lookup key, not a self-contained credential
+
+### Session ID Format
+
+- Prefix: `ses_`
+- 16 random bytes, hex-encoded
+- Total length: 36 characters (`ses_` + 32 hex chars)
+- Used for internal references, logging, and attestation binding
+
+### State Machine
+
+```
+                  ┌──────────────────────────────┐
+                  │                              │
+                  v                              │
+    ┌─────────────────────┐                      │
+    │       active        │──── renewSession ─────┘
+    └─────────────────────┘     (resets TTL, same state)
+        │         │        │
+        │         │        │
+   TTL expires  revoke  material policy change
+        │         │        │
+        v         v        v
+    ┌────────┐ ┌────────┐ ┌──────────────────────────┐
+    │expired │ │revoked │ │reauthorization-required   │
+    └────────┘ └────────┘ └──────────────────────────┘
+```
+
+All three terminal states are final. A session never transitions back to `active`. Renewal creates a continuation of the same session (same ID, reset TTL), not a new session.
+
+### Materiality Rules
+
+The broker determines whether a policy change is material by comparing the old and new view/grant configurations. A change is **material** if any of the following boundaries are crossed:
+
+**Material changes (require new session):**
+
+| Field | Material when... |
+|-------|-----------------|
+| `view.mode` | Escalation toward more access: `redacted` -> any, `summary-only` -> `thread-only`/`full`, `reveal-only` -> `full`, `thread-only` -> `full` |
+| `grant.messaging.send` | `false` -> `true` |
+| `grant.messaging.draftOnly` | `true` -> `false` (removes guardrail) |
+| `grant.groupManagement.*` | Any `false` -> `true` |
+| `grant.egress.*` | Any `false` -> `true` |
+| `grant.tools.scopes` | New tool added, or `allowed: false` -> `true` |
+
+**Non-material changes (apply in-place):**
+
+| Field | Non-material when... |
+|-------|---------------------|
+| `view.threadScopes` | Adding or removing thread scopes within existing groups |
+| `view.contentTypes` | Adding content types to allowlist |
+| `grant.messaging.react` | `false` -> `true` |
+| `grant.messaging.reply` | `false` -> `true` |
+| Any field | Reducing permissions (always non-material) |
+
+**Implementation:** Compare old and new policy via `checkMateriality()`. The function walks each materiality-sensitive field and returns a `MaterialityCheck` with the list of changed fields and whether any crossed a material boundary.
+
+The `policyHash` is computed as `Bun.hash(JSON.stringify(sortedCanonical(view, grant)))` using a deterministic key-sorting canonicalization. Two sessions with the same `policyHash` have identical effective policies.
+
+### Session Deduplication
+
+When `createSession` is called for an agent that already has an active session with the same `policyHash`, the existing session is returned instead of creating a new one. This prevents redundant sessions when a harness reconnects without policy changes.
+
+Dedup only matches on `agentInboxId` + `policyHash`. Different views or grants always produce different sessions.
+
+### Renewal
+
+A harness can request renewal when the session is within the renewal window (default: 5 minutes before expiry). Renewal resets the TTL on the existing session record. It does not create a new token or session ID.
+
+```
+renewSession(sessionId)
+    |
+    +--> Find session by ID
+    |
+    +--> Check state == "active"
+    |
+    +--> Check within renewal window (expiresAt - now <= renewalWindowSeconds)
+    |    |
+    |    +--> If not in window: return AuthError("not in renewal window")
+    |
+    +--> Reset expiresAt = now + ttlSeconds
+    |
+    +--> Return updated SessionRecord
+```
+
+Renewal does not produce an attestation (non-material operation).
+
+### Concurrent Sessions
+
+An agent may have up to `maxConcurrentPerAgent` active sessions (default: 3). This accommodates:
+- Reconnection before old session expires
+- Multiple transport connections (WebSocket + MCP)
+- Rolling deployment of harness code
+
+When the limit is exceeded, the oldest active session is revoked with reason `max-sessions-exceeded`. The harness receives a `session.expired` event on the old connection before disconnect.
+
+### Heartbeat Processing
+
+The broker tracks heartbeats per session. If `heartbeatGracePeriod` consecutive heartbeats are missed (each expected at `heartbeatInterval` seconds), the session is revoked with reason `heartbeat-timeout`.
+
+```
+recordHeartbeat(sessionId)
+    |
+    +--> Find session, check state == "active"
+    |
+    +--> Update lastHeartbeatAt = now
+    |
+    +--> Return Ok(void)
+```
+
+The `sweepExpired()` method checks both TTL expiry and heartbeat timeout in a single pass.
+
+### Session Key Binding
+
+Each session is bound to exactly one session key, identified by `sessionKeyFingerprint`. The key is issued by `@xmtp-broker/keys` and passed to `createSession`. The fingerprint is:
+- Stored in the session record
+- Included in any attestation issued during the session
+- Used to verify that requests come from the session they claim
+
+Session keys are ephemeral. They cannot perform operational-key or root-key operations. When a session is revoked or expires, the corresponding key material should be zeroized by the key manager.
+
+### Revocation
+
+Revocation is immediate and broker-initiated. The flow:
+
+```
+revokeSession(sessionId, reason)
+    |
+    +--> Find session by ID
+    |
+    +--> Set state = "revoked"
+    |
+    +--> Set revokedAt = now
+    |
+    +--> Set revocationReason = reason
+    |
+    +--> Return updated SessionRecord
+```
+
+The transport layer is responsible for:
+1. Emitting a `session.expired` event to the harness with the reason
+2. Closing the connection after a brief drain period
+
+The session manager does not manage connections -- it only manages state.
+
+### In-Place Policy Updates
+
+When the broker determines a policy change is non-material, it calls `updateSessionPolicy()`:
+
+```
+updateSessionPolicy(sessionId, newView, newGrant)
+    |
+    +--> Find session, check state == "active"
+    |
+    +--> Recompute policyHash
+    |
+    +--> Update view, grant, policyHash on the record
+    |
+    +--> Return updated SessionRecord
+```
+
+The transport layer then emits `view.updated` and/or `grant.updated` events to the harness.
+
+## Error Cases
+
+| Scenario | Error | Category |
+|----------|-------|----------|
+| Invalid `SessionConfig` input | `ValidationError` | validation |
+| Token not found in store | `NotFoundError` | not_found |
+| Session ID not found | `NotFoundError` | not_found |
+| Token maps to expired session | `SessionExpiredError` | auth |
+| Token maps to revoked session | `SessionExpiredError` | auth |
+| Renewal requested outside window | `AuthError` | auth |
+| Renewal on non-active session | `SessionExpiredError` | auth |
+| Token generation failure | `InternalError` | internal |
+
+All errors are returned as `Result` values. No exceptions thrown.
+
+## Open Questions Resolved
+
+**Q: Per-thread session scoping?** (PRD Open Questions)
+**A:** Sessions scope to agent + groups, not individual threads. Thread filtering is a view concern applied by the policy engine within a session's group scope. Rationale: thread scope changes are frequent and non-material; making them session-level would cause excessive session churn. This aligns with the PLAN.md decision.
+
+**Q: What triggers session reauthorization vs in-place update?** (PRD: Session and view/grant binding)
+**A:** The materiality rules table above defines the exact boundary. The principle: any change that expands what an agent can see (view escalation) or do (grant escalation) is material and requires a new session. Any change that narrows permissions or adjusts non-security-sensitive configuration is non-material and applies in-place. Reply and react grants are non-material because they operate within the existing view scope -- they don't expose new content or create new egress paths.
+
+**Q: Should session rotation produce attestations?** (PRD: Attestation noise and materiality)
+**A:** No. Routine session rotation (TTL renewal, reconnection with same policy) is a non-material operation. Only policy changes that cross a materiality boundary produce new attestations. The session manager signals materiality to the attestation manager, which decides whether to publish.
+
+## Deferred
+
+- **Persistent session store**: v0 uses an in-memory `Map`. Durable storage (bun:sqlite) is deferred until broker restart recovery is designed post-v0.
+- **Session migration across broker instances**: Requires distributed state. Deferred to hosted/managed broker phase.
+- **Session audit log**: Structured logging of session lifecycle events. Useful but not required for v0 correctness.
+- **Rate limiting on session creation**: Deferred until transport layer matures and abuse patterns are understood.
+- **Session key cryptographic operations**: This spec defines the binding (fingerprint stored, key issued by keys package). Actual crypto is in 07-key-management.
+
+## Testing Strategy
+
+### What to Test
+
+1. **Session creation** — Valid config produces a session with correct fields. Invalid config returns `ValidationError`.
+2. **Token lookup** — Valid token returns session. Unknown token returns `NotFoundError`. Expired/revoked token returns `SessionExpiredError`.
+3. **Deduplication** — Same agent + same policy reuses existing session. Different policy creates new session.
+4. **Concurrent session limit** — Exceeding max revokes oldest. Under max allows all.
+5. **Materiality checks** — Each materiality rule produces correct `MaterialityCheck`. Escalations are material; reductions are not.
+6. **Renewal** — Works within window, fails outside window, fails on non-active session.
+7. **Revocation** — Sets correct state and reason. Revoked sessions fail subsequent lookups with `SessionExpiredError`.
+8. **Heartbeat** — Updates timestamp. Missing heartbeats trigger timeout in sweep.
+9. **Sweep** — Expires sessions past TTL. Revokes sessions with missed heartbeats.
+10. **In-place policy update** — Updates view/grant/hash on active session. Fails on non-active session.
+
+### Key Test Scenarios
+
+```typescript
+// Session creation
+const result = await manager.createSession(validConfig, "fp_abc123");
+expect(result.ok).toBe(true);
+expect(result.value.state).toBe("active");
+expect(result.value.token).toHaveLength(43); // base64url of 32 bytes
+
+// Token lookup on expired session
+const expired = await manager.createSession(expiredConfig, "fp_xyz");
+// ... advance time past TTL ...
+manager.sweepExpired();
+const lookup = manager.getSessionByToken(expired.value.token);
+expect(lookup.ok).toBe(false);
+expect(lookup.error._tag).toBe("SessionExpiredError");
+
+// Materiality: view mode escalation is material
+const check = manager.checkMateriality(sessionId,
+  { ...currentView, mode: "full" },  // was "reveal-only"
+  currentGrant,
+);
+expect(check.value.isMaterial).toBe(true);
+expect(check.value.changedFields).toContain("view.mode");
+
+// Materiality: adding thread scope is non-material
+const check2 = manager.checkMateriality(sessionId,
+  { ...currentView, threadScopes: [...currentView.threadScopes, newScope] },
+  currentGrant,
+);
+expect(check2.value.isMaterial).toBe(false);
+
+// Dedup: same policy reuses session
+const s1 = await manager.createSession(config, "fp_1");
+const s2 = await manager.createSession(config, "fp_1");
+expect(s1.value.sessionId).toBe(s2.value.sessionId);
+
+// Concurrent limit
+for (let i = 0; i < 4; i++) {
+  await manager.createSession(uniqueConfig(i), `fp_${i}`);
+}
+const active = manager.getActiveSessions(agentId);
+expect(active).toHaveLength(3); // oldest was evicted
+```
+
+### Test Utilities
+
+```typescript
+/** Create a SessionManager with short TTLs for testing. */
+function createTestSessionManager(
+  overrides?: Partial<SessionManagerConfig>,
+): SessionManager;
+
+/** Create a valid SessionConfig fixture. */
+function createTestSessionConfig(
+  overrides?: Partial<SessionConfig>,
+): SessionConfig;
+```
+
+## File Layout
+
+```
+packages/sessions/
+  package.json
+  tsconfig.json
+  src/
+    index.ts                    # Re-exports public API
+    session-manager.ts          # createSessionManager factory and implementation
+    session-record.ts           # SessionRecord interface, SessionRevocationReason schema
+    materiality.ts              # checkMateriality logic, materiality rules
+    policy-hash.ts              # Deterministic policy hashing
+    token.ts                    # Token generation (random bytes + base64url)
+    __tests__/
+      session-manager.test.ts   # Creation, lookup, concurrent limits, sweep
+      materiality.test.ts       # All materiality boundary cases
+      policy-hash.test.ts       # Deterministic hashing, canonicalization
+      token.test.ts             # Token format, uniqueness, length
+      fixtures.ts               # Test factories
+```
+
+Each source file stays under 200 LOC. The materiality rules are isolated in their own module for clear ownership and independent testing.

--- a/.agents/plans/v0/06-attestations.md
+++ b/.agents/plans/v0/06-attestations.md
@@ -1,0 +1,573 @@
+# 06-attestations
+
+**Package:** `@xmtp-broker/attestations`
+**Spec version:** 0.1.0
+
+## Overview
+
+The attestations package manages the lifecycle of group-visible capability attestations -- signed assertions about what an agent can see and do, published into XMTP groups so every member can inspect them.
+
+Attestations are the public face of the broker's policy plane. When a material change occurs (view mode, grant, egress policy, agent addition or revocation), the broker creates a new attestation, signs it with the agent's inbox key, and publishes it as a structured XMTP content type message into the group. Each attestation chains to its predecessor, giving clients a complete, verifiable history of permission changes.
+
+The package is responsible for four concerns: deciding _when_ a new attestation is needed (materiality), _building_ the attestation payload (creation), _signing_ it (cryptographic binding), and _publishing_ it to the group (delivery). It does not own the XMTP client (that is `@xmtp-broker/core`) or the policy evaluation (that is `@xmtp-broker/policy`). It consumes their outputs and produces the public artifact.
+
+## Dependencies
+
+**Imports:**
+- `@xmtp-broker/contracts` -- `AttestationSigner`, `AttestationPublisher`, `SignedAttestation`, `AttestationManager`, `MessageProvenanceMetadata`, `SignedAttestationEnvelope`, `SignedRevocationEnvelope`, `PolicyDelta` (canonical interface definitions)
+- `@xmtp-broker/schemas` -- `AttestationSchema`, `RevocationAttestation`, `RevocationReason`, `ViewMode`, `GrantConfig`, `ViewConfig`, `ContentTypeId`, `AttestationError`, `InternalError`, `ValidationError`
+- `@xmtp-broker/policy` -- `isMaterialChange` (policy engine is the canonical owner of materiality logic)
+- `@xmtp-broker/core` -- XMTP client interface for sending messages to groups
+- `@xmtp-broker/keys` -- signing interface for producing signatures with agent inbox keys
+- `better-result` -- `Result` type
+- `zod` -- runtime validation
+
+**Imported by:**
+- `@xmtp-broker/sessions` -- reads current attestation ID for message provenance
+- `@xmtp-broker/ws` -- relays attestation events to harnesses
+
+## Public Interfaces
+
+> **Note:** The following interfaces are canonically defined in `@xmtp-broker/contracts`: `AttestationSigner`, `AttestationPublisher`, `SignedAttestation`, `AttestationManager`, `MessageProvenanceMetadata`, `SignedAttestationEnvelope`, `SignedRevocationEnvelope`. This package implements the `AttestationManager` interface from contracts. The local `MaterialFields` type has been unified with `PolicyDelta` from contracts -- use `PolicyDelta` as the canonical type. Materiality logic (`isMaterialChange`) is imported from `@xmtp-broker/policy`, not defined here.
+
+### Attestation ID Generation
+
+```typescript
+/**
+ * Generates a random attestation ID. Random (not deterministic) because
+ * the same logical change applied at different times is a different
+ * attestation (different timestamps, potentially different session key).
+ *
+ * Format: "att_" prefix + 32 hex chars from crypto.randomUUID().
+ */
+function generateAttestationId(): string;
+```
+
+Rationale for random over deterministic: two attestations with identical policy fields but different `issuedAt` / `expiresAt` are distinct events. Deterministic IDs would require including timestamps in the hash input, which is equivalent to random for collision purposes but adds unnecessary complexity.
+
+### Materiality Check
+
+> **Note:** The `MaterialFields` type below has been unified with `PolicyDelta` from `@xmtp-broker/contracts`. Use `PolicyDelta` as the canonical type. The `isMaterialChange` function is imported from `@xmtp-broker/policy` (the canonical owner of materiality logic) rather than defined locally in this package.
+
+```typescript
+// Imported from @xmtp-broker/policy:
+// function isMaterialChange(deltas: readonly PolicyDelta[]): boolean;
+//
+// Imported from @xmtp-broker/contracts:
+// interface PolicyDelta { field: string; oldValue: unknown; newValue: unknown; }
+```
+
+### Attestation Builder
+
+```typescript
+interface AttestationInput {
+  readonly agentInboxId: string;
+  readonly ownerInboxId: string;
+  readonly groupId: string;
+  readonly threadScope: string | null;
+  readonly view: ViewConfig;
+  readonly grant: GrantConfig;
+  readonly inferenceMode: string;
+  readonly inferenceProviders: readonly string[];
+  readonly contentEgressScope: string;
+  readonly retentionAtProvider: string;
+  readonly hostingMode: string;
+  readonly trustTier: string;
+  readonly buildProvenanceRef: string | null;
+  readonly verifierStatementRef: string | null;
+  readonly sessionKeyFingerprint: string | null;
+  readonly policyHash: string;
+  readonly heartbeatInterval: number;
+  readonly revocationRules: {
+    readonly maxTtlSeconds: number;
+    readonly requireHeartbeat: boolean;
+    readonly ownerCanRevoke: boolean;
+    readonly adminCanRemove: boolean;
+  };
+}
+
+interface AttestationBuildResult {
+  readonly attestation: Attestation;
+  readonly serialized: Uint8Array;
+}
+
+/**
+ * Builds an attestation from input fields, linking to the previous
+ * attestation if one exists. Validates the result against AttestationSchema.
+ */
+function buildAttestation(
+  input: AttestationInput,
+  previousAttestationId: string | null,
+  ttlSeconds?: number,
+): Result<AttestationBuildResult, ValidationError>;
+```
+
+### Grant-to-Ops Mapping
+
+```typescript
+/**
+ * Converts a structured GrantConfig into the flat string array stored
+ * in attestation.grantedOps. This is the canonical mapping.
+ *
+ * Examples: "messaging:send", "messaging:reply", "messaging:react",
+ * "messaging:draft_only", "group:add_members", "egress:forward_to_providers"
+ */
+function grantConfigToOps(grant: GrantConfig): readonly string[];
+
+/**
+ * Converts a GrantConfig's tool scopes into the flat string array
+ * stored in attestation.toolScopes.
+ */
+function grantConfigToToolScopes(grant: GrantConfig): readonly string[];
+```
+
+### Attestation Signing
+
+```typescript
+interface SignedAttestation {
+  readonly attestation: Attestation;
+  readonly signature: Uint8Array;
+  readonly signatureAlgorithm: "Ed25519";
+  readonly signerKeyRef: string;
+}
+
+interface AttestationSigner {
+  /**
+   * Signs the canonical serialization of an attestation using the
+   * agent's inbox key (held by the broker).
+   */
+  sign(
+    attestation: Attestation,
+  ): Promise<Result<SignedAttestation, InternalError>>;
+}
+```
+
+### Attestation Publishing
+
+```typescript
+interface AttestationPublisher {
+  /**
+   * Publishes a signed attestation to the group as a custom content
+   * type message. All group members can read and verify it.
+   *
+   * Returns the XMTP message ID of the published attestation.
+   */
+  publish(
+    signed: SignedAttestation,
+  ): Promise<Result<{ messageId: string }, InternalError>>;
+}
+```
+
+### Attestation Manager
+
+```typescript
+interface AttestationManagerDeps {
+  readonly signer: AttestationSigner;
+  readonly publisher: AttestationPublisher;
+}
+
+interface AttestationManager {
+  /**
+   * Creates, signs, and publishes a new attestation if the change is
+   * material, or if no previous attestation exists for this agent+group.
+   *
+   * For non-material changes, returns the current attestation unchanged.
+   */
+  attestIfMaterial(
+    input: AttestationInput,
+    previousAttestationId: string | null,
+  ): Promise<Result<SignedAttestation, AttestationError | InternalError>>;
+
+  /**
+   * Creates and publishes a revocation attestation. Final -- no un-revoke.
+   */
+  revoke(
+    agentInboxId: string,
+    groupId: string,
+    previousAttestationId: string,
+    reason: RevocationReason,
+  ): Promise<Result<SignedAttestation, AttestationError | InternalError>>;
+
+  /**
+   * Renews an attestation that is approaching expiry without any
+   * material changes. Same fields, new timestamps + attestation ID.
+   */
+  renew(
+    currentAttestation: Attestation,
+  ): Promise<Result<SignedAttestation, AttestationError | InternalError>>;
+
+  /**
+   * Returns the current attestation ID for an agent in a group,
+   * or null if no attestation has been published yet.
+   */
+  currentAttestationId(
+    agentInboxId: string,
+    groupId: string,
+  ): string | null;
+}
+
+function createAttestationManager(
+  deps: AttestationManagerDeps,
+): AttestationManager;
+```
+
+## Zod Schemas
+
+All attestation and revocation schemas are defined in `@xmtp-broker/schemas` (see 02-schemas.md). This package adds:
+
+### Content Type Definition
+
+```typescript
+/**
+ * Custom XMTP content type for attestations.
+ * Follows the authority/type:version convention.
+ */
+const ATTESTATION_CONTENT_TYPE_ID = "xmtp.org/agentAttestation:1.0" as const;
+
+const REVOCATION_CONTENT_TYPE_ID = "xmtp.org/agentRevocation:1.0" as const;
+```
+
+### Signed Attestation Envelope
+
+```typescript
+const SignedAttestationEnvelope = z.object({
+  contentType: z.literal(ATTESTATION_CONTENT_TYPE_ID)
+    .describe("Content type discriminator"),
+  payload: AttestationSchema
+    .describe("The full attestation"),
+  signature: z.string()
+    .describe("Base64-encoded signature over canonical payload bytes"),
+  signatureAlgorithm: z.literal("Ed25519")
+    .describe("Signature algorithm"),
+  signerKeyRef: z.string()
+    .describe("Reference to the signing key (agent inbox key fingerprint)"),
+}).describe("Signed attestation envelope for XMTP group publishing");
+
+type SignedAttestationEnvelope = z.infer<typeof SignedAttestationEnvelope>;
+```
+
+### Signed Revocation Envelope
+
+```typescript
+const SignedRevocationEnvelope = z.object({
+  contentType: z.literal(REVOCATION_CONTENT_TYPE_ID)
+    .describe("Content type discriminator"),
+  payload: RevocationAttestation
+    .describe("The revocation attestation"),
+  signature: z.string()
+    .describe("Base64-encoded signature over canonical payload bytes"),
+  signatureAlgorithm: z.literal("Ed25519")
+    .describe("Signature algorithm"),
+  signerKeyRef: z.string()
+    .describe("Reference to the signing key"),
+}).describe("Signed revocation envelope for XMTP group publishing");
+
+type SignedRevocationEnvelope = z.infer<typeof SignedRevocationEnvelope>;
+```
+
+### Canonical Serialization
+
+```typescript
+/**
+ * Produces the canonical byte representation of an attestation for
+ * signing. Uses deterministic JSON serialization (sorted keys, no
+ * whitespace) encoded as UTF-8.
+ */
+function canonicalize(attestation: Attestation): Uint8Array;
+```
+
+Deterministic JSON (sorted keys, no whitespace) ensures the same attestation always produces the same bytes regardless of field insertion order. This is critical for signature verification by clients.
+
+## Behaviors
+
+### Attestation Lifecycle
+
+```
+                    ┌─────────────┐
+                    │  No Prior   │
+                    │ Attestation │
+                    └──────┬──────┘
+                           │ agent added / first grant
+                           ▼
+                    ┌─────────────┐
+           ┌──────►│   Active    │◄──────────┐
+           │       └──────┬──────┘           │
+           │              │                  │
+     ┌─────┴─────┐  ┌────┴────┐    ┌────────┴───────┐
+     │  Renewed   │  │Material │    │  Non-material   │
+     │ (same      │  │ Change  │    │  (no new        │
+     │  fields,   │  │ (new    │    │   attestation)  │
+     │  new time) │  │  attest)│    └────────────────┘
+     └────────────┘  └────┬────┘
+                          │
+                    ┌─────▼──────┐
+                    │   Active   │ (new attestation, chains to previous)
+                    └─────┬──────┘
+                          │ revoke
+                          ▼
+                    ┌─────────────┐
+                    │  Revoked    │ (terminal, no un-revoke)
+                    └─────────────┘
+```
+
+### Attestation Creation Flow
+
+1. Caller (policy engine) detects a state change and calls `attestIfMaterial()`.
+2. Manager extracts `MaterialFields` from the input and compares against the previous attestation (if any).
+3. If no previous attestation exists, creation is always triggered.
+4. If a previous attestation exists and the change is not material, the current attestation is returned unchanged.
+5. If material, `buildAttestation()` constructs the payload with:
+   - New `attestationId` via `generateAttestationId()`
+   - `previousAttestationId` pointing to the prior attestation
+   - `issuedAt` set to `new Date().toISOString()`
+   - `expiresAt` set to `issuedAt + ttlSeconds` (default: 86400 = 24 hours)
+   - `grantedOps` derived from `grantConfigToOps(grant)`
+   - `toolScopes` derived from `grantConfigToToolScopes(grant)`
+   - `issuer` set to the broker's signing identity
+6. The payload is validated against `AttestationSchema`.
+7. `signer.sign()` canonicalizes and signs the payload.
+8. `publisher.publish()` sends it to the group as the custom content type.
+9. Manager stores the attestation ID as the current attestation for this agent+group.
+
+### Attestation Chaining
+
+Each attestation links to its predecessor via `previousAttestationId`:
+
+```
+att_initial (previousAttestationId: null)
+    ↓
+att_grant_change (previousAttestationId: att_initial)
+    ↓
+att_view_upgrade (previousAttestationId: att_grant_change)
+    ↓
+att_renewal (previousAttestationId: att_view_upgrade)
+    ↓
+att_revocation (previousAttestationId: att_renewal)
+```
+
+Clients reconstruct the full history by walking the chain backward from the most recent attestation. If a client sees attestation N but missed N-1, it can scan the group message history for attestation content type messages to find the gap.
+
+### Materiality Rules
+
+**Material changes** (trigger new attestation):
+
+| Field(s) | Rationale |
+|-----------|-----------|
+| `viewMode` | Changes what the agent can see |
+| `contentTypes` | Changes which message types are visible |
+| `grantedOps` (derived from `GrantConfig`) | Changes what the agent can do |
+| `toolScopes` (derived from tool grants) | Changes which tools are available |
+| `inferenceMode` | Changes privacy posture |
+| `inferenceProviders` | Changes where content may flow |
+| `contentEgressScope` | Changes what leaves the broker boundary |
+| `retentionAtProvider` | Changes provider retention policy |
+| `hostingMode` | Changes trust boundary |
+| `trustTier` | Changes verifiability claim |
+| `verifierStatementRef` | Changes external validation |
+| `ownerInboxId` | Changes who is responsible |
+| `revocationRules` | Changes safety guarantees |
+
+**Non-material changes** (silent, no new attestation):
+
+| Change | Rationale |
+|--------|-----------|
+| Session rotation (same view + grant) | Internal plumbing, no permission change |
+| `sessionKeyFingerprint` change | Session-level concern, not group-visible |
+| Heartbeat / liveness signals | Noise; liveness is a session concern |
+| `policyHash` change without field changes | Hash is derived; if fields didn't change, the hash difference is a bug |
+| Internal broker housekeeping | Not relevant to group members |
+
+### Expiry and Renewal
+
+- Attestations carry `expiresAt`, defaulting to 24 hours from `issuedAt`.
+- The broker schedules renewal before expiry (e.g., at 75% of TTL).
+- Renewal creates a new attestation with identical material fields, new timestamps, and a new `attestationId` chaining to the previous one.
+- If the broker is offline when renewal is due, the attestation expires. Clients show a staleness badge. The broker creates a fresh attestation upon restart.
+
+### Revocation Flow
+
+1. Owner or system (heartbeat timeout, admin removal) triggers revocation.
+2. Manager calls `revoke()` with the reason.
+3. A `RevocationAttestation` is built with:
+   - New `attestationId`
+   - `previousAttestationId` pointing to the last active attestation
+   - `reason` from the `RevocationReason` enum
+   - `revokedAt` set to current time
+   - `issuer` set to broker's signing identity
+4. The revocation is signed and published to the group.
+5. Manager marks the agent+group as revoked. No further attestations can be created for this agent in this group.
+6. Revocation is final. To restore an agent, create a new agent identity.
+
+### Message Provenance
+
+Agent-authored messages reference the current `attestationId` via message metadata. The transport layer (WebSocket/MCP) attaches the attestation reference when forwarding agent messages to `@xmtp-broker/core` for sending.
+
+```typescript
+interface MessageProvenanceMetadata {
+  /** Attestation ID under which this message was produced. */
+  readonly attestationId: string;
+}
+```
+
+Clients receiving a message can:
+1. Look up the referenced attestation in the group's attestation history.
+2. Compare the attestation's `expiresAt` against the current time.
+3. If expired, render a staleness note (e.g., "produced under expired attestation").
+4. If the referenced attestation differs from the current one, render a delta note.
+
+### Client Verification
+
+Clients verify attestation signatures using this flow:
+
+1. Parse the `SignedAttestationEnvelope` from the XMTP message.
+2. Extract the `payload` and `signature`.
+3. Canonicalize the payload using the same deterministic JSON algorithm.
+4. Look up the agent's inbox key from XMTP identity (the `agentInboxId` field).
+5. Verify the Ed25519 signature over the canonical bytes using the inbox key.
+6. Check `expiresAt` -- if past, show staleness badge but still render the attestation.
+7. Validate `previousAttestationId` chains to the last known attestation for continuity.
+
+## Error Cases
+
+| Error | Category | When |
+|-------|----------|------|
+| `AttestationError` | validation | Payload fails `AttestationSchema` validation |
+| `AttestationError` | validation | `previousAttestationId` references unknown attestation |
+| `AttestationError` | validation | Attempted attestation for revoked agent+group |
+| `InternalError` | internal | Signing fails (key unavailable or corrupted) |
+| `InternalError` | internal | Publishing fails (XMTP send error) |
+| `ValidationError` | validation | Input fields fail Zod validation |
+
+The `attestIfMaterial` handler returns `Result`, never throws. Transport-level errors (XMTP send failures) are wrapped in `InternalError` with the original error in `context`.
+
+## Open Questions Resolved
+
+**Q: How should clients render stale or expired attestations?** (PRD Open Questions)
+**A:** Clients show a staleness badge after `expiresAt` passes. Messages still render normally with a note like "produced under expired attestation." The attestation content remains visible -- staleness indicates the broker hasn't refreshed, not that the attestation is invalid. Rationale: hiding history punishes the user; flagging currency lets them decide how much to trust it.
+
+**Q: How much policy should be in-group versus off-chain broker config?** (PRD Open Questions)
+**A:** Attestations (the public summary of permissions) are published in-group. Full policy configuration (view definitions, grant details, egress config, tool scopes) lives off-chain in the broker's local config. The attestation is a projection of the policy state, not a replica. Rationale: keeps group message history clean while ensuring transparency for the fields that matter to group members.
+
+**Q: What is the exact minimum viable attestation schema?** (PRD Open Questions, resolved in 02-schemas)
+**A:** Full 24-field schema from day one. All fields present; optional fields use `null`. Confirmed and adopted by this spec.
+
+**Q: How should content type allowlist updates be surfaced?** (PRD Open Questions, resolved in 02-schemas)
+**A:** Adding or removing content types from the allowlist is a material change that triggers a new attestation. The `contentTypes` array in the attestation reflects the current effective list. Confirmed and adopted by this spec.
+
+## Deferred
+
+- **Owner co-signing.** v1 uses broker-only signing with the agent's inbox key. Optional owner co-signing for high-stakes changes (e.g., upgrading to `full` visibility) is a future enhancement.
+- **Attestation backfill protocol.** Clients can scan group history for attestation messages. A dedicated backfill request/response protocol is deferred to Phase 2.
+- **Custom content type codec registration with XMTP SDK.** The content type IDs are defined; registering them as formal codecs with the SDK's codec registry is an integration concern handled in `@xmtp-broker/core`.
+- **Attestation storage/indexing.** The manager tracks current attestation IDs in memory. Persistent attestation storage for querying history is deferred -- group message history serves as the durable store.
+- **Signature algorithm agility.** v1 uses Ed25519 only. Algorithm negotiation is deferred.
+- **Runtime attestation (TEE) integration.** Trust tier is set to `source-verified` maximum in v1. TEE-backed runtime attestation is Phase 2.
+- **Multi-verifier aggregation.** v1 supports one `verifierStatementRef`. Multiple verifier references are deferred.
+
+## Testing Strategy
+
+### What to Test
+
+1. **Materiality detection** -- `isMaterialChange` correctly identifies material vs non-material changes across all field combinations.
+2. **Attestation building** -- `buildAttestation` produces valid `AttestationSchema`-conformant payloads with correct chaining.
+3. **Grant-to-ops mapping** -- `grantConfigToOps` and `grantConfigToToolScopes` produce correct string arrays for all grant configurations.
+4. **Canonical serialization** -- `canonicalize` is deterministic: same input always produces same bytes regardless of object key order.
+5. **Signing** -- `AttestationSigner.sign` produces verifiable signatures.
+6. **Revocation** -- `revoke` produces valid `RevocationAttestation`, marks agent+group as terminal.
+7. **Renewal** -- `renew` produces new attestation with same material fields but new timestamps.
+8. **ID generation** -- `generateAttestationId` produces unique IDs with correct prefix.
+
+### Key Test Scenarios
+
+```typescript
+// Materiality: view mode change is material
+const prev = { viewMode: "redacted", ...rest };
+const curr = { viewMode: "full", ...rest };
+const result = isMaterialChange(prev, curr);
+expect(result.ok).toBe(true);
+expect(result.value.material).toBe(true);
+expect(result.value.changedFields).toContain("viewMode");
+
+// Materiality: session key change is NOT material
+const prev2 = extractMaterialFields(attestationWithKeyA);
+const curr2 = extractMaterialFields(attestationWithKeyB);
+const result2 = isMaterialChange(prev2, curr2);
+expect(result2.value.material).toBe(false);
+
+// Chaining: first attestation has null previous
+const first = buildAttestation(input, null);
+expect(first.value.attestation.previousAttestationId).toBeNull();
+
+// Chaining: subsequent attestation links to previous
+const second = buildAttestation(input2, first.value.attestation.attestationId);
+expect(second.value.attestation.previousAttestationId)
+  .toBe(first.value.attestation.attestationId);
+
+// Revocation is terminal
+await manager.revoke(agentId, groupId, lastAttId, "owner-initiated");
+const result3 = await manager.attestIfMaterial(input, lastAttId);
+expect(result3.ok).toBe(false);
+expect(result3.error._tag).toBe("AttestationError");
+
+// Canonical serialization is deterministic
+const a = { z: 1, a: 2 };
+const b = { a: 2, z: 1 };
+expect(canonicalize(a)).toEqual(canonicalize(b));
+
+// Grant-to-ops mapping
+const grant = { messaging: { send: true, reply: true, react: false, draftOnly: false }, ... };
+const ops = grantConfigToOps(grant);
+expect(ops).toContain("messaging:send");
+expect(ops).toContain("messaging:reply");
+expect(ops).not.toContain("messaging:react");
+```
+
+### Test Utilities
+
+```typescript
+/** Creates a mock AttestationSigner that signs with a test key. */
+function createTestSigner(): AttestationSigner;
+
+/** Creates a mock AttestationPublisher that records published attestations. */
+function createTestPublisher(): AttestationPublisher & {
+  readonly published: readonly SignedAttestation[];
+};
+
+/** Creates a fully configured AttestationManager with test deps. */
+function createTestAttestationManager(): AttestationManager & {
+  readonly signer: ReturnType<typeof createTestSigner>;
+  readonly publisher: ReturnType<typeof createTestPublisher>;
+};
+```
+
+## File Layout
+
+```
+packages/attestations/
+  package.json
+  tsconfig.json
+  src/
+    index.ts                    # Re-exports all public API
+    attestation-id.ts           # generateAttestationId()
+    materiality.ts              # MaterialFields, isMaterialChange()
+    build.ts                    # AttestationInput, buildAttestation()
+    canonicalize.ts             # canonicalize() deterministic serialization
+    grant-ops.ts                # grantConfigToOps(), grantConfigToToolScopes()
+    content-type.ts             # ATTESTATION_CONTENT_TYPE_ID, REVOCATION_CONTENT_TYPE_ID,
+                                # SignedAttestationEnvelope, SignedRevocationEnvelope
+    signer.ts                   # AttestationSigner interface
+    publisher.ts                # AttestationPublisher interface
+    manager.ts                  # AttestationManager, createAttestationManager()
+    provenance.ts               # MessageProvenanceMetadata
+    __tests__/
+      attestation-id.test.ts
+      materiality.test.ts
+      build.test.ts
+      canonicalize.test.ts
+      grant-ops.test.ts
+      content-type.test.ts
+      manager.test.ts
+      fixtures.ts               # Test utilities (createTestSigner, etc.)
+```
+
+Each source file targets under 150 LOC. The manager is the largest file; if it exceeds 200 LOC, split the revocation flow into `revocation.ts`.

--- a/.agents/plans/v0/07-key-management.md
+++ b/.agents/plans/v0/07-key-management.md
@@ -1,0 +1,693 @@
+# 07-key-management
+
+**Package:** `@xmtp-broker/keys`
+**Spec version:** 0.1.0
+
+## Overview
+
+The key management package implements the three-tier key hierarchy that underpins the broker's security model. It provides hardware-backed signing through macOS Secure Enclave, encrypted secret storage (vault), and the `SignerProvider` interface consumed by `@xmtp-broker/core`.
+
+The fundamental design principle: the broker can **invoke** signing operations without being able to **extract** the signing key. The Secure Enclave generates and holds the root key -- it is non-exportable by hardware design. Operational keys and session keys are derived from root-protected material, each with progressively weaker access policies that enable autonomous broker operation for routine tasks while gating privilege escalation behind biometric authentication.
+
+The package bridges two cryptographic worlds. The Secure Enclave supports P-256 (secp256r1) exclusively. XMTP uses Ed25519 for inbox identity signatures. The bridge strategy: the enclave-backed P-256 root key protects an encrypted vault containing the Ed25519 operational key material. The enclave key never signs XMTP messages directly -- it authorizes access to the software keys that do. This gives us hardware-backed access control without fighting the enclave's algorithm constraints.
+
+On platforms without Secure Enclave (Intel Macs, Linux), the package degrades to software key storage with Keychain or file-based encryption, and the attestation `trustTier` reflects the actual security posture.
+
+## Dependencies
+
+**Imports:**
+- `@xmtp-broker/contracts` -- `SignerProvider`, `AttestationSigner` (canonical interface definitions)
+- `@xmtp-broker/schemas` -- `TrustTier`, error classes (`InternalError`, `ValidationError`, `AuthError`, `NotFoundError`)
+- `better-result` -- `Result` type
+- `zod` -- config validation
+
+**Imported by:**
+- `@xmtp-broker/core` -- consumes `SignerProvider` for XMTP client creation
+- `@xmtp-broker/sessions` -- requests session key issuance
+- `@xmtp-broker/attestations` -- consumes `AttestationSigner` for signing attestations
+
+## Public Interfaces
+
+> **Note:** The `SignerProvider` and `AttestationSigner` interfaces are canonically defined in `@xmtp-broker/contracts`. This package implements both. The duplicate `SignerProvider` definition previously in this spec now references the contracts package as the source of truth.
+
+### Configuration
+
+```typescript
+const KeyPolicySchema = z.enum([
+  "biometric",
+  "passcode",
+  "open",
+]).describe("Access control policy for a key tier");
+
+type KeyPolicy = z.infer<typeof KeyPolicySchema>;
+
+const PlatformCapability = z.enum([
+  "secure-enclave",
+  "keychain-software",
+  "tpm",
+  "software-vault",
+]).describe("Actual hardware security capability detected");
+
+type PlatformCapability = z.infer<typeof PlatformCapability>;
+
+const KeyManagerConfigSchema = z.object({
+  dataDir: z.string()
+    .describe("Base directory for key storage"),
+  rootKeyPolicy: KeyPolicySchema.default("biometric")
+    .describe("Access policy for root key operations"),
+  operationalKeyPolicy: KeyPolicySchema.default("open")
+    .describe("Access policy for routine operations"),
+  sessionKeyTtlSeconds: z.number().int().positive().default(3600)
+    .describe("Default TTL for session keys"),
+}).describe("Key manager configuration");
+
+type KeyManagerConfig = z.infer<typeof KeyManagerConfigSchema>;
+```
+
+### Three-Tier Key Hierarchy
+
+```typescript
+interface RootKeyHandle {
+  /** Opaque reference to the enclave key. Never contains raw key bytes. */
+  readonly keyRef: string;
+  /** P-256 public key, uncompressed hex (0x04...). */
+  readonly publicKey: string;
+  /** Access policy enforced by hardware. */
+  readonly policy: KeyPolicy;
+  /** Platform capability backing this key. */
+  readonly platform: PlatformCapability;
+  readonly createdAt: string;
+}
+
+interface OperationalKey {
+  /** Unique identifier for this operational key. */
+  readonly keyId: string;
+  /** The agent identity this key belongs to. */
+  readonly identityId: string;
+  /** Group ID if per-group identity, null if shared. */
+  readonly groupId: string | null;
+  /** Ed25519 public key, hex-encoded. */
+  readonly publicKey: string;
+  /** SHA-256 fingerprint of the public key, hex-encoded. */
+  readonly fingerprint: string;
+  readonly createdAt: string;
+  readonly rotatedAt: string | null;
+}
+
+interface SessionKey {
+  /** Unique identifier for this session key. */
+  readonly keyId: string;
+  /** Session ID this key is bound to. */
+  readonly sessionId: string;
+  /** SHA-256 fingerprint of the public key. */
+  readonly fingerprint: string;
+  /** When this key expires (matches session TTL). */
+  readonly expiresAt: string;
+  readonly createdAt: string;
+}
+```
+
+### SignerProvider (consumed by broker-core)
+
+> Canonical definition: `@xmtp-broker/contracts`. This package implements it via `KeyManager.toSignerProvider()`.
+
+```typescript
+// Imported from @xmtp-broker/contracts:
+// interface SignerProvider {
+//   getSigner(identityId: string): Promise<Result<Signer, InternalError>>;
+//   getDbEncryptionKey(identityId: string): Promise<Result<Uint8Array, InternalError>>;
+// }
+```
+
+### KeyManager
+
+```typescript
+interface KeyManager {
+  /** Initialize key management: detect platform, create root key if needed. */
+  initialize(): Promise<Result<RootKeyHandle, InternalError | AuthError>>;
+
+  /** Get the current platform capability. */
+  readonly platform: PlatformCapability;
+
+  /** Get the trust tier based on platform capability. */
+  readonly trustTier: TrustTier;
+
+  // -- Operational key management --
+
+  /** Create an operational key for an agent identity. Requires root key. */
+  createOperationalKey(
+    identityId: string,
+    groupId: string | null,
+  ): Promise<Result<OperationalKey, InternalError | AuthError>>;
+
+  /** Get the operational key for an identity. */
+  getOperationalKey(
+    identityId: string,
+  ): Result<OperationalKey, NotFoundError>;
+
+  /** Look up operational key by group ID. */
+  getOperationalKeyByGroupId(
+    groupId: string,
+  ): Result<OperationalKey, NotFoundError>;
+
+  /** Rotate an operational key. Requires root key authorization. */
+  rotateOperationalKey(
+    identityId: string,
+  ): Promise<Result<OperationalKey, InternalError | AuthError>>;
+
+  /** List all operational keys. */
+  listOperationalKeys(): readonly OperationalKey[];
+
+  // -- Session key management --
+
+  /** Issue a session key bound to a session ID. */
+  issueSessionKey(
+    sessionId: string,
+    ttlSeconds: number,
+  ): Promise<Result<SessionKey, InternalError>>;
+
+  /** Zeroize a session key (on session revocation/expiry). */
+  revokeSessionKey(
+    keyId: string,
+  ): Result<void, NotFoundError>;
+
+  // -- Signing operations --
+
+  /** Sign data with an operational key (Ed25519). */
+  signWithOperationalKey(
+    identityId: string,
+    data: Uint8Array,
+  ): Promise<Result<Uint8Array, InternalError | NotFoundError>>;
+
+  /** Sign data with a session key. */
+  signWithSessionKey(
+    keyId: string,
+    data: Uint8Array,
+  ): Promise<Result<Uint8Array, InternalError | NotFoundError>>;
+
+  // -- Vault --
+
+  /** Store a secret in the encrypted vault. */
+  vaultSet(
+    name: string,
+    value: Uint8Array,
+  ): Promise<Result<void, InternalError>>;
+
+  /** Retrieve a secret from the vault. */
+  vaultGet(
+    name: string,
+  ): Promise<Result<Uint8Array, NotFoundError | InternalError>>;
+
+  /** Remove a secret from the vault. */
+  vaultDelete(name: string): Promise<Result<void, NotFoundError>>;
+
+  /** List vault secret names (not values). */
+  vaultList(): readonly string[];
+
+  // -- SignerProvider factory --
+
+  /** Create a SignerProvider for broker-core consumption. */
+  toSignerProvider(): SignerProvider;
+}
+
+function createKeyManager(
+  config: KeyManagerConfig,
+): Promise<Result<KeyManager, InternalError>>;
+```
+
+### AttestationSigner Adapter
+
+```typescript
+import type { AttestationSigner, SignedAttestation } from
+  "@xmtp-broker/contracts";
+
+/** Creates an AttestationSigner backed by the key manager. */
+function createAttestationSigner(
+  keyManager: KeyManager,
+  identityId: string,
+): AttestationSigner;
+```
+
+## Zod Schemas
+
+Key management config schemas are defined above (`KeyManagerConfigSchema`, `KeyPolicySchema`). The `TrustTier` schema is imported from `@xmtp-broker/schemas`.
+
+Runtime key records (`RootKeyHandle`, `OperationalKey`, `SessionKey`) are plain TypeScript interfaces, not Zod schemas, because they are internal to the runtime tier.
+
+## Behaviors
+
+### Platform Detection and Initialization
+
+```
+initialize()
+    |
+    +--> Detect platform capability
+    |    |
+    |    +--> macOS + Apple Silicon: "secure-enclave"
+    |    +--> macOS + Intel: "keychain-software"
+    |    +--> Linux + TPM: "tpm" (deferred, maps to software-vault in v0)
+    |    +--> Linux (no TPM): "software-vault"
+    |
+    +--> Check for existing root key in storage
+    |    |
+    |    +--> Found: load handle, return
+    |    +--> Not found: create new root key
+    |
+    +--> Create root key (may trigger biometric prompt)
+    |
+    +--> Initialize vault with root key
+    |
+    +--> Return RootKeyHandle
+```
+
+### Trust Tier Mapping
+
+| Platform | TrustTier |
+|----------|-----------|
+| `secure-enclave` | `source-verified` |
+| `keychain-software` | `source-verified` (degraded label in logs) |
+| `tpm` | `source-verified` |
+| `software-vault` | `unverified` |
+
+### Secure Enclave FFI: Swift CLI Subprocess
+
+The recommended approach for Bun/TypeScript to call into macOS Secure Enclave is a **Swift CLI subprocess**. The broker ships a small Swift binary (`broker-signer`) that exposes Secure Enclave operations via JSON-over-stdio, following the same architectural pattern as keypo-cli.
+
+**Why subprocess over native addon:**
+- Secure Enclave requires Apple's CryptoKit framework, which is only accessible from Swift/Objective-C. A native addon (napi-rs, Bun FFI) would need to wrap Objective-C bridging into C, adding fragile build complexity.
+- The subprocess model is proven: keypo-cli uses it in production. The latency overhead (~5-15ms per call) is acceptable because root key operations are infrequent (initialization, rotation, privilege escalation).
+- The subprocess boundary provides natural process isolation -- a crash in the signer does not bring down the broker.
+- Build tooling stays simple: `swift build` for the signer, `bun build` for the broker, no cross-language linking.
+
+**Protocol:** The broker spawns `broker-signer <command> [args]` and reads JSON from stdout. Commands:
+
+| Command | Purpose | Triggers biometric |
+|---------|---------|-------------------|
+| `create --policy <policy>` | Generate root P-256 key in enclave | If policy is biometric |
+| `sign --key-ref <ref> --data <hex>` | Sign with enclave key | Per key policy |
+| `encrypt --public-key <hex> --data <hex>` | ECIES encrypt for vault | No |
+| `decrypt --key-ref <ref> --data <json>` | ECIES decrypt from vault | Per key policy |
+| `info` | Platform detection, enclave availability | No |
+| `delete --key-ref <ref>` | Remove enclave key | No |
+
+### P-256 to Ed25519 Bridge
+
+The Secure Enclave only supports P-256. XMTP requires Ed25519 (for `@xmtp/node-sdk` Signer interface). The bridge:
+
+```
+Root Key (P-256, in Secure Enclave)
+    |
+    | protects (ECIES encrypt/decrypt)
+    v
+Encrypted Vault (on disk)
+    |
+    | contains
+    v
+Ed25519 Operational Key Material (software, in vault)
+    |
+    | used for
+    v
+XMTP Signer (Ed25519 signatures)
+```
+
+1. When `createOperationalKey()` is called, the key manager generates Ed25519 key material in memory using `@noble/ed25519` or equivalent.
+2. The private key bytes are encrypted via the Swift subprocess (`encrypt` command) using the root key's P-256 public key for ECIES.
+3. The encrypted blob is stored on disk in the vault file.
+4. When `signWithOperationalKey()` is called, the encrypted key is decrypted via the Swift subprocess (`decrypt` command), the Ed25519 signature is computed in-process, and the plaintext key is zeroized immediately.
+5. For the `SignerProvider.getSigner()` interface, the key manager returns a `Signer` that internally calls through this decrypt-sign-zeroize flow.
+
+### Biometric Gating Rules
+
+**Root key operations (biometric/passcode required):**
+
+| Operation | Why |
+|-----------|-----|
+| Initial inbox creation | Creates a new identity anchor |
+| Privilege escalation (material grant change) | Crosses security boundary |
+| Key rotation | Changes signing material |
+| New operational key creation | Authorizes new agent identity |
+| Grant escalation beyond current scope | Maps to session materiality |
+| Vault secret access (first access per session) | Unlocks encrypted material |
+
+**Operational key operations (no biometric):**
+
+| Operation | Why |
+|-----------|-----|
+| Message signing | Routine, high-frequency |
+| Attestation publishing | Routine, tied to session lifecycle |
+| Session key issuance | Bounded by existing grants |
+| Heartbeat signing | Background liveness |
+
+**Session key operations (harness-scoped):**
+
+| Operation | Why |
+|-----------|-----|
+| Request signing within grant scope | Session-bounded |
+| Heartbeat from harness | Liveness only |
+
+This maps directly to the materiality boundary from 05-sessions.md: non-material operations use operational keys; material changes require root key authorization (biometric).
+
+### Encrypted Vault
+
+The vault stores secrets encrypted at rest using ECIES with the root key:
+
+```
+Vault File: {dataDir}/vault.json
+{
+  "version": 1,
+  "rootKeyRef": "<base64 opaque SE key reference>",
+  "rootPublicKey": "<hex P-256 public key>",
+  "secrets": {
+    "op-key:<identityId>": { <EncryptedBlob> },
+    "db-key:<identityId>": { <EncryptedBlob> },
+    "api-cred:openai": { <EncryptedBlob> },
+    ...
+  }
+}
+```
+
+**EncryptedBlob** follows the ECIES pattern from keypo-cli:
+- `ephemeralPublicKey`: P-256 public key used for ECDH (hex)
+- `nonce`: 12 bytes (base64)
+- `ciphertext`: AES-256-GCM encrypted data (base64)
+- `tag`: 16 bytes GCM auth tag (base64)
+- `createdAt`, `updatedAt`: ISO 8601 timestamps
+
+**What goes in the vault:**
+- Ed25519 operational key material (per identity)
+- Database encryption keys (32 bytes per identity)
+- API credentials for inference providers
+- Webhook tokens
+- Configuration secrets
+
+**What never goes in the vault:**
+- Root key material (lives in Secure Enclave, non-exportable)
+- Session keys (ephemeral, in-memory only)
+- Plaintext of any secret (only ciphertext on disk)
+
+### Key Rotation
+
+**Machine migration** (new hardware):
+
+```
+New Machine
+    |
+    +--> User enrolls biometrics
+    |
+    +--> Broker creates new root key in new enclave
+    |
+    +--> User transfers encrypted vault file to new machine
+    |    (vault is useless without the old root key)
+    |
+    +--> Broker generates new operational keys under new root
+    |
+    +--> Broker performs XMTP installation rotation
+    |    (inbox persists, signing key material rotates)
+    |
+    +--> Broker publishes updated attestation
+    |
+    +--> Old machine's root key is abandoned (non-exportable,
+    |    hardware-bound, automatically inaccessible)
+```
+
+No seed phrases. No recovery keys. Identity continuity is through XMTP's installation management, not key portability.
+
+**Periodic operational key rotation:**
+
+```
+rotateOperationalKey(identityId)
+    |
+    +--> Requires root key authorization (biometric)
+    |
+    +--> Generate new Ed25519 key pair
+    |
+    +--> Encrypt new private key to vault
+    |
+    +--> Update operational key record (new publicKey, fingerprint)
+    |
+    +--> Mark old key as rotated (rotatedAt = now)
+    |
+    +--> Existing sessions continue with current session keys
+    |    (they don't use operational key directly)
+    |
+    +--> New sessions use the new operational key
+    |
+    +--> Trigger attestation update (material change)
+```
+
+### Per-Group Identity Key Management
+
+Each group identity (from `@xmtp-broker/core` per-group mode) gets:
+- Its own Ed25519 operational key stored in the vault as `op-key:<identityId>`
+- Its own database encryption key stored as `db-key:<identityId>`
+- Both protected by the single root key
+
+The root key authorizes creation of new group identities via `createOperationalKey()`.
+
+```
+Root Key (1, in Secure Enclave)
+    |
+    +--> Operational Key for Group A (Ed25519, in vault)
+    +--> Operational Key for Group B (Ed25519, in vault)
+    +--> Operational Key for Group C (Ed25519, in vault)
+    +--> DB Key for Group A (AES-256, in vault)
+    +--> DB Key for Group B (AES-256, in vault)
+    +--> DB Key for Group C (AES-256, in vault)
+```
+
+### Coordinating Agent Pattern
+
+```
+Human Owner (biometric)
+    |
+    +--> Root Key (Secure Enclave)
+         |
+         +--> Coordinating Agent
+         |    (operational key, broad view/grant)
+         |    |
+         |    +--> Task Agent A
+         |    |    (operational key, scoped grant)
+         |    |
+         |    +--> Task Agent B
+         |         (operational key, scoped grant)
+         |
+         +--> createOperationalKey() requires root key
+              (biometric prompt for each new agent)
+```
+
+The coordinating agent can request new task agents, but each creation requires root key authorization. Task agents operate autonomously within their grants. Escalation beyond granted scope bubbles up through the session materiality boundary, ultimately requiring biometric confirmation.
+
+### Platform Degradation
+
+```
+detectPlatform()
+    |
+    +--> Check SecureEnclave.isAvailable (via broker-signer info)
+    |    |
+    |    +--> true: PlatformCapability = "secure-enclave"
+    |    |         Root key in enclave, full hardware protection.
+    |    |
+    |    +--> false (macOS): PlatformCapability = "keychain-software"
+    |    |         Root key in Keychain, software-protected.
+    |    |         Biometric policy maps to Keychain ACL.
+    |    |         Log warning: "Running without Secure Enclave.
+    |    |         Key material is software-protected."
+    |    |
+    |    +--> false (Linux): PlatformCapability = "software-vault"
+    |              Root key is Ed25519, encrypted with passphrase.
+    |              No hardware protection.
+    |              Log warning: "No hardware key storage. Keys are
+    |              software-protected only."
+    |
+    +--> Set trustTier based on platform
+    |
+    +--> Attestation includes actual platform in metadata
+```
+
+All three paths implement the same `KeyManager` interface. The `SignerProvider` returned by `toSignerProvider()` behaves identically regardless of platform. The difference is only in the security guarantees, reflected in `trustTier` and logged at startup.
+
+### Session Key Lifecycle
+
+```
+issueSessionKey(sessionId, ttlSeconds)
+    |
+    +--> Generate Ed25519 key pair in memory
+    |
+    +--> Compute fingerprint = SHA-256(publicKey)
+    |
+    +--> Store in ephemeral in-memory map
+    |    (never written to disk or vault)
+    |
+    +--> Return SessionKey record
+    |
+    ... session active ...
+    |
+revokeSessionKey(keyId)
+    |
+    +--> Zeroize private key bytes
+    |
+    +--> Remove from in-memory map
+```
+
+Session keys are never persisted. Broker restart invalidates all session keys, which is correct -- sessions are also in-memory (per 05-sessions.md).
+
+## Error Cases
+
+| Scenario | Error | Category |
+|----------|-------|----------|
+| Secure Enclave unavailable on expected platform | `InternalError` | internal |
+| Biometric authentication cancelled | `AuthError` | auth |
+| Biometric authentication failed | `AuthError` | auth |
+| Swift subprocess crashed or timed out | `InternalError` | internal |
+| Vault file corrupted (HMAC mismatch) | `InternalError` | internal |
+| Operational key not found for identity | `NotFoundError` | not_found |
+| Session key not found (expired/revoked) | `NotFoundError` | not_found |
+| Vault secret not found | `NotFoundError` | not_found |
+| Config validation fails | `ValidationError` | validation |
+| Key rotation without root authorization | `AuthError` | auth |
+
+The Swift subprocess has a 30-second timeout. If biometric is pending, the OS controls the prompt -- the broker waits. If the subprocess crashes, `InternalError` with the stderr output in `context`.
+
+## Open Questions Resolved
+
+**Q: How should the broker interact with Secure Enclave from Bun/TypeScript?** (PRD: "implement its own purpose-built key management layer")
+**A:** Swift CLI subprocess (`broker-signer`) with JSON-over-stdio protocol. Rationale: CryptoKit is only accessible from Swift. The subprocess model is proven by keypo-cli, adds ~10ms latency per call (acceptable for infrequent root key operations), provides process isolation, and keeps build tooling simple. Native addons (napi-rs, Bun FFI) would require fragile Objective-C bridging into C and introduce build-time platform coupling.
+
+**Q: How does P-256 (Secure Enclave) bridge to Ed25519 (XMTP)?** (PRD: "design the bridge")
+**A:** The enclave P-256 key protects the vault; the vault holds Ed25519 operational keys. The enclave key never signs XMTP messages directly. This avoids algorithm conversion complexity and leverages the enclave for what it does best: access control and encryption. The Ed25519 keys are standard software keys whose material is encrypted at rest.
+
+**Q: Per-group identity -- how do per-group keys interact with the hierarchy?** (PLAN.md)
+**A:** Each group identity gets its own Ed25519 operational key and database encryption key, all stored in the vault under the single root key. The root key is the authority for all group identities. Creating a new group identity requires root key authorization (biometric). This scales linearly with group count but keeps the trust anchor singular.
+
+**Q: What happens on platforms without Secure Enclave?** (PRD: "degrade gracefully with clear labeling")
+**A:** The `KeyManager` interface is platform-agnostic. On Intel Macs, Keychain with software keys. On Linux, passphrase-encrypted file storage. The `trustTier` in attestations reflects the actual security posture (`source-verified` vs `unverified`). The broker logs a warning at startup.
+
+## Deferred
+
+- **TPM integration on Linux**: v0 maps Linux to `software-vault`. Real TPM support (via `tpm2-tss` or similar) is post-v0.
+- **Hosted/TEE key management**: TEE-backed keys for hosted brokers are Phase 2. The `PlatformCapability` enum includes the extension point.
+- **Key escrow or social recovery**: No recovery mechanism in v0. Machine migration requires creating new keys and rotating XMTP installations.
+- **Hardware Security Module (HSM) support**: Enterprise key storage is post-v0.
+- **Operational key caching**: v0 decrypts from vault on every sign operation. An in-memory cache with TTL is a performance optimization for post-v0.
+- **Multi-root-key support**: v0 uses a single root key. Support for multiple root keys (e.g., backup enclave key) is deferred.
+- **broker-signer binary distribution**: v0 assumes the Swift binary is built locally. Prebuilt binary distribution (Homebrew, embedded in npm package) is deferred.
+
+## Testing Strategy
+
+### What to Test
+
+1. **Platform detection** -- Mock subprocess responses for `info` command. Verify correct `PlatformCapability` and `trustTier` mapping.
+2. **Operational key lifecycle** -- Create, retrieve by identity ID, retrieve by group ID, rotate, list.
+3. **Session key lifecycle** -- Issue, sign, revoke, verify zeroization.
+4. **SignerProvider contract** -- `getSigner()` returns a valid XMTP `Signer`. `getDbEncryptionKey()` returns 32 bytes.
+5. **Vault CRUD** -- Set, get, delete, list secrets. Verify encrypted-at-rest (read raw file, confirm not plaintext).
+6. **Biometric gating** -- Operations that require root key return `AuthError` when biometric is unavailable/cancelled (mocked).
+7. **Key rotation** -- New key replaces old, attestation trigger signaled, existing sessions unaffected.
+8. **Platform degradation** -- Software fallback produces correct `trustTier` and logs warnings.
+9. **Subprocess error handling** -- Timeout, crash, invalid JSON all produce `InternalError`.
+10. **AttestationSigner adapter** -- Produces valid `SignedAttestation` with correct `signerKeyRef`.
+
+### How to Test
+
+**Unit tests** (most tests): Mock the Swift subprocess with a test double that returns canned JSON responses. All key operations except actual Secure Enclave interaction are testable without hardware. The vault can be tested with a software-only encryption backend.
+
+**Integration tests** (few, require macOS + Apple Silicon): End-to-end tests that spawn the real `broker-signer` binary and interact with the Secure Enclave. These use `open` policy keys (no biometric prompt) and are gated by CI platform detection.
+
+### Key Test Scenarios
+
+```typescript
+// Platform detection
+const manager = await createKeyManager({ dataDir: tmpDir });
+expect(manager.platform).toBe("secure-enclave"); // or mocked
+
+// Operational key creation and signing
+const opKey = await manager.createOperationalKey("id-1", "group-a");
+expect(opKey.ok).toBe(true);
+const sig = await manager.signWithOperationalKey(
+  "id-1",
+  new Uint8Array([1, 2, 3]),
+);
+expect(sig.ok).toBe(true);
+
+// Session key lifecycle
+const sessKey = await manager.issueSessionKey("ses_abc", 3600);
+expect(sessKey.ok).toBe(true);
+const revoke = manager.revokeSessionKey(sessKey.value.keyId);
+expect(revoke.ok).toBe(true);
+// Signing after revoke fails
+const sig2 = await manager.signWithSessionKey(
+  sessKey.value.keyId,
+  new Uint8Array([1]),
+);
+expect(sig2.ok).toBe(false);
+
+// SignerProvider contract
+const provider = manager.toSignerProvider();
+const signer = await provider.getSigner("id-1");
+expect(signer.ok).toBe(true);
+const dbKey = await provider.getDbEncryptionKey("id-1");
+expect(dbKey.ok).toBe(true);
+expect(dbKey.value).toHaveLength(32);
+
+// Vault operations
+await manager.vaultSet("api-key", encoder.encode("sk-test"));
+const val = await manager.vaultGet("api-key");
+expect(decoder.decode(val.value)).toBe("sk-test");
+
+// Biometric cancellation
+mockSubprocess.nextResponse = { error: "authentication cancelled" };
+const result = await manager.createOperationalKey("id-2", null);
+expect(result.ok).toBe(false);
+expect(result.error._tag).toBe("AuthError");
+```
+
+### Test Utilities
+
+```typescript
+/** Create a KeyManager with a mock subprocess backend. */
+function createTestKeyManager(
+  overrides?: Partial<KeyManagerConfig>,
+): Promise<{ manager: KeyManager; subprocess: MockSubprocess }>;
+
+/** Mock subprocess that returns canned JSON responses. */
+interface MockSubprocess {
+  nextResponse: unknown;
+  calls: readonly { command: string; args: readonly string[] }[];
+}
+
+/** Create a software-only KeyManager (no enclave). */
+function createSoftwareKeyManager(
+  config: KeyManagerConfig,
+): Promise<KeyManager>;
+```
+
+## File Layout
+
+```
+packages/keys/
+  package.json
+  tsconfig.json
+  src/
+    index.ts                    # Re-exports public API
+    config.ts                   # KeyManagerConfigSchema, KeyPolicySchema, PlatformCapability
+    key-manager.ts              # KeyManager interface and createKeyManager factory
+    signer-provider.ts          # SignerProvider implementation (toSignerProvider)
+    attestation-signer.ts       # createAttestationSigner adapter
+    root-key.ts                 # RootKeyHandle, root key initialization
+    operational-key.ts          # OperationalKey, create/rotate/lookup
+    session-key.ts              # SessionKey, issue/revoke, in-memory store
+    vault.ts                    # Encrypted vault read/write, ECIES via subprocess
+    platform.ts                 # Platform detection, trust tier mapping
+    subprocess.ts               # Swift CLI subprocess spawning, JSON parsing
+    __tests__/
+      key-manager.test.ts       # Full lifecycle tests
+      signer-provider.test.ts   # SignerProvider contract tests
+      operational-key.test.ts   # Operational key CRUD + rotation
+      session-key.test.ts       # Session key lifecycle + zeroization
+      vault.test.ts             # Vault CRUD + encryption verification
+      platform.test.ts          # Platform detection + degradation
+      subprocess.test.ts        # Subprocess protocol, error handling
+      fixtures.ts               # Test utilities, mock subprocess
+```
+
+Each source file targets under 200 LOC. The `key-manager.ts` file orchestrates the tiers but delegates to `root-key.ts`, `operational-key.ts`, `session-key.ts`, and `vault.ts` for actual logic.

--- a/.agents/plans/v0/08-websocket-transport.md
+++ b/.agents/plans/v0/08-websocket-transport.md
@@ -1,0 +1,619 @@
+# 08-websocket-transport
+
+**Package:** `@xmtp-broker/ws`
+**Spec version:** 0.1.0
+
+## Overview
+
+The WebSocket transport is the Phase 1 harness-facing interface for xmtp-broker. It translates the transport-agnostic handler contract into a persistent, bidirectional connection between agent harnesses and the broker. A harness connects, authenticates with a session token, and then receives a filtered event stream and sends scoped requests over a single WebSocket connection.
+
+The transport is a thin adapter. It owns connection lifecycle, wire protocol framing, auth handshake, sequence numbering, backpressure, and reconnection support. It does not own policy decisions, session state, or XMTP client operations -- those are delegated to the runtime tier packages (`@xmtp-broker/sessions`, `@xmtp-broker/policy`, `@xmtp-broker/core`) via their handler interfaces.
+
+Built on `Bun.serve()` native WebSocket support, the transport uses per-connection state via `ws.data` typing, a connection registry for event broadcasting, and structured JSON frames with a `type` discriminator. No binary frames in v0. No HTTP-level auth -- authentication happens in-band as the first frame after upgrade.
+
+## Dependencies
+
+**Imports:**
+- `@xmtp-broker/contracts` -- `BrokerCore`, `CoreContext`, `SessionManager`, `SessionRecord`, `AttestationManager`, `RawEvent`, `RevealStateStore` (canonical interface definitions; this package consumes these interfaces, does not implement them)
+- `@xmtp-broker/schemas` -- `BrokerEvent`, `HarnessRequest`, `RequestResponse`, `SessionToken`, `ViewConfig`, `GrantConfig`, error classes (`AuthError`, `SessionExpiredError`, `ValidationError`)
+- `@xmtp-broker/sessions` -- `SessionManager` implementation
+- `@xmtp-broker/policy` -- `projectMessage`, grant validation functions, `RevealStateStore` implementation
+- `@xmtp-broker/core` -- `BrokerCore` implementation
+- `@xmtp-broker/attestations` -- `AttestationManager` implementation
+- `better-result` -- `Result`, `ok`, `err`
+- `zod` -- frame validation at the wire boundary
+
+**Imported by:** Nothing -- this is the top of the dependency graph.
+
+## Public Interfaces
+
+### Server Configuration
+
+```typescript
+const WsServerConfigSchema = z.object({
+  port: z.number().int().positive().default(8393)
+    .describe("Port to listen on"),
+  host: z.string().default("127.0.0.1")
+    .describe("Host to bind to"),
+  heartbeatIntervalMs: z.number().int().positive().default(30_000)
+    .describe("Interval between heartbeat frames in milliseconds"),
+  missedHeartbeatsBeforeDead: z.number().int().positive().default(3)
+    .describe("Consecutive missed heartbeats before connection is considered dead"),
+  authTimeoutMs: z.number().int().positive().default(5_000)
+    .describe("Time allowed for auth handshake after connect"),
+  replayBufferSize: z.number().int().positive().default(1_000)
+    .describe("Max events buffered per connection for reconnection replay"),
+  sendBufferSoftLimit: z.number().int().positive().default(64)
+    .describe("Send buffer depth that triggers backpressure warning"),
+  sendBufferHardLimit: z.number().int().positive().default(256)
+    .describe("Send buffer depth that triggers forced disconnect"),
+  drainTimeoutMs: z.number().int().positive().default(5_000)
+    .describe("Time to wait for in-flight responses during graceful shutdown"),
+  maxFrameSizeBytes: z.number().int().positive().default(1_048_576)
+    .describe("Maximum accepted frame size (1 MiB default)"),
+}).describe("WebSocket server configuration");
+
+type WsServerConfig = z.infer<typeof WsServerConfigSchema>;
+```
+
+### Connection State
+
+```typescript
+/** Per-connection state stored in ws.data. */
+interface ConnectionState {
+  readonly connectionId: string;
+  phase: ConnectionPhase;
+  sessionRecord: SessionRecord | null;
+  lastSeenSeq: number;
+  nextSeq: number;
+  sendBufferDepth: number;
+  backpressureNotified: boolean;
+  authTimer: Timer | null;
+  heartbeatTimer: Timer | null;
+  replayBuffer: CircularBuffer<SequencedFrame>;
+  inFlightRequests: Map<string, { timer: Timer; sentAt: number }>;
+}
+
+type ConnectionPhase =
+  | "authenticating"
+  | "active"
+  | "draining"
+  | "closed";
+```
+
+### Wire Frame Schemas
+
+```typescript
+/** Auth frame sent by harness as first message. */
+const AuthFrame = z.object({
+  type: z.literal("auth"),
+  token: z.string().describe("Session bearer token"),
+  lastSeenSeq: z.number().int().nonnegative().nullable()
+    .describe("Last sequence number seen, null for fresh connection"),
+}).describe("Authentication frame from harness");
+
+type AuthFrame = z.infer<typeof AuthFrame>;
+
+/** Authenticated confirmation from broker. */
+const AuthenticatedFrame = z.object({
+  type: z.literal("authenticated"),
+  connectionId: z.string().describe("Broker-assigned connection identifier"),
+  session: SessionToken.describe("Session info"),
+  view: ViewConfig.describe("Active view configuration"),
+  grant: GrantConfig.describe("Active grant configuration"),
+  resumedFromSeq: z.number().int().nonnegative().nullable()
+    .describe("Sequence number resume started from, null if fresh"),
+}).describe("Authentication success response from broker");
+
+type AuthenticatedFrame = z.infer<typeof AuthenticatedFrame>;
+
+/** Auth error from broker, sent before close. */
+const AuthErrorFrame = z.object({
+  type: z.literal("auth_error"),
+  code: z.number().int().describe("Error code"),
+  message: z.string().describe("Human-readable error description"),
+}).describe("Authentication failure response from broker");
+
+type AuthErrorFrame = z.infer<typeof AuthErrorFrame>;
+
+/** Backpressure warning from broker. */
+const BackpressureFrame = z.object({
+  type: z.literal("backpressure"),
+  buffered: z.number().int().describe("Current buffer depth"),
+  limit: z.number().int().describe("Hard limit before disconnect"),
+}).describe("Backpressure warning from broker");
+
+type BackpressureFrame = z.infer<typeof BackpressureFrame>;
+```
+
+### Sequenced Event Envelope
+
+Every broker-to-harness event is wrapped in a sequenced envelope:
+
+```typescript
+const SequencedFrame = z.object({
+  seq: z.number().int().positive()
+    .describe("Monotonically increasing sequence number, scoped to connection"),
+  event: BrokerEvent.describe("The event payload"),
+}).describe("Sequenced event envelope for replay support");
+
+type SequencedFrame = z.infer<typeof SequencedFrame>;
+```
+
+### Harness Request Envelope
+
+Harness-to-broker messages carry the `HarnessRequest` shape defined in 02-schemas. The `requestId` field on each request type provides correlation. No additional envelope is needed.
+
+### Response Envelope
+
+Broker-to-harness responses use the `RequestResponse` shape from 02-schemas, discriminated on `ok: true | false` with the matching `requestId`.
+
+### WsServer
+
+```typescript
+interface WsServerDeps {
+  readonly core: BrokerCore;
+  readonly sessionManager: SessionManager;
+  readonly attestationManager: AttestationManager;
+}
+
+interface WsServer {
+  /** Start listening for connections. */
+  start(): Promise<Result<{ port: number }, InternalError>>;
+
+  /** Graceful shutdown: drain connections, wait for in-flight, close. */
+  stop(): Promise<Result<void, InternalError>>;
+
+  /** Current server state. */
+  readonly state: WsServerState;
+
+  /** Number of active connections. */
+  readonly connectionCount: number;
+}
+
+type WsServerState = "idle" | "listening" | "draining" | "stopped";
+
+function createWsServer(
+  config: WsServerConfig,
+  deps: WsServerDeps,
+): WsServer;
+```
+
+## Zod Schemas
+
+All event and request schemas are imported from `@xmtp-broker/schemas` (see 02-schemas.md). This package adds:
+
+- `WsServerConfigSchema` -- server configuration
+- `AuthFrame` -- harness auth handshake
+- `AuthenticatedFrame` -- broker auth confirmation
+- `AuthErrorFrame` -- broker auth rejection
+- `BackpressureFrame` -- backpressure signal
+- `SequencedFrame` -- sequenced event envelope
+
+## Behaviors
+
+### Connection Lifecycle State Machine
+
+```
+  Client connects (HTTP upgrade)
+         |
+         v
+  ┌────────────────┐   auth timeout    ┌────────┐
+  │ authenticating  │ ──────────────>   │ closed │
+  └────────┬───────┘                   └────────┘
+           | auth frame received
+           v
+  ┌────────────────┐   session revoked / error
+  │    active      │ ────────────────────────────> ┌────────┐
+  └────────┬───────┘                               │ closed │
+           | server shutdown / session expired      └────────┘
+           v
+  ┌────────────────┐   drain timeout
+  │   draining     │ ──────────────> ┌────────┐
+  └────────────────┘                 │ closed │
+                                     └────────┘
+```
+
+**authenticating**: Connection accepted, waiting for auth frame. A timer fires after `authTimeoutMs` -- if no valid auth frame arrives, the broker sends an `AuthErrorFrame` with message "auth timeout" and closes the connection.
+
+**active**: Authenticated. Events flow broker-to-harness; requests flow harness-to-broker. The connection remains active until session expiry, explicit revocation, server shutdown, or transport failure.
+
+**draining**: The broker has initiated disconnect (shutdown, session revoked, etc.). In-flight responses are completed. No new events are sent except the terminal event (e.g., `session.expired`). After `drainTimeoutMs`, the connection closes regardless.
+
+**closed**: Terminal. Connection resources are released.
+
+### Auth Handshake
+
+```
+  Harness                              Broker
+    |                                    |
+    |--- WebSocket upgrade ------------->|
+    |                                    |  start auth timer
+    |--- auth { token, lastSeenSeq } --->|
+    |                                    |  validate token via SessionManager
+    |                                    |
+    |<-- authenticated { ... } ----------|  (success)
+    |    OR                              |
+    |<-- auth_error { ... } -------------|  (failure, then close)
+    |                                    |
+    |<-- [replayed events if resuming] --|
+    |                                    |
+    |<-- heartbeat ----------------------|  (periodic)
+    |--- send_message { requestId } ---->|
+    |<-- response { requestId, ok } -----|
+```
+
+1. Harness opens a WebSocket connection to `ws://{host}:{port}/v1/agent`.
+2. Broker accepts the upgrade and transitions to `authenticating`. Starts `authTimeoutMs` timer.
+3. Harness sends an `AuthFrame` with its session bearer token and optional `lastSeenSeq`.
+4. Broker validates the token via `sessionManager.getSessionByToken(token)`.
+5. On success:
+   - Cancels auth timer.
+   - Registers connection in the connection registry.
+   - Transitions to `active`.
+   - Sends `AuthenticatedFrame` with session info, view, and grant.
+   - If `lastSeenSeq` is non-null, replays buffered events (see Reconnection).
+   - Starts heartbeat timer.
+   - Subscribes to `BrokerCore` raw events for this session's view scope.
+6. On failure:
+   - Sends `AuthErrorFrame` with the error code and message.
+   - Closes the WebSocket with code 4001 (auth failed).
+
+### Request/Response Flow
+
+1. Harness sends a `HarnessRequest` JSON frame (parsed and validated against the `HarnessRequest` discriminated union).
+2. Broker extracts `requestId` and `type`.
+3. Broker validates the request against the session's active grant (via policy engine functions).
+4. If grant check fails: sends `RequestResponse` with `ok: false` and the error.
+5. If grant check succeeds:
+   - For `send_message` / `send_reply`: if `draftOnly`, emits `action.confirmation_required` event and holds the message. Otherwise, sends via `CoreContext.sendMessage()`.
+   - For `send_reaction`: sends via `CoreContext.sendMessage()` with reaction content type.
+   - For `reveal_content`: delegates to `RevealStateStore`, replays affected messages.
+   - For `heartbeat`: records via `sessionManager.recordHeartbeat()`.
+   - For `confirm_action`: releases or discards the held action.
+   - For `update_view`: checks materiality. Non-material: applies in-place. Material: sends `session.reauthorization_required` event and transitions to draining.
+6. Sends `RequestResponse` with `ok: true` and result data.
+
+Request timeout: if the handler does not respond within 30 seconds, the broker sends `RequestResponse` with `ok: false`, category `timeout`, and cleans up. The `inFlightRequests` map tracks pending requests for this purpose.
+
+### Event Broadcasting
+
+When the `BrokerCore` emits a `RawEvent`:
+
+1. The transport routes it through `projectMessage()` for each active connection's view config.
+2. If the projection result is `emit`, the transport wraps the `MessageEvent` in a `SequencedFrame`.
+3. The frame is serialized to JSON and sent on the connection.
+4. The frame is appended to the connection's replay buffer.
+
+Non-message events (`session.expired`, `heartbeat`, `attestation.updated`, etc.) are sent directly to relevant connections without projection.
+
+### Sequence Numbers
+
+- Every broker-to-harness frame gets a monotonically increasing `seq` number.
+- Sequence numbers are scoped to the connection, starting at 1.
+- `ConnectionState.nextSeq` tracks the next number to assign.
+- The harness tracks `lastSeenSeq` for reconnection.
+- Sequence numbers are assigned at send time, not at event creation time.
+
+### Reconnection and Replay
+
+Reconnection is client-side responsibility. The broker provides replay support:
+
+1. Harness reconnects and sends `AuthFrame` with `lastSeenSeq: N`.
+2. Broker validates the token. If the session is still active:
+   - Scans the connection's replay buffer for events with `seq > N`.
+   - If all events since N are in the buffer: replays them in order, then resumes live.
+   - If the buffer has been overwritten (client too far behind): sends a special `broker.recovery.complete` event signaling the harness should do a full state resync. No replay is attempted.
+3. The `AuthenticatedFrame` includes `resumedFromSeq` indicating where replay started, or `null` if fresh.
+
+**Buffer implementation**: A `CircularBuffer<SequencedFrame>` with capacity `replayBufferSize` (default 1000). Oldest entries are overwritten when full.
+
+**Session continuity**: The replay buffer is keyed by session ID, not connection ID. If a harness disconnects and reconnects with the same session token, it gets the same buffer. The buffer is cleared when the session is revoked or expired.
+
+### Heartbeat
+
+Two layers of liveness checking:
+
+**Application heartbeat** (broker to harness):
+- Broker sends a `HeartbeatEvent` wrapped in a `SequencedFrame` at `heartbeatIntervalMs` intervals.
+- The harness should treat `missedHeartbeatsBeforeDead` consecutive missed heartbeats as connection dead and reconnect.
+- Heartbeats carry the `sessionId` so multi-connection harnesses can track per-session liveness.
+
+**Transport ping/pong** (WebSocket protocol level):
+- `Bun.serve()` handles WebSocket ping/pong automatically.
+- This provides transport-level liveness detection independent of application heartbeats.
+
+**Harness heartbeat** (harness to broker):
+- The harness sends `HeartbeatRequest` frames to keep its session alive.
+- The broker records these via `sessionManager.recordHeartbeat()`.
+- Missing harness heartbeats trigger session revocation via the session manager's sweep.
+
+### Backpressure
+
+The broker tracks per-connection send buffer depth:
+
+1. Each `ws.send()` call increments `sendBufferDepth`. The `drain` event on Bun's WebSocket handler decrements it.
+2. When `sendBufferDepth >= sendBufferSoftLimit`: broker sends a `BackpressureFrame` and sets `backpressureNotified = true`.
+3. When buffer drops below soft limit: broker clears `backpressureNotified`. No explicit "backpressure cleared" frame -- the harness infers relief from continued event flow.
+4. When `sendBufferDepth >= sendBufferHardLimit`: broker closes the connection with code 4008 (backpressure exceeded). The harness should reconnect with a slower request rate.
+
+### Graceful Shutdown
+
+```
+  stop() called
+      |
+      v
+  Set state = "draining"
+      |
+      v
+  Stop accepting new connections
+      |
+      v
+  For each active connection:
+      |-- Send session.expired event (reason: "broker_shutdown")
+      |-- Transition connection to "draining"
+      |
+      v
+  Wait for in-flight responses (up to drainTimeoutMs)
+      |
+      v
+  Close all connections with code 1001 (going away)
+      |
+      v
+  Set state = "stopped"
+```
+
+### Bun.serve() Integration
+
+```typescript
+const server = Bun.serve({
+  port: config.port,
+  hostname: config.host,
+  fetch(req, server) {
+    const url = new URL(req.url);
+    if (url.pathname === "/v1/agent") {
+      const upgraded = server.upgrade(req, {
+        data: createConnectionState(),
+      });
+      if (!upgraded) {
+        return new Response("Upgrade failed", { status: 400 });
+      }
+      return undefined;
+    }
+    return new Response("Not found", { status: 404 });
+  },
+  websocket: {
+    open(ws) { /* start auth timer */ },
+    message(ws, message) { /* route to auth or request handler */ },
+    close(ws, code, reason) { /* cleanup connection state */ },
+    drain(ws) { /* decrement sendBufferDepth */ },
+    maxPayloadLength: config.maxFrameSizeBytes,
+    idleTimeout: 0, // managed by application heartbeat
+  },
+});
+```
+
+The `ws.data` field is typed as `ConnectionState`, giving type-safe access to per-connection state in all handler callbacks.
+
+### Event Ordering
+
+- Events within a single group are ordered by XMTP message timestamp (as received from the core's stream).
+- Events across groups have no guaranteed ordering relative to each other.
+- Heartbeats interleave freely with other events.
+- Sequence numbers provide total ordering within a connection regardless of source group.
+
+### Connection Registry
+
+```typescript
+interface ConnectionRegistry {
+  /** Register a new authenticated connection. */
+  add(ws: ServerWebSocket<ConnectionState>): void;
+
+  /** Remove a connection (disconnect or shutdown). */
+  remove(connectionId: string): void;
+
+  /** Get all connections for a session. */
+  getBySessionId(sessionId: string): readonly ServerWebSocket<ConnectionState>[];
+
+  /** Get all connections for an agent. */
+  getByAgentInboxId(agentInboxId: string): readonly ServerWebSocket<ConnectionState>[];
+
+  /** Broadcast a sequenced event to all connections for a session. */
+  broadcast(sessionId: string, event: BrokerEvent): void;
+
+  /** Total active connection count. */
+  readonly size: number;
+}
+```
+
+### WebSocket Close Codes
+
+| Code | Meaning | Used when |
+|------|---------|-----------|
+| 1000 | Normal | Clean client disconnect |
+| 1001 | Going away | Server shutdown |
+| 4001 | Auth failed | Invalid or expired token |
+| 4002 | Auth timeout | No auth frame within timeout |
+| 4003 | Session expired | Session TTL exceeded |
+| 4004 | Session revoked | Explicit revocation |
+| 4005 | Policy change | Material change requires reauth |
+| 4008 | Backpressure | Send buffer hard limit exceeded |
+| 4009 | Protocol error | Malformed frame or unknown type |
+
+## Error Cases
+
+| Scenario | Error | Close Code | Category |
+|----------|-------|------------|----------|
+| No auth frame within timeout | `AuthError` | 4002 | auth |
+| Invalid token | `AuthError` | 4001 | auth |
+| Expired session token | `SessionExpiredError` | 4001 | auth |
+| Malformed JSON frame | `ValidationError` | 4009 | validation |
+| Unknown request type | `ValidationError` | -- (response only) | validation |
+| Request for group not in view | `PermissionError` | -- (response only) | permission |
+| Grant denied | `GrantDeniedError` | -- (response only) | permission |
+| Handler timeout | `TimeoutError` | -- (response only) | timeout |
+| Send buffer overflow | `InternalError` | 4008 | internal |
+| Server shutdown during active session | -- | 1001 | -- |
+
+Protocol errors (malformed frames, unknown types) send a `RequestResponse` with `ok: false` if a `requestId` can be extracted. If the frame is completely unparseable, the connection is closed with code 4009.
+
+## Open Questions Resolved
+
+**Q: Should auth happen at HTTP upgrade or in-band?** (Transport design)
+**A:** In-band. The first WebSocket frame must be an `AuthFrame`. Rationale: keeps the transport simple -- no custom HTTP headers, no cookie management, no token-in-URL leakage. The 5-second auth timeout prevents unauthenticated connections from lingering.
+
+**Q: How should reconnection replay work?** (PRD: Liveness and Graceful Degradation)
+**A:** Per-session circular buffer with configurable size (default 1000 events). The harness sends `lastSeenSeq` on reconnect; the broker replays from that point if still buffered. If the client is too far behind, the broker signals a full resync via `broker.recovery.complete`. Rationale: bounded memory, simple implementation, no persistent replay log needed for v0.
+
+**Q: What is the default heartbeat interval?** (PLAN.md Key Decisions)
+**A:** 30 seconds, matching the PLAN.md decision. Three missed heartbeats (90 seconds) signals a dead connection. This balances liveness detection speed with bandwidth overhead.
+
+**Q: How should backpressure be handled?** (Transport design)
+**A:** Two-tier: soft limit sends a warning frame (harness should slow down), hard limit disconnects (harness must reconnect). Rationale: the warning frame gives well-behaved harnesses a chance to adapt before forced disconnect.
+
+## Deferred
+
+- **TLS/WSS**: v0 runs on `ws://localhost`. TLS termination is an operational concern for deployment, not a broker concern.
+- **Binary frames**: All frames are JSON text. Binary framing (MessagePack, protobuf) is a Phase 2 performance optimization.
+- **Connection multiplexing**: One connection per session. Multiplexing multiple sessions over a single connection is deferred.
+- **HTTP health endpoint**: A `/health` endpoint for load balancers is useful but not required for local v0.
+- **Rate limiting**: Per-connection request rate limiting is deferred. Backpressure provides a coarse safety valve.
+- **MCP, CLI, HTTP transports**: Other transport surfaces are Phase 2+. The handler contract ensures adding them is mechanical.
+- **Compression**: WebSocket per-message deflate is deferred to Phase 2.
+
+## Testing Strategy
+
+### What to Test
+
+1. **Auth handshake** -- Valid token authenticates. Invalid token rejected with 4001. Timeout fires with 4002.
+2. **Frame parsing** -- Valid JSON parsed and routed. Malformed JSON rejected with 4009. Unknown type rejected.
+3. **Request/response correlation** -- Responses carry matching `requestId`. Multiple concurrent requests resolve independently.
+4. **Sequence numbering** -- Events have monotonically increasing `seq`. Numbering starts at 1. Each connection has independent numbering.
+5. **Reconnection replay** -- Resume with `lastSeenSeq` replays buffered events. Too-far-behind triggers full resync signal.
+6. **Backpressure** -- Soft limit sends warning. Hard limit disconnects.
+7. **Heartbeat** -- Heartbeat frames sent at configured interval. Missing heartbeats trigger session sweep.
+8. **Graceful shutdown** -- Drain sends terminal events, waits for in-flight, then closes.
+9. **Event broadcasting** -- Raw events projected through view and sent to correct connections.
+10. **Grant enforcement** -- Requests validated against session grant before execution.
+
+### How to Test
+
+**Unit tests**: Mock the `BrokerCore`, `SessionManager`, and `AttestationManager`. Test frame parsing, sequence numbering, replay buffer, backpressure logic, and connection state transitions in isolation.
+
+**Integration tests**: Start a real `WsServer` on a random port, connect with a WebSocket client, and exercise the full auth -> request -> response -> disconnect flow. Use mock runtime deps.
+
+### Key Test Scenarios
+
+```typescript
+// Auth handshake success
+const ws = new WebSocket(`ws://localhost:${port}/v1/agent`);
+ws.send(JSON.stringify({ type: "auth", token: validToken, lastSeenSeq: null }));
+const frame = JSON.parse(await nextMessage(ws));
+expect(frame.type).toBe("authenticated");
+expect(frame.session.sessionId).toBeDefined();
+
+// Auth timeout
+const ws2 = new WebSocket(`ws://localhost:${port}/v1/agent`);
+// send nothing, wait for close
+const { code } = await waitForClose(ws2);
+expect(code).toBe(4002);
+
+// Request/response
+ws.send(JSON.stringify({
+  type: "send_message",
+  requestId: "req_1",
+  groupId: "g1",
+  contentType: "xmtp.org/text:1.0",
+  content: { text: "hello" },
+}));
+const resp = JSON.parse(await nextMessage(ws));
+expect(resp.ok).toBe(true);
+expect(resp.requestId).toBe("req_1");
+
+// Sequence numbers on events
+const events = await collectEvents(ws, 3);
+expect(events[0].seq).toBe(1);
+expect(events[1].seq).toBe(2);
+expect(events[2].seq).toBe(3);
+
+// Reconnection replay
+ws.close();
+const ws3 = new WebSocket(`ws://localhost:${port}/v1/agent`);
+ws3.send(JSON.stringify({ type: "auth", token: validToken, lastSeenSeq: 2 }));
+const authFrame = JSON.parse(await nextMessage(ws3));
+expect(authFrame.resumedFromSeq).toBe(2);
+const replayed = JSON.parse(await nextMessage(ws3));
+expect(replayed.seq).toBe(3);
+
+// Backpressure
+// flood the connection with events faster than it drains
+// verify backpressure frame received before disconnect
+```
+
+### Test Utilities
+
+```typescript
+/** Create a WsServer with all deps mocked and a random port. */
+function createTestWsServer(
+  overrides?: Partial<WsServerConfig>,
+): { server: WsServer; mocks: WsTestMocks; port: number };
+
+interface WsTestMocks {
+  core: BrokerCore;
+  sessionManager: SessionManager;
+  attestationManager: AttestationManager;
+  emitRawEvent: (event: RawEvent) => void;
+}
+
+/** Connect a WebSocket client and complete auth. */
+async function connectAndAuth(
+  port: number,
+  token: string,
+): Promise<WebSocket>;
+
+/** Collect N messages from a WebSocket. */
+async function collectMessages(
+  ws: WebSocket,
+  count: number,
+  timeoutMs?: number,
+): Promise<unknown[]>;
+
+/** Wait for a WebSocket close event. */
+async function waitForClose(
+  ws: WebSocket,
+  timeoutMs?: number,
+): Promise<{ code: number; reason: string }>;
+```
+
+## File Layout
+
+```
+packages/ws/
+  package.json
+  tsconfig.json
+  src/
+    index.ts                    # Re-exports public API
+    config.ts                   # WsServerConfigSchema
+    server.ts                   # createWsServer(), WsServer implementation
+    connection-state.ts         # ConnectionState, ConnectionPhase, createConnectionState()
+    connection-registry.ts      # ConnectionRegistry implementation
+    frames.ts                   # AuthFrame, AuthenticatedFrame, AuthErrorFrame,
+                                # BackpressureFrame, SequencedFrame schemas
+    auth-handler.ts             # Auth handshake logic
+    request-router.ts           # Parse HarnessRequest, route to handler, send response
+    event-broadcaster.ts        # Subscribe to core events, project, sequence, broadcast
+    replay-buffer.ts            # CircularBuffer<SequencedFrame> implementation
+    backpressure.ts             # Send buffer tracking, soft/hard limit logic
+    close-codes.ts              # WebSocket close code constants
+    __tests__/
+      auth-handler.test.ts
+      request-router.test.ts
+      event-broadcaster.test.ts
+      replay-buffer.test.ts
+      backpressure.test.ts
+      connection-registry.test.ts
+      server.integration.test.ts  # Full lifecycle integration tests
+      fixtures.ts                 # Test utilities
+```
+
+Each source file targets under 200 LOC. The `server.ts` orchestrates but delegates to `auth-handler.ts`, `request-router.ts`, and `event-broadcaster.ts` for the three main concerns.

--- a/.agents/plans/v0/09-verifier.md
+++ b/.agents/plans/v0/09-verifier.md
@@ -1,0 +1,543 @@
+# 09-verifier
+
+**Package:** `@xmtp-broker/verifier`
+**Spec version:** 0.1.0
+
+## Overview
+
+The verifier is a standalone service that checks broker claims and issues signed verification statements. It exists to answer a single question: "Is this broker what it claims to be?" The answer takes the form of a cryptographically signed statement that brokers can reference in their group-visible attestations via the `verifierStatementRef` field.
+
+The verifier is itself an XMTP inbox. All verification happens over XMTP DMs -- there is no HTTP API, no privileged endpoint, no central authority. A broker (or any group member) opens a DM with the verifier, sends a verification request, and receives a signed verification statement in response. This design means the protocol surface is identical whether the verifier is the reference deployment, a community-run instance, or a self-hosted container. The decentralization path is baked in from day one.
+
+At v0 launch, the verifier supports only the **source-verified** trust tier: checking source code availability, build provenance (SLSA/Sigstore), release signing, and attestation chain validity. Runtime attestation (TEE) verification is deferred to Phase 2.
+
+The verifier publishes its own attestation about its identity and capabilities so that clients can decide which verifier issuers they trust. Multiple independent verifiers can coexist -- no single verifier has authority over the ecosystem.
+
+## Dependencies
+
+**Imports:**
+- `@xmtp-broker/contracts` -- `SignedAttestationEnvelope`, `SignedRevocationEnvelope` (consumed for parsing attestations during verification)
+- `@xmtp-broker/schemas` -- `AttestationSchema`, `TrustTier`, `ValidationError`, `InternalError`, `TimeoutError`
+- `@xmtp/node-sdk` -- XMTP client for DM-based communication
+- `better-result` -- `Result` type
+- `zod` -- runtime validation
+
+**Imported by:** None (standalone service). Brokers interact via XMTP DMs, not package imports.
+
+## Public Interfaces
+
+### Verification Request Content Type
+
+```typescript
+const VERIFICATION_REQUEST_CONTENT_TYPE_ID =
+  "xmtp.org/verificationRequest:1.0" as const;
+```
+
+### Verification Statement Content Type
+
+```typescript
+const VERIFICATION_STATEMENT_CONTENT_TYPE_ID =
+  "xmtp.org/verificationStatement:1.0" as const;
+```
+
+### Verification Request Schema
+
+```typescript
+const VerificationRequestSchema = z.object({
+  requestId: z.string()
+    .describe("Unique request identifier for correlation"),
+  agentInboxId: z.string()
+    .describe("XMTP inbox ID of the agent being verified"),
+  brokerInboxId: z.string()
+    .describe("XMTP inbox ID of the broker operating the agent"),
+  groupId: z.string().nullable()
+    .describe("Group context for verification, null for broker-wide"),
+  attestation: AttestationSchema.nullable()
+    .describe("Attestation to verify, null if only checking provenance"),
+  artifactDigest: z.string()
+    .describe("SHA-256 digest of the broker artifact (hex-encoded)"),
+  buildProvenanceBundle: z.string().nullable()
+    .describe("Base64-encoded SLSA provenance or Sigstore bundle"),
+  sourceRepoUrl: z.string().url()
+    .describe("URL of the broker source repository"),
+  releaseTag: z.string().nullable()
+    .describe("Git tag or release version, null for dev builds"),
+  requestedTier: TrustTier
+    .describe("Trust tier the requester is claiming"),
+  challengeNonce: z.string()
+    .describe("Random nonce to prevent replay (hex-encoded, 32 bytes)"),
+}).describe("Verification request sent to the verifier via XMTP DM");
+
+type VerificationRequest = z.infer<typeof VerificationRequestSchema>;
+```
+
+### Verification Check Result
+
+```typescript
+const CheckVerdict = z.enum([
+  "pass",
+  "fail",
+  "skip",
+]).describe("Outcome of a single verification check");
+
+type CheckVerdict = z.infer<typeof CheckVerdict>;
+
+const VerificationCheck = z.object({
+  checkId: z.string()
+    .describe("Identifier for the check type"),
+  verdict: CheckVerdict
+    .describe("Pass, fail, or skip"),
+  reason: z.string()
+    .describe("Human-readable explanation of the result"),
+  evidence: z.record(z.string(), z.unknown()).nullable()
+    .describe("Structured evidence supporting the verdict"),
+}).describe("Result of a single verification check");
+
+type VerificationCheck = z.infer<typeof VerificationCheck>;
+```
+
+### Verification Statement Schema
+
+```typescript
+const VerificationVerdict = z.enum([
+  "verified",
+  "partial",
+  "rejected",
+]).describe("Overall verification outcome");
+
+type VerificationVerdict = z.infer<typeof VerificationVerdict>;
+
+const VerificationStatementSchema = z.object({
+  statementId: z.string()
+    .describe("Unique statement identifier"),
+  requestId: z.string()
+    .describe("Correlates with the original request"),
+  verifierInboxId: z.string()
+    .describe("XMTP inbox ID of the verifier that issued this statement"),
+  brokerInboxId: z.string()
+    .describe("XMTP inbox ID of the broker being verified"),
+  agentInboxId: z.string()
+    .describe("XMTP inbox ID of the agent being verified"),
+  verdict: VerificationVerdict
+    .describe("Overall verification outcome"),
+  verifiedTier: TrustTier
+    .describe("Highest trust tier confirmed by this verification"),
+  checks: z.array(VerificationCheck)
+    .describe("Individual check results"),
+  challengeNonce: z.string()
+    .describe("Echoed nonce from the request"),
+  issuedAt: z.string().datetime()
+    .describe("When this statement was issued"),
+  expiresAt: z.string().datetime()
+    .describe("When this statement expires"),
+  signature: z.string()
+    .describe("Base64-encoded Ed25519 signature over canonical statement bytes"),
+  signatureAlgorithm: z.literal("Ed25519")
+    .describe("Signature algorithm"),
+}).describe("Signed verification statement issued by the verifier");
+
+type VerificationStatement = z.infer<typeof VerificationStatementSchema>;
+```
+
+### Verifier Self-Attestation
+
+```typescript
+const VerifierCapabilities = z.object({
+  supportedTiers: z.array(TrustTier)
+    .describe("Trust tiers this verifier can check"),
+  supportedChecks: z.array(z.string())
+    .describe("Check IDs this verifier performs"),
+  maxRequestsPerHour: z.number().int().positive()
+    .describe("Rate limit per requester per hour"),
+}).describe("Capabilities advertised by this verifier");
+
+type VerifierCapabilities = z.infer<typeof VerifierCapabilities>;
+
+const VerifierSelfAttestation = z.object({
+  verifierInboxId: z.string()
+    .describe("XMTP inbox ID of this verifier"),
+  capabilities: VerifierCapabilities
+    .describe("What this verifier can do"),
+  sourceRepoUrl: z.string().url()
+    .describe("URL of the verifier's source code"),
+  issuedAt: z.string().datetime()
+    .describe("When this self-attestation was created"),
+  signature: z.string()
+    .describe("Base64-encoded self-signature"),
+}).describe("Self-attestation published by the verifier");
+
+type VerifierSelfAttestation = z.infer<typeof VerifierSelfAttestation>;
+```
+
+### Verifier Service Interface
+
+```typescript
+interface VerifierConfig {
+  readonly xmtpKeyBytes: Uint8Array;
+  readonly xmtpEnv: "dev" | "production";
+  readonly statementTtlSeconds: number;  // default: 86400 (24h)
+  readonly maxRequestsPerRequesterPerHour: number;  // default: 10
+}
+
+interface VerifierService {
+  /** Start the verifier: connect XMTP client, begin listening for DMs. */
+  start(): Promise<Result<void, InternalError>>;
+
+  /** Stop the verifier: disconnect XMTP, clean up. */
+  stop(): Promise<Result<void, InternalError>>;
+
+  /** Process a single verification request (called by the DM listener). */
+  handleRequest(
+    request: VerificationRequest,
+    senderInboxId: string,
+  ): Promise<Result<VerificationStatement, ValidationError | InternalError | TimeoutError>>;
+
+  /** Get the verifier's self-attestation. */
+  selfAttestation(): VerifierSelfAttestation;
+}
+
+function createVerifierService(
+  config: VerifierConfig,
+): VerifierService;
+```
+
+### Check Handlers
+
+```typescript
+/**
+ * Each verification check is an independent handler.
+ * Checks are stateless and composable.
+ */
+interface CheckHandler {
+  readonly checkId: string;
+  execute(
+    request: VerificationRequest,
+  ): Promise<Result<VerificationCheck, InternalError>>;
+}
+```
+
+## Zod Schemas
+
+All schemas are defined inline above. The verifier package owns these schemas directly rather than placing them in `@xmtp-broker/schemas`, because the verifier is a standalone service that other broker packages do not import. The content type IDs (`verificationRequest:1.0`, `verificationStatement:1.0`) follow the same `xmtp.org/type:version` convention used by attestations.
+
+## Behaviors
+
+### XMTP DM Flow
+
+```
+Requester                    Verifier
+(broker or group member)     (XMTP inbox)
+    │                            │
+    │  DM: VerificationRequest   │
+    │───────────────────────────►│
+    │                            │ validate request schema
+    │                            │ check rate limit
+    │                            │ run checks:
+    │                            │   source_available
+    │                            │   build_provenance
+    │                            │   release_signing
+    │                            │   attestation_signature
+    │                            │   attestation_chain
+    │                            │   schema_compliance
+    │                            │ determine verdict + tier
+    │                            │ sign statement
+    │  DM: VerificationStatement │
+    │◄───────────────────────────│
+    │                            │
+    │  (optionally publish       │
+    │   statement to group)      │
+    │                            │
+```
+
+### Request Processing Flow
+
+1. Verifier's XMTP client receives a DM.
+2. Parse the message as `VerificationRequestSchema`. If it fails, respond with a `rejected` statement containing a single `schema_compliance` check with verdict `fail`.
+3. Check rate limit: look up `senderInboxId` in the rate limiter. If over limit, respond with a `rejected` statement and a `rate_limit_exceeded` check.
+4. Run each applicable check handler in parallel. v0 checks:
+   - `source_available` -- HTTP HEAD/GET against `sourceRepoUrl`, expect 200
+   - `build_provenance` -- If `buildProvenanceBundle` is non-null, parse and verify SLSA provenance or Sigstore bundle
+   - `release_signing` -- If `releaseTag` is non-null, check GitHub release for signing signatures
+   - `attestation_signature` -- If `attestation` is non-null, verify the Ed25519 signature against the agent's inbox key
+   - `attestation_chain` -- If `attestation` is non-null, verify `previousAttestationId` chain has no gaps
+   - `schema_compliance` -- If `attestation` is non-null, validate against `AttestationSchema`
+5. Determine overall verdict:
+   - `verified` -- all applicable checks pass
+   - `partial` -- some checks pass, some skip, none fail
+   - `rejected` -- any check fails
+6. Determine `verifiedTier`: the highest tier for which all required checks pass. For v0, the maximum is `source-verified`.
+7. Build `VerificationStatement`, canonicalize (sorted keys, no whitespace, UTF-8), sign with verifier's key.
+8. Send the statement back as a DM to the requester.
+
+### Rate Limiting
+
+The verifier tracks request counts per sender inbox ID using an in-memory sliding window.
+
+- Default: 10 requests per requester per hour.
+- Configurable via `VerifierConfig.maxRequestsPerRequesterPerHour`.
+- Rate limit state is not persisted -- restarting the verifier resets counters. This is acceptable for v0 because the rate limit is a courtesy guard, not a security boundary.
+
+### Check: source_available
+
+```
+Check ID: "source_available"
+Input: request.sourceRepoUrl
+Method: HTTP GET to the repo URL
+Pass: HTTP 200 response
+Fail: Non-200 response or network error
+Evidence: { url, statusCode, responseTimeMs }
+```
+
+Uses `fetch()` (Bun-native) with a 10-second timeout. Follows redirects. Only checks that the URL is reachable and returns a successful status -- does not verify repo content.
+
+### Check: build_provenance
+
+```
+Check ID: "build_provenance"
+Input: request.buildProvenanceBundle, request.artifactDigest
+Pass: Bundle is valid SLSA provenance or Sigstore bundle,
+      and the subject digest matches request.artifactDigest
+Fail: Bundle is malformed, signature invalid, or digest mismatch
+Skip: request.buildProvenanceBundle is null
+Evidence: { bundleType, subjectDigest, builderIdentity, transparency_log_entry }
+```
+
+v0 implementation parses the bundle as JSON, validates structure against SLSA provenance v1.0 or Sigstore bundle format, and verifies the embedded signature chain. Full Rekor transparency log verification (querying the log for inclusion proof) is a stretch goal -- v0 validates the bundle structure and signatures offline.
+
+### Check: release_signing
+
+```
+Check ID: "release_signing"
+Input: request.sourceRepoUrl, request.releaseTag
+Pass: GitHub release exists and has artifact attestations
+Fail: Release not found or no attestations
+Skip: request.releaseTag is null
+Evidence: { releaseUrl, attestationCount, signingIdentity }
+```
+
+Uses the GitHub API (`GET /repos/{owner}/{repo}/releases/tags/{tag}` and `GET /repos/{owner}/{repo}/attestations/{digest}`) to verify release existence and artifact attestations. Requires no authentication for public repos.
+
+### Check: attestation_signature
+
+```
+Check ID: "attestation_signature"
+Input: request.attestation
+Pass: Ed25519 signature verifies against the agent's inbox key
+Fail: Signature invalid or key not found
+Skip: request.attestation is null
+Evidence: { signerKeyRef, signatureValid }
+```
+
+Canonicalizes the attestation payload using deterministic JSON (same algorithm as `@xmtp-broker/attestations`), then verifies the Ed25519 signature. The agent's public key is resolved via XMTP identity lookup using the `agentInboxId`.
+
+### Check: attestation_chain
+
+```
+Check ID: "attestation_chain"
+Input: request.attestation, request.groupId
+Pass: previousAttestationId is null (initial) or references a known prior attestation
+Fail: Chain has gaps or references unknown attestation IDs
+Skip: request.attestation is null
+Evidence: { chainLength, previousId, chainValid }
+```
+
+v0 performs a structural check only: verifies that `previousAttestationId` is either null (for the first attestation) or a well-formed attestation ID. Full chain walk (fetching prior attestations from group history) is deferred -- the verifier cannot access group message history in v0 since it may not be a group member.
+
+### Check: schema_compliance
+
+```
+Check ID: "schema_compliance"
+Input: request.attestation
+Pass: Attestation validates against AttestationSchema
+Fail: Schema validation fails
+Skip: request.attestation is null
+Evidence: { errors (if any) }
+```
+
+### Canonical Statement Serialization
+
+The verification statement is signed over its canonical representation. The serialization algorithm is identical to the one used for attestations:
+
+1. Remove the `signature` and `signatureAlgorithm` fields from the statement.
+2. Serialize remaining fields as deterministic JSON (sorted keys, no whitespace).
+3. Encode as UTF-8 bytes.
+4. Sign with Ed25519 using the verifier's private key.
+
+### Verifier XMTP Client
+
+The verifier maintains a persistent XMTP client connection:
+
+- Connects on `start()`, listens for incoming DMs via streaming.
+- Filters messages by content type (`verificationRequest:1.0`).
+- Ignores messages with other content types.
+- Responds in the same DM conversation.
+- Disconnects on `stop()`.
+
+### Statement Reference
+
+After receiving a verification statement, the broker stores the `statementId` and references it in subsequent attestations via the `verifierStatementRef` field. The statement itself is not published to the group -- only the reference. Group members who want to validate the statement can request it from the verifier or from the broker.
+
+## Error Cases
+
+| Error | Category | When |
+|-------|----------|------|
+| `ValidationError` | validation | Request fails schema validation |
+| `ValidationError` | validation | Malformed provenance bundle |
+| `InternalError` | internal | XMTP client connection failure |
+| `InternalError` | internal | Signing failure |
+| `TimeoutError` | timeout | Source repo check exceeds 10s timeout |
+| `TimeoutError` | timeout | GitHub API check exceeds 10s timeout |
+
+Rate limit violations are not errors in the handler sense -- they produce a `rejected` statement with explanation. The verifier never throws; all check failures produce structured `VerificationCheck` results with `fail` verdicts.
+
+## Open Questions Resolved
+
+**Q: Which verification classes should the reference verifier support at launch?** (PRD Open Questions)
+**A:** Source-verified only. The verifier checks: source availability, build provenance (SLSA/Sigstore bundle structure and signatures), release signing (GitHub attestations), attestation signature validity, attestation chain structure, and schema compliance. Runtime attestation (TEE) is deferred to Phase 2. Rationale: source-verified provides meaningful trust signals without requiring TEE infrastructure. It ships something useful fast and establishes the verifier-over-XMTP protocol pattern that runtime attestation will later extend.
+
+**Q: Should the verifier use HTTP or XMTP for communication?** (Implicit from PRD)
+**A:** XMTP DMs only. No HTTP API. The verifier is an XMTP inbox that processes DMs. This ensures: (1) the protocol surface is uniform regardless of who runs the verifier, (2) the decentralization path requires no infrastructure changes, (3) any XMTP participant can interact with any verifier using the same tools they use for messaging. The tradeoff is that the verifier requires a persistent XMTP client connection, which rules out purely stateless deployments (like bare Cloudflare Workers).
+
+## Deferred
+
+- **Runtime attestation (TEE) verification.** Phase 2. Requires defining TEE-agnostic attestation evidence formats and integrating with platform-specific verification APIs (AWS Nitro, etc.).
+- **Reproducible build verification.** Checking that an artifact reproduces bit-for-bit from source requires running builds, which is out of scope for a lightweight verifier. Deferred until the broker project has reproducible build infrastructure.
+- **Rekor transparency log queries.** v0 verifies Sigstore bundle structure and signatures offline. Querying the Rekor transparency log for inclusion proofs adds network dependency and complexity. Stretch goal for v0, required for v1.
+- **Full attestation chain walk.** The verifier cannot access group message history to walk the full attestation chain. v0 checks structural validity only. A future version may accept the chain as input or join the group temporarily.
+- **Multi-statement aggregation.** v0 supports one verifier statement per attestation (`verifierStatementRef` is a single string). Supporting references to multiple independent verifier statements is deferred.
+- **Verifier discovery protocol.** How brokers find verifiers. v0 assumes the verifier inbox ID is configured manually. A discovery mechanism (e.g., well-known XMTP group, ENS records) is future work.
+- **Statement revocation.** Verifier statements expire but cannot be actively revoked in v0. If a verifier discovers a previously-verified broker is compromised, it can only refuse new verifications. Active revocation broadcast is deferred.
+- **Cloudflare Workers deployment.** The DM-based flow requires a persistent XMTP client, which is incompatible with Workers' stateless execution model. Railway or a long-running container is required for v0.
+
+## Testing Strategy
+
+### What to Test
+
+1. **Request parsing** -- `VerificationRequestSchema` accepts valid requests and rejects malformed ones.
+2. **Statement building** -- Statements are schema-compliant, include all checks, and have correct verdicts.
+3. **Individual checks** -- Each `CheckHandler` produces correct verdicts for pass, fail, and skip cases.
+4. **Verdict determination** -- Overall verdict logic: all pass = verified, some skip = partial, any fail = rejected.
+5. **Tier determination** -- `verifiedTier` reflects the highest tier with all required checks passing.
+6. **Statement signing** -- Canonical serialization is deterministic; signatures verify.
+7. **Rate limiting** -- Requests over the limit produce `rejected` statements.
+8. **Nonce echo** -- The `challengeNonce` from the request appears unchanged in the statement.
+
+### Key Test Scenarios
+
+```typescript
+// All checks pass -> verified
+const request = createTestVerificationRequest({
+  sourceRepoUrl: "https://github.com/xmtp/xmtp-broker",
+  buildProvenanceBundle: validSlsaBundle,
+  releaseTag: "v0.1.0",
+  attestation: validAttestation,
+  requestedTier: "source-verified",
+});
+const result = await verifier.handleRequest(request, senderInboxId);
+expect(result.ok).toBe(true);
+expect(result.value.verdict).toBe("verified");
+expect(result.value.verifiedTier).toBe("source-verified");
+
+// Source unavailable -> rejected
+const request2 = createTestVerificationRequest({
+  sourceRepoUrl: "https://github.com/nonexistent/repo",
+});
+const result2 = await verifier.handleRequest(request2, senderInboxId);
+expect(result2.value.verdict).toBe("rejected");
+expect(result2.value.checks.find(c => c.checkId === "source_available")?.verdict)
+  .toBe("fail");
+
+// No provenance bundle -> partial (source_available passes, provenance skips)
+const request3 = createTestVerificationRequest({
+  buildProvenanceBundle: null,
+  releaseTag: null,
+  attestation: null,
+});
+const result3 = await verifier.handleRequest(request3, senderInboxId);
+expect(result3.value.verdict).toBe("partial");
+
+// Rate limit exceeded
+for (let i = 0; i < 11; i++) {
+  await verifier.handleRequest(validRequest, senderInboxId);
+}
+const result4 = await verifier.handleRequest(validRequest, senderInboxId);
+expect(result4.value.verdict).toBe("rejected");
+
+// Statement signature verifies
+const stmt = result.value;
+const canonical = canonicalizeStatement(stmt);
+expect(verifyEd25519(canonical, stmt.signature, verifierPublicKey)).toBe(true);
+
+// Nonce is echoed
+expect(result.value.challengeNonce).toBe(request.challengeNonce);
+```
+
+### Test Utilities
+
+```typescript
+/** Creates a valid VerificationRequest fixture. */
+function createTestVerificationRequest(
+  overrides?: Partial<VerificationRequest>,
+): VerificationRequest;
+
+/** Creates a mock HTTP fetcher for source_available checks. */
+function createTestFetcher(
+  responses: Record<string, { status: number }>,
+): typeof fetch;
+
+/** Creates a mock GitHub API client for release_signing checks. */
+function createTestGitHubClient(
+  releases: Record<string, { attestations: number }>,
+): GitHubClient;
+
+/** Creates a fully configured VerifierService with test deps. */
+function createTestVerifierService(
+  overrides?: Partial<VerifierConfig>,
+): VerifierService;
+```
+
+## File Layout
+
+```
+packages/verifier/
+  package.json
+  tsconfig.json
+  Dockerfile                    # Self-hosted deployment
+  src/
+    index.ts                    # Re-exports public API
+    config.ts                   # VerifierConfig schema and defaults
+    content-types.ts            # Content type IDs for request/statement
+    schemas/
+      request.ts                # VerificationRequestSchema
+      statement.ts              # VerificationStatementSchema, VerificationVerdict
+      check.ts                  # VerificationCheck, CheckVerdict
+      self-attestation.ts       # VerifierSelfAttestation, VerifierCapabilities
+    checks/
+      handler.ts                # CheckHandler interface
+      source-available.ts       # source_available check
+      build-provenance.ts       # build_provenance check
+      release-signing.ts        # release_signing check
+      attestation-signature.ts  # attestation_signature check
+      attestation-chain.ts      # attestation_chain check
+      schema-compliance.ts      # schema_compliance check
+    canonicalize.ts             # Canonical statement serialization
+    rate-limiter.ts             # In-memory sliding window rate limiter
+    verdict.ts                  # Verdict + tier determination logic
+    service.ts                  # VerifierService, createVerifierService()
+    xmtp-listener.ts            # XMTP DM listener + message routing
+    __tests__/
+      request.test.ts
+      statement.test.ts
+      source-available.test.ts
+      build-provenance.test.ts
+      release-signing.test.ts
+      attestation-signature.test.ts
+      attestation-chain.test.ts
+      schema-compliance.test.ts
+      rate-limiter.test.ts
+      verdict.test.ts
+      service.test.ts
+      fixtures.ts               # Test utilities
+```
+
+Each source file targets under 150 LOC. The `checks/` directory isolates each verification check for independent testing and future extensibility. The `schemas/` directory keeps verifier-specific schemas separate from the shared `@xmtp-broker/schemas` package.

--- a/.agents/plans/v0/PLAN.md
+++ b/.agents/plans/v0/PLAN.md
@@ -1,0 +1,188 @@
+# xmtp-broker v0 Architecture Plan
+
+**Version:** 0.1.0
+**Status:** Draft
+**Created:** 2026-03-13
+
+## One-Line Summary
+
+A brokered agent architecture where the broker is the real XMTP client, agents consume filtered views through scoped grants, and group-visible attestations make permissions inspectable.
+
+## Architecture Overview
+
+The broker separates raw XMTP access from agent consumption through three planes:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Agent Harness A                          │
+│                    (any framework/language)                      │
+├──────────────────────────┬──────────────────────────────────────┤
+│                          │ WebSocket (Phase 1)                  │
+│                          │ MCP / CLI / HTTP (later)             │
+│                     ┌────▼────┐                                 │
+│                     │ Session │ ← scoped token, short-lived     │
+│                     └────┬────┘                                 │
+│ ╔════════════════════════╪═══════════════════════════════════╗  │
+│ ║              DERIVED PLANE (agent-facing)                  ║  │
+│ ║  Filtered event stream · Scoped action interface           ║  │
+│ ╠════════════════════════╪═══════════════════════════════════╣  │
+│ ║               POLICY PLANE (enforcement)                   ║  │
+│ ║  ┌──────────┐  ┌──────────────┐  ┌──────────────────────┐ ║  │
+│ ║  │   View   │  │    Grant     │  │    Attestation       │ ║  │
+│ ║  │ Filter   │  │  Enforcer    │  │    Manager           │ ║  │
+│ ║  └──────────┘  └──────────────┘  └──────────────────────┘ ║  │
+│ ║  ┌──────────────────┐  ┌─────────────────────────────────┐ ║  │
+│ ║  │ Session Manager  │  │  Reveal State                   │ ║  │
+│ ║  └──────────────────┘  └─────────────────────────────────┘ ║  │
+│ ╠════════════════════════╪═══════════════════════════════════╣  │
+│ ║                RAW PLANE (broker-only)                      ║  │
+│ ║  ┌────────────┐ ┌───────────┐ ┌──────────┐ ┌────────────┐ ║  │
+│ ║  │ XMTP       │ │ Raw DB +  │ │ Signer   │ │ Per-Group  │ ║  │
+│ ║  │ Client     │ │ Enc Keys  │ │ Material │ │ Identity   │ ║  │
+│ ║  └────────────┘ └───────────┘ └──────────┘ └────────────┘ ║  │
+│ ╚════════════════════════════════════════════════════════════╝  │
+│                                                                 │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │              KEY MANAGEMENT LAYER                        │   │
+│  │  Root Key (Secure Enclave) → Operational → Session Keys  │   │
+│  └──────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+
+External:
+  ┌───────────────────┐
+  │  Reference        │   Verifies broker claims via XMTP DM
+  │  Verifier         │   Deployable to CF Workers / Railway
+  └───────────────────┘
+```
+
+## Key Decisions
+
+These decisions resolve PRD open questions and establish constraints for all specs:
+
+| Decision | Resolution | Rationale |
+|----------|-----------|-----------|
+| Min attestation schema | Full schema from PRD day one; optional fields use `null` not omission | Prevents schema drift; clients always know the shape |
+| Stale attestation rendering | Clients show staleness badge after `expiresAt`; messages still render with "produced under expired attestation" note | Don't hide history, but flag currency |
+| Reveal history UX | Out of scope for v0 specs (client concern) | Broker provides the data; UX is per-client |
+| Per-thread session scoping | Sessions scope to agent+groups, not individual threads; thread filtering is a view concern | Simpler session model; threads are view config |
+| In-group vs off-chain policy | Attestations in-group; full policy config off-chain in broker | Keeps groups clean; attestation is the public summary |
+| Recovery for hosted deployments | Deferred to post-v0; v0 focuses on local broker | Hosted adds TEE complexity; local Secure Enclave is Phase 1 |
+| Verification classes at launch | Source-verified only; runtime-attested is Phase 2 | Ship something useful fast |
+| Default heartbeat interval | 30 seconds; configurable per-agent | Balances liveness visibility with noise |
+| Content type allowlist updates | Material change → new attestation; broker logs the delta | Consistent with materiality rules |
+| Per-group identity | Default-on, configurable; each group gets a unique identity key | Strongest isolation; matches convos-node-sdk pattern |
+| Mono-package vs monorepo | Monorepo with Bun workspaces from day one | Clean dependency boundaries between tiers |
+| Foundation tier split | `schemas` = data shapes (Zod schemas, enums, error taxonomy); `contracts` = cross-package interfaces (service/provider contracts, event types). `contracts` imports from `schemas` only. | 22 interfaces defined in runtime specs belong in Foundation. Separating shapes from contracts keeps `schemas` zero-dep beyond Zod and gives runtime packages a stable interface layer. |
+| `summary-only` view mode | Schema defined in v0; implementation deferred to Phase 2 | Schema completeness now; summarization logic is non-trivial and not needed for initial transport |
+
+## Component Map
+
+### Foundation Tier (dependency-free)
+
+| Spec | Package | Purpose |
+|------|---------|---------|
+| [01-repo-scaffolding](01-repo-scaffolding.md) | (workspace root) | Build tooling, config, conventions |
+| [02-schemas](02-schemas.md) | `@xmtp-broker/schemas` | Zod schemas, inferred types, error taxonomy, enums |
+| [02b-contracts](02b-contracts.md) | `@xmtp-broker/contracts` | Cross-package interfaces, provider contracts, event types |
+
+### Runtime Tier (depends on Foundation)
+
+| Spec | Package | Purpose |
+|------|---------|---------|
+| [03-broker-core](03-broker-core.md) | `@xmtp-broker/core` | XMTP client lifecycle, raw plane, per-group identity |
+| [04-policy-engine](04-policy-engine.md) | `@xmtp-broker/policy` | View filtering, grant enforcement, reveal state |
+| [05-sessions](05-sessions.md) | `@xmtp-broker/sessions` | Session issuance, binding, lifecycle |
+| [06-attestations](06-attestations.md) | `@xmtp-broker/attestations` | Attestation lifecycle, signing, publishing |
+| [07-key-management](07-key-management.md) | `@xmtp-broker/keys` | Secure Enclave, derived key hierarchy |
+
+### Transport Tier (depends on Runtime)
+
+| Spec | Package | Purpose |
+|------|---------|---------|
+| [08-websocket-transport](08-websocket-transport.md) | `@xmtp-broker/ws` | Phase 1 harness-facing interface |
+
+### External Services
+
+| Spec | Package | Purpose |
+|------|---------|---------|
+| [09-verifier](09-verifier.md) | `@xmtp-broker/verifier` | Reference verification service |
+
+## Dependency Graph
+
+```
+                [01-scaffolding]
+                       │
+                 [02-schemas]
+                       │
+               [02b-contracts]
+                /    |    |    \
+       [03-core] [04-policy] [05-sessions] [06-attestations]
+           │          │            │              │
+       [07-key-mgmt]  │            │              │
+           │          │            │              │
+           └──────────┴────────────┴──────────────┘
+                              │
+                     [08-ws-transport]
+                              │
+                      [09-verifier]
+```
+
+Notes:
+- `02b-contracts` imports from `02-schemas` only; defines cross-package interfaces
+- `07-key-mgmt` is Runtime tier (used by core, sessions, attestations for signing)
+- `08-ws-transport` is the orchestrator connecting core, policy, sessions, and attestations
+- `09-verifier` depends only on schemas (standalone service)
+- `04-policy` owns the canonical materiality logic; `06-attestations` imports from it
+- Dependencies flow downward only within tiers
+
+## Package Scope Convention
+
+All internal packages use the `@xmtp-broker/` scope. This is a workspace-internal scope, not published to npm. It provides clean import paths and prevents accidental external dependency.
+
+## Spec Template
+
+Every spec doc follows this structure:
+
+1. **Overview** — What this component does and why
+2. **Dependencies** — What it imports, what imports it
+3. **Public Interfaces** — Exported types, functions, classes
+4. **Zod Schemas** — Complete schema definitions (or references to 02-schemas)
+5. **Behaviors** — How the component works, state machines, flows
+6. **Error Cases** — What can go wrong, error types returned
+7. **Open Questions Resolved** — PRD questions answered in this spec
+8. **Deferred** — What's explicitly out of scope for v0
+9. **Testing Strategy** — What to test, how to test it
+10. **File Layout** — Exact files to create
+
+## Phase Boundaries
+
+**Phase 1 (v0 specs cover this):**
+- Local broker on macOS with Secure Enclave
+- WebSocket transport
+- Core view/grant/attestation model
+- Per-group identity (default-on)
+- Reference verifier (source-verified tier)
+- Single-owner governance
+
+**Deferred (not in v0 specs):**
+- Hosted/managed broker deployment
+- MCP, CLI, HTTP transports
+- Runtime attestation (TEE)
+- Group governance beyond owner-only
+- Cross-broker federation
+- Formal XIP proposals
+
+## Conventions
+
+All specs assume:
+- **Bun-first**: Bun-native APIs before npm packages
+- **TDD**: Test before code, always
+- **Result types**: `better-result` for all fallible operations
+- **Schema-first**: Zod schemas define types; `z.infer<>` for TS types
+- **No @outfitter/* deps**: Zero external framework dependencies
+- **ESM-only**: `"type": "module"` throughout
+- **Strict TS**: Full strictness flags as defined in 01-scaffolding
+
+## Working Reference
+
+The full PRD is preserved as [SPEC.md](SPEC.md) in this directory. All specs should reference it for context but resolve (not defer) open questions within their scope.

--- a/.agents/plans/v0/SPEC.md
+++ b/.agents/plans/v0/SPEC.md
@@ -1,0 +1,1379 @@
+# XMTP Agent Broker PRD
+
+**Version:** 0.2.1
+**Status:** Draft
+**Updated:** 2026-03-12
+
+## Summary
+
+This document proposes an **agent broker** architecture for XMTP-based applications and agents.
+
+The core idea is simple:
+
+- A **broker** is the real XMTP client.
+- The broker owns the raw XMTP signer, installation continuity, local encrypted database, and message sync.
+- An **agent harness** never touches the raw XMTP client directly.
+- Instead, the harness connects to the broker over a controlled interface and receives a filtered **view** of one or more conversations and a scoped **grant** of allowed actions.
+- The permissions and scope of the view and grant are represented by group-visible **attestations**.
+
+This model is designed to support agents in XMTP and Convos without pretending that a standard group member can somehow be cryptographically blind to ordinary group messages. It creates a practical, harness-agnostic security boundary that works with local brokers, self-hosted brokers, and managed broker deployments.
+
+The proposal also outlines candidate XIP directions that could improve interoperability and richer client experiences over time, and describes a trust chain model that moves agent participation from opaque trust to inspectable trust.
+
+## Motivation
+
+There is growing interest in agents that participate in XMTP group chats, especially in apps such as Convos.
+
+That interest is well-founded:
+
+- Agents are a natural fit for group coordination, summarization, memory, retrieval, automation, and tool use.
+- Group chat is a powerful environment for collaborative workflows and multi-party context.
+- XMTP offers strong identity, messaging, and group primitives that make agent participation possible in a decentralized setting.
+
+At the same time, the current agent shape is too blunt.
+
+A typical setup today looks like this:
+
+- An agent harness spins up a new account or inbox.
+- It stores wallet material and database encryption keys locally.
+- It runs the XMTP client directly.
+- It joins a group as a normal member.
+
+That pattern is convenient, but it has major problems:
+
+- The harness effectively becomes the XMTP client.
+- Any “read-only” or “limited” tool permissions are mostly advisory if the harness holds raw credentials.
+- The blast radius is too large if keys, storage, logs, or tool integrations are compromised.
+- There is little group-visible provenance around what an agent can actually do.
+- There is no durable, shared language for agent capability posture inside a conversation.
+
+We need a better boundary.
+
+## From Opaque Trust to Inspectable Trust
+
+Today, nobody should trust an XMTP agent just because it exists in a chat. An agent is basically just another XMTP inbox. XMTP gives you strong cryptographic identity primitives around inboxes and linked identities, signatures, and group-role permissions, but it does not currently tell other participants what software stack is behind that inbox, whether a broker is involved, or what capability boundary is actually being enforced.
+
+The current state:
+
+- An agent joins a group.
+- You know it is some inbox.
+- You do not know what code is running behind it.
+- You do not know whether it has raw credentials.
+- You do not know whether its claimed limits are real.
+
+This proposal does not solve trust by decree. It moves us from **opaque trust** to **inspectable trust**.
+
+Concretely, that means a brokered agent can publish signed, group-visible attestations describing its current permissions, hosting mode, and scope, and agent-authored messages can reference the attestation they were produced under.
+
+That still does not prove the operator is honest. But it gives the group something cryptographic and inspectable to verify, which is strictly better than the current state where agents can make claims and nobody can tell what is actually behind them.
+
+The important honesty clause: a broker does not magically make an agent trustworthy. It makes the system **auditable and constrainable** in a way today’s pattern is not. That is the difference.
+
+## Ground Setting
+
+### What we are proposing
+
+We are proposing an **application-layer brokered model** for agent access to XMTP conversations.
+
+In this model:
+
+- The broker is the real XMTP participant runtime.
+- The agent consumes a derived and policy-filtered interface.
+- Permissions are enforced at the broker boundary.
+- Group-visible attestation messages communicate the current capability state of an agent.
+- The same conceptual model works across local, self-hosted, and managed deployments.
+
+### What we are not proposing
+
+We are **not** proposing that a standard XMTP group member can be given a weaker token and thereby become selectively unable to decrypt ordinary group messages.
+
+We are **not** proposing a centralized authority that all agent permissions must flow through.
+
+We are **not** claiming that a hosted broker preserves the same trust boundary as a local broker.
+
+We are **not** trying to fully solve cross-session or cross-group memory leakage inside the agent model itself. The immediate goal is to create a better boundary for raw message access and action authority.
+
+### MLS and the cryptographic reality
+
+XMTP v3 uses the Messaging Layer Security (MLS) protocol for group encryption. The broker, as the real XMTP client, is a full MLS group member. It holds the complete epoch key schedule and can decrypt all group messages it receives. The view model described in this proposal is purely application-layer filtering on top of MLS. The broker always has access to the full ciphertext-to-plaintext path for its groups.
+
+This is by design. The security boundary this proposal creates is between the broker and the agent harness, not between the broker and the MLS group. The broker is trusted to enforce policy on the derived view; MLS is not being extended or modified.
+
+### Design truth statements
+
+Several truths should remain explicit throughout the design:
+
+- If the harness holds the raw XMTP signer and raw DB access, token-based restrictions are largely cosmetic.
+- If the broker is remote, plaintext exists at the remote broker boundary for anything the broker is allowed to process.
+- If an agent is allowed to send content to an external LLM provider, privacy guarantees are weaker than pure end-to-end delivery between human clients.
+- A clean user experience should not rely on magical hidden guarantees that the system does not actually provide.
+- An inbox alone can prove identity association and signatures. It cannot prove “I am definitely running behind a real broker with these exact internal controls.”
+
+## Product Goals
+
+### Primary goals
+
+- Enable safe and ergonomic agent participation in XMTP and Convos conversations.
+- Make permissions meaningful by enforcing them below the harness layer.
+- Keep the capabilities model agnostic to the agent framework or harness.
+- Create group-visible provenance for agent permissions and permission changes.
+- Support both local and hosted deployment topologies.
+- Preserve a clean path toward standardization through future XIPs.
+
+### Secondary goals
+
+- Allow flexible message visibility modes, including reveal-oriented flows.
+- Support multiple transport surfaces such as WebSocket, MCP, HTTP, CLI, and SDK adapters.
+- Make it easy for users to self-host or one-click deploy their own broker.
+- Give apps like Convos rich UX affordances without requiring immediate protocol changes.
+- Provide a near-term deployable verification path for broker trust.
+
+## Non-Goals
+
+- Full protocol-level selective message visibility for standard group members.
+- Hiding metadata from infrastructure operators beyond what XMTP already protects.
+- Preventing an agent from storing or inferring information it has already been shown.
+- Solving every governance question about group approval and social policy in v1.
+
+## Core Concepts
+
+### Broker
+
+The **broker** is the trusted runtime boundary that owns the real XMTP client.
+
+Responsibilities:
+
+- Hold the XMTP signer or equivalent identity material for one or more agent inboxes.
+- Maintain installation continuity.
+- Persist the raw XMTP database and its encryption keys.
+- Sync, receive, and store the real conversation state.
+- Enforce policy for views, grants, and message projection.
+- Issue sessions to agent harnesses.
+- Publish group-visible capability attestations.
+- Manage per-agent isolation when serving multiple agents.
+
+The term “broker” is preferred over “gateway” to avoid confusion with XMTP Gateway Service and other gateway terminology in the ecosystem.
+
+### Identity Model
+
+Each agent has its own XMTP inbox. The broker holds the signer for that inbox and operates its MLS state, but from the protocol’s perspective, the agent is the group member.
+
+This means:
+
+- The group sees each agent as a distinct participant with its own inbox identity.
+- Attestations are about a specific agent, not about the broker as a whole.
+- One broker can manage multiple agent inboxes, each joining different groups independently.
+- There is no “ventriloquist” problem where one broker identity speaks as multiple agents.
+- The broker is infrastructure, not a participant. It does not appear in group membership.
+
+When a single broker serves multiple agents in the same group, each agent has its own inbox, its own attestation, its own view, and its own grant. The broker maintains strict isolation between agents internally — Agent A’s view must not leak into Agent B’s derived state.
+
+### View
+
+A **view** is a policy-filtered description of what an agent can see across one or more conversations.
+
+A view may specify:
+
+- Full visibility over a conversation or thread.
+- Redacted visibility.
+- Reveal-only visibility.
+- Thread-scoped visibility.
+- Summary-only visibility.
+
+A view also specifies allowed **content types** via an explicit allowlist. Content types not in the allowlist are held at the broker and not forwarded to the agent.
+
+Content type allowlists follow three tiers:
+
+- **Baseline allowlist:** Content types that have passed through the XIP process and are part of the accepted XMTP spec. These are allowed by default.
+- **Broker-level configuration:** The broker operator can expand or restrict beyond the baseline across all agents the broker manages.
+- **Per-agent view configuration:** The owner can further scope what a specific agent sees within what the broker allows.
+
+The effective allowlist for any given agent is the intersection of what the broker permits and what the agent’s view config includes.
+
+**Default-deny for unknown content types.** If a content type is not in the effective allowlist, it does not reach the agent. When a new XIP content type is accepted and the baseline list updates, existing agents do not automatically start seeing it. The broker updates its baseline, but each agent’s view must explicitly include the new type.
+
+A view is not the real XMTP message state. It is a derived projection enforced by the broker.
+
+### Grant
+
+A **grant** is a structured description of what actions an agent is allowed to perform.
+
+Grant categories:
+
+#### Messaging capabilities
+
+- Send messages.
+- Reply in thread.
+- React.
+- Draft only.
+- Post only with confirmation.
+
+#### Group management capabilities
+
+- Add members.
+- Remove members.
+- Update metadata.
+- Invite users.
+- Change agent policy.
+
+#### Tool capabilities
+
+- Calendar access.
+- Payment actions.
+- External HTTP access.
+- Search/retrieval.
+- Custom application tools.
+
+#### Retention and egress capabilities
+
+- Store message excerpts.
+- Use content for memory.
+- Forward to model providers.
+- Quote revealed content.
+- Summarize hidden or revealed content.
+
+A view and a grant are independently composable. An agent can have a `reveal-only` view paired with `send + react` capabilities, or a `full` view paired with `draft-only` capabilities, without needing named modes for every combination.
+
+### View Modes
+
+Suggested initial view modes as convenience labels:
+
+- `full`
+- `thread-only`
+- `redacted`
+- `reveal-only`
+- `summary-only`
+
+A view mode is only a convenience label. The underlying view object (including the content type allowlist) and grant object should remain explicit and authoritative.
+
+### Attestation
+
+An **attestation** is a signed assertion about an agent’s current permissions, scope, and operating posture.
+
+Attestations are meant to be visible to the group and updated whenever permissions change materially.
+
+Attestations establish shared understanding of:
+
+- Who owns the agent.
+- Which inbox the agent uses.
+- What the agent can see (view).
+- What the agent can do (grant).
+- How the agent handles egress and inference.
+- Whether content is reveal-only or broader.
+- The hosting mode and trust posture.
+- What changed since the previous state.
+
+#### Attestation noise and materiality
+
+Not every internal state change should produce a group-visible attestation. The system should distinguish **material changes** from **routine operations**.
+
+Material changes that produce group-visible attestations:
+
+- View mode or scope changes.
+- Grant additions or removals.
+- Egress or inference policy changes.
+- Agent addition or revocation.
+- Ownership or hosting mode changes.
+- Verifier statement updates.
+
+Routine operations that remain silent:
+
+- Session rotation within the same view and grant.
+- Heartbeat / liveness signals.
+- Internal broker housekeeping.
+
+This prevents the conversation timeline from becoming a compliance log while ensuring that meaningful permission changes are always visible.
+
+### Session
+
+A **session** is the ephemeral authorization context between an agent harness and the broker.
+
+A session is how the harness receives its active view and grant.
+
+Sessions should be:
+
+- Short-lived.
+- Rotatable.
+- Scoped.
+- Revocable.
+- Bound to a specific view and grant.
+
+#### Session and view/grant binding
+
+View and grant updates that do not change the security boundary can be applied within an existing session without requiring reconnection. Examples: adjusting a thread scope, adding a new content type to the allowlist, or enabling a reaction capability.
+
+Changes that materially expand the security boundary require session reauthorization. Examples: upgrading from `reveal-only` to `full` visibility, adding egress permissions, or granting group management capabilities. The broker should terminate the current session and require the harness to establish a new one under the updated policy.
+
+This prevents excessive reconnection churn while ensuring that privilege escalation always involves a clean authorization step.
+
+## Users and Stakeholders
+
+### End users
+
+People who want to add agents to their private or group conversations without surrendering raw account access to the agent harness.
+
+### Group members
+
+People sharing a conversation with an agent who need visibility into what that agent can currently do.
+
+### App developers
+
+Teams building XMTP or Convos clients that want first-class agent support with clear permission UX.
+
+### Agent developers
+
+People building harnesses, tools, and integrations who need a stable, framework-agnostic interface.
+
+### Infrastructure operators
+
+People who want to self-host or provide managed broker services.
+
+## Problem Statement
+
+Today, the easiest way to run an XMTP agent is to let the harness run the XMTP client directly.
+
+That creates several structural problems:
+
+- The harness can often bypass app-level permissions by calling the SDK or CLI directly.
+- There is no clean separation between the real client and the agent’s policy view.
+- Hosted deployments become hard to reason about because the host is effectively the agent endpoint anyway.
+- Users and group members do not have a durable, shared language for understanding current capability state.
+- Different apps and agent frameworks are likely to reinvent incompatible patterns.
+
+The system needs a boundary that is real, visible, and portable.
+
+## Proposed Solution
+
+### High-level architecture
+
+The proposed architecture separates the system into three layers:
+
+#### Raw plane
+
+The raw plane contains the real XMTP client and raw conversation state.
+
+Owned by the broker:
+
+- Signer material for agent inboxes.
+- Installation continuity.
+- Raw message retrieval and sync.
+- Raw local database.
+- DB encryption keys.
+
+#### Policy plane
+
+The policy plane determines what an agent is allowed to see and do.
+
+It includes:
+
+- View definitions (visibility scope and content type allowlists).
+- Grant definitions (action permissions).
+- Reveal state.
+- Group policy state.
+- Attestations.
+- Revocations.
+
+#### Derived plane
+
+The derived plane is what the agent actually consumes.
+
+This may be:
+
+- A filtered event stream.
+- A derived encrypted cache.
+- A session-bound local store.
+- A transformed API surface.
+- A combination of the above.
+
+### Core rule
+
+The harness never touches the raw plane.
+
+The broker is the only component allowed to operate the real XMTP client.
+
+### Harness-agnostic interface
+
+The broker should expose a canonical interface that can be adapted to:
+
+- WebSocket
+- HTTP
+- MCP
+- CLI bindings
+- OpenClaw channel adapters
+- AI SDK adapters
+- Claude Agent SDK adapters
+- OpenAI agent adapters
+
+The system should define one capability model and multiple connection adapters, rather than one permission system per harness.
+
+## Egress and Inference Disclosure
+
+When an agent sends conversation content to an external LLM provider, the privacy story changes fundamentally. This is arguably the single most consequential thing a group member would want to know about an agent.
+
+Egress and inference posture must be declared as structured, first-class fields in the attestation — not buried in a generic policy blob.
+
+### Required egress fields
+
+- `inferenceMode` — `local` | `external` | `hybrid`
+- `inferenceProviders` — A list of providers the agent may use, e.g. `["anthropic", "openai"]`. Empty for purely local inference.
+- `contentEgressScope` — What content leaves the broker boundary: `full-messages` | `summaries-only` | `tool-calls-only` | `none`
+- `retentionAtProvider` — `none` | `session` | `persistent` | `unknown`
+
+These fields are **required** in every attestation. If the value cannot be determined, the field must be set to `unknown` rather than omitted. Silent omission is not allowed. Every attestation takes an explicit position, even if that position is “I don’t know.”
+
+### Envelope declaration
+
+For agent frameworks that dynamically switch inference providers (such as OpenClaw), the attestation should declare the **envelope** of possible providers, not the instantaneous state. If the agent may route to Anthropic, OpenAI, or a local model depending on the query, the attestation declares all three and sets `inferenceMode` to `hybrid`.
+
+Overstating the envelope is acceptable. Understating it is not.
+
+### Verification and honesty
+
+In v1, these fields are self-reported by the broker. An unverified broker claiming `inferenceMode: local` gets treated with the same skepticism as any other unverified claim. A source-verified or runtime-attested broker making that claim is more credible. The schema does not solve trust — it gives trust something structured to attach to.
+
+## Attestation Model
+
+### Why attestations matter
+
+Attestations make agent posture legible to the conversation itself.
+
+Without attestations, permissions live only in the owner’s client or broker config. That is not enough for a multi-party environment.
+
+### Attestation signing in v1
+
+In v1, the broker signs attestations using the agent’s inbox key (which the broker holds). The attestation includes the `ownerInboxId` field, which creates a social accountability link — the group can see who is responsible for the agent — even though the owner is not cryptographically co-signing every update.
+
+Clients verify the signature against the agent’s inbox, confirming the attestation came from the entity that controls that agent.
+
+In future versions, optional owner co-signing could be added for high-stakes permission changes (such as upgrading from `reveal-only` to `full` visibility), while keeping routine attestations broker-signed only.
+
+### Attestation lifecycle
+
+An attestation should be published when a material change occurs:
+
+- An agent is added.
+- Permissions are first granted.
+- View or grant changes.
+- Egress or inference policy changes.
+- The agent is revoked.
+- The ownership or hosting mode changes.
+- A verifier statement is updated.
+
+### Suggested attestation fields
+
+- `attestationId`
+- `previousAttestationId`
+- `agentInboxId`
+- `ownerInboxId`
+- `groupId`
+- `threadScope`
+- `viewMode`
+- `contentTypes`
+- `grantedOps`
+- `toolScopes`
+- `inferenceMode`
+- `inferenceProviders`
+- `contentEgressScope`
+- `retentionAtProvider`
+- `hostingMode`
+- `trustTier`
+- `buildProvenanceRef` (optional, populated when available)
+- `verifierStatementRef` (optional, populated when available)
+- `sessionKeyFingerprint`
+- `policyHash`
+- `heartbeatInterval`
+- `issuedAt`
+- `expiresAt`
+- `revocationRules`
+- `issuer`
+
+### Message provenance
+
+Agent-authored messages should reference the attestation under which they were produced.
+
+This gives clients the ability to render:
+
+- The current capability posture.
+- Whether a message was generated under different permissions than the current state.
+- Whether permissions changed mid-conversation.
+
+### Trust model for attestations
+
+The system should not rely on self-attestation from the agent alone.
+
+The more trustworthy path is:
+
+- The broker signs the attestation with the agent’s inbox key.
+- The attestation is posted into the group.
+- Agent messages reference the current attestation.
+- Clients compare references over time.
+- Verifier statements (when available) add external validation.
+
+## Trust Chain Model
+
+The trust model for brokers is built as a chain of four independent layers. Each layer adds assurance, but none alone is sufficient.
+
+### Layer 1: XMTP Identity
+
+What XMTP already provides. Proves which inbox is speaking, with cryptographic identity association and signatures. This tells you **who**, but not what software or controls are behind that identity.
+
+### Layer 2: Build Provenance
+
+What the broker project publishes. Establishes that a specific artifact was built from a specific source by a specific pipeline. Relevant evidence includes: repo, commit SHA, build workflow, artifact digest, SBOM, signing identity, and transparency log entries.
+
+Tools in this layer include SLSA provenance, Sigstore signing and transparency logs, and GitHub artifact attestations.
+
+Open source plus build provenance gets you to: “this artifact likely came from that source/build pipeline.”
+
+### Layer 3: Runtime Attestation
+
+What the live broker instance proves. Establishes that a specific measured workload is actually running in the deployment environment. This is where enclave-style attestation (such as AWS Nitro Enclaves or other TEE platforms) fits for hosted deployments.
+
+Runtime attestation gets you to: “this live hosted broker is likely running the artifact it claims to be running.”
+
+The design should be **TEE-agnostic and verifier-agnostic** — AWS Nitro today, other attested runtimes tomorrow, or purely source/build-verified self-hosting for users who do not want enclave dependencies.
+
+### Layer 4: Capability Attestation
+
+What gets posted into the group. Describes what this broker claims the agent can do right now. This is the app/XIP layer — the view, the grant, the hosting mode, the egress posture.
+
+This layer becomes far more credible when it chains back to the first three layers.
+
+### Trust Tiers
+
+The trust chain maps to three practical tiers that clients can render:
+
+#### Tier 1 — Source-verified
+
+- Open source broker implementation.
+- Signed release.
+- Build provenance available and verifiable.
+
+#### Tier 2 — Reproducibly verified
+
+- All of Tier 1.
+- Independent parties can reproduce the artifact bit-for-bit from source.
+
+#### Tier 3 — Runtime-attested
+
+- All of Tier 2.
+- Hosted runtime proves measurement via remote attestation.
+- Secrets are released only to approved measurements.
+
+The group-visible attestation includes a `trustTier` field reflecting the highest tier the broker can currently demonstrate.
+
+## Broker Verification
+
+### Near-term: Reference Verifier
+
+To provide a fast path to verification without waiting for the full trust chain to mature, the system should ship an open source **reference verifier** — a lightweight service deployable to Cloudflare Workers, Railway, or similar platforms.
+
+The reference verifier:
+
+- Accepts a verification request containing the broker inbox ID, artifact digest, and build provenance bundle.
+- Checks the provenance against a known set of published releases (GitHub artifact attestations, Sigstore transparency log entries).
+- Returns a signed verification statement bound to the broker’s inbox, artifact digest, and an expiry.
+
+The verifier identity is just an XMTP inbox. The verification statement is a signed message (or structured content type). This means the protocol surface is the same whether the verifier is a reference instance, a community-run deployment, or eventually a node operator sidecar. The decentralization path is baked in from day one because there is no privileged API endpoint — just inboxes that issue statements and clients that decide which issuers to trust.
+
+### Verifier-over-XMTP flow
+
+1. Broker inbox opens a DM with verifier inbox.
+1. Broker sends a verification request containing: broker inbox identity, challenge nonce, artifact digest, build provenance bundle, optional runtime attestation evidence, requested verification class.
+1. Verifier checks policy and evidence.
+1. Verifier replies over XMTP with a signed verification statement.
+1. Broker references that statement in its group-visible capability attestation via the `verifierStatementRef` field.
+1. Clients validate: the verifier issuer, the signature, expiry, evidence class, and whether subsequent agent messages still point to a current statement.
+
+### Multiple issuers
+
+The system should support multiple verifier issuers. Apps, auditors, node operators, XMTP Labs, third parties, and self-run verifiers can all participate. Clients and groups choose which issuers they trust. There should be no single central authority blessing all brokers.
+
+### XMTP node operators
+
+XMTP node operators could run verifier services alongside their nodes in the future, but the node software itself should not be required to become the verifier layer. This preserves decentralization of issuers without bloating the network’s base responsibilities. A later XIP could explore whether the node layer should participate more directly.
+
+## Reveal and Selective Visibility
+
+### Important distinction
+
+This proposal does not assume protocol-level selective decryptability for normal XMTP group messages.
+
+Instead, it uses **broker-enforced selective disclosure**.
+
+### Practical reveal model
+
+The broker receives and stores the real conversation state.
+
+For each incoming message, the broker decides what to project into the view:
+
+- Full plaintext.
+- Redacted content.
+- Hidden placeholder.
+- Summary.
+- Nothing.
+
+### Reveal behaviors
+
+Suggested reveal patterns:
+
+- Reveal per message.
+- Reveal per thread.
+- Temporary reveal mode for a time window.
+- Reveal by content type.
+- Reveal by sender or role.
+
+### Group-visible policy
+
+Reveal behavior should be understandable in the client UX.
+
+For example, Convos could render:
+
+- Hidden from assistant.
+- Revealed to assistant.
+- Reveal this message.
+- Reveal this thread.
+- Pause assistant visibility.
+
+### Why this matters
+
+This preserves a meaningful distinction between:
+
+- The real XMTP message state.
+- The materialized agent view.
+
+That distinction is what makes broker-enforced permissions real.
+
+## Liveness and Graceful Degradation
+
+The broker-mediated model adds a mandatory dependency: if the broker goes down, the agent goes completely silent. From the group’s perspective, a crashed broker is indistinguishable from a healthy agent that is choosing not to respond. The system should address this.
+
+### Heartbeat and staleness
+
+The attestation includes a `heartbeatInterval` field indicating the expected liveness cadence. Clients should render an “agent unreachable” or “last active N minutes ago” indicator when the interval is exceeded. This does not require noisy group-visible messages — it can be inferred from session keepalives or lightweight structured signals.
+
+### Broker recovery: inbound messages
+
+Messages sent by the group while the broker was down should still be delivered to the agent on recovery. The agent needs that context to understand what happened during the outage. However, the broker must tag these messages as **historical** — they carry their original timestamps, but the broker signals to the agent that they are not fresh messages to act on. The agent gets context, not action triggers.
+
+### Broker recovery: outbound messages
+
+Outbound agent actions that were queued or implied during downtime should be subject to a **configurable expiry window**. If the broker recovers within that window, queued actions can proceed. Beyond the window, they expire silently. This prevents stale responses to questions asked hours earlier.
+
+### Client-side rendering
+
+When the broker recovers, the client can show a notice such as “agent back online, caught up through [timestamp]” to indicate that the agent has resynced but may have missed real-time participation during the outage.
+
+## Revocation
+
+Revocation should be **immediate, visible, and fail-closed**. If there is any ambiguity about whether an agent is still authorized, the answer is no.
+
+### Normal revocation
+
+The owner instructs the broker to revoke the agent. The broker immediately terminates the agent’s session, posts a revocation attestation to the group, and stops projecting any view to that agent.
+
+### Owner loses access
+
+If the owner’s device is lost or the owner leaves the group, two safety valves apply:
+
+- **Mandatory expiration:** Attestations must have an `expiresAt` field. A broker with no owner contact eventually stops being authorized.
+- **Group admin override:** Group admins can remove the agent’s inbox from the group at the XMTP group permissions level, which effectively kills access regardless of what the broker thinks.
+
+### Session expiry without rotation
+
+If a session expires and the harness does not re-authenticate, the broker automatically stops projecting the view. No silent continuation on stale credentials. The broker posts a session-expired attestation so the group knows the agent is no longer active under valid authorization.
+
+### In-flight messages during revocation
+
+If the agent has a message in transit when revocation hits, the broker drops it. A message that arrives at the broker after the revocation attestation was posted should never reach the group. Better to lose a message than to have an agent act after its permissions were pulled.
+
+## Threat Model
+
+The broker architecture concentrates trust in the broker and its host. The following threat profiles map attacker types to what they gain across deployment modes.
+
+### Compromised harness
+
+What they gain: nothing beyond the current view and grant. The harness has no raw signer, no DB encryption key, no direct XMTP SDK access. The attacker can abuse the agent’s currently granted actions and read whatever the current view exposes, but cannot escalate beyond the session’s permissions.
+
+This is the scenario the architecture is specifically designed to contain, and represents a major improvement over the current model where a compromised harness has full client access.
+
+### Compromised broker host (local)
+
+What they gain: access to operational keys and the raw DB, but not the root signing key if it is stored in the Secure Enclave. The attacker can read raw messages and abuse the operational key for routine signing, but cannot perform privilege escalation (which requires biometric authentication on the root key) and cannot extract the root key from hardware.
+
+On platforms without hardware-backed key storage, a compromised local machine means full access to the raw plane including all key material.
+
+Mitigation includes hardware-backed key storage (Secure Enclave, TPM), standard local security hygiene, and biometric gating on privilege escalation. The broker does not make a compromised machine safer — but hardware-bound keys significantly limit what an attacker can do even with process-level access.
+
+### Compromised broker host (self-hosted / managed)
+
+What they gain: full raw message access for all agents the broker manages, all signer material, and the ability to forge attestations. The hosted environment is the real client boundary, and compromise of it is equivalent to owning every agent on that broker.
+
+Mitigations: short-lived sessions limit exposure window, mandatory attestation expiry forces periodic renewal, runtime attestation (Tier 3) can detect environment tampering, and the broker’s attestation history creates a forensic trail.
+
+### Malicious operator (managed deployment)
+
+What they gain: the same access as a compromised host, but with the added ability to operate covertly over time. A malicious managed broker operator can silently exfiltrate messages, forge attestations, and impersonate agents.
+
+Mitigations: the `hostingMode` field in attestations discloses managed deployment, allowing clients to render appropriate trust indicators. Runtime attestation (Tier 3) with TEE-backed key release is the strongest counter. Verifier statements from independent issuers provide a cross-check. But fundamentally, a managed broker requires trust in the operator — the system should be honest about that.
+
+### Network adversary
+
+What they gain: limited value. XMTP messages are encrypted in transit via MLS. The attacker cannot read message contents. They may observe metadata (who is communicating, when, message sizes) to the extent XMTP’s transport layer exposes it, but the broker architecture does not change this posture relative to the current model.
+
+## Governance and Group Policy
+
+### Initial ownership model (v1)
+
+For v1, an agent is owned and configured by one group member.
+
+That owner can:
+
+- Add the agent.
+- Configure the view and grant.
+- Rotate permissions.
+- Revoke access.
+
+### Group visibility
+
+Even in the owner-driven model, the resulting permissions are visible to the group via attestations. Group members can inspect what an agent can see and do at any time.
+
+### Power asymmetry in v1
+
+The v1 model creates a known power asymmetry. If Alice adds an agent with `full` visibility, Bob can see that via the attestation, but he has no direct mechanism to override or restrict the agent’s permissions — his recourse is limited to leaving the group or asking Alice to change the configuration.
+
+This is an accepted limitation of v1. The attestation model makes the situation transparent, which is a meaningful improvement over the current state where Bob has no visibility at all.
+
+### Future group governance
+
+Over time, clients and standards could support richer governance patterns that address this asymmetry:
+
+- Group-level caps on maximum permissions (e.g. “no agent in this group may exceed reveal-only visibility”).
+- Approval thresholds for risky capabilities.
+- Admin-only control of agent policy.
+- Automatic revocation if owner leaves or is removed.
+- Per-member objection mechanisms.
+
+## Client Experience
+
+### Convos as a rich reference client
+
+Convos is especially well-positioned to make this model understandable because it already leans into per-conversation identity, privacy-forward UX, and explicit assistant behavior.
+
+Possible Convos additions:
+
+- Agent creation and connection flow from within a conversation.
+- Visual view mode and grant badges.
+- Trust tier indicators.
+- Permission editing UI.
+- Reveal toggles on messages and threads.
+- Timeline cards for attestation changes (material changes only).
+- Agent ownership labeling.
+- Hosting mode labeling.
+- Inference and egress disclosure (e.g. “processes locally” or “sends to Anthropic, session only”).
+- Confirmation flows for risky actions.
+- Explainability UI for why an agent did or did not see a message.
+- Agent offline / staleness indicators.
+
+### UX principles
+
+- Make capability posture visible without being noisy.
+- Default to understandable safety labels.
+- Keep message timelines coherent.
+- Avoid creating excessive side-chat tax unless the user explicitly chooses that mode.
+- Show provenance on agent actions.
+- Distinguish material permission changes from routine operations in the timeline.
+
+### Trust tier rendering
+
+Clients should render trust posture in a way that is accurate but not alarmist:
+
+- **Unverified** — no verifier statement, self-asserted only.
+- **Source-verified** — build provenance verified by a recognized issuer.
+- **Reproducibly verified** — independent reproduction confirmed.
+- **Runtime-attested** — live environment measurement verified.
+
+Additionally:
+
+- **Local** — broker runs on the user’s machine.
+- **Self-hosted** — broker runs on user-controlled infrastructure.
+- **Managed** — broker hosted by a third party.
+
+These two dimensions (trust tier and hosting mode) should be shown together so users can make informed decisions.
+
+### Side-chat and side-room support
+
+Even if reveal-in-place is the main UX, clients should still support side-room patterns for higher-risk or higher-privacy tasks.
+
+Useful variants:
+
+- Task-specific side rooms.
+- Temporary assistant workrooms.
+- Private reveal rooms for selected participants.
+
+## Deployment Model
+
+### Local broker
+
+A local broker runs on the user’s machine.
+
+Benefits:
+
+- Strongest practical trust boundary.
+- Lowest third-party exposure.
+- Natural fit for users already running local agents.
+
+Trade-offs:
+
+- Requires an always-on machine for long-lived agents.
+- More setup friction.
+- Local networking and process management complexity.
+
+### Self-hosted broker
+
+A self-hosted broker runs on a machine or service the user controls.
+
+Examples: home server, private VM, personal cloud deployment.
+
+Benefits:
+
+- Persistent uptime.
+- Better privacy posture than a fully managed service.
+- Operational flexibility.
+
+Trade-offs:
+
+- More operational burden.
+- Trust still moves to the hosted environment.
+
+### Managed broker
+
+A managed broker is hosted by a third party.
+
+Benefits:
+
+- Lowest setup friction.
+- Makes the model accessible to users without an always-on machine.
+- Good default for agents that need continuous operation.
+
+Trade-offs:
+
+- The managed broker becomes the real client boundary.
+- Plaintext exists where the broker processes it.
+- The trust boundary is weaker than local or self-hosted deployments.
+
+### Product truth
+
+All deployment modes share:
+
+- The same broker protocol.
+- The same view and grant model.
+- The same attestation model.
+- The same client UX semantics.
+
+They do not share the same trust boundary.
+
+That difference should be clearly disclosed.
+
+Managed broker deployments have real operational costs — compute, storage, bandwidth. The protocol should support lightweight and hibernatable broker modes to keep deployment sustainable.
+
+## Hosting and Deployment Strategy
+
+### Spec-first approach
+
+The system should be defined as an open specification first, with multiple reference deployments.
+
+Recommended outputs:
+
+- Broker protocol spec.
+- View, grant, and session spec.
+- Attestation schema.
+- Reference verifier implementation (deployable to Cloudflare Workers or Railway).
+- Broker reference implementations.
+- One-click deployment templates.
+
+### Recommended deployment profiles
+
+#### Desktop local profile
+
+- Runs as a local service.
+- Connects over localhost WebSocket, Unix socket, or local MCP.
+- Best for privacy-sensitive users and local agent workflows.
+
+#### Self-hosted container profile
+
+- Runs in a stateful Linux container or VM.
+- Uses persistent disk.
+- Good fit for Fly, Railway, VPS, or home-server deployment.
+
+#### Cloudflare hybrid profile
+
+- Cloudflare handles control-plane tasks.
+- A stateful raw broker runs elsewhere.
+- Good fit for global session management, fanout, and attestation coordination.
+
+### Platform considerations
+
+#### Fly.io
+
+A strong candidate for stateful self-hosted or semi-managed broker deployment because it maps well to persistent container workloads.
+
+#### Railway
+
+Also a strong candidate for persistent broker deployment with good ergonomics for rapid setup.
+
+#### Cloudflare
+
+Best suited to control-plane roles, hybrid deployment patterns, and hosting the reference verifier.
+
+### One-click deployment
+
+A one-click deployment experience should:
+
+- Generate broker secrets inside the target environment.
+- Avoid showing long-lived secrets back to the user in plaintext when possible.
+- Support user-controlled recovery and rotation.
+- Publish broker identity and attestation fingerprints.
+- Make the hosting mode visible to the client.
+
+### Honest security posture for hosted deployment
+
+A hosted deployment may keep secrets from leaving the environment in plaintext to the user, but that is not equivalent to a cryptographic guarantee that the hosting platform or deployer can never access them.
+
+The product language should reflect that honestly.
+
+## Transport and Interface Design
+
+### Primary transport
+
+WebSocket is the most natural primary transport for live agent interaction.
+
+Reasons:
+
+- Real-time event streaming.
+- Bi-directional messaging.
+- Natural fit for session-oriented connections.
+- Good substrate for harness adapters.
+
+### Additional adapters
+
+The broker should also support:
+
+- MCP adapter
+- HTTP API
+- CLI client
+- SDK helper libraries
+- OpenClaw channel adapter
+
+### Canonical broker events
+
+Suggested event types:
+
+- `session.started`
+- `session.expired`
+- `session.reauthorization_required`
+- `attestation.updated`
+- `view.updated`
+- `grant.updated`
+- `message.visible`
+- `message.visible.historical`
+- `message.hidden`
+- `message.revealed`
+- `tool.allowed`
+- `tool.denied`
+- `action.confirmation_required`
+- `agent.revoked`
+- `broker.recovery.complete`
+
+## Security and Privacy Model
+
+### Trusted computing base
+
+In this architecture, the broker and its host form the trusted computing base for the raw XMTP view.
+
+That is true whether the broker is local or hosted.
+
+### Security goals
+
+- Keep raw XMTP credentials out of the harness.
+- Make permissions meaningful through enforced mediation.
+- Minimize blast radius through short-lived sessions and explicit scopes.
+- Make agent posture visible to conversation participants.
+- Reduce accidental overexposure to tools and models.
+- Ensure revocation is immediate, visible, and fail-closed.
+
+### Security limitations
+
+- A compromised broker can expose raw content.
+- A malicious host or operator may still exfiltrate data in hosted environments.
+- An agent can still remember or infer content it has already seen.
+- Egress to an LLM provider weakens privacy relative to pure client-to-client messaging.
+- Attestation fields beyond the trust chain are self-reported in v1.
+
+### Hard requirements
+
+- No direct harness access to raw keys.
+- No direct harness access to raw DB files.
+- No unsupported side-channel access to the raw plane.
+- Signing keys stored in hardware-backed storage where available (Secure Enclave, TEE).
+- Privilege escalation requires root key authorization (biometric or equivalent).
+- Clear session expiration and rotation.
+- Clear revocation flow with fail-closed behavior.
+- Mandatory `expiresAt` on all attestations.
+
+## Key Management and Hardware Binding
+
+The PRD states that the broker “holds the signer” for agent inboxes. This section specifies *how* that signer material should be managed, with a strong preference for hardware-backed key storage that prevents extraction even by the broker process itself.
+
+### Design principle
+
+The broker should be able to **invoke** signing operations without being able to **extract** the signing key. This is the difference between “the broker holds the key” and “the broker can use the key through hardware-enforced mediation.” The latter is materially stronger.
+
+### Inspiration
+
+Projects such as keypo-cli demonstrate that Mac Secure Enclave-backed P-256 key management for AI agents is practical and shippable today. The architectural pattern — keys generated inside hardware, never exportable, with policy-gated access (open, passcode, biometric) and a vault system for encrypted secret storage — is directly applicable to the broker’s key management needs.
+
+However, for supply chain integrity, the broker should implement its own purpose-built key management layer rather than taking a dependency on a third-party tool. The core security boundary of the broker should not depend on external packages whose maintenance, auditability, or future direction is outside the project’s control. The keypo-cli architecture should be treated as a reference design, not a runtime dependency.
+
+### Recommended key hierarchy
+
+The broker should maintain a three-tier derived key hierarchy:
+
+#### Root key
+
+- Generated inside the Secure Enclave (local) or TEE (hosted).
+- Protected by biometric authentication (Touch ID) or equivalent strong authentication.
+- Non-exportable by hardware design.
+- Used for: initial agent inbox creation, privilege escalation authorization, key rotation, and recovery flows.
+- This is the agent’s true identity anchor.
+
+#### Operational key
+
+- Derived from the root key.
+- Protected by `passcode` or `open` policy depending on deployment mode.
+- Used for: routine message signing, attestation publishing, session issuance, and day-to-day broker operations.
+- Does not require biometric authentication per operation, allowing the broker to function autonomously for routine tasks.
+
+#### Session keys
+
+- Ephemeral, scoped to a specific session and grant.
+- Issued to the agent harness.
+- Short-lived and revocable.
+- Cannot escalate to operational-level or root-level operations.
+- This is what the harness actually holds.
+
+### Privilege escalation and biometric gating
+
+Routine broker operations — sending messages, publishing routine attestations, managing sessions — should flow through the operational key without requiring per-operation authentication. This allows agents to function autonomously within their granted permissions.
+
+Operations that cross a privilege threshold should require root key authorization, which means biometric (or equivalent) authentication:
+
+- Upgrading a view from `reveal-only` to `full` visibility.
+- Adding egress permissions or new inference providers.
+- Granting group management capabilities.
+- Creating new agent inboxes.
+- Performing key rotation.
+- Any grant escalation beyond the current session’s scope.
+
+This maps directly to the session reauthorization boundary defined in the Session section: non-material operations flow through the session, material privilege escalations require a clean authorization step backed by the root key.
+
+### Coordinating agent pattern
+
+A broker with root key access can act as a key authority for its managed agents. A coordinating agent — itself operating under a specific view and grant — could be authorized to create new agent inboxes on the fly, each with their own derived operational key, each scoped to specific grants.
+
+Those downstream agents can operate autonomously within their scoped permissions, but they can never reach back up to the root key without a biometric check from the human owner. This enables patterns like:
+
+- A coordinating agent that spins up task-specific agents for a conversation.
+- Each task agent gets a scoped grant and derived key.
+- If any task agent needs to exceed its granted scope, the request bubbles up to the coordinating agent, which in turn requires root key authorization from the owner.
+
+### Encrypted secret storage
+
+Beyond signing keys, brokers need to manage other secrets: database encryption keys, API credentials for inference providers, webhook tokens, and configuration secrets.
+
+These should be stored in an encrypted vault backed by the same hardware key hierarchy. Secrets are encrypted at rest using enclave-backed keys and injected into processes as environment variables at runtime — never written to disk in plaintext, never stored in `.env` files, and never visible in shell history or process listings.
+
+### Local broker key management
+
+For local brokers on macOS with Apple Silicon:
+
+- Root key lives in the Secure Enclave, protected by biometric policy.
+- Operational and session keys are derived and managed in memory or in the encrypted vault.
+- The user can set up a broker with a single biometric authentication.
+- Day-to-day operation does not require repeated biometric prompts.
+- The key literally cannot be extracted — not by the agent, not by the harness, not by malware, and not by the broker process itself.
+
+For local brokers on other platforms, the implementation should use the best available hardware-backed key storage (TPM, platform keychain with hardware binding, etc.) and degrade gracefully with clear labeling of the actual security posture.
+
+### Hosted broker key management
+
+For hosted brokers, the Secure Enclave is not available. The equivalent pattern is TEE-backed key storage:
+
+- Root key generated inside the enclave/TEE.
+- Signing operations invoked through the TEE interface without key extraction.
+- Key release conditioned on runtime attestation measurements.
+- The architectural boundary is the same — the broker can use the key but never see it — just implemented with different hardware.
+
+The attestation’s `trustTier` and `hostingMode` fields should reflect whether hardware-backed key storage is in use.
+
+## Key Rotation
+
+Key rotation is essential for operational continuity — machines change, hardware fails, and security hygiene requires periodic rotation.
+
+### Machine migration
+
+Secure Enclave keys are non-exportable and device-bound by hardware design. Moving to a new machine means:
+
+1. Authenticate on the new machine (biometric enrollment).
+1. The broker creates new enclave-backed keys on the new hardware.
+1. The broker performs an XMTP installation rotation — the agent’s inbox identity persists, but the signing key material rotates.
+1. The broker publishes an updated attestation reflecting the new key material and any updated verifier statements.
+1. The old machine’s keys are revoked.
+
+This is cleaner than a “recovery key” approach because it avoids ever having exportable root material. There are no seed phrases or recovery keys to secure, leak, or lose. The agent’s identity continuity is maintained through XMTP’s installation management, not through key portability.
+
+### Periodic rotation
+
+Even without a machine change, operational keys should support periodic rotation as a security hygiene measure. The broker should be able to rotate operational keys without disrupting active sessions — new sessions use the new key, existing sessions continue until their natural expiry, and the attestation is updated to reflect the rotation.
+
+### Rotation attestation
+
+Any key rotation event is a material change and should produce a group-visible attestation update. The group should be able to see that key material changed, when it changed, and that the new material chains back to a valid root.
+
+## Candidate XIP Directions
+
+This proposal is intentionally app-layer first, but several pieces are candidates for future XIPs.
+
+### Capability Attestation XIP (recommended first)
+
+Standardize a portable, signed attestation format for agent capabilities.
+
+Potential scope:
+
+- Required attestation fields (including structured egress/inference fields).
+- View and grant semantics.
+- Update semantics and materiality thresholds.
+- Revocation semantics.
+- Ownership and issuer model.
+- Attestation references in agent-authored messages.
+
+This is recommended as the first XIP because it is the foundation everything else references.
+
+### Broker Verification Statement XIP
+
+Standardize the verification request and verification statement content types.
+
+Potential scope:
+
+- Verification request format.
+- Verification statement format.
+- Issuer / expiry / revocation semantics.
+- Standard verification classes (self-asserted, source-verified, build-provenance-verified, runtime-attested).
+- Standard way for attestations to reference verifier statements.
+
+### Agent Message Provenance XIP
+
+Standardize how agent-authored messages indicate:
+
+- Which attestation they were produced under.
+- Whether the agent was acting with full, reveal-only, or other view modes.
+- Whether tool use or external actions were involved.
+
+### Group-Scoped Delegation XIP
+
+Explore a first-class group-scoped delegated principal model.
+
+This would be richer than inbox-level delegation and better aligned with group agent use cases.
+
+Possible semantics:
+
+- Delegate bound to one group.
+- Scoped capabilities.
+- Auto-revocation if delegator is removed.
+- Optional multi-admin approval.
+
+### Reveal Policy XIP
+
+Define portable message or thread-level policy objects for assistant visibility and reveal intent.
+
+This could give apps a shared language for:
+
+- Hidden from assistant.
+- Revealed to assistant.
+- Reveal thread.
+- Revoke future reveal.
+
+### Hosting and Trust Disclosure XIP
+
+Standardize a lightweight representation of hosting mode and trust posture.
+
+For example: local, self-hosted, managed, hybrid.
+
+This would help clients surface the real trust boundary to users.
+
+## Why XIPs matter here
+
+Without standardization, each app may invent different agent policy semantics, provenance formats, and UX expectations.
+
+A small number of targeted XIPs could:
+
+- Improve interoperability.
+- Make clients more consistent.
+- Reduce ambiguity around agent posture.
+- Encourage healthier defaults across the ecosystem.
+
+## Convos-Specific Opportunities
+
+Convos can add flavor to this model without waiting for protocol-level changes.
+
+### Identity and presentation
+
+- Present agents as first-class conversation participants with visible capability posture.
+- Highlight owner relationship and hosting mode.
+- Show trust tier alongside hosting mode.
+- Show when an agent is scoped to one convo versus broadly reused.
+
+### Message UX
+
+- Reveal-to-assistant controls inline.
+- Thread-level visibility toggles.
+- Agent-only summaries.
+- Hidden content placeholders.
+- Timeline notices when capabilities change (material changes only).
+
+### Trust and safety UX
+
+- Explain what the assistant can currently access.
+- Show inference and egress posture clearly.
+- Show when content may leave the device or local broker boundary.
+- Require confirmations for send, tool use, or risky actions.
+- Make revocation easy and legible.
+- Show agent offline/staleness state.
+
+### Developer and power-user UX
+
+- Attach to local broker.
+- Attach to self-hosted broker.
+- Inspect active session details.
+- Inspect attestation history.
+- Export broker fingerprints and configuration.
+
+## Rollout Strategy
+
+### Phase 1
+
+- Define broker, view, grant, attestation, and session concepts.
+- Ship local broker reference implementation with Secure Enclave-backed key management.
+- Implement derived key hierarchy (root → operational → session).
+- Ship open source reference verifier (Cloudflare Workers / Railway).
+- Expose WebSocket interface.
+- Support basic view modes (full, reveal-only) and grant configurations.
+- Ship Convos experimental client integration.
+- Define structured egress/inference disclosure fields.
+
+### Phase 2
+
+- Add self-hosted deployment templates.
+- Add MCP and SDK adapters.
+- Add permission editing UX.
+- Add attestation timeline UX (material changes only).
+- Add action confirmations and richer tool scopes.
+- Verifier-over-XMTP flow operational.
+- Draft Capability Attestation XIP based on implementation learnings.
+
+### Phase 3
+
+- Add managed broker product surface.
+- Add hybrid control-plane support.
+- Add key rotation and machine migration flows.
+- Add coordinating agent pattern for dynamic agent creation.
+- Add reproducible build verification support.
+- Draft Broker Verification Statement XIP.
+- Explore runtime attestation integration (TEE-agnostic) with TEE-backed key storage for hosted brokers.
+
+## Open Questions
+
+- What is the exact minimum viable attestation schema?
+- How should clients render stale or expired attestations?
+- How should reveal history be represented in UX?
+- Should session issuance be tied to explicit per-thread scopes by default?
+- How much policy should be in-group versus off-chain broker config?
+- What is the cleanest recovery story for one-click hosted deployments?
+- Which verification classes should the reference verifier support at launch?
+- What is the appropriate default heartbeat interval?
+- How should content type allowlist updates be surfaced in client UX?
+
+## Success Criteria
+
+The proposal is successful if it achieves the following:
+
+- Agents no longer need raw XMTP credentials in the harness to participate in a useful way.
+- Users can run local or hosted agents through the same conceptual model.
+- Group members can understand what an agent can do right now.
+- Permission changes become visible and attributable.
+- Egress and inference posture is explicitly disclosed, not hidden.
+- A reference verifier is available for early trust verification.
+- Apps such as Convos can create a rich, understandable UX without waiting on large protocol changes.
+- The model produces enough clarity and adoption pressure to justify one or more focused XIPs.
+
+## Risks
+
+### Technical risks
+
+- Broker complexity grows too quickly.
+- Too much app-layer behavior creates interop fragmentation.
+- Reveal semantics become inconsistent across clients.
+- Hosted deployment is oversold relative to its trust boundary.
+- Multi-agent isolation within a single broker proves harder than expected.
+
+### Product risks
+
+- Users misunderstand the difference between local and hosted modes.
+- The view and grant model feels too complex.
+- Too much UX ceremony discourages agent usage.
+- Attestations become noisy despite the materiality threshold.
+- Group members feel powerless under the v1 owner-only governance model.
+
+### Mitigations
+
+- Keep v1 narrow.
+- Start with simple view modes and basic grants.
+- Make hosting mode and trust tier explicit.
+- Focus first on clear provenance and meaningful enforcement.
+- Ship the reference verifier early for fast trust bootstrapping.
+- Standardize only after implementation learning.
+- Name the v1 governance asymmetry explicitly so expectations are set.
+
+## Recommendation
+
+Proceed with an app-layer broker architecture as the primary design direction.
+
+Start with:
+
+- A local broker reference implementation with Secure Enclave-backed key management.
+- A purpose-built key management layer (inspired by keypo-cli’s architecture, built in-house for supply chain integrity).
+- Derived key hierarchy with biometric-gated privilege escalation.
+- WebSocket as the primary live interface.
+- Structured view and grant model.
+- Group-visible capability attestations with structured egress disclosure.
+- An open source reference verifier deployable to Cloudflare Workers or Railway.
+- Convos as a rich UX proving ground.
+- Self-hosted templates for Fly and Railway.
+- A Cloudflare-friendly hybrid control-plane design.
+
+Use implementation learnings to identify which parts should become formal XIPs, starting with Capability Attestation.
+
+## Appendix: Crisp Framing
+
+The simplest way to explain the proposal is:
+
+- The **broker** is the real XMTP client.
+- The **view** is what the agent is allowed to see.
+- The **grant** is what the agent is allowed to do.
+- The **attestation** is what the group is told about that view and grant.
+- The **session** is how the harness connects to it.
+- The **verifier** is how the group can check whether the broker is what it claims.
+
+Or more simply:
+
+**The group trusts the attestation. The broker enforces the view and grant. The agent never touches the raw client. The verifier keeps the broker honest.**

--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.claude/agents/xmtp-expert.md
+++ b/.claude/agents/xmtp-expert.md
@@ -1,0 +1,60 @@
+---
+name: xmtp-expert
+description: "XMTP protocol and SDK expert — looks up current documentation via blz before answering. Use proactively whenever XMTP concepts, SDK patterns, or API signatures need to be verified."
+model: sonnet
+skills:
+  - xmtp-docs-blz
+memory: project
+---
+
+You are an XMTP protocol and SDK expert working on the xmtp-broker project. Your job is to answer questions about XMTP by looking up current documentation, not from memory alone.
+
+**Core principle:** Always verify SDK patterns against documentation before answering. The XMTP SDK evolves frequently — do not rely on training data for method signatures, parameter names, or API patterns.
+
+**Your workflow:**
+
+1. When asked about XMTP, use the `blz` CLI to search documentation:
+   ```bash
+   blz query -s xmtp "your search terms" --limit 5 --text
+   ```
+
+2. Retrieve full content for relevant sections:
+   ```bash
+   blz get xmtp:<line-range> --raw
+   ```
+
+3. For broader exploration, expand results to full sections:
+   ```bash
+   blz query -s xmtp "your query" -C all --text
+   ```
+
+4. Synthesize findings into a clear, specific answer with code examples where appropriate.
+
+**What you can answer:**
+
+- XMTP protocol concepts: MLS, epochs, groups, inboxes, identities, installations
+- SDK usage: Client.create(), conversations, messages, streaming, sync
+- Group chat: permissions, metadata, admin roles, member management
+- Content types: text, reactions, replies, attachments, custom types
+- Identity model: signers, wallet signatures, inbox IDs, linked identities
+- Consent and spam: user consent preferences, blocking
+- Network: environments (dev, production), Gateway Service, fees
+- Push notifications, history sync, backups
+
+**What you should not do:**
+
+- Guess at SDK method signatures — always look them up
+- Answer from training data alone when documentation is available
+- Make claims about XMTP behavior without citing documentation
+
+**Agent memory:**
+
+Your memory directory persists across sessions. Use it to avoid redundant lookups and build institutional knowledge about the XMTP SDK.
+
+Write to memory when you:
+- Discover a frequently-needed line range (e.g., "Client.create() docs are at xmtp:7408-7493")
+- Find an answer that required multiple search steps — save the shortcut
+- Notice SDK patterns that differ from what training data would suggest
+- Learn which search terms work best for specific topics
+
+Read from memory before searching — a previous session may have already found what you need.

--- a/.claude/skills/xmtp-docs-blz/SKILL.md
+++ b/.claude/skills/xmtp-docs-blz/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: xmtp-docs-blz
+description: >
+  Look up current XMTP documentation using the blz CLI. Use when you need to
+  check XMTP SDK methods, group permissions, identity model, content types,
+  MLS details, or any XMTP protocol or API question. Prevents hallucinating
+  outdated SDK patterns.
+  Use when: (1) looking up XMTP SDK methods or patterns, (2) verifying API
+  signatures before writing code, (3) understanding XMTP protocol concepts
+  (groups, MLS, inboxes, attestations), (4) checking content type schemas,
+  (5) any question about how XMTP works.
+---
+
+# XMTP Documentation Lookup via blz
+
+The `xmtp` source is indexed locally via `blz` and contains the full XMTP documentation (~16,700 lines, 833 sections). Always look up SDK patterns before writing XMTP code — the SDK evolves frequently.
+
+## Workflow
+
+### Step 1: Search for the topic
+
+Use `blz query` to find relevant sections:
+
+```bash
+blz query -s xmtp "your search terms" --limit 5 --text
+```
+
+This returns ranked results with section paths and line numbers (e.g., `xmtp:7408-7408`).
+
+**Tips for good queries:**
+- Use 2-4 specific terms: `"group permissions admin"`
+- Use `+term` to require a word: `"+signer +create +node"`
+- Use quotes for exact phrases: `'"Client.create"'`
+- Add `--block` to auto-expand results to their full section
+
+### Step 2: Retrieve full content by line range
+
+Once you have line numbers from search results, fetch the full content:
+
+```bash
+blz get xmtp:7408-7493 --raw
+```
+
+**Retrieval options:**
+- `--raw` — clean content, best for reading code examples
+- `-C 10` — add 10 lines of context before and after
+- `-C all` — expand to the full containing section (very useful)
+- `--block` — same as `-C all`, expand to heading boundary
+- Multiple ranges: `blz get xmtp:7408-7493,9456-9530 --raw`
+
+### Step 3: Browse structure (when you don't know what to search for)
+
+List all documentation sections:
+
+```bash
+# Top-level sections only
+blz map xmtp -H "<=2" --text
+
+# All sections matching a filter
+blz map xmtp --filter "group" --text
+
+# Full tree view
+blz map xmtp --tree --text
+```
+
+## One-Shot Pattern (Recommended Default)
+
+For most lookups, a single command gets you everything:
+
+```bash
+blz query -s xmtp "your query" --limit 3 -C all --text
+```
+
+This searches, ranks results, and expands each hit to its full section — usually enough context in one call.
+
+## Key XMTP Documentation Sections
+
+| Topic | Search terms |
+|-------|-------------|
+| Node SDK setup | `"node SDK" +create +client` |
+| Creating groups | `+create +group +conversation` |
+| Group permissions | `"group permissions"` |
+| Identity / inboxes | `+identity +inbox +signer` |
+| Content types | `"content type" +text +reaction` |
+| MLS / encryption | `+MLS +encryption +epoch` |
+| Streaming messages | `+stream +messages +conversation` |
+| Consent / spam | `+consent +preferences +spam` |
+| Push notifications | `"push notification"` |
+| Agent SDK | `"agent SDK" +middleware` |
+
+## Other Available Sources
+
+Besides `xmtp`, these sources are also indexed in blz and may be useful:
+
+- `bun` — Bun runtime docs (APIs, test runner, SQLite, etc.)
+- `cloudflare` — Cloudflare Workers, D1, KV, etc.
+- `turbo` — Turborepo docs
+- `anthropic` — Claude API and platform docs
+
+Query any source with `-s <alias>`, e.g., `blz query -s bun "websocket server" --limit 3 --text`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,184 @@
+# CLAUDE.md -- xmtp-broker
+
+An agent broker for XMTP. The broker is the real XMTP client; agent harnesses connect through a controlled interface with scoped views and grants. See [README.md](README.md) for an overview and [.agents/docs/init/xmtp-broker.md](.agents/docs/init/xmtp-broker.md) for the full PRD.
+
+## Status
+
+Early development. No runnable code yet.
+
+## Project Structure
+
+- `packages/` — Versioned libraries (source in `src/`, tests in `src/__tests__/`)
+- `.agents/docs/` — Planning documents and PRD
+- `.agents/notes/` — Working notes and research (not permanent docs)
+- `.reference/` — Read-only reference codebases (gitignored)
+
+Tests live alongside code in `src/__tests__/` with `*.test.ts` files.
+
+## Commands
+
+```bash
+# Build
+bun run build
+
+# Test
+bun run test                    # all packages
+cd packages/<pkg> && bun test   # single package
+
+# Lint / Format
+bun run lint                    # oxlint
+bun run format:check            # oxfmt check
+bun run format:fix              # oxfmt fix
+bun run typecheck               # tsc --noEmit
+
+# Documentation lookup (XMTP SDK, protocol, etc.)
+blz query -s xmtp "your query" --limit 5 --text   # search
+blz get xmtp:1234-1280 --raw                       # retrieve lines
+blz query -s xmtp "your query" -C all --text       # search + expand sections
+```
+
+**Documentation lookup**: Delegate XMTP questions to the `xmtp-expert` agent (`.claude/agents/xmtp-expert.md`), which preloads the `xmtp-docs-blz` skill and maintains project-scoped memory of past lookups. For quick manual searches, use `blz` directly. The XMTP SDK evolves frequently — always verify patterns against documentation.
+
+## Development Principles
+
+### Non-Negotiable
+
+**TDD-First** — Write the test before the code. Always.
+
+1. **Red**: Write a failing test that defines behavior
+2. **Green**: Minimal code to pass
+3. **Refactor**: Improve while green
+
+**Result Types** — Functions that can fail return `Result<T, E>`, not exceptions. No `throw` in handler code.
+
+**Schema-First** — Zod schemas are the single source of truth for types and validation. Use `z.infer<>` for TypeScript types. No manual type duplication.
+
+**No Raw Credentials in Harness** — The core security invariant of the entire project. The harness never touches raw keys, raw DB, or raw XMTP SDK.
+
+### Strong Preferences
+
+**Bun-First** — Use Bun-native APIs before npm packages (`Bun.hash()`, `Bun.Glob`, `bun:sqlite`, `Bun.serve()`, etc.).
+
+**Small Files** — Under 200 LOC is healthy. 200-400: identify seams. Over 400: refactor before extending.
+
+**Transport-Agnostic Handlers** — Domain logic knows nothing about WebSocket, MCP, or CLI. Handlers receive typed input and context, return `Result<T, E>`. Transport adapters handle protocol concerns.
+
+**Validate at Boundaries** — Parse external data (harness requests, config, env vars) with Zod schemas at the edge. Trust types internally.
+
+### Blessed Dependencies
+
+| Concern           | Package           |
+| ----------------- | ----------------- |
+| Result type       | `better-result`   |
+| Schema validation | `zod`             |
+| Testing           | `bun:test`        |
+| XMTP SDK          | `@xmtp/node-sdk`  |
+| Ethereum crypto   | `viem`                      |
+| Elliptic curves   | `@noble/curves`             |
+| Hash functions    | `@noble/hashes`             |
+| AEAD ciphers      | `@noble/ciphers`            |
+| Protobuf          | `protobufjs`                |
+
+Add new dependencies deliberately. Check here first — if a concern isn't listed, discuss before pulling something in.
+
+## Architecture
+
+### Handler Contract
+
+All domain logic uses transport-agnostic handlers:
+
+```typescript
+type Handler<TInput, TOutput, TError extends BrokerError> = (
+  input: TInput,
+  ctx: HandlerContext,
+) => Promise<Result<TOutput, TError>>;
+```
+
+Note: `HandlerContext` is the planned canonical type. The current implementation uses `CoreContext` from `@xmtp-broker/contracts`.
+
+Handlers receive pre-validated input and a context object. They return `Result`, never throw. CLI, WebSocket, MCP, and HTTP are thin adapters over the same handlers.
+
+### Package Tiers (dependency flows downward only)
+
+**Foundation** — Stable types and contracts:
+- Schemas (views, grants, attestations, sessions, events)
+- Result/Error types and error taxonomy
+- Shared type utilities
+
+**Runtime** — Core broker functionality:
+- XMTP client management (raw plane)
+- Policy engine (view filtering, grant enforcement)
+- Session management
+- Attestation lifecycle
+- Key management
+
+**Transport** — Protocol adapters:
+- WebSocket (primary, Phase 1)
+- MCP (Phase 2)
+- CLI (Phase 2)
+- HTTP (Phase 3)
+
+### Error Taxonomy
+
+Errors are categorized for consistent handling across transports:
+
+| Category   | When to use                                    |
+| ---------- | ---------------------------------------------- |
+| validation | Bad input, schema violation                    |
+| not_found  | Resource doesn't exist                         |
+| permission | Grant denied, insufficient scope               |
+| auth       | Session expired, invalid token                 |
+| internal   | Invariant violation, unexpected state          |
+| timeout    | Operation exceeded time limit                  |
+| cancelled  | Cancelled by signal or user                    |
+
+Each category maps to exit codes (CLI), status codes (HTTP), and JSON-RPC codes (MCP). Only `timeout` errors are retryable.
+
+## Code Style
+
+### TypeScript
+
+Strict mode with maximum safety:
+- `strict: true` with `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`
+- `verbatimModuleSyntax`, `isolatedDeclarations`
+- No `any`, no `as` casts — narrow instead of assert
+- ESM-only (`"type": "module"`)
+
+### Formatting
+
+oxfmt: 80-char width, 2-space indent, double quotes, trailing commas (ES5), semicolons.
+
+### Linting
+
+oxlint with `correctness` and `suspicious` categories at error level.
+
+## Testing
+
+- Runner: `bun:test`
+- Test files: `src/__tests__/*.test.ts`
+- Write tests first (TDD). New behavior needs tests unless trivially obvious.
+
+## Git Workflow
+
+- Trunk-based development on `main`
+- Conventional commits: `feat(scope):`, `fix(scope):`, `test(scope):`
+- Stacked PRs via Graphite (`gt` over `git`)
+- Pre-commit: format + lint on staged files (Lefthook)
+- Pre-push: full verification
+
+## Reference Material
+
+The `.reference/` directory (gitignored) contains source material from related projects. These are read-only context — do not modify them.
+
+| Directory | What it is | Why it matters |
+|---|---|---|
+| `.reference/keypo-cli/` | Hardware-bound key management CLI (Secure Enclave P-256 + encrypted vault). Swift signer, Rust wallet, Solidity smart account. | Reference architecture for the broker's key management layer. The PRD calls out keypo-cli's Secure Enclave patterns as direct inspiration for the derived key hierarchy (root -> operational -> session). |
+| `.reference/xmtp-js/` | Official XMTP TypeScript monorepo: browser SDK, node SDK, agent SDK, content types, and CLI. | The broker wraps the XMTP client that these SDKs provide. Understanding the node SDK and agent SDK interfaces is essential for designing the broker's raw plane and the harness-facing derived plane. |
+| `.reference/skills/` | Claude Code agent skills for XMTP: documentation lookup (`xmtp-docs`) and agent identity/messaging (`xmtp-agent`). | Useful for querying current XMTP SDK patterns and methods during development. |
+| `.reference/convos-node-sdk/` | Convos Node SDK by XMTP Labs. Opinionated wrapper around `@xmtp/node-sdk` with per-group identity keys, agent runtime, and conversation management. | Key patterns for the broker: separate identity keys per group chat, agent lifecycle management, and how an opinionated client layer sits above the raw XMTP SDK. Per-group identity is a strong candidate for a first-class broker feature. |
+| `.reference/convos-cli/` | Convos CLI by XMTP Labs. Command-line interface for Convos agent operations. | Reference for CLI patterns around XMTP agent management, conversation commands, and how a CLI surfaces XMTP operations. |
+| `.reference/convos-agents/` | Convos Agents by XMTP Labs. Agent runtime, pool management, and dashboard for running XMTP agents at scale. | Reference for agent orchestration patterns: runtime lifecycle, pool scaling, monitoring, and multi-agent coordination. |
+
+## Research Notes
+
+Working notes from codebase analysis are in `.agents/notes/outfitter-patterns/`. These capture patterns extracted from `outfitter/stack` that informed the conventions above. They are working documents, not permanent documentation.


### PR DESCRIPTION
## Context
This is the base planning branch for the xmtp-broker stack. Review this PR against `main`, not `main` plus later implementation branches.

## What Changed
- adds the v0 product plan and PRD in `.agents/plans/v0/PLAN.md` and `.agents/plans/v0/SPEC.md`
- defines the implementation slices for scaffolding, schemas, contracts, core, policy, sessions, attestations, keys, websocket transport, and verifier
- captures repo-wide working conventions in `AGENTS.md` and `CLAUDE.md`
- includes outfitter pattern notes and the `xmtp-expert` / `xmtp-docs-blz` agent setup used to ground later implementation work

## Why This Branch Exists
This branch establishes the architecture and delivery plan before code lands. Everything above it in the stack should line up with these specs.

## Key Files
- `.agents/plans/v0/PLAN.md`
- `.agents/plans/v0/SPEC.md`
- `.agents/plans/v0/0*.md`
- `AGENTS.md`
- `CLAUDE.md`

## Verification
- reviewed as documentation and planning material
- forms the base of the managed Graphite stack
