### PR TITLE
feat(contracts): add cross-package service and provider interfaces

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,11 @@
     "packages/contracts": {
       "name": "@xmtp-broker/contracts",
       "version": "0.0.0",
+      "dependencies": {
+        "@xmtp-broker/schemas": "workspace:*",
+        "better-result": "catalog:",
+        "zod": "catalog:",
+      },
       "devDependencies": {
         "bun-types": "catalog:",
         "typescript": "catalog:",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -15,7 +15,11 @@
     "lint": "oxlint .",
     "test": "bun test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@xmtp-broker/schemas": "workspace:*",
+    "better-result": "catalog:",
+    "zod": "catalog:"
+  },
   "devDependencies": {
     "bun-types": "catalog:",
     "typescript": "catalog:"

--- a/packages/contracts/src/__tests__/envelope.test.ts
+++ b/packages/contracts/src/__tests__/envelope.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SignedAttestationEnvelope,
+  SignedRevocationEnvelope,
+} from "../attestation-types.js";
+
+/** Minimal valid attestation payload matching AttestationSchema. */
+function validAttestation() {
+  return {
+    attestationId: "att-001",
+    previousAttestationId: null,
+    agentInboxId: "agent-inbox-1",
+    ownerInboxId: "owner-inbox-1",
+    groupId: "group-1",
+    threadScope: null,
+    viewMode: "full",
+    contentTypes: ["xmtp.org/text:1.0"],
+    grantedOps: ["send"],
+    toolScopes: [],
+    inferenceMode: "local",
+    inferenceProviders: [],
+    contentEgressScope: "none",
+    retentionAtProvider: "none",
+    hostingMode: "local",
+    trustTier: "unverified",
+    buildProvenanceRef: null,
+    verifierStatementRef: null,
+    sessionKeyFingerprint: null,
+    policyHash: "sha256:abc123",
+    heartbeatInterval: 30,
+    issuedAt: "2026-01-01T00:00:00Z",
+    expiresAt: "2026-01-01T01:00:00Z",
+    revocationRules: {
+      maxTtlSeconds: 3600,
+      requireHeartbeat: true,
+      ownerCanRevoke: true,
+      adminCanRemove: true,
+    },
+    issuer: "broker-1",
+  };
+}
+
+/** Minimal valid revocation payload matching RevocationAttestation. */
+function validRevocation() {
+  return {
+    attestationId: "rev-001",
+    previousAttestationId: "att-001",
+    agentInboxId: "agent-inbox-1",
+    groupId: "group-1",
+    reason: "owner-initiated",
+    revokedAt: "2026-01-01T00:30:00Z",
+    issuer: "broker-1",
+  };
+}
+
+describe("SignedAttestationEnvelope", () => {
+  test("accepts a valid signed attestation", () => {
+    const input = {
+      attestation: validAttestation(),
+      signature: "dGVzdC1zaWduYXR1cmU=",
+      signatureAlgorithm: "Ed25519",
+      signerKeyRef: "key-ref-001",
+    };
+
+    const result = SignedAttestationEnvelope.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects missing signature", () => {
+    const input = {
+      attestation: validAttestation(),
+      signatureAlgorithm: "Ed25519",
+      signerKeyRef: "key-ref-001",
+    };
+
+    const result = SignedAttestationEnvelope.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing attestation", () => {
+    const input = {
+      signature: "dGVzdC1zaWduYXR1cmU=",
+      signatureAlgorithm: "Ed25519",
+      signerKeyRef: "key-ref-001",
+    };
+
+    const result = SignedAttestationEnvelope.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid attestation payload", () => {
+    const input = {
+      attestation: { attestationId: "att-001" },
+      signature: "dGVzdC1zaWduYXR1cmU=",
+      signatureAlgorithm: "Ed25519",
+      signerKeyRef: "key-ref-001",
+    };
+
+    const result = SignedAttestationEnvelope.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing signatureAlgorithm", () => {
+    const input = {
+      attestation: validAttestation(),
+      signature: "dGVzdC1zaWduYXR1cmU=",
+      signerKeyRef: "key-ref-001",
+    };
+
+    const result = SignedAttestationEnvelope.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing signerKeyRef", () => {
+    const input = {
+      attestation: validAttestation(),
+      signature: "dGVzdC1zaWduYXR1cmU=",
+      signatureAlgorithm: "Ed25519",
+    };
+
+    const result = SignedAttestationEnvelope.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects empty attestation signature", () => {
+    const input = {
+      attestation: validAttestation(),
+      signature: "",
+      signatureAlgorithm: "Ed25519",
+      signerKeyRef: "key-ref-001",
+    };
+
+    const result = SignedAttestationEnvelope.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-base64 attestation signature", () => {
+    const input = {
+      attestation: validAttestation(),
+      signature: "not-base64!!!",
+      signatureAlgorithm: "Ed25519",
+      signerKeyRef: "key-ref-001",
+    };
+
+    const result = SignedAttestationEnvelope.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("SignedRevocationEnvelope", () => {
+  test("accepts a valid signed revocation", () => {
+    const input = {
+      revocation: validRevocation(),
+      signature: "dGVzdC1zaWduYXR1cmU=",
+      signatureAlgorithm: "Ed25519",
+      signerKeyRef: "key-ref-001",
+    };
+
+    const result = SignedRevocationEnvelope.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects missing revocation", () => {
+    const input = {
+      signature: "dGVzdC1zaWduYXR1cmU=",
+      signatureAlgorithm: "Ed25519",
+      signerKeyRef: "key-ref-001",
+    };
+
+    const result = SignedRevocationEnvelope.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid revocation payload", () => {
+    const input = {
+      revocation: { attestationId: "rev-001" },
+      signature: "dGVzdC1zaWduYXR1cmU=",
+      signatureAlgorithm: "Ed25519",
+      signerKeyRef: "key-ref-001",
+    };
+
+    const result = SignedRevocationEnvelope.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing signature", () => {
+    const input = {
+      revocation: validRevocation(),
+      signatureAlgorithm: "Ed25519",
+      signerKeyRef: "key-ref-001",
+    };
+
+    const result = SignedRevocationEnvelope.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid revocation reason", () => {
+    const input = {
+      revocation: { ...validRevocation(), reason: "invalid-reason" },
+      signature: "dGVzdC1zaWduYXR1cmU=",
+      signatureAlgorithm: "Ed25519",
+      signerKeyRef: "key-ref-001",
+    };
+
+    const result = SignedRevocationEnvelope.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects empty revocation signature", () => {
+    const input = {
+      revocation: validRevocation(),
+      signature: "",
+      signatureAlgorithm: "Ed25519",
+      signerKeyRef: "key-ref-001",
+    };
+
+    const result = SignedRevocationEnvelope.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-base64 revocation signature", () => {
+    const input = {
+      revocation: validRevocation(),
+      signature: "not-base64!!!",
+      signatureAlgorithm: "Ed25519",
+      signerKeyRef: "key-ref-001",
+    };
+
+    const result = SignedRevocationEnvelope.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/contracts/src/__tests__/smoke.test.ts
+++ b/packages/contracts/src/__tests__/smoke.test.ts
@@ -1,7 +1,0 @@
-import { describe, expect, it } from "bun:test";
-
-describe("workspace", () => {
-  it("test runner works", () => {
-    expect(true).toBe(true);
-  });
-});

--- a/packages/contracts/src/attestation-types.ts
+++ b/packages/contracts/src/attestation-types.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+import { AttestationSchema, RevocationAttestation } from "@xmtp-broker/schemas";
+
+/** Provenance info attached to outbound messages. */
+export interface MessageProvenanceMetadata {
+  readonly attestationId: string;
+  readonly sessionKeyFingerprint: string;
+  readonly policyHash: string;
+}
+
+const BASE64_SIGNATURE: z.ZodString = z
+  .string()
+  .min(1)
+  .regex(/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/)
+  .describe("Base64-encoded signature bytes");
+
+type SignedAttestationEnvelopeShape = {
+  attestation: typeof AttestationSchema;
+  signature: typeof BASE64_SIGNATURE;
+  signatureAlgorithm: z.ZodString;
+  signerKeyRef: z.ZodString;
+};
+
+const signedAttestationEnvelopeShape: SignedAttestationEnvelopeShape = {
+  attestation: AttestationSchema.describe("The attestation payload"),
+  signature: BASE64_SIGNATURE.describe(
+    "Base64-encoded signature over the canonical attestation bytes",
+  ),
+  signatureAlgorithm: z
+    .string()
+    .describe("Algorithm used to produce the signature"),
+  signerKeyRef: z
+    .string()
+    .describe("Reference to the key that produced the signature"),
+};
+
+/** Signed attestation ready for group publication. */
+export const SignedAttestationEnvelope: z.ZodObject<SignedAttestationEnvelopeShape> =
+  z
+    .object(signedAttestationEnvelopeShape)
+    .describe("Signed attestation ready for group publication");
+
+export type SignedAttestation = z.infer<typeof SignedAttestationEnvelope>;
+
+type SignedRevocationEnvelopeShape = {
+  revocation: typeof RevocationAttestation;
+  signature: typeof BASE64_SIGNATURE;
+  signatureAlgorithm: z.ZodString;
+  signerKeyRef: z.ZodString;
+};
+
+const signedRevocationEnvelopeShape: SignedRevocationEnvelopeShape = {
+  revocation: RevocationAttestation.describe("The revocation payload"),
+  signature: BASE64_SIGNATURE.describe(
+    "Base64-encoded signature over the canonical revocation bytes",
+  ),
+  signatureAlgorithm: z
+    .string()
+    .describe("Algorithm used to produce the signature"),
+  signerKeyRef: z
+    .string()
+    .describe("Reference to the key that produced the signature"),
+};
+
+/** Signed revocation ready for group publication. */
+export const SignedRevocationEnvelope: z.ZodObject<SignedRevocationEnvelopeShape> =
+  z
+    .object(signedRevocationEnvelopeShape)
+    .describe("Signed revocation ready for group publication");
+
+export type SignedRevocationEnvelope = z.infer<typeof SignedRevocationEnvelope>;

--- a/packages/contracts/src/core-types.ts
+++ b/packages/contracts/src/core-types.ts
@@ -1,0 +1,58 @@
+import type { ContentTypeId } from "@xmtp-broker/schemas";
+import type { SignerProvider } from "./providers.js";
+
+/** Broker lifecycle states. */
+export type CoreState =
+  | "uninitialized"
+  | "initializing"
+  | "ready-local"
+  | "ready"
+  | "shutting-down"
+  | "stopped"
+  | "error";
+
+/** Context object passed to handlers during broker operations. */
+export interface CoreContext {
+  readonly brokerId: string;
+  readonly signerProvider: SignerProvider;
+}
+
+/** Broker-internal representation of a group's state. */
+export interface GroupInfo {
+  readonly groupId: string;
+  readonly identityKeyFingerprint: string;
+  readonly memberInboxIds: readonly string[];
+  readonly createdAt: string;
+}
+
+/** Unfiltered message from the XMTP client. */
+export interface RawMessage {
+  readonly messageId: string;
+  readonly groupId: string;
+  readonly senderInboxId: string;
+  readonly contentType: ContentTypeId;
+  readonly content: unknown;
+  readonly sentAt: string;
+}
+
+/** Union of raw XMTP events before view filtering. */
+export type RawEvent =
+  | {
+      readonly type: "message";
+      readonly message: RawMessage;
+    }
+  | {
+      readonly type: "group.member_added";
+      readonly groupId: string;
+      readonly inboxId: string;
+    }
+  | {
+      readonly type: "group.member_removed";
+      readonly groupId: string;
+      readonly inboxId: string;
+    }
+  | {
+      readonly type: "group.metadata_updated";
+      readonly groupId: string;
+      readonly fields: Record<string, string>;
+    };

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,2 +1,42 @@
-// Placeholder — real exports added by subsequent specs.
-export {};
+// Core types
+export type {
+  CoreState,
+  CoreContext,
+  GroupInfo,
+  RawMessage,
+  RawEvent,
+} from "./core-types.js";
+
+// Session types
+export type { SessionRecord, MaterialityCheck } from "./session-types.js";
+
+// Policy types
+export type { PolicyDelta, GrantError } from "./policy-types.js";
+
+// Attestation types and wire format schemas
+export {
+  SignedAttestationEnvelope,
+  SignedRevocationEnvelope,
+} from "./attestation-types.js";
+export type {
+  SignedAttestation,
+  MessageProvenanceMetadata,
+} from "./attestation-types.js";
+
+// Handler types
+export type { HandlerContext, Handler } from "./handler-types.js";
+
+// Service interfaces
+export type {
+  BrokerCore,
+  SessionManager,
+  AttestationManager,
+} from "./services.js";
+
+// Provider interfaces
+export type {
+  SignerProvider,
+  AttestationSigner,
+  AttestationPublisher,
+  RevealStateStore,
+} from "./providers.js";

--- a/packages/contracts/src/policy-types.ts
+++ b/packages/contracts/src/policy-types.ts
@@ -1,0 +1,26 @@
+import type {
+  ContentTypeId,
+  GrantDeniedError,
+  PermissionError,
+} from "@xmtp-broker/schemas";
+
+/** Describes a change between two policy configurations. */
+export interface PolicyDelta {
+  readonly viewChanges: ReadonlyArray<{
+    field: string;
+    from: unknown;
+    to: unknown;
+  }>;
+  readonly grantChanges: ReadonlyArray<{
+    field: string;
+    from: unknown;
+    to: unknown;
+  }>;
+  readonly contentTypeChanges: {
+    readonly added: readonly ContentTypeId[];
+    readonly removed: readonly ContentTypeId[];
+  };
+}
+
+/** Type alias for grant enforcement error results. */
+export type GrantError = GrantDeniedError | PermissionError;

--- a/packages/contracts/src/providers.ts
+++ b/packages/contracts/src/providers.ts
@@ -1,0 +1,57 @@
+import type { Result } from "better-result";
+import type {
+  Attestation,
+  BrokerError,
+  RevealGrant,
+  RevealState,
+  RevocationAttestation,
+} from "@xmtp-broker/schemas";
+import type {
+  SignedAttestation,
+  SignedRevocationEnvelope,
+} from "./attestation-types.js";
+
+/** Abstracts key material for signing and identity-scoped encryption. */
+export interface SignerProvider {
+  sign(data: Uint8Array): Promise<Result<Uint8Array, BrokerError>>;
+  getPublicKey(): Promise<Result<Uint8Array, BrokerError>>;
+  getFingerprint(): Promise<Result<string, BrokerError>>;
+  /** Derive a deterministic DB encryption key for the bound identity. */
+  getDbEncryptionKey(): Promise<Result<Uint8Array, BrokerError>>;
+  /**
+   * Retrieve the secp256k1 private key for XMTP identity registration.
+   * Returns a hex-encoded 0x-prefixed key.
+   */
+  getXmtpIdentityKey(): Promise<Result<`0x${string}`, BrokerError>>;
+}
+
+/** Signs attestation payloads. */
+export interface AttestationSigner {
+  sign(payload: Attestation): Promise<Result<SignedAttestation, BrokerError>>;
+  signRevocation(
+    payload: RevocationAttestation,
+  ): Promise<Result<SignedRevocationEnvelope, BrokerError>>;
+}
+
+/** Publishes signed attestations to groups. */
+export interface AttestationPublisher {
+  publish(
+    groupId: string,
+    attestation: SignedAttestation,
+  ): Promise<Result<void, BrokerError>>;
+  publishRevocation(
+    groupId: string,
+    revocation: SignedRevocationEnvelope,
+  ): Promise<Result<void, BrokerError>>;
+}
+
+/** Persists and queries reveal grant state. */
+export interface RevealStateStore {
+  grant(revealGrant: RevealGrant): Promise<Result<void, BrokerError>>;
+  revoke(revealId: string): Promise<Result<void, BrokerError>>;
+  activeReveals(sessionId: string): Promise<Result<RevealState, BrokerError>>;
+  isRevealed(
+    sessionId: string,
+    messageId: string,
+  ): Promise<Result<boolean, BrokerError>>;
+}

--- a/packages/contracts/src/services.ts
+++ b/packages/contracts/src/services.ts
@@ -1,0 +1,61 @@
+import type { Result } from "better-result";
+import type {
+  AgentRevocationReason,
+  BrokerError,
+  IssuedSession,
+  SessionConfig,
+  SessionRevocationReason,
+} from "@xmtp-broker/schemas";
+import type { SignedAttestation } from "./attestation-types.js";
+import type { CoreState, GroupInfo } from "./core-types.js";
+import type { SessionRecord } from "./session-types.js";
+
+/** Top-level broker lifecycle: initialize, shutdown, state transitions. */
+export interface BrokerCore {
+  readonly state: CoreState;
+  initializeLocal(): Promise<Result<void, BrokerError>>;
+  initialize(): Promise<Result<void, BrokerError>>;
+  shutdown(): Promise<Result<void, BrokerError>>;
+  sendMessage(
+    groupId: string,
+    contentType: string,
+    content: unknown,
+  ): Promise<Result<{ messageId: string }, BrokerError>>;
+  getGroupInfo(groupId: string): Promise<Result<GroupInfo, BrokerError>>;
+}
+
+/** Session issuance, lookup, revocation, heartbeat processing. */
+export interface SessionManager {
+  issue(config: SessionConfig): Promise<Result<IssuedSession, BrokerError>>;
+  list(
+    agentInboxId?: string,
+  ): Promise<Result<readonly SessionRecord[], BrokerError>>;
+  lookup(sessionId: string): Promise<Result<SessionRecord, BrokerError>>;
+  /** Resolve a bearer token to its session record. */
+  lookupByToken(token: string): Promise<Result<SessionRecord, BrokerError>>;
+  revoke(
+    sessionId: string,
+    reason: SessionRevocationReason,
+  ): Promise<Result<void, BrokerError>>;
+  heartbeat(sessionId: string): Promise<Result<void, BrokerError>>;
+  isActive(sessionId: string): Promise<Result<boolean, BrokerError>>;
+}
+
+/** Attestation lifecycle: issue, refresh, revoke, query. */
+export interface AttestationManager {
+  issue(
+    sessionId: string,
+    groupId: string,
+  ): Promise<Result<SignedAttestation, BrokerError>>;
+  refresh(
+    attestationId: string,
+  ): Promise<Result<SignedAttestation, BrokerError>>;
+  revoke(
+    attestationId: string,
+    reason: AgentRevocationReason,
+  ): Promise<Result<void, BrokerError>>;
+  current(
+    agentInboxId: string,
+    groupId: string,
+  ): Promise<Result<SignedAttestation | null, BrokerError>>;
+}

--- a/packages/contracts/src/session-types.ts
+++ b/packages/contracts/src/session-types.ts
@@ -1,0 +1,26 @@
+import type {
+  GrantConfig,
+  SessionState,
+  ViewConfig,
+} from "@xmtp-broker/schemas";
+import type { PolicyDelta } from "./policy-types.js";
+
+/** Internal session state (superset of SessionToken). */
+export interface SessionRecord {
+  readonly sessionId: string;
+  readonly agentInboxId: string;
+  readonly sessionKeyFingerprint: string;
+  readonly view: ViewConfig;
+  readonly grant: GrantConfig;
+  readonly state: SessionState;
+  readonly issuedAt: string;
+  readonly expiresAt: string;
+  readonly lastHeartbeat: string;
+}
+
+/** Result of checking whether a policy change is material. */
+export interface MaterialityCheck {
+  readonly isMaterial: boolean;
+  readonly reason: string | null;
+  readonly delta: PolicyDelta | null;
+}


### PR DESCRIPTION
## Context
This branch introduces the typed seams between runtime packages. Review this PR against `v0/schemas`, not `main`.

## What Changed
- adds contract types for broker core, policy, sessions, attestations, and provider/service interfaces
- defines envelope and wire-facing contract helpers used across transports and runtime packages
- keeps package boundaries explicit so implementations depend on stable interfaces instead of concrete modules
- adds tests for contract exports and envelope behavior

## Why This Branch Exists
The runtime packages in the next branches need shared interfaces to compose cleanly without collapsing package boundaries.

## Key Files
- `packages/contracts/src/services.ts`
- `packages/contracts/src/providers.ts`
- `packages/contracts/src/core-types.ts`
- `packages/contracts/src/session-types.ts`
- `packages/contracts/src/attestation-types.ts`

## Verification
- `packages/contracts/src/__tests__/*.test.ts`
- repo verification via pre-push stack checks (`lint`, `test`, `typecheck`)
