### PR TITLE
feat(schemas): add broker schemas, content types, and error taxonomy

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -55,6 +55,10 @@
     "packages/schemas": {
       "name": "@xmtp-broker/schemas",
       "version": "0.0.0",
+      "dependencies": {
+        "better-result": "catalog:",
+        "zod": "catalog:",
+      },
       "devDependencies": {
         "bun-types": "catalog:",
         "typescript": "catalog:",
@@ -86,7 +90,7 @@
     },
   },
   "catalog": {
-    "better-result": "^1.1.0",
+    "better-result": "^2.7.0",
     "bun-types": "^1.2.0",
     "lefthook": "^1.11.0",
     "oxfmt": "^0.40.0",
@@ -97,6 +101,10 @@
   },
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
+
+    "@clack/core": ["@clack/core@0.5.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow=="],
+
+    "@clack/prompts": ["@clack/prompts@0.11.0", "", { "dependencies": { "@clack/core": "0.5.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw=="],
 
     "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
@@ -186,6 +194,8 @@
 
     "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
+    "better-result": ["better-result@2.7.0", "", { "dependencies": { "@clack/prompts": "^0.11.0" }, "bin": { "better-result": "bin/cli.mjs" } }, "sha512-7zrmXjAK8u8Z6SOe4R65XObOR5X+Y2I/VVku3t5cPOGQ8/WsBcfFmfnIPiEl5EBMDOzPHRwbiPbMtQBKYdw7RA=="],
+
     "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "lefthook": ["lefthook@1.13.6", "", { "optionalDependencies": { "lefthook-darwin-arm64": "1.13.6", "lefthook-darwin-x64": "1.13.6", "lefthook-freebsd-arm64": "1.13.6", "lefthook-freebsd-x64": "1.13.6", "lefthook-linux-arm64": "1.13.6", "lefthook-linux-x64": "1.13.6", "lefthook-openbsd-arm64": "1.13.6", "lefthook-openbsd-x64": "1.13.6", "lefthook-windows-arm64": "1.13.6", "lefthook-windows-x64": "1.13.6" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-ojj4/4IJ29Xn4drd5emqVgilegAPN3Kf0FQM2p/9+lwSTpU+SZ1v4Ig++NF+9MOa99UKY8bElmVrLhnUUNFh5g=="],
@@ -216,6 +226,10 @@
 
     "oxlint": ["oxlint@0.18.1", "", { "optionalDependencies": { "@oxlint/darwin-arm64": "0.18.1", "@oxlint/darwin-x64": "0.18.1", "@oxlint/linux-arm64-gnu": "0.18.1", "@oxlint/linux-arm64-musl": "0.18.1", "@oxlint/linux-x64-gnu": "0.18.1", "@oxlint/linux-x64-musl": "0.18.1", "@oxlint/win32-arm64": "0.18.1", "@oxlint/win32-x64": "0.18.1" }, "bin": { "oxlint": "bin/oxlint", "oxc_language_server": "bin/oxc_language_server" } }, "sha512-JGcQvbhd00Qb+nq4f9sYYRh7mZIb0K/7rbMepNdJDMzo8pbmBpx1N2XOG61RjHDsNnY6ImAmVk3h4QVwFenwUQ=="],
 
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
     "turbo": ["turbo@2.8.17", "", { "optionalDependencies": { "turbo-darwin-64": "2.8.17", "turbo-darwin-arm64": "2.8.17", "turbo-linux-64": "2.8.17", "turbo-linux-arm64": "2.8.17", "turbo-windows-64": "2.8.17", "turbo-windows-arm64": "2.8.17" }, "bin": { "turbo": "bin/turbo" } }, "sha512-YwPsNSqU2f/RXU/+Kcb7cPkPZARxom4+me7LKEdN5jsvy2tpfze3zDZ4EiGrJnvOm9Avu9rK0aaYsP7qZ3iz7A=="],
@@ -235,5 +249,9 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "packageManager": "bun@1.2.9",
   "catalog": {
-    "better-result": "^1.1.0",
+    "better-result": "^2.7.0",
     "zod": "^3.24.0",
     "typescript": "^5.8.0",
     "oxfmt": "^0.40.0",

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -7,6 +7,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./test-utils": {
+      "types": "./src/__tests__/fixtures.ts",
+      "default": "./src/__tests__/fixtures.ts"
     }
   },
   "scripts": {
@@ -15,7 +19,10 @@
     "lint": "oxlint .",
     "test": "bun test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "better-result": "catalog:",
+    "zod": "catalog:"
+  },
   "devDependencies": {
     "bun-types": "catalog:",
     "typescript": "catalog:"

--- a/packages/schemas/src/__tests__/attestation.test.ts
+++ b/packages/schemas/src/__tests__/attestation.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "bun:test";
+import {
+  InferenceMode,
+  ContentEgressScope,
+  RetentionAtProvider,
+  HostingMode,
+  TrustTier,
+  RevocationRules,
+  AttestationSchema,
+} from "../attestation.js";
+
+describe("InferenceMode", () => {
+  it("accepts all valid modes", () => {
+    for (const m of ["local", "external", "hybrid", "unknown"]) {
+      expect(InferenceMode.safeParse(m).success).toBe(true);
+    }
+  });
+
+  it("rejects invalid mode", () => {
+    expect(InferenceMode.safeParse("other").success).toBe(false);
+  });
+});
+
+describe("ContentEgressScope", () => {
+  it("accepts all valid scopes", () => {
+    for (const s of [
+      "full-messages",
+      "summaries-only",
+      "tool-calls-only",
+      "none",
+      "unknown",
+    ]) {
+      expect(ContentEgressScope.safeParse(s).success).toBe(true);
+    }
+  });
+});
+
+describe("RetentionAtProvider", () => {
+  it("accepts all valid retention values", () => {
+    for (const r of ["none", "session", "persistent", "unknown"]) {
+      expect(RetentionAtProvider.safeParse(r).success).toBe(true);
+    }
+  });
+});
+
+describe("HostingMode", () => {
+  it("accepts all valid hosting modes", () => {
+    for (const h of ["local", "self-hosted", "managed"]) {
+      expect(HostingMode.safeParse(h).success).toBe(true);
+    }
+  });
+});
+
+describe("TrustTier", () => {
+  it("accepts all valid trust tiers", () => {
+    for (const t of [
+      "unverified",
+      "source-verified",
+      "reproducibly-verified",
+      "runtime-attested",
+    ]) {
+      expect(TrustTier.safeParse(t).success).toBe(true);
+    }
+  });
+});
+
+describe("RevocationRules", () => {
+  it("accepts valid revocation rules", () => {
+    const valid = {
+      maxTtlSeconds: 3600,
+      requireHeartbeat: true,
+      ownerCanRevoke: true,
+      adminCanRemove: false,
+    };
+    expect(RevocationRules.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejects non-positive maxTtlSeconds", () => {
+    const invalid = {
+      maxTtlSeconds: 0,
+      requireHeartbeat: true,
+      ownerCanRevoke: true,
+      adminCanRemove: false,
+    };
+    expect(RevocationRules.safeParse(invalid).success).toBe(false);
+  });
+
+  it("rejects non-integer maxTtlSeconds", () => {
+    const invalid = {
+      maxTtlSeconds: 3600.5,
+      requireHeartbeat: true,
+      ownerCanRevoke: true,
+      adminCanRemove: false,
+    };
+    expect(RevocationRules.safeParse(invalid).success).toBe(false);
+  });
+});
+
+function createValidAttestation(
+  overrides?: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    attestationId: "att-001",
+    previousAttestationId: null,
+    agentInboxId: "agent-inbox-1",
+    ownerInboxId: "owner-inbox-1",
+    groupId: "group-1",
+    threadScope: null,
+    viewMode: "full",
+    contentTypes: ["xmtp.org/text:1.0"],
+    grantedOps: ["send", "reply"],
+    toolScopes: [],
+    inferenceMode: "external",
+    inferenceProviders: ["openai"],
+    contentEgressScope: "full-messages",
+    retentionAtProvider: "session",
+    hostingMode: "managed",
+    trustTier: "unverified",
+    buildProvenanceRef: null,
+    verifierStatementRef: null,
+    sessionKeyFingerprint: null,
+    policyHash: "abc123",
+    heartbeatInterval: 30,
+    issuedAt: "2024-01-01T00:00:00Z",
+    expiresAt: "2024-01-01T01:00:00Z",
+    revocationRules: {
+      maxTtlSeconds: 3600,
+      requireHeartbeat: true,
+      ownerCanRevoke: true,
+      adminCanRemove: false,
+    },
+    issuer: "broker-identity-1",
+    ...overrides,
+  };
+}
+
+describe("AttestationSchema", () => {
+  it("accepts a valid full attestation", () => {
+    const result = AttestationSchema.safeParse(createValidAttestation());
+    expect(result.success).toBe(true);
+  });
+
+  it("has exactly 25 fields", () => {
+    const keys = Object.keys(AttestationSchema.shape);
+    expect(keys).toHaveLength(25);
+  });
+
+  it("defaults heartbeatInterval to 30", () => {
+    const input = createValidAttestation();
+    delete input["heartbeatInterval"];
+    const result = AttestationSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.heartbeatInterval).toBe(30);
+    }
+  });
+
+  it("rejects undefined for nullable fields (must be explicit null)", () => {
+    const input = createValidAttestation();
+    delete input["buildProvenanceRef"];
+    expect(AttestationSchema.safeParse(input).success).toBe(false);
+  });
+
+  it("accepts null for all nullable fields", () => {
+    const result = AttestationSchema.safeParse(
+      createValidAttestation({
+        previousAttestationId: null,
+        threadScope: null,
+        buildProvenanceRef: null,
+        verifierStatementRef: null,
+        sessionKeyFingerprint: null,
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid datetime format", () => {
+    expect(
+      AttestationSchema.safeParse(
+        createValidAttestation({ issuedAt: "not-a-date" }),
+      ).success,
+    ).toBe(false);
+  });
+
+  it("rejects invalid viewMode", () => {
+    expect(
+      AttestationSchema.safeParse(createValidAttestation({ viewMode: "bad" }))
+        .success,
+    ).toBe(false);
+  });
+
+  it("rejects invalid content type in contentTypes array", () => {
+    expect(
+      AttestationSchema.safeParse(
+        createValidAttestation({ contentTypes: ["invalid"] }),
+      ).success,
+    ).toBe(false);
+  });
+});

--- a/packages/schemas/src/__tests__/content-types.test.ts
+++ b/packages/schemas/src/__tests__/content-types.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "bun:test";
+import {
+  ContentTypeId,
+  BASELINE_CONTENT_TYPES,
+  TextPayload,
+  ReactionPayload,
+  ReplyPayload,
+  ReadReceiptPayload,
+  GroupUpdatedPayload,
+  CONTENT_TYPE_SCHEMAS,
+} from "../content-types.js";
+
+describe("ContentTypeId", () => {
+  it("accepts valid XMTP content type strings", () => {
+    expect(ContentTypeId.safeParse("xmtp.org/text:1.0").success).toBe(true);
+    expect(ContentTypeId.safeParse("xmtp.org/reaction:1.0").success).toBe(true);
+    expect(ContentTypeId.safeParse("xmtp.org/readReceipt:1.0").success).toBe(
+      true,
+    );
+    expect(ContentTypeId.safeParse("custom.org/myType:2.1").success).toBe(true);
+  });
+
+  it("rejects malformed content type strings", () => {
+    expect(ContentTypeId.safeParse("invalid").success).toBe(false);
+    expect(ContentTypeId.safeParse("xmtp.org/text").success).toBe(false);
+    expect(ContentTypeId.safeParse("text:1.0").success).toBe(false);
+    expect(ContentTypeId.safeParse("").success).toBe(false);
+    expect(ContentTypeId.safeParse("xmtp.org/text:1").success).toBe(false);
+    expect(ContentTypeId.safeParse("XMTP.ORG/text:1.0").success).toBe(false);
+  });
+});
+
+describe("BASELINE_CONTENT_TYPES", () => {
+  it("contains exactly 5 standard content types", () => {
+    expect(BASELINE_CONTENT_TYPES).toHaveLength(5);
+  });
+
+  it("includes all standard XMTP types", () => {
+    expect(BASELINE_CONTENT_TYPES).toContain("xmtp.org/text:1.0");
+    expect(BASELINE_CONTENT_TYPES).toContain("xmtp.org/reaction:1.0");
+    expect(BASELINE_CONTENT_TYPES).toContain("xmtp.org/reply:1.0");
+    expect(BASELINE_CONTENT_TYPES).toContain("xmtp.org/readReceipt:1.0");
+    expect(BASELINE_CONTENT_TYPES).toContain("xmtp.org/groupUpdated:1.0");
+  });
+
+  it("all entries are valid ContentTypeId values", () => {
+    for (const ct of BASELINE_CONTENT_TYPES) {
+      expect(ContentTypeId.safeParse(ct).success).toBe(true);
+    }
+  });
+});
+
+describe("TextPayload", () => {
+  it("accepts valid text payload", () => {
+    expect(TextPayload.safeParse({ text: "hello" }).success).toBe(true);
+  });
+
+  it("rejects empty text", () => {
+    expect(TextPayload.safeParse({ text: "" }).success).toBe(false);
+  });
+
+  it("rejects missing text field", () => {
+    expect(TextPayload.safeParse({}).success).toBe(false);
+  });
+});
+
+describe("ReactionPayload", () => {
+  it("accepts valid reaction payload", () => {
+    const valid = {
+      reference: "msg-123",
+      action: "added",
+      content: "thumbsup",
+      schema: "unicode",
+    };
+    expect(ReactionPayload.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejects invalid action", () => {
+    const invalid = {
+      reference: "msg-123",
+      action: "unknown",
+      content: "thumbsup",
+      schema: "unicode",
+    };
+    expect(ReactionPayload.safeParse(invalid).success).toBe(false);
+  });
+
+  it("rejects invalid schema type", () => {
+    const invalid = {
+      reference: "msg-123",
+      action: "added",
+      content: "thumbsup",
+      schema: "invalid",
+    };
+    expect(ReactionPayload.safeParse(invalid).success).toBe(false);
+  });
+});
+
+describe("ReplyPayload", () => {
+  it("accepts valid reply payload", () => {
+    const valid = {
+      reference: "msg-456",
+      content: {
+        type: "xmtp.org/text:1.0",
+        payload: { text: "reply text" },
+      },
+    };
+    expect(ReplyPayload.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejects reply with invalid content type", () => {
+    const invalid = {
+      reference: "msg-456",
+      content: {
+        type: "invalid",
+        payload: { text: "reply" },
+      },
+    };
+    expect(ReplyPayload.safeParse(invalid).success).toBe(false);
+  });
+});
+
+describe("ReadReceiptPayload", () => {
+  it("accepts empty object", () => {
+    expect(ReadReceiptPayload.safeParse({}).success).toBe(true);
+  });
+});
+
+describe("GroupUpdatedPayload", () => {
+  it("accepts valid group update payload", () => {
+    const valid = {
+      initiatedByInboxId: "inbox-1",
+      addedInboxes: ["inbox-2"],
+      removedInboxes: [],
+      metadataFieldsChanged: [
+        { fieldName: "name", oldValue: "Old", newValue: "New" },
+      ],
+    };
+    expect(GroupUpdatedPayload.safeParse(valid).success).toBe(true);
+  });
+
+  it("accepts null values for metadata old/new values", () => {
+    const valid = {
+      initiatedByInboxId: "inbox-1",
+      addedInboxes: [],
+      removedInboxes: [],
+      metadataFieldsChanged: [
+        { fieldName: "desc", oldValue: null, newValue: "set" },
+      ],
+    };
+    expect(GroupUpdatedPayload.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejects undefined for metadata values (must be nullable)", () => {
+    const invalid = {
+      initiatedByInboxId: "inbox-1",
+      addedInboxes: [],
+      removedInboxes: [],
+      metadataFieldsChanged: [{ fieldName: "desc", newValue: "set" }],
+    };
+    expect(GroupUpdatedPayload.safeParse(invalid).success).toBe(false);
+  });
+});
+
+describe("CONTENT_TYPE_SCHEMAS", () => {
+  it("has entries for all baseline content types", () => {
+    for (const ct of BASELINE_CONTENT_TYPES) {
+      expect(CONTENT_TYPE_SCHEMAS[ct]).toBeDefined();
+    }
+  });
+});

--- a/packages/schemas/src/__tests__/errors.test.ts
+++ b/packages/schemas/src/__tests__/errors.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it } from "bun:test";
+import {
+  ErrorCategory,
+  ERROR_CATEGORY_META,
+  errorCategoryMeta,
+  ValidationError,
+  AttestationError,
+  NotFoundError,
+  PermissionError,
+  GrantDeniedError,
+  AuthError,
+  SessionExpiredError,
+  InternalError,
+  TimeoutError,
+  CancelledError,
+  NetworkError,
+  matchError,
+} from "../errors/index.js";
+import type { AnyBrokerError } from "../errors/index.js";
+
+describe("ErrorCategory", () => {
+  it("accepts all 8 categories", () => {
+    for (const c of [
+      "validation",
+      "not_found",
+      "permission",
+      "auth",
+      "internal",
+      "timeout",
+      "cancelled",
+      "network",
+    ]) {
+      expect(ErrorCategory.safeParse(c).success).toBe(true);
+    }
+  });
+
+  it("rejects invalid category", () => {
+    expect(ErrorCategory.safeParse("unknown").success).toBe(false);
+  });
+});
+
+describe("ERROR_CATEGORY_META", () => {
+  it("has entries for all 8 categories", () => {
+    const categories = ErrorCategory.options;
+    for (const c of categories) {
+      const meta = ERROR_CATEGORY_META[c];
+      expect(meta).toBeDefined();
+      expect(typeof meta.exitCode).toBe("number");
+      expect(typeof meta.statusCode).toBe("number");
+      expect(typeof meta.jsonRpcCode).toBe("number");
+      expect(typeof meta.retryable).toBe("boolean");
+    }
+  });
+
+  it("maps validation to correct codes", () => {
+    const meta = ERROR_CATEGORY_META.validation;
+    expect(meta.exitCode).toBe(1);
+    expect(meta.statusCode).toBe(400);
+    expect(meta.jsonRpcCode).toBe(-32602);
+    expect(meta.retryable).toBe(false);
+  });
+
+  it("marks only timeout and network as retryable", () => {
+    const categories = ErrorCategory.options;
+    for (const c of categories) {
+      expect(ERROR_CATEGORY_META[c].retryable).toBe(
+        c === "timeout" || c === "network",
+      );
+    }
+  });
+
+  it("maps network to exit code 6 and HTTP 503", () => {
+    const meta = ERROR_CATEGORY_META.network;
+    expect(meta.exitCode).toBe(6);
+    expect(meta.statusCode).toBe(503);
+    expect(meta.jsonRpcCode).toBe(-32002);
+    expect(meta.retryable).toBe(true);
+  });
+
+  it("maps cancelled to exit code 130 and HTTP 499", () => {
+    const meta = ERROR_CATEGORY_META.cancelled;
+    expect(meta.exitCode).toBe(130);
+    expect(meta.statusCode).toBe(499);
+  });
+});
+
+describe("errorCategoryMeta", () => {
+  it("returns the same object as direct lookup", () => {
+    expect(errorCategoryMeta("auth")).toBe(ERROR_CATEGORY_META.auth);
+  });
+});
+
+describe("ValidationError", () => {
+  it("creates with correct properties", () => {
+    const err = ValidationError.create("email", "invalid format");
+    expect(err._tag).toBe("ValidationError");
+    expect(err.code).toBe(1000);
+    expect(err.category).toBe("validation");
+    expect(err.context.field).toBe("email");
+    expect(err.context.reason).toBe("invalid format");
+    expect(err.message).toBe("Validation failed on 'email': invalid format");
+  });
+
+  it("includes extra context", () => {
+    const err = ValidationError.create("age", "too low", {
+      min: 18,
+    });
+    expect(err.context.min).toBe(18);
+  });
+
+  it("is an instance of Error", () => {
+    expect(ValidationError.create("f", "r")).toBeInstanceOf(Error);
+  });
+});
+
+describe("AttestationError", () => {
+  it("creates with correct properties", () => {
+    const err = AttestationError.create("att-1", "expired");
+    expect(err._tag).toBe("AttestationError");
+    expect(err.code).toBe(1010);
+    expect(err.category).toBe("validation");
+    expect(err.context.attestationId).toBe("att-1");
+    expect(err.message).toBe("Attestation 'att-1': expired");
+  });
+});
+
+describe("NotFoundError", () => {
+  it("creates with correct properties", () => {
+    const err = NotFoundError.create("Session", "sess-42");
+    expect(err._tag).toBe("NotFoundError");
+    expect(err.code).toBe(1100);
+    expect(err.category).toBe("not_found");
+    expect(err.context.resourceType).toBe("Session");
+    expect(err.context.resourceId).toBe("sess-42");
+    expect(err.message).toBe("Session 'sess-42' not found");
+  });
+});
+
+describe("PermissionError", () => {
+  it("creates with null context by default", () => {
+    const err = PermissionError.create("Access denied");
+    expect(err._tag).toBe("PermissionError");
+    expect(err.code).toBe(1200);
+    expect(err.category).toBe("permission");
+    expect(err.context).toBeNull();
+  });
+
+  it("creates with provided context", () => {
+    const err = PermissionError.create("Denied", { scope: "admin" });
+    expect(err.context).toEqual({ scope: "admin" });
+  });
+});
+
+describe("GrantDeniedError", () => {
+  it("creates with correct properties", () => {
+    const err = GrantDeniedError.create("send", "messaging");
+    expect(err._tag).toBe("GrantDeniedError");
+    expect(err.code).toBe(1210);
+    expect(err.category).toBe("permission");
+    expect(err.context.operation).toBe("send");
+    expect(err.context.grantType).toBe("messaging");
+    expect(err.message).toBe(
+      "Operation 'send' denied: missing messaging grant",
+    );
+  });
+});
+
+describe("AuthError", () => {
+  it("creates with null context by default", () => {
+    const err = AuthError.create("Unauthorized");
+    expect(err._tag).toBe("AuthError");
+    expect(err.code).toBe(1300);
+    expect(err.category).toBe("auth");
+    expect(err.context).toBeNull();
+  });
+});
+
+describe("SessionExpiredError", () => {
+  it("creates with correct properties", () => {
+    const err = SessionExpiredError.create("sess-99");
+    expect(err._tag).toBe("SessionExpiredError");
+    expect(err.code).toBe(1310);
+    expect(err.category).toBe("auth");
+    expect(err.context.sessionId).toBe("sess-99");
+    expect(err.message).toBe("Session 'sess-99' has expired");
+  });
+});
+
+describe("InternalError", () => {
+  it("creates with null context by default", () => {
+    const err = InternalError.create("Invariant violated");
+    expect(err._tag).toBe("InternalError");
+    expect(err.code).toBe(1400);
+    expect(err.category).toBe("internal");
+    expect(err.context).toBeNull();
+  });
+});
+
+describe("TimeoutError", () => {
+  it("creates with correct properties", () => {
+    const err = TimeoutError.create("fetchMessages", 5000);
+    expect(err._tag).toBe("TimeoutError");
+    expect(err.code).toBe(1500);
+    expect(err.category).toBe("timeout");
+    expect(err.context.operation).toBe("fetchMessages");
+    expect(err.context.timeoutMs).toBe(5000);
+    expect(err.message).toBe(
+      "Operation 'fetchMessages' timed out after 5000ms",
+    );
+  });
+});
+
+describe("CancelledError", () => {
+  it("creates with null context", () => {
+    const err = CancelledError.create("User cancelled");
+    expect(err._tag).toBe("CancelledError");
+    expect(err.code).toBe(1600);
+    expect(err.category).toBe("cancelled");
+    expect(err.context).toBeNull();
+  });
+});
+
+describe("NetworkError", () => {
+  it("creates with correct properties", () => {
+    const err = NetworkError.create("xmtp://node.example.com", "connection refused");
+    expect(err._tag).toBe("NetworkError");
+    expect(err.code).toBe(1700);
+    expect(err.category).toBe("network");
+    expect(err.context.endpoint).toBe("xmtp://node.example.com");
+    expect(err.message).toBe(
+      "Network error reaching 'xmtp://node.example.com': connection refused",
+    );
+  });
+
+  it("includes extra context", () => {
+    const err = NetworkError.create("api.example.com", "timeout", {
+      attemptNumber: 3,
+    });
+    expect(err.context.endpoint).toBe("api.example.com");
+    expect(err.context.attemptNumber).toBe(3);
+  });
+
+  it("is an instance of Error", () => {
+    expect(NetworkError.create("ep", "reason")).toBeInstanceOf(Error);
+  });
+});
+
+describe("matchError", () => {
+  it("dispatches to correct handler by _tag", () => {
+    const err: AnyBrokerError = GrantDeniedError.create("send", "messaging");
+    const result = matchError(err, {
+      ValidationError: () => "validation",
+      AttestationError: () => "attestation",
+      NotFoundError: () => "not_found",
+      PermissionError: () => "permission",
+      GrantDeniedError: (e) => `denied:${e.context.operation}`,
+      AuthError: () => "auth",
+      SessionExpiredError: () => "session_expired",
+      InternalError: () => "internal",
+      TimeoutError: () => "timeout",
+      CancelledError: () => "cancelled",
+      NetworkError: () => "network",
+    });
+    expect(result).toBe("denied:send");
+  });
+
+  it("handles every error class", () => {
+    const errors: AnyBrokerError[] = [
+      ValidationError.create("f", "r"),
+      AttestationError.create("a", "r"),
+      NotFoundError.create("T", "id"),
+      PermissionError.create("msg"),
+      GrantDeniedError.create("op", "gt"),
+      AuthError.create("msg"),
+      SessionExpiredError.create("s"),
+      InternalError.create("msg"),
+      TimeoutError.create("op", 1000),
+      CancelledError.create("msg"),
+      NetworkError.create("ep", "reason"),
+    ];
+
+    for (const err of errors) {
+      const result = matchError(err, {
+        ValidationError: () => "ValidationError",
+        AttestationError: () => "AttestationError",
+        NotFoundError: () => "NotFoundError",
+        PermissionError: () => "PermissionError",
+        GrantDeniedError: () => "GrantDeniedError",
+        AuthError: () => "AuthError",
+        SessionExpiredError: () => "SessionExpiredError",
+        InternalError: () => "InternalError",
+        TimeoutError: () => "TimeoutError",
+        CancelledError: () => "CancelledError",
+        NetworkError: () => "NetworkError",
+      });
+      expect(result).toBe(err._tag);
+    }
+  });
+});

--- a/packages/schemas/src/__tests__/events.test.ts
+++ b/packages/schemas/src/__tests__/events.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from "bun:test";
+import {
+  MessageVisibility,
+  MessageEvent,
+  SessionStartedEvent,
+  HeartbeatEvent,
+  BrokerRecoveryEvent,
+  BrokerEvent,
+} from "../events.js";
+
+describe("MessageVisibility", () => {
+  it("accepts all valid visibility values", () => {
+    for (const v of [
+      "visible",
+      "historical",
+      "hidden",
+      "revealed",
+      "redacted",
+    ]) {
+      expect(MessageVisibility.safeParse(v).success).toBe(true);
+    }
+  });
+});
+
+describe("MessageEvent", () => {
+  const valid = {
+    type: "message.visible",
+    messageId: "msg-1",
+    groupId: "group-1",
+    senderInboxId: "inbox-1",
+    contentType: "xmtp.org/text:1.0",
+    content: { text: "hello" },
+    visibility: "visible",
+    sentAt: "2024-01-01T00:00:00Z",
+    attestationId: null,
+  };
+
+  it("accepts valid message event", () => {
+    expect(MessageEvent.safeParse(valid).success).toBe(true);
+  });
+
+  it("accepts message with attestation ID", () => {
+    expect(
+      MessageEvent.safeParse({ ...valid, attestationId: "att-1" }).success,
+    ).toBe(true);
+  });
+
+  it("rejects wrong type discriminator", () => {
+    expect(MessageEvent.safeParse({ ...valid, type: "wrong" }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe("SessionStartedEvent", () => {
+  const valid = {
+    type: "session.started",
+    session: {
+      sessionId: "sess-1",
+      agentInboxId: "agent-1",
+      sessionKeyFingerprint: "fp",
+      issuedAt: "2024-01-01T00:00:00Z",
+      expiresAt: "2024-01-01T01:00:00Z",
+    },
+    view: {
+      mode: "full",
+      threadScopes: [{ groupId: "g1", threadId: null }],
+      contentTypes: ["xmtp.org/text:1.0"],
+    },
+    grant: {
+      messaging: { send: true, reply: true, react: true, draftOnly: false },
+      groupManagement: {
+        addMembers: false,
+        removeMembers: false,
+        updateMetadata: false,
+        inviteUsers: false,
+      },
+      tools: { scopes: [] },
+      egress: {
+        storeExcerpts: false,
+        useForMemory: false,
+        forwardToProviders: false,
+        quoteRevealed: false,
+        summarize: false,
+      },
+    },
+  };
+
+  it("accepts valid session started event", () => {
+    expect(SessionStartedEvent.safeParse(valid).success).toBe(true);
+  });
+});
+
+describe("HeartbeatEvent", () => {
+  it("accepts valid heartbeat", () => {
+    const valid = {
+      type: "heartbeat",
+      sessionId: "sess-1",
+      timestamp: "2024-01-01T00:00:00Z",
+    };
+    expect(HeartbeatEvent.safeParse(valid).success).toBe(true);
+  });
+});
+
+describe("BrokerRecoveryEvent", () => {
+  it("accepts valid recovery event", () => {
+    const valid = {
+      type: "broker.recovery.complete",
+      caughtUpThrough: "2024-01-01T00:00:00Z",
+    };
+    expect(BrokerRecoveryEvent.safeParse(valid).success).toBe(true);
+  });
+});
+
+describe("BrokerEvent discriminated union", () => {
+  it("discriminates on type field", () => {
+    const heartbeat = {
+      type: "heartbeat",
+      sessionId: "sess-1",
+      timestamp: "2024-01-01T00:00:00Z",
+    };
+    const result = BrokerEvent.safeParse(heartbeat);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.type).toBe("heartbeat");
+    }
+  });
+
+  it("rejects events with unknown type", () => {
+    const invalid = { type: "unknown.event", data: {} };
+    expect(BrokerEvent.safeParse(invalid).success).toBe(false);
+  });
+
+  it("accepts all 12 event types", () => {
+    const validAttestation = {
+      attestationId: "att-001",
+      previousAttestationId: null,
+      agentInboxId: "agent-1",
+      ownerInboxId: "owner-1",
+      groupId: "group-1",
+      threadScope: null,
+      viewMode: "full",
+      contentTypes: ["xmtp.org/text:1.0"],
+      grantedOps: [],
+      toolScopes: [],
+      inferenceMode: "external",
+      inferenceProviders: [],
+      contentEgressScope: "none",
+      retentionAtProvider: "none",
+      hostingMode: "managed",
+      trustTier: "unverified",
+      buildProvenanceRef: null,
+      verifierStatementRef: null,
+      sessionKeyFingerprint: null,
+      policyHash: "abc",
+      heartbeatInterval: 30,
+      issuedAt: "2024-01-01T00:00:00Z",
+      expiresAt: "2024-01-01T01:00:00Z",
+      revocationRules: {
+        maxTtlSeconds: 3600,
+        requireHeartbeat: true,
+        ownerCanRevoke: true,
+        adminCanRemove: false,
+      },
+      issuer: "broker-1",
+    };
+
+    const validGrant = {
+      messaging: { send: true, reply: true, react: true, draftOnly: false },
+      groupManagement: {
+        addMembers: false,
+        removeMembers: false,
+        updateMetadata: false,
+        inviteUsers: false,
+      },
+      tools: { scopes: [] },
+      egress: {
+        storeExcerpts: false,
+        useForMemory: false,
+        forwardToProviders: false,
+        quoteRevealed: false,
+        summarize: false,
+      },
+    };
+
+    const events = [
+      {
+        type: "message.visible",
+        messageId: "m1",
+        groupId: "g1",
+        senderInboxId: "i1",
+        contentType: "xmtp.org/text:1.0",
+        content: {},
+        visibility: "visible",
+        sentAt: "2024-01-01T00:00:00Z",
+        attestationId: null,
+      },
+      { type: "attestation.updated", attestation: validAttestation },
+      {
+        type: "session.started",
+        session: {
+          sessionId: "s1",
+          agentInboxId: "a1",
+          sessionKeyFingerprint: "fp",
+          issuedAt: "2024-01-01T00:00:00Z",
+          expiresAt: "2024-01-01T01:00:00Z",
+        },
+        view: {
+          mode: "full",
+          threadScopes: [{ groupId: "g1", threadId: null }],
+          contentTypes: ["xmtp.org/text:1.0"],
+        },
+        grant: validGrant,
+      },
+      { type: "session.expired", sessionId: "s1", reason: "ttl" },
+      {
+        type: "session.reauthorization_required",
+        sessionId: "s1",
+        reason: "policy change",
+      },
+      {
+        type: "heartbeat",
+        sessionId: "s1",
+        timestamp: "2024-01-01T00:00:00Z",
+      },
+      {
+        type: "message.revealed",
+        messageId: "m1",
+        groupId: "g1",
+        contentType: "xmtp.org/text:1.0",
+        content: {},
+        revealId: "r1",
+      },
+      {
+        type: "view.updated",
+        view: {
+          mode: "full",
+          threadScopes: [{ groupId: "g1", threadId: null }],
+          contentTypes: ["xmtp.org/text:1.0"],
+        },
+      },
+      { type: "grant.updated", grant: validGrant },
+      {
+        type: "agent.revoked",
+        revocation: {
+          attestationId: "rev-1",
+          previousAttestationId: "att-001",
+          agentInboxId: "a1",
+          groupId: "g1",
+          reason: "owner-initiated",
+          revokedAt: "2024-01-01T00:00:00Z",
+          issuer: "broker-1",
+        },
+      },
+      {
+        type: "action.confirmation_required",
+        actionId: "act-1",
+        actionType: "send_message",
+        preview: { text: "hello" },
+      },
+      {
+        type: "broker.recovery.complete",
+        caughtUpThrough: "2024-01-01T00:00:00Z",
+      },
+    ];
+
+    for (const event of events) {
+      const result = BrokerEvent.safeParse(event);
+      expect(result.success).toBe(true);
+    }
+  });
+});

--- a/packages/schemas/src/__tests__/fixtures.ts
+++ b/packages/schemas/src/__tests__/fixtures.ts
@@ -1,0 +1,104 @@
+import type { Attestation } from "../attestation.js";
+import type { ViewConfig } from "../view.js";
+import type { GrantConfig } from "../grant.js";
+import type { IssuedSession, SessionToken } from "../session.js";
+
+/** Valid attestation fixture for testing. */
+export function createTestAttestation(
+  overrides?: Partial<Attestation>,
+): Attestation {
+  return {
+    attestationId: "test-att-001",
+    previousAttestationId: null,
+    agentInboxId: "test-agent-inbox",
+    ownerInboxId: "test-owner-inbox",
+    groupId: "test-group-1",
+    threadScope: null,
+    viewMode: "full",
+    contentTypes: ["xmtp.org/text:1.0"],
+    grantedOps: ["send", "reply"],
+    toolScopes: [],
+    inferenceMode: "external",
+    inferenceProviders: ["openai"],
+    contentEgressScope: "full-messages",
+    retentionAtProvider: "session",
+    hostingMode: "managed",
+    trustTier: "unverified",
+    buildProvenanceRef: null,
+    verifierStatementRef: null,
+    sessionKeyFingerprint: null,
+    policyHash: "test-policy-hash",
+    heartbeatInterval: 30,
+    issuedAt: "2024-01-01T00:00:00Z",
+    expiresAt: "2024-01-01T01:00:00Z",
+    revocationRules: {
+      maxTtlSeconds: 3600,
+      requireHeartbeat: true,
+      ownerCanRevoke: true,
+      adminCanRemove: false,
+    },
+    issuer: "test-broker-identity",
+    ...overrides,
+  };
+}
+
+/** Valid view config fixture. */
+export function createTestViewConfig(
+  overrides?: Partial<ViewConfig>,
+): ViewConfig {
+  return {
+    mode: "full",
+    threadScopes: [{ groupId: "test-group-1", threadId: null }],
+    contentTypes: ["xmtp.org/text:1.0"],
+    ...overrides,
+  };
+}
+
+/** Valid grant config fixture. */
+export function createTestGrantConfig(
+  overrides?: Partial<GrantConfig>,
+): GrantConfig {
+  return {
+    messaging: { send: true, reply: true, react: true, draftOnly: false },
+    groupManagement: {
+      addMembers: false,
+      removeMembers: false,
+      updateMetadata: false,
+      inviteUsers: false,
+    },
+    tools: { scopes: [] },
+    egress: {
+      storeExcerpts: false,
+      useForMemory: false,
+      forwardToProviders: false,
+      quoteRevealed: false,
+      summarize: false,
+    },
+    ...overrides,
+  };
+}
+
+/** Valid session token fixture. */
+export function createTestSessionToken(
+  overrides?: Partial<SessionToken>,
+): SessionToken {
+  return {
+    sessionId: "test-session-001",
+    agentInboxId: "test-agent-inbox",
+    sessionKeyFingerprint: "test-fingerprint",
+    issuedAt: "2024-01-01T00:00:00Z",
+    expiresAt: "2024-01-01T01:00:00Z",
+    ...overrides,
+  };
+}
+
+/** Valid issued session fixture. */
+export function createTestIssuedSession(
+  overrides?: Partial<IssuedSession>,
+): IssuedSession {
+  return {
+    token: "test-bearer-token",
+    session: createTestSessionToken(),
+    ...overrides,
+  };
+}

--- a/packages/schemas/src/__tests__/grant.test.ts
+++ b/packages/schemas/src/__tests__/grant.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "bun:test";
+import {
+  MessagingGrant,
+  GroupManagementGrant,
+  ToolScope,
+  ToolGrant,
+  EgressGrant,
+  GrantConfig,
+} from "../grant.js";
+
+describe("MessagingGrant", () => {
+  it("accepts valid messaging grant", () => {
+    const valid = { send: true, reply: true, react: false, draftOnly: false };
+    expect(MessagingGrant.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejects missing fields", () => {
+    expect(MessagingGrant.safeParse({ send: true }).success).toBe(false);
+  });
+
+  it("rejects non-boolean values", () => {
+    const invalid = {
+      send: "yes",
+      reply: true,
+      react: false,
+      draftOnly: false,
+    };
+    expect(MessagingGrant.safeParse(invalid).success).toBe(false);
+  });
+});
+
+describe("GroupManagementGrant", () => {
+  it("accepts valid group management grant", () => {
+    const valid = {
+      addMembers: true,
+      removeMembers: false,
+      updateMetadata: true,
+      inviteUsers: false,
+    };
+    expect(GroupManagementGrant.safeParse(valid).success).toBe(true);
+  });
+});
+
+describe("ToolScope", () => {
+  it("accepts scope with null parameters", () => {
+    const valid = { toolId: "tool-1", allowed: true, parameters: null };
+    expect(ToolScope.safeParse(valid).success).toBe(true);
+  });
+
+  it("accepts scope with parameter constraints", () => {
+    const valid = {
+      toolId: "tool-1",
+      allowed: true,
+      parameters: { maxTokens: 100 },
+    };
+    expect(ToolScope.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejects undefined parameters (must be explicit null)", () => {
+    const invalid = { toolId: "tool-1", allowed: true };
+    expect(ToolScope.safeParse(invalid).success).toBe(false);
+  });
+});
+
+describe("ToolGrant", () => {
+  it("accepts grant with empty scopes", () => {
+    expect(ToolGrant.safeParse({ scopes: [] }).success).toBe(true);
+  });
+
+  it("accepts grant with multiple scopes", () => {
+    const valid = {
+      scopes: [
+        { toolId: "a", allowed: true, parameters: null },
+        { toolId: "b", allowed: false, parameters: { limit: 5 } },
+      ],
+    };
+    expect(ToolGrant.safeParse(valid).success).toBe(true);
+  });
+});
+
+describe("EgressGrant", () => {
+  it("accepts valid egress grant", () => {
+    const valid = {
+      storeExcerpts: false,
+      useForMemory: false,
+      forwardToProviders: true,
+      quoteRevealed: false,
+      summarize: true,
+    };
+    expect(EgressGrant.safeParse(valid).success).toBe(true);
+  });
+});
+
+describe("GrantConfig", () => {
+  const validConfig = {
+    messaging: { send: true, reply: true, react: true, draftOnly: false },
+    groupManagement: {
+      addMembers: false,
+      removeMembers: false,
+      updateMetadata: false,
+      inviteUsers: false,
+    },
+    tools: { scopes: [] },
+    egress: {
+      storeExcerpts: false,
+      useForMemory: false,
+      forwardToProviders: false,
+      quoteRevealed: false,
+      summarize: false,
+    },
+  };
+
+  it("accepts valid full grant config", () => {
+    expect(GrantConfig.safeParse(validConfig).success).toBe(true);
+  });
+
+  it("rejects missing sections", () => {
+    const { messaging: _, ...rest } = validConfig;
+    expect(GrantConfig.safeParse(rest).success).toBe(false);
+  });
+});

--- a/packages/schemas/src/__tests__/requests.test.ts
+++ b/packages/schemas/src/__tests__/requests.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "bun:test";
+import {
+  SendMessageRequest,
+  SendReactionRequest,
+  SendReplyRequest,
+  UpdateViewRequest,
+  RevealContentRequest,
+  ConfirmActionRequest,
+  HeartbeatRequest,
+  HarnessRequest,
+} from "../requests.js";
+
+describe("SendMessageRequest", () => {
+  it("accepts valid send message request", () => {
+    const valid = {
+      type: "send_message",
+      requestId: "req-1",
+      groupId: "group-1",
+      contentType: "xmtp.org/text:1.0",
+      content: { text: "hello" },
+    };
+    expect(SendMessageRequest.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejects invalid content type", () => {
+    const invalid = {
+      type: "send_message",
+      requestId: "req-1",
+      groupId: "group-1",
+      contentType: "invalid",
+      content: {},
+    };
+    expect(SendMessageRequest.safeParse(invalid).success).toBe(false);
+  });
+});
+
+describe("SendReactionRequest", () => {
+  it("accepts valid reaction request", () => {
+    const valid = {
+      type: "send_reaction",
+      requestId: "req-1",
+      groupId: "group-1",
+      messageId: "msg-1",
+      action: "added",
+      content: "thumbsup",
+    };
+    expect(SendReactionRequest.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejects invalid action", () => {
+    const invalid = {
+      type: "send_reaction",
+      requestId: "req-1",
+      groupId: "group-1",
+      messageId: "msg-1",
+      action: "toggled",
+      content: "thumbsup",
+    };
+    expect(SendReactionRequest.safeParse(invalid).success).toBe(false);
+  });
+});
+
+describe("SendReplyRequest", () => {
+  it("accepts valid reply request", () => {
+    const valid = {
+      type: "send_reply",
+      requestId: "req-1",
+      groupId: "group-1",
+      messageId: "msg-1",
+      contentType: "xmtp.org/text:1.0",
+      content: { text: "reply" },
+    };
+    expect(SendReplyRequest.safeParse(valid).success).toBe(true);
+  });
+});
+
+describe("UpdateViewRequest", () => {
+  it("accepts valid update view request", () => {
+    const valid = {
+      type: "update_view",
+      requestId: "req-1",
+      view: {
+        mode: "thread-only",
+        threadScopes: [{ groupId: "g1", threadId: "t1" }],
+        contentTypes: ["xmtp.org/text:1.0"],
+      },
+    };
+    expect(UpdateViewRequest.safeParse(valid).success).toBe(true);
+  });
+});
+
+describe("RevealContentRequest", () => {
+  it("accepts valid reveal content request", () => {
+    const valid = {
+      type: "reveal_content",
+      requestId: "req-1",
+      reveal: {
+        revealId: "rev-1",
+        groupId: "group-1",
+        scope: "message",
+        targetId: "msg-123",
+        requestedBy: "inbox-1",
+        expiresAt: null,
+      },
+    };
+    expect(RevealContentRequest.safeParse(valid).success).toBe(true);
+  });
+});
+
+describe("ConfirmActionRequest", () => {
+  it("accepts valid confirmation", () => {
+    const valid = {
+      type: "confirm_action",
+      requestId: "req-1",
+      actionId: "act-1",
+      confirmed: true,
+    };
+    expect(ConfirmActionRequest.safeParse(valid).success).toBe(true);
+  });
+
+  it("accepts denial", () => {
+    const valid = {
+      type: "confirm_action",
+      requestId: "req-1",
+      actionId: "act-1",
+      confirmed: false,
+    };
+    expect(ConfirmActionRequest.safeParse(valid).success).toBe(true);
+  });
+});
+
+describe("HeartbeatRequest", () => {
+  it("accepts valid heartbeat request", () => {
+    const valid = {
+      type: "heartbeat",
+      requestId: "req-1",
+      sessionId: "sess-1",
+    };
+    expect(HeartbeatRequest.safeParse(valid).success).toBe(true);
+  });
+});
+
+describe("HarnessRequest discriminated union", () => {
+  it("discriminates on type field", () => {
+    const heartbeat = {
+      type: "heartbeat",
+      requestId: "req-1",
+      sessionId: "sess-1",
+    };
+    const result = HarnessRequest.safeParse(heartbeat);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.type).toBe("heartbeat");
+    }
+  });
+
+  it("rejects unknown request types", () => {
+    expect(
+      HarnessRequest.safeParse({ type: "unknown", requestId: "r1" }).success,
+    ).toBe(false);
+  });
+
+  it("accepts all 7 request types", () => {
+    const requests = [
+      {
+        type: "send_message",
+        requestId: "r1",
+        groupId: "g1",
+        contentType: "xmtp.org/text:1.0",
+        content: {},
+      },
+      {
+        type: "send_reaction",
+        requestId: "r2",
+        groupId: "g1",
+        messageId: "m1",
+        action: "added",
+        content: "ok",
+      },
+      {
+        type: "send_reply",
+        requestId: "r3",
+        groupId: "g1",
+        messageId: "m1",
+        contentType: "xmtp.org/text:1.0",
+        content: {},
+      },
+      {
+        type: "update_view",
+        requestId: "r4",
+        view: {
+          mode: "full",
+          threadScopes: [{ groupId: "g1", threadId: null }],
+          contentTypes: ["xmtp.org/text:1.0"],
+        },
+      },
+      {
+        type: "reveal_content",
+        requestId: "r5",
+        reveal: {
+          revealId: "rev-1",
+          groupId: "g1",
+          scope: "message",
+          targetId: "m1",
+          requestedBy: "i1",
+          expiresAt: null,
+        },
+      },
+      {
+        type: "confirm_action",
+        requestId: "r6",
+        actionId: "a1",
+        confirmed: true,
+      },
+      { type: "heartbeat", requestId: "r7", sessionId: "s1" },
+    ];
+
+    for (const req of requests) {
+      expect(HarnessRequest.safeParse(req).success).toBe(true);
+    }
+  });
+});

--- a/packages/schemas/src/__tests__/response.test.ts
+++ b/packages/schemas/src/__tests__/response.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "bun:test";
+import {
+  RequestSuccess,
+  RequestFailure,
+  RequestResponse,
+} from "../response.js";
+
+describe("RequestSuccess", () => {
+  it("accepts valid success response", () => {
+    const valid = {
+      ok: true,
+      requestId: "req-1",
+      data: { messageId: "msg-1" },
+    };
+    expect(RequestSuccess.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejects ok: false", () => {
+    const invalid = {
+      ok: false,
+      requestId: "req-1",
+      data: {},
+    };
+    expect(RequestSuccess.safeParse(invalid).success).toBe(false);
+  });
+});
+
+describe("RequestFailure", () => {
+  it("accepts valid failure response", () => {
+    const valid = {
+      ok: false,
+      requestId: "req-1",
+      error: {
+        code: 1000,
+        category: "validation",
+        message: "Invalid input",
+        context: { field: "groupId" },
+      },
+    };
+    expect(RequestFailure.safeParse(valid).success).toBe(true);
+  });
+
+  it("accepts null context", () => {
+    const valid = {
+      ok: false,
+      requestId: "req-1",
+      error: {
+        code: 1400,
+        category: "internal",
+        message: "Unexpected error",
+        context: null,
+      },
+    };
+    expect(RequestFailure.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejects ok: true", () => {
+    const invalid = {
+      ok: true,
+      requestId: "req-1",
+      error: {
+        code: 1000,
+        category: "validation",
+        message: "Invalid",
+        context: null,
+      },
+    };
+    expect(RequestFailure.safeParse(invalid).success).toBe(false);
+  });
+
+  it("rejects unsupported error categories", () => {
+    const invalid = {
+      ok: false,
+      requestId: "req-1",
+      error: {
+        code: 1000,
+        category: "permision",
+        message: "Invalid input",
+        context: null,
+      },
+    };
+    expect(RequestFailure.safeParse(invalid).success).toBe(false);
+  });
+});
+
+describe("RequestResponse discriminated union", () => {
+  it("discriminates on ok field", () => {
+    const success = {
+      ok: true,
+      requestId: "req-1",
+      data: null,
+    };
+    const result = RequestResponse.safeParse(success);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.ok).toBe(true);
+    }
+  });
+
+  it("parses failure correctly", () => {
+    const failure = {
+      ok: false,
+      requestId: "req-1",
+      error: {
+        code: 1100,
+        category: "not_found",
+        message: "Not found",
+        context: null,
+      },
+    };
+    const result = RequestResponse.safeParse(failure);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.ok).toBe(false);
+    }
+  });
+});

--- a/packages/schemas/src/__tests__/reveal.test.ts
+++ b/packages/schemas/src/__tests__/reveal.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "bun:test";
+import {
+  RevealScope,
+  RevealRequest,
+  RevealGrant,
+  RevealState,
+} from "../reveal.js";
+
+describe("RevealScope", () => {
+  it("accepts all valid scopes", () => {
+    for (const s of [
+      "message",
+      "thread",
+      "time-window",
+      "content-type",
+      "sender",
+    ]) {
+      expect(RevealScope.safeParse(s).success).toBe(true);
+    }
+  });
+
+  it("rejects invalid scope", () => {
+    expect(RevealScope.safeParse("group").success).toBe(false);
+  });
+});
+
+describe("RevealRequest", () => {
+  const valid = {
+    revealId: "rev-1",
+    groupId: "group-1",
+    scope: "message",
+    targetId: "msg-123",
+    requestedBy: "inbox-1",
+    expiresAt: null,
+  };
+
+  it("accepts valid reveal request with null expiry", () => {
+    expect(RevealRequest.safeParse(valid).success).toBe(true);
+  });
+
+  it("accepts valid reveal request with datetime expiry", () => {
+    expect(
+      RevealRequest.safeParse({
+        ...valid,
+        expiresAt: "2024-06-01T00:00:00Z",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects missing expiresAt (must be explicit null)", () => {
+    const { expiresAt: _, ...rest } = valid;
+    expect(RevealRequest.safeParse(rest).success).toBe(false);
+  });
+
+  it("rejects invalid scope", () => {
+    expect(
+      RevealRequest.safeParse({ ...valid, scope: "invalid" }).success,
+    ).toBe(false);
+  });
+});
+
+describe("RevealGrant", () => {
+  it("accepts valid grant with null expiry", () => {
+    const valid = {
+      revealId: "rev-1",
+      grantedAt: "2024-01-01T00:00:00Z",
+      grantedBy: "inbox-2",
+      expiresAt: null,
+    };
+    expect(RevealGrant.safeParse(valid).success).toBe(true);
+  });
+
+  it("accepts valid grant with datetime expiry", () => {
+    const valid = {
+      revealId: "rev-1",
+      grantedAt: "2024-01-01T00:00:00Z",
+      grantedBy: "inbox-2",
+      expiresAt: "2024-06-01T00:00:00Z",
+    };
+    expect(RevealGrant.safeParse(valid).success).toBe(true);
+  });
+});
+
+describe("RevealState", () => {
+  it("accepts empty active reveals", () => {
+    expect(RevealState.safeParse({ activeReveals: [] }).success).toBe(true);
+  });
+
+  it("accepts active reveals with valid grants", () => {
+    const valid = {
+      activeReveals: [
+        {
+          revealId: "rev-1",
+          grantedAt: "2024-01-01T00:00:00Z",
+          grantedBy: "inbox-2",
+          expiresAt: null,
+        },
+      ],
+    };
+    expect(RevealState.safeParse(valid).success).toBe(true);
+  });
+});

--- a/packages/schemas/src/__tests__/revocation.test.ts
+++ b/packages/schemas/src/__tests__/revocation.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test";
+import {
+  AgentRevocationReason,
+  SessionRevocationReason,
+  RevocationAttestation,
+} from "../revocation.js";
+
+describe("AgentRevocationReason", () => {
+  it("accepts all valid reasons", () => {
+    for (const r of [
+      "owner-initiated",
+      "session-expired",
+      "admin-removed",
+      "heartbeat-timeout",
+      "policy-violation",
+    ]) {
+      expect(AgentRevocationReason.safeParse(r).success).toBe(true);
+    }
+  });
+
+  it("rejects invalid reason", () => {
+    expect(AgentRevocationReason.safeParse("unknown").success).toBe(false);
+  });
+});
+
+describe("SessionRevocationReason", () => {
+  it("accepts all valid reasons", () => {
+    for (const r of [
+      "owner-initiated",
+      "session-expired",
+      "heartbeat-timeout",
+      "policy-violation",
+      "reauthorization-required",
+    ]) {
+      expect(SessionRevocationReason.safeParse(r).success).toBe(true);
+    }
+  });
+
+  it("rejects admin-removed (agent-only reason)", () => {
+    expect(SessionRevocationReason.safeParse("admin-removed").success).toBe(
+      false,
+    );
+  });
+});
+
+describe("RevocationAttestation", () => {
+  const valid = {
+    attestationId: "rev-att-1",
+    previousAttestationId: "att-001",
+    agentInboxId: "agent-1",
+    groupId: "group-1",
+    reason: "owner-initiated",
+    revokedAt: "2024-01-01T00:00:00Z",
+    issuer: "broker-1",
+  };
+
+  it("accepts valid revocation attestation", () => {
+    expect(RevocationAttestation.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejects invalid reason", () => {
+    expect(
+      RevocationAttestation.safeParse({ ...valid, reason: "invalid" }).success,
+    ).toBe(false);
+  });
+
+  it("rejects invalid datetime", () => {
+    expect(
+      RevocationAttestation.safeParse({ ...valid, revokedAt: "bad" }).success,
+    ).toBe(false);
+  });
+
+  it("requires previousAttestationId as non-nullable string", () => {
+    expect(
+      RevocationAttestation.safeParse({
+        ...valid,
+        previousAttestationId: null,
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/schemas/src/__tests__/session.test.ts
+++ b/packages/schemas/src/__tests__/session.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "bun:test";
+import {
+  SessionConfig,
+  SessionToken,
+  IssuedSession,
+  SessionState,
+} from "../session.js";
+
+const validView = {
+  mode: "full" as const,
+  threadScopes: [{ groupId: "g1", threadId: null }],
+  contentTypes: ["xmtp.org/text:1.0"],
+};
+
+const validGrant = {
+  messaging: { send: true, reply: true, react: true, draftOnly: false },
+  groupManagement: {
+    addMembers: false,
+    removeMembers: false,
+    updateMetadata: false,
+    inviteUsers: false,
+  },
+  tools: { scopes: [] },
+  egress: {
+    storeExcerpts: false,
+    useForMemory: false,
+    forwardToProviders: false,
+    quoteRevealed: false,
+    summarize: false,
+  },
+};
+
+describe("SessionConfig", () => {
+  it("accepts valid config with defaults", () => {
+    const result = SessionConfig.safeParse({
+      agentInboxId: "agent-1",
+      view: validView,
+      grant: validGrant,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.ttlSeconds).toBe(3600);
+      expect(result.data.heartbeatInterval).toBe(30);
+    }
+  });
+
+  it("accepts custom ttl and heartbeat", () => {
+    const result = SessionConfig.safeParse({
+      agentInboxId: "agent-1",
+      view: validView,
+      grant: validGrant,
+      ttlSeconds: 7200,
+      heartbeatInterval: 15,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.ttlSeconds).toBe(7200);
+      expect(result.data.heartbeatInterval).toBe(15);
+    }
+  });
+
+  it("rejects non-positive ttlSeconds", () => {
+    const result = SessionConfig.safeParse({
+      agentInboxId: "agent-1",
+      view: validView,
+      grant: validGrant,
+      ttlSeconds: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("SessionToken", () => {
+  it("accepts valid session token", () => {
+    const result = SessionToken.safeParse({
+      sessionId: "sess-1",
+      agentInboxId: "agent-1",
+      sessionKeyFingerprint: "fp-abc",
+      issuedAt: "2024-01-01T00:00:00Z",
+      expiresAt: "2024-01-01T01:00:00Z",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid datetime", () => {
+    const result = SessionToken.safeParse({
+      sessionId: "sess-1",
+      agentInboxId: "agent-1",
+      sessionKeyFingerprint: "fp-abc",
+      issuedAt: "not-a-date",
+      expiresAt: "2024-01-01T01:00:00Z",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("SessionState", () => {
+  it("accepts all valid states", () => {
+    for (const s of [
+      "active",
+      "expired",
+      "revoked",
+      "reauthorization-required",
+    ]) {
+      expect(SessionState.safeParse(s).success).toBe(true);
+    }
+  });
+
+  it("rejects invalid state", () => {
+    expect(SessionState.safeParse("pending").success).toBe(false);
+  });
+});
+
+describe("IssuedSession", () => {
+  it("accepts valid issued session credentials", () => {
+    const result = IssuedSession.safeParse({
+      token: "bearer-token",
+      session: {
+        sessionId: "sess-1",
+        agentInboxId: "agent-1",
+        sessionKeyFingerprint: "fp-abc",
+        issuedAt: "2024-01-01T00:00:00Z",
+        expiresAt: "2024-01-01T01:00:00Z",
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing bearer token", () => {
+    const result = IssuedSession.safeParse({
+      session: {
+        sessionId: "sess-1",
+        agentInboxId: "agent-1",
+        sessionKeyFingerprint: "fp-abc",
+        issuedAt: "2024-01-01T00:00:00Z",
+        expiresAt: "2024-01-01T01:00:00Z",
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/schemas/src/__tests__/smoke.test.ts
+++ b/packages/schemas/src/__tests__/smoke.test.ts
@@ -1,7 +1,0 @@
-import { describe, expect, it } from "bun:test";
-
-describe("workspace", () => {
-  it("test runner works", () => {
-    expect(true).toBe(true);
-  });
-});

--- a/packages/schemas/src/__tests__/view.test.ts
+++ b/packages/schemas/src/__tests__/view.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "bun:test";
+import {
+  ViewMode,
+  ContentTypeAllowlist,
+  ThreadScope,
+  ViewConfig,
+} from "../view.js";
+
+describe("ViewMode", () => {
+  it("accepts all valid view modes", () => {
+    for (const mode of [
+      "full",
+      "thread-only",
+      "redacted",
+      "reveal-only",
+      "summary-only",
+    ]) {
+      expect(ViewMode.safeParse(mode).success).toBe(true);
+    }
+  });
+
+  it("rejects invalid view mode", () => {
+    expect(ViewMode.safeParse("invalid").success).toBe(false);
+  });
+});
+
+describe("ContentTypeAllowlist", () => {
+  it("accepts array with at least one valid content type", () => {
+    expect(ContentTypeAllowlist.safeParse(["xmtp.org/text:1.0"]).success).toBe(
+      true,
+    );
+  });
+
+  it("rejects empty array", () => {
+    expect(ContentTypeAllowlist.safeParse([]).success).toBe(false);
+  });
+
+  it("rejects array with invalid content type", () => {
+    expect(ContentTypeAllowlist.safeParse(["invalid"]).success).toBe(false);
+  });
+});
+
+describe("ThreadScope", () => {
+  it("accepts scope with group and thread", () => {
+    const result = ThreadScope.safeParse({
+      groupId: "group-1",
+      threadId: "thread-1",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts scope with null threadId for entire group", () => {
+    const result = ThreadScope.safeParse({
+      groupId: "group-1",
+      threadId: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing threadId (must be explicit null)", () => {
+    const result = ThreadScope.safeParse({ groupId: "group-1" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("ViewConfig", () => {
+  const validConfig = {
+    mode: "full",
+    threadScopes: [{ groupId: "group-1", threadId: null }],
+    contentTypes: ["xmtp.org/text:1.0"],
+  };
+
+  it("accepts valid view config", () => {
+    expect(ViewConfig.safeParse(validConfig).success).toBe(true);
+  });
+
+  it("rejects empty threadScopes", () => {
+    expect(
+      ViewConfig.safeParse({ ...validConfig, threadScopes: [] }).success,
+    ).toBe(false);
+  });
+
+  it("rejects empty contentTypes", () => {
+    expect(
+      ViewConfig.safeParse({ ...validConfig, contentTypes: [] }).success,
+    ).toBe(false);
+  });
+
+  it("rejects invalid mode", () => {
+    expect(ViewConfig.safeParse({ ...validConfig, mode: "bad" }).success).toBe(
+      false,
+    );
+  });
+});

--- a/packages/schemas/src/attestation.ts
+++ b/packages/schemas/src/attestation.ts
@@ -1,0 +1,189 @@
+import { z } from "zod";
+import { ContentTypeId } from "./content-types.js";
+import { ViewMode } from "./view.js";
+
+export const InferenceMode: z.ZodEnum<
+  ["local", "external", "hybrid", "unknown"]
+> = z
+  .enum(["local", "external", "hybrid", "unknown"])
+  .describe("How the agent performs inference");
+
+export type InferenceMode = z.infer<typeof InferenceMode>;
+
+export const ContentEgressScope: z.ZodEnum<
+  ["full-messages", "summaries-only", "tool-calls-only", "none", "unknown"]
+> = z
+  .enum([
+    "full-messages",
+    "summaries-only",
+    "tool-calls-only",
+    "none",
+    "unknown",
+  ])
+  .describe("What content leaves the broker boundary");
+
+export type ContentEgressScope = z.infer<typeof ContentEgressScope>;
+
+export const RetentionAtProvider: z.ZodEnum<
+  ["none", "session", "persistent", "unknown"]
+> = z
+  .enum(["none", "session", "persistent", "unknown"])
+  .describe("How long the inference provider retains content");
+
+export type RetentionAtProvider = z.infer<typeof RetentionAtProvider>;
+
+export const HostingMode: z.ZodEnum<["local", "self-hosted", "managed"]> = z
+  .enum(["local", "self-hosted", "managed"])
+  .describe("Where the broker runs");
+
+export type HostingMode = z.infer<typeof HostingMode>;
+
+export const TrustTier: z.ZodEnum<
+  [
+    "unverified",
+    "source-verified",
+    "reproducibly-verified",
+    "runtime-attested",
+  ]
+> = z
+  .enum([
+    "unverified",
+    "source-verified",
+    "reproducibly-verified",
+    "runtime-attested",
+  ])
+  .describe("Highest trust tier the broker can demonstrate");
+
+export type TrustTier = z.infer<typeof TrustTier>;
+
+export type RevocationRules = {
+  maxTtlSeconds: number;
+  requireHeartbeat: boolean;
+  ownerCanRevoke: boolean;
+  adminCanRemove: boolean;
+};
+
+export const RevocationRules: z.ZodType<RevocationRules> = z
+  .object({
+    maxTtlSeconds: z
+      .number()
+      .int()
+      .positive()
+      .describe("Maximum attestation lifetime in seconds"),
+    requireHeartbeat: z
+      .boolean()
+      .describe("Whether missed heartbeats trigger auto-revocation"),
+    ownerCanRevoke: z
+      .boolean()
+      .describe("Whether the owner can revoke at any time"),
+    adminCanRemove: z
+      .boolean()
+      .describe("Whether group admins can remove the agent"),
+  })
+  .describe("Rules governing how this attestation can be revoked");
+
+export type Attestation = {
+  attestationId: string;
+  previousAttestationId: string | null;
+  agentInboxId: string;
+  ownerInboxId: string;
+  groupId: string;
+  threadScope: string | null;
+  viewMode: ViewMode;
+  contentTypes: string[];
+  grantedOps: string[];
+  toolScopes: string[];
+  inferenceMode: InferenceMode;
+  inferenceProviders: string[];
+  contentEgressScope: ContentEgressScope;
+  retentionAtProvider: RetentionAtProvider;
+  hostingMode: HostingMode;
+  trustTier: TrustTier;
+  buildProvenanceRef: string | null;
+  verifierStatementRef: string | null;
+  sessionKeyFingerprint: string | null;
+  policyHash: string;
+  heartbeatInterval?: number | undefined;
+  issuedAt: string;
+  expiresAt: string;
+  revocationRules: RevocationRules;
+  issuer: string;
+};
+
+export const AttestationSchema: z.ZodType<Attestation> = z
+  .object({
+    attestationId: z
+      .string()
+      .describe("Unique identifier for this attestation"),
+    previousAttestationId: z
+      .string()
+      .nullable()
+      .describe("ID of the attestation this supersedes, null for initial"),
+    agentInboxId: z.string().describe("XMTP inbox ID of the agent"),
+    ownerInboxId: z.string().describe("XMTP inbox ID of the agent's owner"),
+    groupId: z.string().describe("Group this attestation applies to"),
+    threadScope: z
+      .string()
+      .nullable()
+      .describe(
+        "Thread scope if narrower than full group, null for group-wide",
+      ),
+    viewMode: ViewMode.describe("Current view mode"),
+    contentTypes: z
+      .array(ContentTypeId)
+      .describe("Content types the agent can see"),
+    grantedOps: z.array(z.string()).describe("Granted operation identifiers"),
+    toolScopes: z
+      .array(z.string())
+      .describe("Tool scope identifiers the agent may use"),
+    inferenceMode: InferenceMode.describe("How the agent performs inference"),
+    inferenceProviders: z
+      .array(z.string())
+      .describe("Envelope of inference providers the agent may use"),
+    contentEgressScope: ContentEgressScope.describe(
+      "What content leaves the broker boundary",
+    ),
+    retentionAtProvider: RetentionAtProvider.describe(
+      "Provider-side retention policy",
+    ),
+    hostingMode: HostingMode.describe("Where the broker runs"),
+    trustTier: TrustTier.describe("Highest demonstrated trust tier"),
+    buildProvenanceRef: z
+      .string()
+      .nullable()
+      .describe("Reference to build provenance bundle, null if unavailable"),
+    verifierStatementRef: z
+      .string()
+      .nullable()
+      .describe("Reference to verifier statement, null if unavailable"),
+    sessionKeyFingerprint: z
+      .string()
+      .nullable()
+      .describe("Fingerprint of the current session key, null if not bound"),
+    policyHash: z
+      .string()
+      .describe("Hash of the full policy config for integrity checking"),
+    heartbeatInterval: z
+      .number()
+      .int()
+      .positive()
+      .default(30)
+      .describe("Expected heartbeat cadence in seconds"),
+    issuedAt: z
+      .string()
+      .datetime()
+      .describe("ISO 8601 timestamp when this attestation was issued"),
+    expiresAt: z
+      .string()
+      .datetime()
+      .describe("ISO 8601 timestamp when this attestation expires"),
+    revocationRules: RevocationRules.describe(
+      "Rules governing revocation of this attestation",
+    ),
+    issuer: z
+      .string()
+      .describe(
+        "Identity of the attestation issuer (broker's signing identity)",
+      ),
+  })
+  .describe("Group-visible capability attestation for an agent");

--- a/packages/schemas/src/content-types.ts
+++ b/packages/schemas/src/content-types.ts
@@ -1,0 +1,132 @@
+import { z } from "zod";
+
+/**
+ * XMTP content type identifier following the authority/type:version convention.
+ * Examples: "xmtp.org/text:1.0", "xmtp.org/reaction:1.0"
+ */
+export const ContentTypeId: z.ZodString = z
+  .string()
+  .regex(/^[a-z0-9.-]+\/[a-zA-Z0-9]+:\d+\.\d+$/)
+  .describe("XMTP content type identifier (authority/type:version)");
+
+export type ContentTypeId = z.infer<typeof ContentTypeId>;
+
+/** Standard XMTP content types accepted by default. */
+export const BASELINE_CONTENT_TYPES: readonly [
+  "xmtp.org/text:1.0",
+  "xmtp.org/reaction:1.0",
+  "xmtp.org/reply:1.0",
+  "xmtp.org/readReceipt:1.0",
+  "xmtp.org/groupUpdated:1.0",
+] = [
+  "xmtp.org/text:1.0",
+  "xmtp.org/reaction:1.0",
+  "xmtp.org/reply:1.0",
+  "xmtp.org/readReceipt:1.0",
+  "xmtp.org/groupUpdated:1.0",
+] as const;
+
+export type BaselineContentType = (typeof BASELINE_CONTENT_TYPES)[number];
+
+export type TextPayload = {
+  text: string;
+};
+
+export const TextPayload: z.ZodType<TextPayload> = z
+  .object({
+    text: z.string().min(1).describe("Message text content"),
+  })
+  .describe("Text message payload");
+
+export type ReactionPayload = {
+  reference: string;
+  action: "added" | "removed";
+  content: string;
+  schema: "unicode" | "shortcode" | "custom";
+};
+
+export const ReactionPayload: z.ZodType<ReactionPayload> = z
+  .object({
+    reference: z.string().describe("Message ID being reacted to"),
+    action: z
+      .enum(["added", "removed"])
+      .describe("Whether reaction is added or removed"),
+    content: z.string().describe("Reaction content (emoji or text)"),
+    schema: z
+      .enum(["unicode", "shortcode", "custom"])
+      .describe("Reaction schema type"),
+  })
+  .describe("Reaction payload");
+
+export type ReplyPayload = {
+  reference: string;
+  content: {
+    type: string;
+    payload?: unknown;
+  };
+};
+
+export const ReplyPayload: z.ZodType<ReplyPayload> = z
+  .object({
+    reference: z.string().describe("Message ID being replied to"),
+    content: z
+      .object({
+        type: ContentTypeId.describe("Content type of the reply body"),
+        payload: z.unknown().describe("Encoded reply content"),
+      })
+      .describe("Reply body"),
+  })
+  .describe("Reply payload");
+
+export type ReadReceiptPayload = Record<string, never>;
+
+export const ReadReceiptPayload: z.ZodType<ReadReceiptPayload> = z
+  .object({})
+  .describe("Read receipt payload (empty body)");
+
+export type GroupUpdatedPayload = {
+  initiatedByInboxId: string;
+  addedInboxes: string[];
+  removedInboxes: string[];
+  metadataFieldsChanged: {
+    fieldName: string;
+    oldValue: string | null;
+    newValue: string | null;
+  }[];
+};
+
+export const GroupUpdatedPayload: z.ZodType<GroupUpdatedPayload> = z
+  .object({
+    initiatedByInboxId: z
+      .string()
+      .describe("Inbox ID of the member who initiated the update"),
+    addedInboxes: z.array(z.string()).describe("Inbox IDs added to the group"),
+    removedInboxes: z
+      .array(z.string())
+      .describe("Inbox IDs removed from the group"),
+    metadataFieldsChanged: z
+      .array(
+        z.object({
+          fieldName: z.string().describe("Name of the changed metadata field"),
+          oldValue: z.string().nullable().describe("Previous value"),
+          newValue: z.string().nullable().describe("New value"),
+        }),
+      )
+      .describe("Metadata fields that changed"),
+  })
+  .describe("Group membership/metadata update payload");
+
+/** Map from content type ID to its payload schema. Extensible at runtime. */
+export const CONTENT_TYPE_SCHEMAS: {
+  readonly "xmtp.org/text:1.0": z.ZodType<TextPayload>;
+  readonly "xmtp.org/reaction:1.0": z.ZodType<ReactionPayload>;
+  readonly "xmtp.org/reply:1.0": z.ZodType<ReplyPayload>;
+  readonly "xmtp.org/readReceipt:1.0": z.ZodType<ReadReceiptPayload>;
+  readonly "xmtp.org/groupUpdated:1.0": z.ZodType<GroupUpdatedPayload>;
+} = {
+  "xmtp.org/text:1.0": TextPayload,
+  "xmtp.org/reaction:1.0": ReactionPayload,
+  "xmtp.org/reply:1.0": ReplyPayload,
+  "xmtp.org/readReceipt:1.0": ReadReceiptPayload,
+  "xmtp.org/groupUpdated:1.0": GroupUpdatedPayload,
+} as const satisfies Partial<Record<string, z.ZodType>>;

--- a/packages/schemas/src/errors/auth.ts
+++ b/packages/schemas/src/errors/auth.ts
@@ -1,0 +1,39 @@
+import type { BrokerError } from "./base.js";
+
+export class AuthError extends Error implements BrokerError {
+  readonly _tag = "AuthError" as const;
+  readonly code = 1300;
+  readonly category = "auth" as const;
+
+  constructor(
+    message: string,
+    readonly context: Record<string, unknown> | null,
+  ) {
+    super(message);
+    this.name = "AuthError";
+  }
+
+  static create(message: string, context?: Record<string, unknown>): AuthError {
+    return new AuthError(message, context ?? null);
+  }
+}
+
+export class SessionExpiredError extends Error implements BrokerError {
+  readonly _tag = "SessionExpiredError" as const;
+  readonly code = 1310;
+  readonly category = "auth" as const;
+
+  constructor(
+    message: string,
+    readonly context: { sessionId: string } & Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "SessionExpiredError";
+  }
+
+  static create(sessionId: string): SessionExpiredError {
+    return new SessionExpiredError(`Session '${sessionId}' has expired`, {
+      sessionId,
+    });
+  }
+}

--- a/packages/schemas/src/errors/base.ts
+++ b/packages/schemas/src/errors/base.ts
@@ -1,0 +1,54 @@
+import type { ErrorCategory } from "./category.js";
+import type { ValidationError, AttestationError } from "./validation.js";
+import type { NotFoundError } from "./not-found.js";
+import type { PermissionError, GrantDeniedError } from "./permission.js";
+import type { AuthError, SessionExpiredError } from "./auth.js";
+import type { InternalError } from "./internal.js";
+import type { TimeoutError } from "./timeout.js";
+import type { CancelledError } from "./cancelled.js";
+import type { NetworkError } from "./network.js";
+
+/**
+ * Base interface for all broker errors. Discriminated by `_tag`.
+ * Never constructed directly -- use the static factory on each subclass.
+ */
+export interface BrokerError extends Error {
+  readonly _tag: string;
+  readonly code: number;
+  readonly category: ErrorCategory;
+  readonly context: Record<string, unknown> | null;
+}
+
+export type AnyBrokerError =
+  | ValidationError
+  | NotFoundError
+  | PermissionError
+  | GrantDeniedError
+  | AuthError
+  | SessionExpiredError
+  | InternalError
+  | TimeoutError
+  | CancelledError
+  | AttestationError
+  | NetworkError;
+
+/** Type-safe error matching by _tag discriminant. */
+export function matchError<T>(
+  error: AnyBrokerError,
+  handlers: {
+    [K in AnyBrokerError["_tag"]]: (
+      e: Extract<AnyBrokerError, { _tag: K }>,
+    ) => T;
+  },
+): T {
+  // Safety: error._tag is already AnyBrokerError["_tag"] so the lookup is
+  // type-safe, but TS can't narrow an indexed-access on a union discriminant
+  // back to the matching handler signature. The mapped-type constraint on
+  // `handlers` guarantees every _tag has the correctly-typed handler, so the
+  // single cast on invocation is sound.
+  const tag = error._tag;
+  const handler: (e: AnyBrokerError) => T = handlers[tag] as (
+    e: AnyBrokerError,
+  ) => T;
+  return handler(error);
+}

--- a/packages/schemas/src/errors/cancelled.ts
+++ b/packages/schemas/src/errors/cancelled.ts
@@ -1,0 +1,19 @@
+import type { BrokerError } from "./base.js";
+
+export class CancelledError extends Error implements BrokerError {
+  readonly _tag = "CancelledError" as const;
+  readonly code = 1600;
+  readonly category = "cancelled" as const;
+
+  constructor(
+    message: string,
+    readonly context: Record<string, unknown> | null,
+  ) {
+    super(message);
+    this.name = "CancelledError";
+  }
+
+  static create(message: string): CancelledError {
+    return new CancelledError(message, null);
+  }
+}

--- a/packages/schemas/src/errors/category.ts
+++ b/packages/schemas/src/errors/category.ts
@@ -1,0 +1,100 @@
+import { z } from "zod";
+
+export const ErrorCategory: z.ZodEnum<
+  [
+    "validation",
+    "not_found",
+    "permission",
+    "auth",
+    "internal",
+    "timeout",
+    "cancelled",
+    "network",
+  ]
+> = z
+  .enum([
+    "validation",
+    "not_found",
+    "permission",
+    "auth",
+    "internal",
+    "timeout",
+    "cancelled",
+    "network",
+  ])
+  .describe("Error category for cross-transport mapping");
+
+export type ErrorCategory = z.infer<typeof ErrorCategory>;
+
+export type ErrorCategoryMeta = {
+  readonly exitCode: number;
+  readonly statusCode: number;
+  readonly jsonRpcCode: number;
+  readonly retryable: boolean;
+};
+
+export const ErrorCategoryMetaSchema: z.ZodType<ErrorCategoryMeta> = z
+  .object({
+    exitCode: z.number().int(),
+    statusCode: z.number().int(),
+    jsonRpcCode: z.number().int(),
+    retryable: z.boolean(),
+  })
+  .readonly()
+  .describe("Cross-transport metadata for an error category");
+
+/** Lookup table for category metadata. */
+export const ERROR_CATEGORY_META: Record<ErrorCategory, ErrorCategoryMeta> = {
+  validation: {
+    exitCode: 1,
+    statusCode: 400,
+    jsonRpcCode: -32602,
+    retryable: false,
+  },
+  not_found: {
+    exitCode: 2,
+    statusCode: 404,
+    jsonRpcCode: -32007,
+    retryable: false,
+  },
+  permission: {
+    exitCode: 4,
+    statusCode: 403,
+    jsonRpcCode: -32003,
+    retryable: false,
+  },
+  auth: {
+    exitCode: 9,
+    statusCode: 401,
+    jsonRpcCode: -32000,
+    retryable: false,
+  },
+  internal: {
+    exitCode: 8,
+    statusCode: 500,
+    jsonRpcCode: -32603,
+    retryable: false,
+  },
+  timeout: {
+    exitCode: 5,
+    statusCode: 504,
+    jsonRpcCode: -32001,
+    retryable: true,
+  },
+  cancelled: {
+    exitCode: 130,
+    statusCode: 499,
+    jsonRpcCode: -32006,
+    retryable: false,
+  },
+  network: {
+    exitCode: 6,
+    statusCode: 503,
+    jsonRpcCode: -32002,
+    retryable: true,
+  },
+};
+
+export function errorCategoryMeta(category: ErrorCategory): ErrorCategoryMeta {
+  return ERROR_CATEGORY_META[category];
+}

--- a/packages/schemas/src/errors/index.ts
+++ b/packages/schemas/src/errors/index.ts
@@ -1,0 +1,16 @@
+export {
+  ErrorCategory,
+  ErrorCategoryMetaSchema,
+  type ErrorCategoryMeta,
+  ERROR_CATEGORY_META,
+  errorCategoryMeta,
+} from "./category.js";
+export { type BrokerError, type AnyBrokerError, matchError } from "./base.js";
+export { ValidationError, AttestationError } from "./validation.js";
+export { NotFoundError } from "./not-found.js";
+export { PermissionError, GrantDeniedError } from "./permission.js";
+export { AuthError, SessionExpiredError } from "./auth.js";
+export { InternalError } from "./internal.js";
+export { TimeoutError } from "./timeout.js";
+export { CancelledError } from "./cancelled.js";
+export { NetworkError } from "./network.js";

--- a/packages/schemas/src/errors/internal.ts
+++ b/packages/schemas/src/errors/internal.ts
@@ -1,0 +1,22 @@
+import type { BrokerError } from "./base.js";
+
+export class InternalError extends Error implements BrokerError {
+  readonly _tag = "InternalError" as const;
+  readonly code = 1400;
+  readonly category = "internal" as const;
+
+  constructor(
+    message: string,
+    readonly context: Record<string, unknown> | null,
+  ) {
+    super(message);
+    this.name = "InternalError";
+  }
+
+  static create(
+    message: string,
+    context?: Record<string, unknown>,
+  ): InternalError {
+    return new InternalError(message, context ?? null);
+  }
+}

--- a/packages/schemas/src/errors/not-found.ts
+++ b/packages/schemas/src/errors/not-found.ts
@@ -1,0 +1,25 @@
+import type { BrokerError } from "./base.js";
+
+export class NotFoundError extends Error implements BrokerError {
+  readonly _tag = "NotFoundError" as const;
+  readonly code = 1100;
+  readonly category = "not_found" as const;
+
+  constructor(
+    message: string,
+    readonly context: {
+      resourceType: string;
+      resourceId: string;
+    } & Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "NotFoundError";
+  }
+
+  static create(resourceType: string, resourceId: string): NotFoundError {
+    return new NotFoundError(`${resourceType} '${resourceId}' not found`, {
+      resourceType,
+      resourceId,
+    });
+  }
+}

--- a/packages/schemas/src/errors/permission.ts
+++ b/packages/schemas/src/errors/permission.ts
@@ -1,0 +1,46 @@
+import type { BrokerError } from "./base.js";
+
+export class PermissionError extends Error implements BrokerError {
+  readonly _tag = "PermissionError" as const;
+  readonly code = 1200;
+  readonly category = "permission" as const;
+
+  constructor(
+    message: string,
+    readonly context: Record<string, unknown> | null,
+  ) {
+    super(message);
+    this.name = "PermissionError";
+  }
+
+  static create(
+    message: string,
+    context?: Record<string, unknown>,
+  ): PermissionError {
+    return new PermissionError(message, context ?? null);
+  }
+}
+
+export class GrantDeniedError extends Error implements BrokerError {
+  readonly _tag = "GrantDeniedError" as const;
+  readonly code = 1210;
+  readonly category = "permission" as const;
+
+  constructor(
+    message: string,
+    readonly context: {
+      operation: string;
+      grantType: string;
+    } & Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "GrantDeniedError";
+  }
+
+  static create(operation: string, grantType: string): GrantDeniedError {
+    return new GrantDeniedError(
+      `Operation '${operation}' denied: missing ${grantType} grant`,
+      { operation, grantType },
+    );
+  }
+}

--- a/packages/schemas/src/errors/timeout.ts
+++ b/packages/schemas/src/errors/timeout.ts
@@ -1,0 +1,25 @@
+import type { BrokerError } from "./base.js";
+
+export class TimeoutError extends Error implements BrokerError {
+  readonly _tag = "TimeoutError" as const;
+  readonly code = 1500;
+  readonly category = "timeout" as const;
+
+  constructor(
+    message: string,
+    readonly context: {
+      operation: string;
+      timeoutMs: number;
+    } & Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "TimeoutError";
+  }
+
+  static create(operation: string, timeoutMs: number): TimeoutError {
+    return new TimeoutError(
+      `Operation '${operation}' timed out after ${timeoutMs}ms`,
+      { operation, timeoutMs },
+    );
+  }
+}

--- a/packages/schemas/src/errors/validation.ts
+++ b/packages/schemas/src/errors/validation.ts
@@ -1,0 +1,51 @@
+import type { BrokerError } from "./base.js";
+
+export class ValidationError extends Error implements BrokerError {
+  readonly _tag = "ValidationError" as const;
+  readonly code = 1000;
+  readonly category = "validation" as const;
+
+  constructor(
+    message: string,
+    readonly context: { field: string; reason: string } & Record<
+      string,
+      unknown
+    >,
+  ) {
+    super(message);
+    this.name = "ValidationError";
+  }
+
+  static create(
+    field: string,
+    reason: string,
+    extra?: Record<string, unknown>,
+  ): ValidationError {
+    return new ValidationError(`Validation failed on '${field}': ${reason}`, {
+      field,
+      reason,
+      ...extra,
+    });
+  }
+}
+
+export class AttestationError extends Error implements BrokerError {
+  readonly _tag = "AttestationError" as const;
+  readonly code = 1010;
+  readonly category = "validation" as const;
+
+  constructor(
+    message: string,
+    readonly context: { attestationId: string } & Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "AttestationError";
+  }
+
+  static create(attestationId: string, reason: string): AttestationError {
+    return new AttestationError(`Attestation '${attestationId}': ${reason}`, {
+      attestationId,
+      reason,
+    });
+  }
+}

--- a/packages/schemas/src/events.ts
+++ b/packages/schemas/src/events.ts
@@ -1,0 +1,271 @@
+import { z } from "zod";
+import { ContentTypeId } from "./content-types.js";
+import { AttestationSchema } from "./attestation.js";
+import type { Attestation } from "./attestation.js";
+import { SessionToken } from "./session.js";
+import { ViewConfig } from "./view.js";
+import { GrantConfig } from "./grant.js";
+import { RevocationAttestation } from "./revocation.js";
+
+export const MessageVisibility: z.ZodEnum<
+  ["visible", "historical", "hidden", "revealed", "redacted"]
+> = z
+  .enum(["visible", "historical", "hidden", "revealed", "redacted"])
+  .describe("How the message is being projected to the agent");
+
+export type MessageVisibility = z.infer<typeof MessageVisibility>;
+
+export type MessageEvent = {
+  type: "message.visible";
+  messageId: string;
+  groupId: string;
+  senderInboxId: string;
+  contentType: string;
+  content?: unknown;
+  visibility: MessageVisibility;
+  sentAt: string;
+  attestationId: string | null;
+};
+
+const _MessageEvent = z
+  .object({
+    type: z.literal("message.visible").describe("Event type discriminator"),
+    messageId: z.string().describe("XMTP message ID"),
+    groupId: z.string().describe("Group the message belongs to"),
+    senderInboxId: z.string().describe("Inbox ID of the sender"),
+    contentType: ContentTypeId.describe("Content type of the message"),
+    content: z.unknown().describe("Decoded message payload"),
+    visibility: MessageVisibility.describe("How this message is projected"),
+    sentAt: z.string().datetime().describe("When the message was sent"),
+    attestationId: z
+      .string()
+      .nullable()
+      .describe("Attestation ID if sent by a brokered agent, null otherwise"),
+  })
+  .describe("A message projected to the agent according to its view");
+
+export const MessageEvent: z.ZodType<MessageEvent> = _MessageEvent;
+
+export type AttestationEvent = {
+  type: "attestation.updated";
+  attestation: Attestation;
+};
+
+const _AttestationEvent = z
+  .object({
+    type: z.literal("attestation.updated").describe("Event type discriminator"),
+    attestation: AttestationSchema.describe("The updated attestation"),
+  })
+  .describe("Attestation was published or updated");
+
+export const AttestationEvent: z.ZodType<AttestationEvent> = _AttestationEvent;
+
+export type SessionStartedEvent = {
+  type: "session.started";
+  session: z.infer<typeof SessionToken>;
+  view: z.infer<typeof ViewConfig>;
+  grant: z.infer<typeof GrantConfig>;
+};
+
+const _SessionStartedEvent = z
+  .object({
+    type: z.literal("session.started").describe("Event type discriminator"),
+    session: SessionToken.describe("The issued session token"),
+    view: ViewConfig.describe("Active view for this session"),
+    grant: GrantConfig.describe("Active grant for this session"),
+  })
+  .describe("Session successfully established");
+
+export const SessionStartedEvent: z.ZodType<SessionStartedEvent> =
+  _SessionStartedEvent;
+
+export type SessionExpiredEvent = {
+  type: "session.expired";
+  sessionId: string;
+  reason: string;
+};
+
+const _SessionExpiredEvent = z
+  .object({
+    type: z.literal("session.expired").describe("Event type discriminator"),
+    sessionId: z.string().describe("Expired session ID"),
+    reason: z.string().describe("Why the session expired"),
+  })
+  .describe("Session has expired");
+
+export const SessionExpiredEvent: z.ZodType<SessionExpiredEvent> =
+  _SessionExpiredEvent;
+
+export type SessionReauthRequiredEvent = {
+  type: "session.reauthorization_required";
+  sessionId: string;
+  reason: string;
+};
+
+const _SessionReauthRequiredEvent = z
+  .object({
+    type: z
+      .literal("session.reauthorization_required")
+      .describe("Event type discriminator"),
+    sessionId: z.string().describe("Session requiring reauthorization"),
+    reason: z.string().describe("What policy change triggered reauthorization"),
+  })
+  .describe("Session must be reauthorized due to material policy change");
+
+export const SessionReauthRequiredEvent: z.ZodType<SessionReauthRequiredEvent> =
+  _SessionReauthRequiredEvent;
+
+export type HeartbeatEvent = {
+  type: "heartbeat";
+  sessionId: string;
+  timestamp: string;
+};
+
+const _HeartbeatEvent = z
+  .object({
+    type: z.literal("heartbeat").describe("Event type discriminator"),
+    sessionId: z.string().describe("Session this heartbeat is for"),
+    timestamp: z.string().datetime().describe("Heartbeat timestamp"),
+  })
+  .describe("Liveness signal from the broker");
+
+export const HeartbeatEvent: z.ZodType<HeartbeatEvent> = _HeartbeatEvent;
+
+export type RevealEvent = {
+  type: "message.revealed";
+  messageId: string;
+  groupId: string;
+  contentType: string;
+  content?: unknown;
+  revealId: string;
+};
+
+const _RevealEvent = z
+  .object({
+    type: z.literal("message.revealed").describe("Event type discriminator"),
+    messageId: z.string().describe("Message being revealed"),
+    groupId: z.string().describe("Group the message belongs to"),
+    contentType: ContentTypeId.describe("Content type of the revealed message"),
+    content: z.unknown().describe("Decoded message payload"),
+    revealId: z.string().describe("Reveal grant that authorized this"),
+  })
+  .describe("Previously hidden content revealed to the agent");
+
+export const RevealEvent: z.ZodType<RevealEvent> = _RevealEvent;
+
+export type ViewUpdatedEvent = {
+  type: "view.updated";
+  view: z.infer<typeof ViewConfig>;
+};
+
+const _ViewUpdatedEvent = z
+  .object({
+    type: z.literal("view.updated").describe("Event type discriminator"),
+    view: ViewConfig.describe("Updated view configuration"),
+  })
+  .describe("View configuration changed within the current session");
+
+export const ViewUpdatedEvent: z.ZodType<ViewUpdatedEvent> = _ViewUpdatedEvent;
+
+export type GrantUpdatedEvent = {
+  type: "grant.updated";
+  grant: z.infer<typeof GrantConfig>;
+};
+
+const _GrantUpdatedEvent = z
+  .object({
+    type: z.literal("grant.updated").describe("Event type discriminator"),
+    grant: GrantConfig.describe("Updated grant configuration"),
+  })
+  .describe("Grant configuration changed within the current session");
+
+export const GrantUpdatedEvent: z.ZodType<GrantUpdatedEvent> =
+  _GrantUpdatedEvent;
+
+export type AgentRevokedEvent = {
+  type: "agent.revoked";
+  revocation: z.infer<typeof RevocationAttestation>;
+};
+
+const _AgentRevokedEvent = z
+  .object({
+    type: z.literal("agent.revoked").describe("Event type discriminator"),
+    revocation: RevocationAttestation.describe("The revocation details"),
+  })
+  .describe("Agent has been revoked from the group");
+
+export const AgentRevokedEvent: z.ZodType<AgentRevokedEvent> =
+  _AgentRevokedEvent;
+
+export type ActionConfirmationEvent = {
+  type: "action.confirmation_required";
+  actionId: string;
+  actionType: string;
+  preview?: unknown;
+};
+
+const _ActionConfirmationEvent = z
+  .object({
+    type: z
+      .literal("action.confirmation_required")
+      .describe("Event type discriminator"),
+    actionId: z.string().describe("ID of the pending action"),
+    actionType: z.string().describe("Type of action awaiting confirmation"),
+    preview: z.unknown().describe("Preview of the action for owner review"),
+  })
+  .describe("An action requires owner confirmation before execution");
+
+export const ActionConfirmationEvent: z.ZodType<ActionConfirmationEvent> =
+  _ActionConfirmationEvent;
+
+export type BrokerRecoveryEvent = {
+  type: "broker.recovery.complete";
+  caughtUpThrough: string;
+};
+
+const _BrokerRecoveryEvent = z
+  .object({
+    type: z
+      .literal("broker.recovery.complete")
+      .describe("Event type discriminator"),
+    caughtUpThrough: z
+      .string()
+      .datetime()
+      .describe("Timestamp through which the broker has resynced"),
+  })
+  .describe("Broker has recovered and resynced");
+
+export const BrokerRecoveryEvent: z.ZodType<BrokerRecoveryEvent> =
+  _BrokerRecoveryEvent;
+
+export type BrokerEvent =
+  | MessageEvent
+  | AttestationEvent
+  | SessionStartedEvent
+  | SessionExpiredEvent
+  | SessionReauthRequiredEvent
+  | HeartbeatEvent
+  | RevealEvent
+  | ViewUpdatedEvent
+  | GrantUpdatedEvent
+  | AgentRevokedEvent
+  | ActionConfirmationEvent
+  | BrokerRecoveryEvent;
+
+/** Discriminated union of all broker-to-harness events. */
+export const BrokerEvent: z.ZodType<BrokerEvent> = z
+  .discriminatedUnion("type", [
+    _MessageEvent,
+    _AttestationEvent,
+    _SessionStartedEvent,
+    _SessionExpiredEvent,
+    _SessionReauthRequiredEvent,
+    _HeartbeatEvent,
+    _RevealEvent,
+    _ViewUpdatedEvent,
+    _GrantUpdatedEvent,
+    _AgentRevokedEvent,
+    _ActionConfirmationEvent,
+    _BrokerRecoveryEvent,
+  ])
+  .describe("Any event the broker may send to a harness");

--- a/packages/schemas/src/grant.ts
+++ b/packages/schemas/src/grant.ts
@@ -1,0 +1,102 @@
+import { z } from "zod";
+
+export type MessagingGrant = {
+  send: boolean;
+  reply: boolean;
+  react: boolean;
+  draftOnly: boolean;
+};
+
+export const MessagingGrant: z.ZodType<MessagingGrant> = z
+  .object({
+    send: z.boolean().describe("Can send messages"),
+    reply: z.boolean().describe("Can reply in threads"),
+    react: z.boolean().describe("Can add/remove reactions"),
+    draftOnly: z
+      .boolean()
+      .describe("Messages require owner confirmation before sending"),
+  })
+  .describe("Messaging action permissions");
+
+export type GroupManagementGrant = {
+  addMembers: boolean;
+  removeMembers: boolean;
+  updateMetadata: boolean;
+  inviteUsers: boolean;
+};
+
+export const GroupManagementGrant: z.ZodType<GroupManagementGrant> = z
+  .object({
+    addMembers: z.boolean().describe("Can add members to the group"),
+    removeMembers: z.boolean().describe("Can remove members from the group"),
+    updateMetadata: z.boolean().describe("Can update group metadata"),
+    inviteUsers: z.boolean().describe("Can issue invitations"),
+  })
+  .describe("Group management permissions");
+
+export type ToolScope = {
+  toolId: string;
+  allowed: boolean;
+  parameters: Record<string, unknown> | null;
+};
+
+export const ToolScope: z.ZodType<ToolScope> = z
+  .object({
+    toolId: z.string().describe("Identifier for the tool"),
+    allowed: z.boolean().describe("Whether this tool is currently allowed"),
+    parameters: z
+      .record(z.string(), z.unknown())
+      .nullable()
+      .describe("Permitted parameter constraints, null for unconstrained"),
+  })
+  .describe("Permission scope for a single tool");
+
+export type ToolGrant = {
+  scopes: ToolScope[];
+};
+
+export const ToolGrant: z.ZodType<ToolGrant> = z
+  .object({
+    scopes: z.array(ToolScope).describe("Per-tool permission scopes"),
+  })
+  .describe("Tool capability permissions");
+
+export type EgressGrant = {
+  storeExcerpts: boolean;
+  useForMemory: boolean;
+  forwardToProviders: boolean;
+  quoteRevealed: boolean;
+  summarize: boolean;
+};
+
+export const EgressGrant: z.ZodType<EgressGrant> = z
+  .object({
+    storeExcerpts: z.boolean().describe("Can store message excerpts"),
+    useForMemory: z.boolean().describe("Can use content for persistent memory"),
+    forwardToProviders: z
+      .boolean()
+      .describe("Can forward content to inference providers"),
+    quoteRevealed: z
+      .boolean()
+      .describe("Can quote revealed content in messages"),
+    summarize: z.boolean().describe("Can summarize hidden or revealed content"),
+  })
+  .describe("Retention and egress permissions");
+
+export type GrantConfig = {
+  messaging: MessagingGrant;
+  groupManagement: GroupManagementGrant;
+  tools: ToolGrant;
+  egress: EgressGrant;
+};
+
+export const GrantConfig: z.ZodType<GrantConfig> = z
+  .object({
+    messaging: MessagingGrant.describe("Messaging action permissions"),
+    groupManagement: GroupManagementGrant.describe(
+      "Group management permissions",
+    ),
+    tools: ToolGrant.describe("Tool capability permissions"),
+    egress: EgressGrant.describe("Retention and egress permissions"),
+  })
+  .describe("Complete grant configuration for an agent session");

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -1,2 +1,121 @@
-// Placeholder — real exports added by subsequent specs.
-export {};
+// Content types
+export {
+  ContentTypeId,
+  BASELINE_CONTENT_TYPES,
+  type BaselineContentType,
+  TextPayload,
+  ReactionPayload,
+  ReplyPayload,
+  ReadReceiptPayload,
+  GroupUpdatedPayload,
+  CONTENT_TYPE_SCHEMAS,
+} from "./content-types.js";
+
+// Views
+export {
+  ViewMode,
+  ContentTypeAllowlist,
+  ThreadScope,
+  ViewConfig,
+} from "./view.js";
+
+// Grants
+export {
+  MessagingGrant,
+  GroupManagementGrant,
+  ToolScope,
+  ToolGrant,
+  EgressGrant,
+  GrantConfig,
+} from "./grant.js";
+
+// Attestation
+export {
+  InferenceMode,
+  ContentEgressScope,
+  RetentionAtProvider,
+  HostingMode,
+  TrustTier,
+  RevocationRules,
+  AttestationSchema,
+  type Attestation,
+} from "./attestation.js";
+
+// Session
+export {
+  SessionConfig,
+  SessionToken,
+  IssuedSession,
+  SessionState,
+} from "./session.js";
+
+// Reveal
+export {
+  RevealScope,
+  RevealRequest,
+  RevealGrant,
+  RevealState,
+} from "./reveal.js";
+
+// Revocation
+export {
+  AgentRevocationReason,
+  SessionRevocationReason,
+  RevocationAttestation,
+} from "./revocation.js";
+
+// Events
+export {
+  MessageVisibility,
+  MessageEvent,
+  AttestationEvent,
+  SessionStartedEvent,
+  SessionExpiredEvent,
+  SessionReauthRequiredEvent,
+  HeartbeatEvent,
+  RevealEvent,
+  ViewUpdatedEvent,
+  GrantUpdatedEvent,
+  AgentRevokedEvent,
+  ActionConfirmationEvent,
+  BrokerRecoveryEvent,
+  BrokerEvent,
+} from "./events.js";
+
+// Requests
+export {
+  SendMessageRequest,
+  SendReactionRequest,
+  SendReplyRequest,
+  UpdateViewRequest,
+  RevealContentRequest,
+  ConfirmActionRequest,
+  HeartbeatRequest,
+  HarnessRequest,
+} from "./requests.js";
+
+// Response
+export { RequestSuccess, RequestFailure, RequestResponse } from "./response.js";
+
+// Errors
+export {
+  ErrorCategory,
+  ErrorCategoryMetaSchema,
+  type ErrorCategoryMeta,
+  ERROR_CATEGORY_META,
+  errorCategoryMeta,
+  type BrokerError,
+  type AnyBrokerError,
+  matchError,
+  ValidationError,
+  AttestationError,
+  NotFoundError,
+  PermissionError,
+  GrantDeniedError,
+  AuthError,
+  SessionExpiredError,
+  InternalError,
+  TimeoutError,
+  CancelledError,
+  NetworkError,
+} from "./errors/index.js";

--- a/packages/schemas/src/requests.ts
+++ b/packages/schemas/src/requests.ts
@@ -1,0 +1,163 @@
+import { z } from "zod";
+import { ContentTypeId } from "./content-types.js";
+import { ViewConfig } from "./view.js";
+import { RevealRequest } from "./reveal.js";
+
+export type SendMessageRequest = {
+  type: "send_message";
+  requestId: string;
+  groupId: string;
+  contentType: string;
+  content?: unknown;
+};
+
+const _SendMessageRequest = z
+  .object({
+    type: z.literal("send_message").describe("Request type discriminator"),
+    requestId: z
+      .string()
+      .describe("Client-generated request ID for correlation"),
+    groupId: z.string().describe("Target group"),
+    contentType: ContentTypeId.describe("Content type of the message"),
+    content: z.unknown().describe("Encoded message payload"),
+  })
+  .describe("Send a message to a group");
+
+export const SendMessageRequest: z.ZodType<SendMessageRequest> =
+  _SendMessageRequest;
+
+export type SendReactionRequest = {
+  type: "send_reaction";
+  requestId: string;
+  groupId: string;
+  messageId: string;
+  action: "added" | "removed";
+  content: string;
+};
+
+const _SendReactionRequest = z
+  .object({
+    type: z.literal("send_reaction").describe("Request type discriminator"),
+    requestId: z.string().describe("Client-generated request ID"),
+    groupId: z.string().describe("Target group"),
+    messageId: z.string().describe("Message to react to"),
+    action: z.enum(["added", "removed"]).describe("Add or remove reaction"),
+    content: z.string().describe("Reaction content"),
+  })
+  .describe("React to a message");
+
+export const SendReactionRequest: z.ZodType<SendReactionRequest> =
+  _SendReactionRequest;
+
+export type SendReplyRequest = {
+  type: "send_reply";
+  requestId: string;
+  groupId: string;
+  messageId: string;
+  contentType: string;
+  content?: unknown;
+};
+
+const _SendReplyRequest = z
+  .object({
+    type: z.literal("send_reply").describe("Request type discriminator"),
+    requestId: z.string().describe("Client-generated request ID"),
+    groupId: z.string().describe("Target group"),
+    messageId: z.string().describe("Message to reply to"),
+    contentType: ContentTypeId.describe("Content type of the reply body"),
+    content: z.unknown().describe("Encoded reply payload"),
+  })
+  .describe("Reply to a message in a thread");
+
+export const SendReplyRequest: z.ZodType<SendReplyRequest> = _SendReplyRequest;
+
+export type UpdateViewRequest = {
+  type: "update_view";
+  requestId: string;
+  view: z.infer<typeof ViewConfig>;
+};
+
+const _UpdateViewRequest = z
+  .object({
+    type: z.literal("update_view").describe("Request type discriminator"),
+    requestId: z.string().describe("Client-generated request ID"),
+    view: ViewConfig.describe("Requested view update"),
+  })
+  .describe("Request a view update (broker may reject if material escalation)");
+
+export const UpdateViewRequest: z.ZodType<UpdateViewRequest> =
+  _UpdateViewRequest;
+
+export type RevealContentRequest = {
+  type: "reveal_content";
+  requestId: string;
+  reveal: z.infer<typeof RevealRequest>;
+};
+
+const _RevealContentRequest = z
+  .object({
+    type: z.literal("reveal_content").describe("Request type discriminator"),
+    requestId: z.string().describe("Client-generated request ID"),
+    reveal: RevealRequest.describe("Reveal details"),
+  })
+  .describe("Request content be revealed to the agent");
+
+export const RevealContentRequest: z.ZodType<RevealContentRequest> =
+  _RevealContentRequest;
+
+export type ConfirmActionRequest = {
+  type: "confirm_action";
+  requestId: string;
+  actionId: string;
+  confirmed: boolean;
+};
+
+const _ConfirmActionRequest = z
+  .object({
+    type: z.literal("confirm_action").describe("Request type discriminator"),
+    requestId: z.string().describe("Client-generated request ID"),
+    actionId: z.string().describe("Action being confirmed or denied"),
+    confirmed: z.boolean().describe("Whether the action is approved"),
+  })
+  .describe("Confirm or deny a pending action");
+
+export const ConfirmActionRequest: z.ZodType<ConfirmActionRequest> =
+  _ConfirmActionRequest;
+
+export type HeartbeatRequest = {
+  type: "heartbeat";
+  requestId: string;
+  sessionId: string;
+};
+
+const _HeartbeatRequest = z
+  .object({
+    type: z.literal("heartbeat").describe("Request type discriminator"),
+    requestId: z.string().describe("Client-generated request ID"),
+    sessionId: z.string().describe("Session sending the heartbeat"),
+  })
+  .describe("Heartbeat from the harness to keep the session alive");
+
+export const HeartbeatRequest: z.ZodType<HeartbeatRequest> = _HeartbeatRequest;
+
+export type HarnessRequest =
+  | SendMessageRequest
+  | SendReactionRequest
+  | SendReplyRequest
+  | UpdateViewRequest
+  | RevealContentRequest
+  | ConfirmActionRequest
+  | HeartbeatRequest;
+
+/** Discriminated union of all harness-to-broker requests. */
+export const HarnessRequest: z.ZodType<HarnessRequest> = z
+  .discriminatedUnion("type", [
+    _SendMessageRequest,
+    _SendReactionRequest,
+    _SendReplyRequest,
+    _UpdateViewRequest,
+    _RevealContentRequest,
+    _ConfirmActionRequest,
+    _HeartbeatRequest,
+  ])
+  .describe("Any request a harness may send to the broker");

--- a/packages/schemas/src/response.ts
+++ b/packages/schemas/src/response.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import type { ErrorCategory } from "./errors/index.js";
+import { ErrorCategory as ErrorCategorySchema } from "./errors/index.js";
+
+export type RequestSuccess = {
+  ok: true;
+  requestId: string;
+  data?: unknown;
+};
+
+const _RequestSuccess = z
+  .object({
+    ok: z.literal(true).describe("Success indicator"),
+    requestId: z.string().describe("Correlates with the original request"),
+    data: z.unknown().describe("Response payload, type depends on request"),
+  })
+  .describe("Successful response to a harness request");
+
+export const RequestSuccess: z.ZodType<RequestSuccess> = _RequestSuccess;
+
+export type RequestFailure = {
+  ok: false;
+  requestId: string;
+  error: {
+    code: number;
+    category: ErrorCategory;
+    message: string;
+    context: Record<string, unknown> | null;
+  };
+};
+
+const _RequestFailure = z
+  .object({
+    ok: z.literal(false).describe("Failure indicator"),
+    requestId: z.string().describe("Correlates with the original request"),
+    error: z
+      .object({
+        code: z.number().int().describe("Numeric error code"),
+        category: ErrorCategorySchema.describe(
+          "Error category from taxonomy",
+        ),
+        message: z.string().describe("Human-readable error description"),
+        context: z
+          .record(z.string(), z.unknown())
+          .nullable()
+          .describe("Structured error context for debugging"),
+      })
+      .describe("Error details"),
+  })
+  .describe("Failed response to a harness request");
+
+export const RequestFailure: z.ZodType<RequestFailure> = _RequestFailure;
+
+export type RequestResponse = RequestSuccess | RequestFailure;
+
+export const RequestResponse: z.ZodType<RequestResponse> = z
+  .discriminatedUnion("ok", [_RequestSuccess, _RequestFailure])
+  .describe("Response envelope for harness requests");

--- a/packages/schemas/src/reveal.ts
+++ b/packages/schemas/src/reveal.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+
+export const RevealScope: z.ZodEnum<
+  ["message", "thread", "time-window", "content-type", "sender"]
+> = z
+  .enum(["message", "thread", "time-window", "content-type", "sender"])
+  .describe("Granularity of a reveal operation");
+
+export type RevealScope = z.infer<typeof RevealScope>;
+
+export type RevealRequest = {
+  revealId: string;
+  groupId: string;
+  scope: RevealScope;
+  targetId: string;
+  requestedBy: string;
+  expiresAt: string | null;
+};
+
+export const RevealRequest: z.ZodType<RevealRequest> = z
+  .object({
+    revealId: z.string().describe("Unique reveal request identifier"),
+    groupId: z.string().describe("Group containing the content"),
+    scope: RevealScope.describe("What granularity to reveal"),
+    targetId: z
+      .string()
+      .describe("ID of the message, thread, content type, or sender"),
+    requestedBy: z
+      .string()
+      .describe("Inbox ID of the member requesting the reveal"),
+    expiresAt: z
+      .string()
+      .datetime()
+      .nullable()
+      .describe("When this reveal expires, null for permanent"),
+  })
+  .describe("Request to reveal content to an agent");
+
+export type RevealGrant = {
+  revealId: string;
+  grantedAt: string;
+  grantedBy: string;
+  expiresAt: string | null;
+};
+
+export const RevealGrant: z.ZodType<RevealGrant> = z
+  .object({
+    revealId: z.string().describe("Matches the RevealRequest.revealId"),
+    grantedAt: z.string().datetime().describe("When the reveal was granted"),
+    grantedBy: z.string().describe("Inbox ID of the granting member"),
+    expiresAt: z
+      .string()
+      .datetime()
+      .nullable()
+      .describe("When this grant expires, null for permanent"),
+  })
+  .describe("Granted reveal making content visible to the agent");
+
+export type RevealState = {
+  activeReveals: RevealGrant[];
+};
+
+export const RevealState: z.ZodType<RevealState> = z
+  .object({
+    activeReveals: z
+      .array(RevealGrant)
+      .describe("Currently active reveal grants"),
+  })
+  .describe("Aggregate reveal state for a session");

--- a/packages/schemas/src/revocation.ts
+++ b/packages/schemas/src/revocation.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+export const AgentRevocationReason: z.ZodEnum<
+  [
+    "owner-initiated",
+    "session-expired",
+    "admin-removed",
+    "heartbeat-timeout",
+    "policy-violation",
+  ]
+> = z
+  .enum([
+    "owner-initiated",
+    "session-expired",
+    "admin-removed",
+    "heartbeat-timeout",
+    "policy-violation",
+  ])
+  .describe("Why the agent was revoked from a group");
+
+export type AgentRevocationReason = z.infer<typeof AgentRevocationReason>;
+
+export const SessionRevocationReason: z.ZodEnum<
+  [
+    "owner-initiated",
+    "session-expired",
+    "heartbeat-timeout",
+    "policy-violation",
+    "reauthorization-required",
+  ]
+> = z
+  .enum([
+    "owner-initiated",
+    "session-expired",
+    "heartbeat-timeout",
+    "policy-violation",
+    "reauthorization-required",
+  ])
+  .describe("Why a session was revoked");
+
+export type SessionRevocationReason = z.infer<typeof SessionRevocationReason>;
+
+export type RevocationAttestation = {
+  attestationId: string;
+  previousAttestationId: string;
+  agentInboxId: string;
+  groupId: string;
+  reason: AgentRevocationReason;
+  revokedAt: string;
+  issuer: string;
+};
+
+export const RevocationAttestation: z.ZodType<RevocationAttestation> = z
+  .object({
+    attestationId: z.string().describe("ID of this revocation attestation"),
+    previousAttestationId: z
+      .string()
+      .describe("ID of the attestation being revoked"),
+    agentInboxId: z.string().describe("Agent being revoked"),
+    groupId: z.string().describe("Group the revocation applies to"),
+    reason: AgentRevocationReason.describe("Why the agent was revoked"),
+    revokedAt: z
+      .string()
+      .datetime()
+      .describe("When the revocation took effect"),
+    issuer: z.string().describe("Identity of the revocation issuer"),
+  })
+  .describe("Group-visible revocation of an agent's attestation");

--- a/packages/schemas/src/session.ts
+++ b/packages/schemas/src/session.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+import { ViewConfig } from "./view.js";
+import { GrantConfig } from "./grant.js";
+
+export type SessionConfig = {
+  agentInboxId: string;
+  view: ViewConfig;
+  grant: GrantConfig;
+  ttlSeconds?: number | undefined;
+  heartbeatInterval?: number | undefined;
+};
+
+export const SessionConfig: z.ZodType<SessionConfig> = z
+  .object({
+    agentInboxId: z.string().describe("Agent this session is for"),
+    view: ViewConfig.describe("View configuration for this session"),
+    grant: GrantConfig.describe("Grant configuration for this session"),
+    ttlSeconds: z
+      .number()
+      .int()
+      .positive()
+      .default(3600)
+      .describe("Session time-to-live in seconds"),
+    heartbeatInterval: z
+      .number()
+      .int()
+      .positive()
+      .default(30)
+      .describe("Expected heartbeat cadence in seconds"),
+  })
+  .describe("Configuration for issuing a new session");
+
+export type SessionToken = {
+  sessionId: string;
+  agentInboxId: string;
+  sessionKeyFingerprint: string;
+  issuedAt: string;
+  expiresAt: string;
+};
+
+export const SessionToken: z.ZodType<SessionToken> = z
+  .object({
+    sessionId: z.string().describe("Unique session identifier"),
+    agentInboxId: z.string().describe("Agent this session belongs to"),
+    sessionKeyFingerprint: z
+      .string()
+      .describe("Fingerprint of the session key"),
+    issuedAt: z.string().datetime().describe("When the session was issued"),
+    expiresAt: z.string().datetime().describe("When the session expires"),
+  })
+  .describe("Opaque session token issued to the harness");
+
+export type IssuedSession = {
+  token: string;
+  session: SessionToken;
+};
+
+export const IssuedSession: z.ZodType<IssuedSession> = z
+  .object({
+    token: z.string().min(1).describe("Session bearer token"),
+    session: SessionToken.describe("Session metadata"),
+  })
+  .describe("Issued session credentials returned by session.issue");
+
+export const SessionState: z.ZodEnum<
+  ["active", "expired", "revoked", "reauthorization-required"]
+> = z
+  .enum(["active", "expired", "revoked", "reauthorization-required"])
+  .describe("Current lifecycle state of a session");
+
+export type SessionState = z.infer<typeof SessionState>;

--- a/packages/schemas/src/view.ts
+++ b/packages/schemas/src/view.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import { ContentTypeId } from "./content-types.js";
+
+export const ViewMode: z.ZodEnum<
+  ["full", "thread-only", "redacted", "reveal-only", "summary-only"]
+> = z
+  .enum(["full", "thread-only", "redacted", "reveal-only", "summary-only"])
+  .describe("Visibility mode for the agent's view of conversations");
+
+export type ViewMode = z.infer<typeof ViewMode>;
+
+export type ContentTypeAllowlist = string[];
+
+export const ContentTypeAllowlist: z.ZodType<ContentTypeAllowlist> = z
+  .array(ContentTypeId)
+  .min(1)
+  .describe("Content types the agent is allowed to see");
+
+export type ThreadScope = {
+  groupId: string;
+  threadId: string | null;
+};
+
+export const ThreadScope: z.ZodType<ThreadScope> = z
+  .object({
+    groupId: z.string().describe("Group the thread belongs to"),
+    threadId: z
+      .string()
+      .nullable()
+      .describe("Specific thread ID, or null for entire group"),
+  })
+  .describe("Scopes a view to a specific group and optional thread");
+
+export type ViewConfig = {
+  mode: ViewMode;
+  threadScopes: ThreadScope[];
+  contentTypes: ContentTypeAllowlist;
+};
+
+export const ViewConfig: z.ZodType<ViewConfig> = z
+  .object({
+    mode: ViewMode.describe("Base visibility mode"),
+    threadScopes: z
+      .array(ThreadScope)
+      .min(1)
+      .describe("Groups and threads this view covers"),
+    contentTypes: ContentTypeAllowlist.describe(
+      "Allowed content types for this view",
+    ),
+  })
+  .describe("Complete view configuration for an agent session");


### PR DESCRIPTION
## Context
This branch defines the schema-first foundation for the broker. Review this PR against `v0/scaffolding`, not `main`.

## What Changed
- adds Zod schemas for views, grants, requests, responses, sessions, events, attestations, revocations, reveals, and XMTP content types
- establishes the shared error taxonomy with typed validation, auth, permission, not-found, timeout, cancelled, and internal errors
- exports inferred TypeScript types from schema definitions instead of duplicating contract types by hand
- adds focused tests across the schema surface to lock serialization and validation behavior

## Why This Branch Exists
Every higher package depends on these runtime-validated contracts. This PR is the single source of truth for wire shapes and shared broker errors.

## Key Files
- `packages/schemas/src/view.ts`
- `packages/schemas/src/grant.ts`
- `packages/schemas/src/requests.ts`
- `packages/schemas/src/response.ts`
- `packages/schemas/src/events.ts`
- `packages/schemas/src/errors/*`

## Verification
- schema package test suite under `packages/schemas/src/__tests__`
- repo verification via pre-push stack checks (`lint`, `test`, `typecheck`)
