### PR TITLE
feat(core): add broker core lifecycle, identity store, and raw events

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,13 @@
     "packages/core": {
       "name": "@xmtp-broker/core",
       "version": "0.0.0",
+      "dependencies": {
+        "@xmtp-broker/contracts": "workspace:*",
+        "@xmtp-broker/schemas": "workspace:*",
+        "better-result": "catalog:",
+        "viem": "^2.47.4",
+        "zod": "catalog:",
+      },
       "devDependencies": {
         "bun-types": "catalog:",
         "typescript": "catalog:",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,13 @@
     "lint": "oxlint .",
     "test": "bun test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@xmtp-broker/contracts": "workspace:*",
+    "@xmtp-broker/schemas": "workspace:*",
+    "better-result": "catalog:",
+    "viem": "^2.47.4",
+    "zod": "catalog:"
+  },
   "devDependencies": {
     "bun-types": "catalog:",
     "typescript": "catalog:"

--- a/packages/core/src/__tests__/broker-core.test.ts
+++ b/packages/core/src/__tests__/broker-core.test.ts
@@ -1,0 +1,693 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { Result } from "better-result";
+import { InternalError } from "@xmtp-broker/schemas";
+import type { BrokerError } from "@xmtp-broker/schemas";
+import { BrokerCoreImpl } from "../broker-core.js";
+import type { CoreRawEvent } from "../raw-events.js";
+import type {
+  SignerProviderLike,
+  XmtpClient,
+  XmtpClientCreateOptions,
+  XmtpGroupInfo,
+} from "../xmtp-client-factory.js";
+import {
+  createMockSignerProviderFactory,
+  createMockClientFactory,
+  createMockXmtpClient,
+  createTestConfig,
+} from "./fixtures.js";
+
+let core: BrokerCoreImpl;
+
+function createCore(
+  configOverrides?: Parameters<typeof createTestConfig>[0],
+  factoryOverrides?: Partial<XmtpClient>,
+) {
+  const { factory } = createMockSignerProviderFactory();
+  return new BrokerCoreImpl(
+    createTestConfig(configOverrides),
+    factory,
+    createMockClientFactory(factoryOverrides),
+  );
+}
+
+beforeEach(() => {
+  core = createCore();
+});
+
+afterEach(async () => {
+  // Ensure cleanup regardless of test state
+  if (core.state === "running") {
+    await core.stop();
+  }
+});
+
+describe("BrokerCoreImpl", () => {
+  describe("initial state", () => {
+    test("starts in idle state", () => {
+      expect(core.state).toBe("idle");
+    });
+  });
+
+  describe("start", () => {
+    test("transitions from idle to local with startLocal", async () => {
+      const result = await core.startLocal();
+      expect(result.isOk()).toBe(true);
+      expect(core.state).toBe("local");
+    });
+
+    test("transitions from idle to running", async () => {
+      const result = await core.start();
+      expect(result.isOk()).toBe(true);
+      expect(core.state).toBe("running");
+    });
+
+    test("emits raw.core.started event", async () => {
+      const events: CoreRawEvent[] = [];
+      core.on((e) => events.push(e));
+
+      await core.start();
+
+      const started = events.find((e) => e.type === "raw.core.started");
+      expect(started).toBeDefined();
+      if (started?.type === "raw.core.started") {
+        expect(started.identityCount).toBeGreaterThanOrEqual(0);
+        expect(started.syncedThrough).toBeTruthy();
+      }
+    });
+
+    test("rejects start from running state", async () => {
+      await core.start();
+      const result = await core.start();
+      expect(result.isErr()).toBe(true);
+    });
+
+    test("rejects start from stopped state", async () => {
+      await core.start();
+      await core.stop();
+      const result = await core.start();
+      expect(result.isErr()).toBe(true);
+    });
+
+    test("fails startup when message stream initialization returns an error", async () => {
+      const { factory: signerFactory } = createMockSignerProviderFactory();
+      core = new BrokerCoreImpl(
+        createTestConfig(),
+        signerFactory,
+        createMockClientFactory({
+          streamAllMessages: async () =>
+            Result.err(InternalError.create("message stream failed")),
+        }),
+      );
+
+      await core.identityStore.create(null);
+
+      const result = await core.start();
+      expect(result.isErr()).toBe(true);
+      expect(core.state).toBe("error");
+    });
+
+    test("fails startup when group stream initialization returns an error", async () => {
+      const { factory: signerFactory } = createMockSignerProviderFactory();
+      core = new BrokerCoreImpl(
+        createTestConfig(),
+        signerFactory,
+        createMockClientFactory({
+          streamGroups: async () =>
+            Result.err(InternalError.create("group stream failed")),
+        }),
+      );
+
+      await core.identityStore.create(null);
+
+      const result = await core.start();
+      expect(result.isErr()).toBe(true);
+      expect(core.state).toBe("error");
+    });
+
+    test("returns to local state when full startup fails after local init", async () => {
+      let failSync = true;
+      const { factory: signerFactory } = createMockSignerProviderFactory();
+      core = new BrokerCoreImpl(
+        createTestConfig(),
+        signerFactory,
+        createMockClientFactory({
+          syncAll: async () => {
+            if (failSync) {
+              failSync = false;
+              return Result.err(InternalError.create("sync failed"));
+            }
+            return Result.ok(undefined);
+          },
+        }),
+      );
+
+      await core.identityStore.create(null);
+
+      const localResult = await core.startLocal();
+      expect(localResult.isOk()).toBe(true);
+      expect(core.state).toBe("local");
+
+      const firstStart = await core.start();
+      expect(firstStart.isErr()).toBe(true);
+      expect(core.state).toBe("local");
+
+      const secondStart = await core.start();
+      expect(secondStart.isOk()).toBe(true);
+      expect(core.state).toBe("running");
+    });
+  });
+
+  describe("stop", () => {
+    test("transitions from running to stopped", async () => {
+      await core.start();
+      const result = await core.stop();
+      expect(result.isOk()).toBe(true);
+      expect(core.state).toBe("stopped");
+    });
+
+    test("emits raw.core.stopped event", async () => {
+      const events: CoreRawEvent[] = [];
+      core.on((e) => events.push(e));
+
+      await core.start();
+      await core.stop();
+
+      const stopped = events.find((e) => e.type === "raw.core.stopped");
+      expect(stopped).toBeDefined();
+      if (stopped?.type === "raw.core.stopped") {
+        expect(stopped.reason).toBe("shutdown");
+      }
+    });
+
+    test("rejects stop from idle state", async () => {
+      const result = await core.stop();
+      expect(result.isErr()).toBe(true);
+    });
+
+    test("rejects stop from stopped state", async () => {
+      await core.start();
+      await core.stop();
+      const result = await core.stop();
+      expect(result.isErr()).toBe(true);
+    });
+
+    test("allows cleanup from error state", async () => {
+      const syncError = InternalError.create("sync failed");
+
+      const { factory: signerFactory } = createMockSignerProviderFactory();
+      core = new BrokerCoreImpl(
+        createTestConfig(),
+        signerFactory,
+        createMockClientFactory({
+          syncAll: async () => Result.err(syncError),
+        }),
+      );
+
+      await core.identityStore.create(null);
+      await core.start();
+
+      expect(core.state).toBe("error");
+
+      const result = await core.stop();
+      expect(result.isOk()).toBe(true);
+      expect(core.state).toBe("stopped");
+    });
+  });
+
+  describe("event subscription", () => {
+    test("on returns unsubscribe function", async () => {
+      const events: CoreRawEvent[] = [];
+      const unsub = core.on((e) => events.push(e));
+
+      await core.start();
+      unsub();
+      await core.stop();
+
+      // Should only have the started event, not stopped
+      expect(events.some((e) => e.type === "raw.core.started")).toBe(true);
+      expect(events.some((e) => e.type === "raw.core.stopped")).toBe(false);
+    });
+  });
+
+  describe("heartbeat", () => {
+    test("emits heartbeat events at configured interval", async () => {
+      core = createCore({ heartbeatIntervalMs: 50 });
+      const events: CoreRawEvent[] = [];
+      core.on((e) => events.push(e));
+
+      await core.start();
+      // Wait for at least 2 heartbeats
+      await new Promise((resolve) => setTimeout(resolve, 130));
+      await core.stop();
+
+      const heartbeats = events.filter((e) => e.type === "raw.heartbeat");
+      expect(heartbeats.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test("stops heartbeat on shutdown", async () => {
+      core = createCore({ heartbeatIntervalMs: 50 });
+      const events: CoreRawEvent[] = [];
+      core.on((e) => events.push(e));
+
+      await core.start();
+      await new Promise((resolve) => setTimeout(resolve, 70));
+      await core.stop();
+
+      const countAfterStop = events.filter(
+        (e) => e.type === "raw.heartbeat",
+      ).length;
+
+      // Wait to confirm no more heartbeats arrive
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const countLater = events.filter(
+        (e) => e.type === "raw.heartbeat",
+      ).length;
+
+      expect(countLater).toBe(countAfterStop);
+    });
+  });
+
+  describe("context", () => {
+    test("provides context for performing actions", () => {
+      expect(core.context).toBeDefined();
+    });
+
+    test("context methods work after start", async () => {
+      await core.start();
+      const result = await core.context.listGroups();
+      expect(result.isOk()).toBe(true);
+    });
+  });
+
+  describe("state machine guards", () => {
+    test("idle -> starting -> running -> stopping -> stopped", async () => {
+      expect(core.state).toBe("idle");
+
+      const startPromise = core.start();
+      // The implementation transitions synchronously to starting then running
+      const startResult = await startPromise;
+      expect(startResult.isOk()).toBe(true);
+      expect(core.state).toBe("running");
+
+      const stopPromise = core.stop();
+      const stopResult = await stopPromise;
+      expect(stopResult.isOk()).toBe(true);
+      expect(core.state).toBe("stopped");
+    });
+  });
+
+  describe("per-identity signer provider (fix 1)", () => {
+    test("creates distinct signer providers for each persisted identity", async () => {
+      const { factory: signerFactory, createdFor } =
+        createMockSignerProviderFactory();
+
+      // Track which options each create() call receives
+      const receivedOptions: XmtpClientCreateOptions[] = [];
+      const clientFactory = {
+        create: async (options: XmtpClientCreateOptions) => {
+          receivedOptions.push(options);
+          const client = createMockXmtpClient({
+            inboxId: `inbox-${options.identityId}`,
+          });
+          return Result.ok(client) as Result<XmtpClient, BrokerError>;
+        },
+      };
+
+      core = new BrokerCoreImpl(
+        createTestConfig(),
+        signerFactory,
+        clientFactory,
+      );
+
+      // Seed two identities before starting
+      await core.identityStore.create(null);
+      await core.identityStore.create(null);
+
+      const result = await core.start();
+      expect(result.isOk()).toBe(true);
+
+      // Factory should have been called once per identity
+      expect(createdFor.length).toBe(2);
+      // Each identity should get its own signer provider
+      expect(createdFor[0]).not.toBe(createdFor[1]);
+      // The client factory should receive options with signerPrivateKey
+      expect(receivedOptions.length).toBe(2);
+      expect(receivedOptions[0]!.signerPrivateKey).toBeDefined();
+      expect(receivedOptions[1]!.signerPrivateKey).toBeDefined();
+    });
+
+    test("each provider is bound to the correct identity id", async () => {
+      const requestedIdentityIds: string[] = [];
+
+      const signerFactory = (identityId: string): SignerProviderLike => {
+        requestedIdentityIds.push(identityId);
+        const publicKey = new Uint8Array(32).fill(1);
+        const dbEncKey = new Uint8Array(32);
+        crypto.getRandomValues(dbEncKey);
+        return {
+          sign: async () => Result.ok(new Uint8Array(64).fill(2)),
+          getPublicKey: async () => Result.ok(publicKey),
+          getFingerprint: async () => Result.ok(`fingerprint-${identityId}`),
+          getDbEncryptionKey: async () => Result.ok(dbEncKey),
+          getXmtpIdentityKey: async () =>
+            Result.ok(
+              "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" as const,
+            ),
+        };
+      };
+
+      core = new BrokerCoreImpl(
+        createTestConfig(),
+        signerFactory,
+        createMockClientFactory(),
+      );
+
+      // Seed identities and capture their IDs
+      const id1Result = await core.identityStore.create(null);
+      const id2Result = await core.identityStore.create(null);
+      expect(id1Result.isOk()).toBe(true);
+      expect(id2Result.isOk()).toBe(true);
+      const id1 = id1Result.value.id;
+      const id2 = id2Result.value.id;
+
+      await core.start();
+
+      // The factory was called with the actual identity IDs
+      expect(requestedIdentityIds).toContain(id1);
+      expect(requestedIdentityIds).toContain(id2);
+    });
+  });
+
+  describe("hydrate shared-mode group membership (fix 2)", () => {
+    test("seeds groupIds from listGroups after syncAll", async () => {
+      const testGroups: XmtpGroupInfo[] = [
+        {
+          groupId: "group-a",
+          name: "Group A",
+          description: "",
+          memberInboxIds: [],
+          createdAt: new Date().toISOString(),
+        },
+        {
+          groupId: "group-b",
+          name: "Group B",
+          description: "",
+          memberInboxIds: [],
+          createdAt: new Date().toISOString(),
+        },
+      ];
+
+      const { factory: signerFactory } = createMockSignerProviderFactory();
+      core = new BrokerCoreImpl(
+        createTestConfig(),
+        signerFactory,
+        createMockClientFactory({
+          listGroups: async () => Result.ok(testGroups),
+          getGroupInfo: async (groupId: string) => {
+            const group = testGroups.find((g) => g.groupId === groupId);
+            if (!group) {
+              return Result.err(InternalError.create("not found")) as Result<
+                XmtpGroupInfo,
+                BrokerError
+              >;
+            }
+            return Result.ok(group);
+          },
+        }),
+      );
+
+      // Seed a shared-mode identity (groupId === null)
+      await core.identityStore.create(null);
+
+      const result = await core.start();
+      expect(result.isOk()).toBe(true);
+
+      // After start, the context should be able to find groups by ID
+      const groupAResult = await core.context.getGroupInfo("group-a");
+      expect(groupAResult.isOk()).toBe(true);
+
+      const groupBResult = await core.context.getGroupInfo("group-b");
+      expect(groupBResult.isOk()).toBe(true);
+    });
+
+    test("operations succeed for hydrated group ids", async () => {
+      const testGroups: XmtpGroupInfo[] = [
+        {
+          groupId: "hydrated-group",
+          name: "Hydrated",
+          description: "",
+          memberInboxIds: [],
+          createdAt: new Date().toISOString(),
+        },
+      ];
+
+      const { factory: signerFactory } = createMockSignerProviderFactory();
+      core = new BrokerCoreImpl(
+        createTestConfig(),
+        signerFactory,
+        createMockClientFactory({
+          listGroups: async () => Result.ok(testGroups),
+        }),
+      );
+
+      await core.identityStore.create(null);
+      await core.start();
+
+      // sendMessage should route to the correct client
+      const sendResult = await core.context.sendMessage(
+        "hydrated-group",
+        "text",
+        "hello",
+      );
+      expect(sendResult.isOk()).toBe(true);
+    });
+
+    test("unhydrated group id returns not found", async () => {
+      const { factory: signerFactory } = createMockSignerProviderFactory();
+      core = new BrokerCoreImpl(
+        createTestConfig(),
+        signerFactory,
+        createMockClientFactory({
+          listGroups: async () => Result.ok([]),
+        }),
+      );
+
+      await core.identityStore.create(null);
+      await core.start();
+
+      const result = await core.context.sendMessage(
+        "nonexistent-group",
+        "text",
+        "hello",
+      );
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe("listGroups failure at startup", () => {
+    test("returns error when listGroups fails", async () => {
+      const listError = InternalError.create("listGroups failed");
+
+      const { factory: signerFactory } = createMockSignerProviderFactory();
+      core = new BrokerCoreImpl(
+        createTestConfig(),
+        signerFactory,
+        createMockClientFactory({
+          listGroups: async () => Result.err(listError),
+        }),
+      );
+
+      await core.identityStore.create(null);
+
+      const result = await core.start();
+      expect(result.isErr()).toBe(true);
+    });
+
+    test("transitions to error state on listGroups failure", async () => {
+      const listError = InternalError.create("listGroups failed");
+
+      const { factory: signerFactory } = createMockSignerProviderFactory();
+      core = new BrokerCoreImpl(
+        createTestConfig(),
+        signerFactory,
+        createMockClientFactory({
+          listGroups: async () => Result.err(listError),
+        }),
+      );
+
+      await core.identityStore.create(null);
+      await core.start();
+
+      expect(core.state).toBe("error");
+    });
+
+    test("does not emit raw.core.started on listGroups failure", async () => {
+      const listError = InternalError.create("listGroups failed");
+      const events: CoreRawEvent[] = [];
+
+      const { factory: signerFactory } = createMockSignerProviderFactory();
+      core = new BrokerCoreImpl(
+        createTestConfig(),
+        signerFactory,
+        createMockClientFactory({
+          listGroups: async () => Result.err(listError),
+        }),
+      );
+      core.on((e) => events.push(e));
+
+      await core.identityStore.create(null);
+      await core.start();
+
+      const started = events.find((e) => e.type === "raw.core.started");
+      expect(started).toBeUndefined();
+    });
+
+    test("does not start heartbeat on listGroups failure", async () => {
+      const listError = InternalError.create("listGroups failed");
+      const events: CoreRawEvent[] = [];
+
+      const { factory: signerFactory } = createMockSignerProviderFactory();
+      core = new BrokerCoreImpl(
+        createTestConfig({ heartbeatIntervalMs: 10 }),
+        signerFactory,
+        createMockClientFactory({
+          listGroups: async () => Result.err(listError),
+        }),
+      );
+      core.on((e) => events.push(e));
+
+      await core.identityStore.create(null);
+      await core.start();
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const heartbeats = events.filter((e) => e.type === "raw.heartbeat");
+      expect(heartbeats.length).toBe(0);
+    });
+  });
+
+  describe("syncAll failure (fix 3)", () => {
+    test("returns error when syncAll fails", async () => {
+      const syncError = InternalError.create("sync failed");
+
+      const { factory: signerFactory } = createMockSignerProviderFactory();
+      core = new BrokerCoreImpl(
+        createTestConfig(),
+        signerFactory,
+        createMockClientFactory({
+          syncAll: async () => Result.err(syncError),
+        }),
+      );
+
+      // Seed an identity so the startup loop runs
+      await core.identityStore.create(null);
+
+      const result = await core.start();
+      expect(result.isErr()).toBe(true);
+    });
+
+    test("transitions to error state on syncAll failure", async () => {
+      const syncError = InternalError.create("sync failed");
+
+      const { factory: signerFactory } = createMockSignerProviderFactory();
+      core = new BrokerCoreImpl(
+        createTestConfig(),
+        signerFactory,
+        createMockClientFactory({
+          syncAll: async () => Result.err(syncError),
+        }),
+      );
+
+      await core.identityStore.create(null);
+      await core.start();
+
+      expect(core.state).toBe("error");
+    });
+
+    test("does not emit raw.core.started on syncAll failure", async () => {
+      const syncError = InternalError.create("sync failed");
+      const events: CoreRawEvent[] = [];
+
+      const { factory: signerFactory } = createMockSignerProviderFactory();
+      core = new BrokerCoreImpl(
+        createTestConfig(),
+        signerFactory,
+        createMockClientFactory({
+          syncAll: async () => Result.err(syncError),
+        }),
+      );
+      core.on((e) => events.push(e));
+
+      await core.identityStore.create(null);
+      await core.start();
+
+      const started = events.find((e) => e.type === "raw.core.started");
+      expect(started).toBeUndefined();
+    });
+
+    test("does not start heartbeat on syncAll failure", async () => {
+      const syncError = InternalError.create("sync failed");
+      const events: CoreRawEvent[] = [];
+
+      const { factory: signerFactory } = createMockSignerProviderFactory();
+      core = new BrokerCoreImpl(
+        createTestConfig({ heartbeatIntervalMs: 10 }),
+        signerFactory,
+        createMockClientFactory({
+          syncAll: async () => Result.err(syncError),
+        }),
+      );
+      core.on((e) => events.push(e));
+
+      await core.identityStore.create(null);
+      await core.start();
+
+      // Wait to see if any heartbeats arrive
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const heartbeats = events.filter((e) => e.type === "raw.heartbeat");
+      expect(heartbeats.length).toBe(0);
+    });
+  });
+
+  describe("stream initialization failures", () => {
+    test("returns error when streamAllMessages fails", async () => {
+      const streamError = InternalError.create("message stream failed");
+
+      const { factory: signerFactory } = createMockSignerProviderFactory();
+      core = new BrokerCoreImpl(
+        createTestConfig(),
+        signerFactory,
+        createMockClientFactory({
+          streamAllMessages: async () => Result.err(streamError),
+        }),
+      );
+
+      await core.identityStore.create(null);
+
+      const result = await core.start();
+      expect(result.isErr()).toBe(true);
+      expect(core.state).toBe("error");
+    });
+
+    test("returns error when streamGroups fails", async () => {
+      const streamError = InternalError.create("group stream failed");
+
+      const { factory: signerFactory } = createMockSignerProviderFactory();
+      core = new BrokerCoreImpl(
+        createTestConfig(),
+        signerFactory,
+        createMockClientFactory({
+          streamGroups: async () => Result.err(streamError),
+        }),
+      );
+
+      await core.identityStore.create(null);
+
+      const result = await core.start();
+      expect(result.isErr()).toBe(true);
+      expect(core.state).toBe("error");
+    });
+  });
+});

--- a/packages/core/src/__tests__/client-registry.test.ts
+++ b/packages/core/src/__tests__/client-registry.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { ClientRegistry } from "../client-registry.js";
+import type { ManagedClient } from "../client-registry.js";
+import { createMockXmtpClient } from "./fixtures.js";
+
+let registry: ClientRegistry;
+
+beforeEach(() => {
+  registry = new ClientRegistry();
+});
+
+function makeManagedClient(identityId: string, inboxId: string): ManagedClient {
+  return {
+    identityId,
+    inboxId,
+    client: createMockXmtpClient({ inboxId }),
+    groupIds: new Set<string>(),
+  };
+}
+
+describe("ClientRegistry", () => {
+  describe("register", () => {
+    test("registers a client by identity ID", () => {
+      const managed = makeManagedClient("id-1", "inbox-1");
+      registry.register(managed);
+
+      expect(registry.get("id-1")).toBe(managed);
+    });
+
+    test("overwrites existing registration", () => {
+      const first = makeManagedClient("id-1", "inbox-a");
+      const second = makeManagedClient("id-1", "inbox-b");
+
+      registry.register(first);
+      registry.register(second);
+
+      expect(registry.get("id-1")?.inboxId).toBe("inbox-b");
+    });
+  });
+
+  describe("get", () => {
+    test("returns undefined for unregistered identity", () => {
+      expect(registry.get("nonexistent")).toBeUndefined();
+    });
+  });
+
+  describe("getByGroupId", () => {
+    test("returns client managing a group", () => {
+      const managed = makeManagedClient("id-1", "inbox-1");
+      managed.groupIds.add("group-abc");
+      registry.register(managed);
+
+      expect(registry.getByGroupId("group-abc")).toBe(managed);
+    });
+
+    test("returns undefined for unregistered group", () => {
+      expect(registry.getByGroupId("unknown")).toBeUndefined();
+    });
+  });
+
+  describe("unregister", () => {
+    test("removes a registered client", () => {
+      const managed = makeManagedClient("id-1", "inbox-1");
+      registry.register(managed);
+      const removed = registry.unregister("id-1");
+
+      expect(removed).toBe(true);
+      expect(registry.get("id-1")).toBeUndefined();
+    });
+
+    test("returns false for unregistered identity", () => {
+      expect(registry.unregister("nonexistent")).toBe(false);
+    });
+  });
+
+  describe("list", () => {
+    test("returns empty array when empty", () => {
+      expect(registry.list()).toHaveLength(0);
+    });
+
+    test("returns all registered clients", () => {
+      registry.register(makeManagedClient("id-1", "inbox-1"));
+      registry.register(makeManagedClient("id-2", "inbox-2"));
+
+      const list = registry.list();
+      expect(list).toHaveLength(2);
+    });
+  });
+
+  describe("size", () => {
+    test("tracks registration count", () => {
+      expect(registry.size).toBe(0);
+
+      registry.register(makeManagedClient("id-1", "inbox-1"));
+      expect(registry.size).toBe(1);
+
+      registry.register(makeManagedClient("id-2", "inbox-2"));
+      expect(registry.size).toBe(2);
+
+      registry.unregister("id-1");
+      expect(registry.size).toBe(1);
+    });
+  });
+
+  describe("clear", () => {
+    test("removes all clients", () => {
+      registry.register(makeManagedClient("id-1", "inbox-1"));
+      registry.register(makeManagedClient("id-2", "inbox-2"));
+      registry.clear();
+
+      expect(registry.size).toBe(0);
+      expect(registry.list()).toHaveLength(0);
+    });
+  });
+});

--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BrokerCoreConfigSchema,
+  IdentityModeSchema,
+  XmtpEnvSchema,
+} from "../config.js";
+
+describe("XmtpEnvSchema", () => {
+  test("accepts valid environments", () => {
+    expect(XmtpEnvSchema.parse("local")).toBe("local");
+    expect(XmtpEnvSchema.parse("dev")).toBe("dev");
+    expect(XmtpEnvSchema.parse("production")).toBe("production");
+  });
+
+  test("rejects invalid environment", () => {
+    const result = XmtpEnvSchema.safeParse("staging");
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("IdentityModeSchema", () => {
+  test("accepts valid modes", () => {
+    expect(IdentityModeSchema.parse("per-group")).toBe("per-group");
+    expect(IdentityModeSchema.parse("shared")).toBe("shared");
+  });
+
+  test("rejects invalid mode", () => {
+    const result = IdentityModeSchema.safeParse("custom");
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("BrokerCoreConfigSchema", () => {
+  test("requires dataDir", () => {
+    const result = BrokerCoreConfigSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  test("accepts minimal config with defaults", () => {
+    const config = BrokerCoreConfigSchema.parse({
+      dataDir: "/tmp/broker",
+    });
+    expect(config.dataDir).toBe("/tmp/broker");
+    expect(config.env).toBe("dev");
+    expect(config.identityMode).toBe("per-group");
+    expect(config.heartbeatIntervalMs).toBe(30_000);
+    expect(config.syncTimeoutMs).toBe(30_000);
+    expect(config.appVersion).toBe("xmtp-broker/0.1.0");
+  });
+
+  test("accepts fully specified config", () => {
+    const config = BrokerCoreConfigSchema.parse({
+      dataDir: "/data/broker",
+      env: "production",
+      identityMode: "shared",
+      heartbeatIntervalMs: 10_000,
+      syncTimeoutMs: 60_000,
+      appVersion: "custom/1.0.0",
+    });
+    expect(config.env).toBe("production");
+    expect(config.identityMode).toBe("shared");
+    expect(config.heartbeatIntervalMs).toBe(10_000);
+    expect(config.syncTimeoutMs).toBe(60_000);
+    expect(config.appVersion).toBe("custom/1.0.0");
+  });
+
+  test("rejects non-positive heartbeatIntervalMs", () => {
+    const result = BrokerCoreConfigSchema.safeParse({
+      dataDir: "/tmp",
+      heartbeatIntervalMs: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-positive syncTimeoutMs", () => {
+    const result = BrokerCoreConfigSchema.safeParse({
+      dataDir: "/tmp",
+      syncTimeoutMs: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-integer heartbeatIntervalMs", () => {
+    const result = BrokerCoreConfigSchema.safeParse({
+      dataDir: "/tmp",
+      heartbeatIntervalMs: 1.5,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/core/src/__tests__/core-context.test.ts
+++ b/packages/core/src/__tests__/core-context.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { BrokerCoreContext } from "../core-context.js";
+import { ClientRegistry } from "../client-registry.js";
+import { SqliteIdentityStore } from "../identity-store.js";
+import type { ManagedClient } from "../client-registry.js";
+import { createMockXmtpClient } from "./fixtures.js";
+import type { XmtpGroupInfo } from "../xmtp-client-factory.js";
+
+const testGroup: XmtpGroupInfo = {
+  groupId: "group-1",
+  name: "Test Group",
+  description: "A test group",
+  memberInboxIds: ["inbox-a", "inbox-b"],
+  createdAt: "2024-01-01T00:00:00.000Z",
+};
+
+let registry: ClientRegistry;
+let identityStore: SqliteIdentityStore;
+let ctx: BrokerCoreContext;
+
+beforeEach(() => {
+  registry = new ClientRegistry();
+  identityStore = new SqliteIdentityStore(":memory:");
+  ctx = new BrokerCoreContext(registry, identityStore);
+});
+
+function registerClientForGroup(
+  identityId: string,
+  groupId: string,
+  groups?: XmtpGroupInfo[],
+): ManagedClient {
+  const client = createMockXmtpClient({
+    inboxId: `inbox-${identityId}`,
+    groups: groups ?? [testGroup],
+  });
+  const managed: ManagedClient = {
+    identityId,
+    inboxId: client.inboxId,
+    client,
+    groupIds: new Set([groupId]),
+  };
+  registry.register(managed);
+  return managed;
+}
+
+describe("BrokerCoreContext", () => {
+  describe("sendMessage", () => {
+    test("sends through the correct client", async () => {
+      registerClientForGroup("id-1", "group-1");
+
+      const result = await ctx.sendMessage("group-1", "text", "hello");
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.messageId).toBeTruthy();
+      }
+    });
+
+    test("returns NotFoundError for unknown group", async () => {
+      const result = await ctx.sendMessage("unknown", "text", "hello");
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error._tag).toBe("NotFoundError");
+      }
+    });
+  });
+
+  describe("getGroupInfo", () => {
+    test("returns group info from client", async () => {
+      registerClientForGroup("id-1", "group-1");
+
+      const result = await ctx.getGroupInfo("group-1");
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.groupId).toBe("group-1");
+        expect(result.value.name).toBe("Test Group");
+        expect(result.value.memberInboxIds).toEqual(["inbox-a", "inbox-b"]);
+      }
+    });
+
+    test("returns NotFoundError for unknown group", async () => {
+      const result = await ctx.getGroupInfo("unknown");
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe("listGroups", () => {
+    test("aggregates groups from all clients", async () => {
+      const group2: XmtpGroupInfo = {
+        ...testGroup,
+        groupId: "group-2",
+        name: "Group 2",
+      };
+
+      registerClientForGroup("id-1", "group-1", [testGroup]);
+      registerClientForGroup("id-2", "group-2", [group2]);
+
+      const result = await ctx.listGroups();
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(2);
+      }
+    });
+
+    test("returns empty when no clients", async () => {
+      const result = await ctx.listGroups();
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toHaveLength(0);
+      }
+    });
+  });
+
+  describe("addMembers", () => {
+    test("delegates to correct client", async () => {
+      registerClientForGroup("id-1", "group-1");
+
+      const result = await ctx.addMembers("group-1", ["inbox-new"]);
+      expect(result.isOk()).toBe(true);
+    });
+
+    test("returns NotFoundError for unknown group", async () => {
+      const result = await ctx.addMembers("unknown", ["inbox-1"]);
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe("removeMembers", () => {
+    test("delegates to correct client", async () => {
+      registerClientForGroup("id-1", "group-1");
+
+      const result = await ctx.removeMembers("group-1", ["inbox-b"]);
+      expect(result.isOk()).toBe(true);
+    });
+
+    test("returns NotFoundError for unknown group", async () => {
+      const result = await ctx.removeMembers("unknown", ["inbox-1"]);
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe("getInboxId", () => {
+    test("returns inbox ID from registry for hydrated shared group", async () => {
+      // Shared identity: no per-group identity in the store,
+      // but the group is hydrated in the runtime registry.
+      const managed: ManagedClient = {
+        identityId: "shared-id",
+        inboxId: "shared-inbox-42",
+        client: createMockXmtpClient({ inboxId: "shared-inbox-42" }),
+        groupIds: new Set(["shared-group-1"]),
+      };
+      registry.register(managed);
+
+      const result = await ctx.getInboxId("shared-group-1");
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe("shared-inbox-42");
+      }
+    });
+
+    test("falls back to identity store for per-group identities", async () => {
+      const created = await identityStore.create("group-1");
+      if (!created.isOk()) return;
+      await identityStore.setInboxId(created.value.id, "inbox-123");
+
+      const result = await ctx.getInboxId("group-1");
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe("inbox-123");
+      }
+    });
+
+    test("returns NotFoundError when no identity for group", async () => {
+      const result = await ctx.getInboxId("unknown-group");
+      expect(result.isErr()).toBe(true);
+    });
+
+    test("returns NotFoundError when identity has no inboxId", async () => {
+      await identityStore.create("group-1");
+
+      const result = await ctx.getInboxId("group-1");
+      expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe("syncGroup", () => {
+    test("delegates to correct client", async () => {
+      registerClientForGroup("id-1", "group-1");
+
+      const result = await ctx.syncGroup("group-1");
+      expect(result.isOk()).toBe(true);
+    });
+
+    test("returns NotFoundError for unknown group", async () => {
+      const result = await ctx.syncGroup("unknown");
+      expect(result.isErr()).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/__tests__/event-emitter.test.ts
+++ b/packages/core/src/__tests__/event-emitter.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import { CoreEventEmitter } from "../event-emitter.js";
+import type {
+  CoreRawEvent,
+  RawHeartbeatEvent,
+  RawMessageEvent,
+} from "../raw-events.js";
+
+function makeHeartbeat(): RawHeartbeatEvent {
+  return { type: "raw.heartbeat", timestamp: new Date().toISOString() };
+}
+
+function makeMessage(): RawMessageEvent {
+  return {
+    type: "raw.message",
+    messageId: "msg-1",
+    groupId: "group-1",
+    senderInboxId: "inbox-1",
+    contentType: "text",
+    content: "hello",
+    sentAt: new Date().toISOString(),
+    isHistorical: false,
+  };
+}
+
+describe("CoreEventEmitter", () => {
+  test("delivers events to subscribers", () => {
+    const emitter = new CoreEventEmitter();
+    const received: CoreRawEvent[] = [];
+    emitter.on((event) => received.push(event));
+
+    const heartbeat = makeHeartbeat();
+    emitter.emit(heartbeat);
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toBe(heartbeat);
+  });
+
+  test("delivers to multiple subscribers", () => {
+    const emitter = new CoreEventEmitter();
+    const a: CoreRawEvent[] = [];
+    const b: CoreRawEvent[] = [];
+    emitter.on((e) => a.push(e));
+    emitter.on((e) => b.push(e));
+
+    emitter.emit(makeHeartbeat());
+
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(1);
+  });
+
+  test("unsubscribe stops delivery", () => {
+    const emitter = new CoreEventEmitter();
+    const received: CoreRawEvent[] = [];
+    const unsub = emitter.on((e) => received.push(e));
+
+    emitter.emit(makeHeartbeat());
+    unsub();
+    emitter.emit(makeHeartbeat());
+
+    expect(received).toHaveLength(1);
+  });
+
+  test("double unsubscribe is safe", () => {
+    const emitter = new CoreEventEmitter();
+    const unsub = emitter.on(() => {});
+    unsub();
+    unsub(); // should not throw
+  });
+
+  test("subscriber error does not stop other subscribers", () => {
+    const emitter = new CoreEventEmitter();
+    const received: CoreRawEvent[] = [];
+
+    emitter.on(() => {
+      throw new Error("boom");
+    });
+    emitter.on((e) => received.push(e));
+
+    emitter.emit(makeHeartbeat());
+
+    expect(received).toHaveLength(1);
+  });
+
+  test("removeAll clears all subscribers", () => {
+    const emitter = new CoreEventEmitter();
+    const received: CoreRawEvent[] = [];
+    emitter.on((e) => received.push(e));
+    emitter.on((e) => received.push(e));
+
+    emitter.removeAll();
+    emitter.emit(makeHeartbeat());
+
+    expect(received).toHaveLength(0);
+  });
+
+  test("listenerCount returns active subscriber count", () => {
+    const emitter = new CoreEventEmitter();
+    expect(emitter.listenerCount).toBe(0);
+
+    const unsub1 = emitter.on(() => {});
+    expect(emitter.listenerCount).toBe(1);
+
+    const _unsub2 = emitter.on(() => {});
+    expect(emitter.listenerCount).toBe(2);
+
+    unsub1();
+    expect(emitter.listenerCount).toBe(1);
+
+    emitter.removeAll();
+    expect(emitter.listenerCount).toBe(0);
+  });
+
+  test("delivers different event types", () => {
+    const emitter = new CoreEventEmitter();
+    const received: CoreRawEvent[] = [];
+    emitter.on((e) => received.push(e));
+
+    emitter.emit(makeMessage());
+    emitter.emit(makeHeartbeat());
+
+    expect(received).toHaveLength(2);
+    expect(received[0]?.type).toBe("raw.message");
+    expect(received[1]?.type).toBe("raw.heartbeat");
+  });
+});

--- a/packages/core/src/__tests__/fixtures.ts
+++ b/packages/core/src/__tests__/fixtures.ts
@@ -1,0 +1,146 @@
+import { Result } from "better-result";
+import { NotFoundError } from "@xmtp-broker/schemas";
+import type { BrokerError } from "@xmtp-broker/schemas";
+import type {
+  SignerProviderLike,
+  XmtpClient,
+  XmtpClientCreateOptions,
+  XmtpClientFactory,
+  XmtpDecodedMessage,
+  XmtpGroupInfo,
+} from "../xmtp-client-factory.js";
+import type { BrokerCoreConfig } from "../config.js";
+
+/** A fixed test secp256k1 private key (not used for real signing). */
+const TEST_XMTP_IDENTITY_KEY =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" as const;
+
+/** Create a mock SignerProviderLike for testing. */
+export function createMockSignerProvider(): SignerProviderLike {
+  const publicKey = new Uint8Array(32).fill(1);
+  const dbEncKey = new Uint8Array(32);
+  crypto.getRandomValues(dbEncKey);
+  return {
+    sign: async (_data: Uint8Array) => Result.ok(new Uint8Array(64).fill(2)),
+    getPublicKey: async () => Result.ok(publicKey),
+    getFingerprint: async () => Result.ok("mock-fingerprint"),
+    getDbEncryptionKey: async (_identityId: string) => Result.ok(dbEncKey),
+    getXmtpIdentityKey: async (_identityId: string) =>
+      Result.ok(TEST_XMTP_IDENTITY_KEY),
+  };
+}
+
+/**
+ * Create a signer-provider factory that produces a distinct provider
+ * per identityId. Tracks which identityIds were requested.
+ */
+export function createMockSignerProviderFactory(): {
+  factory: (identityId: string) => SignerProviderLike;
+  createdFor: string[];
+} {
+  const createdFor: string[] = [];
+  const factory = (identityId: string): SignerProviderLike => {
+    createdFor.push(identityId);
+    return createMockSignerProvider();
+  };
+  return { factory, createdFor };
+}
+
+/** Create a mock XMTP client for testing. */
+export function createMockXmtpClient(options?: {
+  inboxId?: string;
+  groups?: XmtpGroupInfo[];
+}): XmtpClient {
+  const inboxId = options?.inboxId ?? "mock-inbox-id";
+  const groups = options?.groups ?? [];
+
+  return {
+    inboxId,
+    sendMessage: async (_groupId, _content) => Result.ok(`msg-${Date.now()}`),
+    syncAll: async () => Result.ok(),
+    syncGroup: async (_groupId) => Result.ok(),
+    getGroupInfo: async (groupId) => {
+      const group = groups.find((g) => g.groupId === groupId);
+      if (!group) {
+        return Result.err(
+          NotFoundError.create("group", groupId) as BrokerError,
+        );
+      }
+      return Result.ok(group);
+    },
+    listGroups: async () => Result.ok(groups),
+    addMembers: async (_groupId, _inboxIds) => Result.ok(),
+    removeMembers: async (_groupId, _inboxIds) => Result.ok(),
+    streamAllMessages: async () =>
+      Result.ok({
+        messages: emptyAsyncIterable<XmtpDecodedMessage>(),
+        abort: () => {},
+      }),
+    streamGroups: async () =>
+      Result.ok({
+        groups: emptyAsyncIterable(),
+        abort: () => {},
+      }),
+  };
+}
+
+/** Create a mock XmtpClientFactory for testing. */
+export function createMockClientFactory(
+  clientOverrides?: Partial<XmtpClient>,
+): XmtpClientFactory {
+  return {
+    create: async (options: XmtpClientCreateOptions) => {
+      const base = createMockXmtpClient({
+        inboxId: `inbox-${options.identityId}`,
+      });
+      return Result.ok({ ...base, ...clientOverrides });
+    },
+  };
+}
+
+/** Create a minimal BrokerCoreConfig for testing. */
+export function createTestConfig(
+  overrides?: Partial<BrokerCoreConfig>,
+): BrokerCoreConfig {
+  return {
+    dataDir: ":memory:",
+    env: "dev",
+    identityMode: "per-group",
+    heartbeatIntervalMs: 30_000,
+    syncTimeoutMs: 30_000,
+    appVersion: "xmtp-broker/test",
+    ...overrides,
+  };
+}
+
+/** Helper: create an async iterable that yields nothing. */
+function emptyAsyncIterable<T>(): AsyncIterable<T> {
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          return { done: true as const, value: undefined as unknown as T };
+        },
+      };
+    },
+  };
+}
+
+/** Helper: create an async iterable that yields specific items then completes. */
+export function asyncIterableOf<T>(...items: T[]): AsyncIterable<T> {
+  return {
+    [Symbol.asyncIterator]() {
+      let index = 0;
+      return {
+        async next() {
+          if (index < items.length) {
+            const value = items[index]!;
+            index++;
+            return { done: false as const, value };
+          }
+          return { done: true as const, value: undefined as unknown as T };
+        },
+      };
+    },
+  };
+}

--- a/packages/core/src/__tests__/identity-store.test.ts
+++ b/packages/core/src/__tests__/identity-store.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { SqliteIdentityStore } from "../identity-store.js";
+
+let store: SqliteIdentityStore;
+
+beforeEach(() => {
+  // In-memory SQLite for test isolation
+  store = new SqliteIdentityStore(":memory:");
+});
+
+describe("SqliteIdentityStore", () => {
+  describe("create", () => {
+    test("creates identity with null groupId for shared mode", async () => {
+      const result = await store.create(null);
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+
+      const identity = result.value;
+      expect(identity.id).toMatch(/^[a-f0-9]{64}$/);
+      expect(identity.inboxId).toBeNull();
+      expect(identity.groupId).toBeNull();
+      expect(identity.createdAt).toBeTruthy();
+    });
+
+    test("creates identity bound to a groupId", async () => {
+      const result = await store.create("group-abc");
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+
+      expect(result.value.groupId).toBe("group-abc");
+    });
+
+    test("generates unique IDs", async () => {
+      const r1 = await store.create(null);
+      const r2 = await store.create(null);
+      expect(r1.isOk()).toBe(true);
+      expect(r2.isOk()).toBe(true);
+      if (!r1.isOk() || !r2.isOk()) return;
+
+      expect(r1.value.id).not.toBe(r2.value.id);
+    });
+  });
+
+  describe("getById", () => {
+    test("returns identity by id", async () => {
+      const created = await store.create("group-1");
+      if (!created.isOk()) return;
+
+      const found = await store.getById(created.value.id);
+      expect(found).not.toBeNull();
+      expect(found?.id).toBe(created.value.id);
+      expect(found?.groupId).toBe("group-1");
+    });
+
+    test("returns null for unknown id", async () => {
+      const found = await store.getById("nonexistent");
+      expect(found).toBeNull();
+    });
+  });
+
+  describe("getByGroupId", () => {
+    test("returns identity bound to group", async () => {
+      const created = await store.create("group-xyz");
+      if (!created.isOk()) return;
+
+      const found = await store.getByGroupId("group-xyz");
+      expect(found).not.toBeNull();
+      expect(found?.id).toBe(created.value.id);
+    });
+
+    test("returns null for unknown group", async () => {
+      const found = await store.getByGroupId("no-such-group");
+      expect(found).toBeNull();
+    });
+  });
+
+  describe("list", () => {
+    test("returns empty array when no identities", async () => {
+      const list = await store.list();
+      expect(list).toHaveLength(0);
+    });
+
+    test("returns all identities", async () => {
+      await store.create("group-1");
+      await store.create("group-2");
+      await store.create(null);
+
+      const list = await store.list();
+      expect(list).toHaveLength(3);
+    });
+  });
+
+  describe("setInboxId", () => {
+    test("updates inboxId on existing identity", async () => {
+      const created = await store.create("group-1");
+      if (!created.isOk()) return;
+
+      const result = await store.setInboxId(created.value.id, "inbox-123");
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+
+      expect(result.value.inboxId).toBe("inbox-123");
+
+      // Verify persisted
+      const found = await store.getById(created.value.id);
+      expect(found?.inboxId).toBe("inbox-123");
+    });
+
+    test("returns NotFoundError for unknown id", async () => {
+      const result = await store.setInboxId("nonexistent", "inbox-1");
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) return;
+      expect(result.error._tag).toBe("NotFoundError");
+    });
+  });
+
+  describe("remove", () => {
+    test("removes existing identity", async () => {
+      const created = await store.create("group-1");
+      if (!created.isOk()) return;
+
+      const result = await store.remove(created.value.id);
+      expect(result.isOk()).toBe(true);
+
+      const found = await store.getById(created.value.id);
+      expect(found).toBeNull();
+    });
+
+    test("returns NotFoundError for unknown id", async () => {
+      const result = await store.remove("nonexistent");
+      expect(result.isErr()).toBe(true);
+      if (!result.isErr()) return;
+      expect(result.error._tag).toBe("NotFoundError");
+    });
+  });
+});

--- a/packages/core/src/__tests__/smoke.test.ts
+++ b/packages/core/src/__tests__/smoke.test.ts
@@ -1,7 +1,0 @@
-import { describe, expect, it } from "bun:test";
-
-describe("workspace", () => {
-  it("test runner works", () => {
-    expect(true).toBe(true);
-  });
-});

--- a/packages/core/src/broker-core.ts
+++ b/packages/core/src/broker-core.ts
@@ -1,0 +1,369 @@
+import { Result } from "better-result";
+import { InternalError, ValidationError } from "@xmtp-broker/schemas";
+import type { BrokerError } from "@xmtp-broker/schemas";
+import type { BrokerCoreConfig } from "./config.js";
+import { CoreEventEmitter } from "./event-emitter.js";
+import { SqliteIdentityStore } from "./identity-store.js";
+import { ClientRegistry } from "./client-registry.js";
+import { BrokerCoreContext } from "./core-context.js";
+import type { RawEventHandler } from "./raw-events.js";
+import type {
+  SignerProviderLike,
+  XmtpClientFactory,
+  XmtpDecodedMessage,
+  XmtpGroupEvent,
+} from "./xmtp-client-factory.js";
+
+/** Broker lifecycle states. */
+export type BrokerState =
+  | "idle"
+  | "local"
+  | "starting"
+  | "running"
+  | "stopping"
+  | "stopped"
+  | "error";
+
+/**
+ * Factory that produces a signer provider bound to a specific identity.
+ * Each call must return a provider whose signing key corresponds to
+ * the given identityId.
+ */
+export type SignerProviderFactory = (identityId: string) => SignerProviderLike;
+
+/**
+ * The core service managing the raw XMTP plane.
+ *
+ * Owns the lifecycle state machine, identity store, client registry,
+ * heartbeat timer, and event emission. All XMTP client interactions
+ * are delegated to the injected XmtpClientFactory.
+ */
+export class BrokerCoreImpl {
+  #state: BrokerState = "idle";
+  readonly #config: BrokerCoreConfig;
+  readonly #signerProviderFactory: SignerProviderFactory;
+  readonly #clientFactory: XmtpClientFactory;
+  readonly #emitter = new CoreEventEmitter();
+  readonly #registry = new ClientRegistry();
+  readonly #identityStore: SqliteIdentityStore;
+  readonly #context: BrokerCoreContext;
+  #heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  #streams: Array<{ abort: () => void }> = [];
+
+  constructor(
+    config: BrokerCoreConfig,
+    signerProviderFactory: SignerProviderFactory,
+    clientFactory: XmtpClientFactory,
+  ) {
+    this.#config = config;
+    this.#signerProviderFactory = signerProviderFactory;
+    this.#clientFactory = clientFactory;
+    this.#identityStore = new SqliteIdentityStore(
+      config.dataDir === ":memory:"
+        ? ":memory:"
+        : `${config.dataDir}/identities.db`,
+    );
+    this.#context = new BrokerCoreContext(this.#registry, this.#identityStore);
+  }
+
+  /** Current lifecycle state. */
+  get state(): BrokerState {
+    return this.#state;
+  }
+
+  /** Get the sealed context for performing actions. */
+  get context(): BrokerCoreContext {
+    return this.#context;
+  }
+
+  /** The identity store (exposed for seeding in tests). */
+  get identityStore(): SqliteIdentityStore {
+    return this.#identityStore;
+  }
+
+  /** The core configuration (exposed for wiring conversation actions). */
+  get config(): BrokerCoreConfig {
+    return this.#config;
+  }
+
+  /** Subscribe to raw events. Returns an unsubscribe function. */
+  on(handler: RawEventHandler): () => void {
+    return this.#emitter.on(handler);
+  }
+
+  /** Start the core: initialize clients, begin streaming. */
+  async startLocal(): Promise<Result<void, BrokerError>> {
+    if (this.#state !== "idle") {
+      return Result.err(
+        ValidationError.create(
+          "state",
+          `Cannot initialize locally from '${this.#state}' state (expected 'idle')`,
+        ),
+      );
+    }
+
+    this.#state = "local";
+    return Result.ok();
+  }
+
+  /** Start the core: initialize clients, begin streaming. */
+  async start(): Promise<Result<void, BrokerError>> {
+    if (this.#state !== "idle" && this.#state !== "local") {
+      return Result.err(
+        ValidationError.create(
+          "state",
+          `Cannot start from '${this.#state}' state (expected 'idle' or 'local')`,
+        ),
+      );
+    }
+
+    const fallbackState = this.#state === "local" ? "local" : "error";
+    this.#state = "starting";
+
+    const failStart = <T extends BrokerError>(error: T): Result<void, T> => {
+      this.#resetStartupArtifacts();
+      this.#state = fallbackState;
+      return Result.err(error);
+    };
+
+    try {
+      // Load existing identities and create clients
+      const identities = await this.#identityStore.list();
+
+      for (const identity of identities) {
+        // Fix 1: Create a fresh signer provider per identity
+        const signerProvider = this.#signerProviderFactory(identity.id);
+
+        const dbEncKeyResult = await signerProvider.getDbEncryptionKey(
+          identity.id,
+        );
+        if (dbEncKeyResult.isErr()) {
+          return failStart(
+            InternalError.create(
+              "Failed to get DB encryption key for identity",
+            ),
+          );
+        }
+
+        const xmtpKeyResult = await signerProvider.getXmtpIdentityKey(
+          identity.id,
+        );
+        if (xmtpKeyResult.isErr()) {
+          return failStart(
+            InternalError.create(
+              "Failed to get XMTP identity key for identity",
+            ),
+          );
+        }
+
+        const clientResult = await this.#clientFactory.create({
+          identityId: identity.id,
+          dbPath:
+            this.#config.dataDir === ":memory:"
+              ? ":memory:"
+              : `${this.#config.dataDir}/db/${this.#config.env}/${identity.id}.db3`,
+          dbEncryptionKey: dbEncKeyResult.value,
+          env: this.#config.env,
+          appVersion: this.#config.appVersion,
+          signerPrivateKey: xmtpKeyResult.value,
+        });
+
+        if (clientResult.isErr()) {
+          return failStart(clientResult.error);
+        }
+
+        const client = clientResult.value;
+        const managedClient = {
+          identityId: identity.id,
+          inboxId: client.inboxId,
+          client,
+          groupIds: new Set(identity.groupId ? [identity.groupId] : []),
+        };
+        this.#registry.register(managedClient);
+
+        // Update inboxId if not set
+        if (!identity.inboxId) {
+          await this.#identityStore.setInboxId(identity.id, client.inboxId);
+        }
+
+        // Fix 3: Check syncAll result — fail fast on error
+        const syncResult = await client.syncAll();
+        if (syncResult.isErr()) {
+          return failStart(syncResult.error);
+        }
+
+        // Hydrate group membership from the XMTP client.
+        // Fail startup if listGroups() errors — without hydration the
+        // broker cannot route any group operations.
+        const groupsResult = await client.listGroups();
+        if (groupsResult.isErr()) {
+          return failStart(groupsResult.error);
+        }
+        for (const group of groupsResult.value) {
+          managedClient.groupIds.add(group.groupId);
+        }
+
+        const msgStreamResult = await client.streamAllMessages();
+        if (msgStreamResult.isErr()) {
+          return failStart(msgStreamResult.error);
+        }
+        const msgStream = msgStreamResult.value;
+        this.#streams.push(msgStream);
+        this.#consumeMessageStream(msgStream.messages);
+
+        const groupStreamResult = await client.streamGroups();
+        if (groupStreamResult.isErr()) {
+          return failStart(groupStreamResult.error);
+        }
+        const groupStream = groupStreamResult.value;
+        this.#streams.push(groupStream);
+        this.#consumeGroupStream(identity.id, groupStream.groups);
+      }
+
+      // Start heartbeat
+      this.#startHeartbeat();
+
+      this.#state = "running";
+
+      // Emit started event
+      this.#emitter.emit({
+        type: "raw.core.started",
+        identityCount: this.#registry.size,
+        syncedThrough: new Date().toISOString(),
+      });
+
+      return Result.ok();
+    } catch (cause) {
+      return failStart(
+        InternalError.create("Unexpected error during startup", {
+          cause: String(cause),
+        }),
+      );
+    }
+  }
+
+  /** Stop the core: close streams, disconnect clients. */
+  async stop(): Promise<Result<void, BrokerError>> {
+    const previousState = this.#state;
+
+    if (
+      previousState !== "local" &&
+      previousState !== "running" &&
+      previousState !== "error"
+    ) {
+      return Result.err(
+        ValidationError.create(
+          "state",
+          `Cannot stop from '${previousState}' state (expected 'local', 'running', or 'error')`,
+        ),
+      );
+    }
+
+    this.#state = "stopping";
+
+    // Clear heartbeat
+    this.#stopHeartbeat();
+
+    // Abort all active streams
+    for (const stream of this.#streams) {
+      stream.abort();
+    }
+    this.#streams = [];
+
+    // Emit stopped event only after full startup has occurred.
+    if (previousState !== "local") {
+      this.#emitter.emit({
+        type: "raw.core.stopped",
+        reason: "shutdown",
+      });
+    }
+
+    // Clear registry and close identity store
+    this.#registry.clear();
+    this.#identityStore.close();
+
+    this.#state = "stopped";
+
+    return Result.ok();
+  }
+
+  /**
+   * Consume messages from a stream and emit raw events.
+   * Runs as a fire-and-forget async loop; errors are swallowed.
+   */
+  #consumeMessageStream(messages: AsyncIterable<XmtpDecodedMessage>): void {
+    void (async () => {
+      try {
+        for await (const msg of messages) {
+          this.#emitter.emit({
+            type: "raw.message",
+            messageId: msg.messageId,
+            groupId: msg.groupId,
+            senderInboxId: msg.senderInboxId,
+            contentType: msg.contentType,
+            content: msg.content,
+            sentAt: msg.sentAt,
+            isHistorical: false,
+          });
+        }
+      } catch {
+        // Stream aborted or errored — expected during shutdown.
+      }
+    })();
+  }
+
+  /**
+   * Consume group events from a stream and emit raw events.
+   * Also registers newly joined groups in the client registry.
+   * Runs as a fire-and-forget async loop; errors are swallowed.
+   */
+  #consumeGroupStream(
+    identityId: string,
+    groups: AsyncIterable<XmtpGroupEvent>,
+  ): void {
+    void (async () => {
+      try {
+        for await (const group of groups) {
+          // Fix 2: Register newly streamed groups in the registry
+          const managed = this.#registry.get(identityId);
+          if (managed) {
+            managed.groupIds.add(group.groupId);
+          }
+
+          this.#emitter.emit({
+            type: "raw.group.joined",
+            groupId: group.groupId,
+            groupName: group.groupName,
+          });
+        }
+      } catch {
+        // Stream aborted or errored — expected during shutdown.
+      }
+    })();
+  }
+
+  #resetStartupArtifacts(): void {
+    this.#stopHeartbeat();
+    for (const stream of this.#streams) {
+      stream.abort();
+    }
+    this.#streams = [];
+    this.#registry.clear();
+  }
+
+  #startHeartbeat(): void {
+    this.#heartbeatTimer = setInterval(() => {
+      this.#emitter.emit({
+        type: "raw.heartbeat",
+        timestamp: new Date().toISOString(),
+      });
+    }, this.#config.heartbeatIntervalMs);
+  }
+
+  #stopHeartbeat(): void {
+    if (this.#heartbeatTimer !== null) {
+      clearInterval(this.#heartbeatTimer);
+      this.#heartbeatTimer = null;
+    }
+  }
+}

--- a/packages/core/src/client-registry.ts
+++ b/packages/core/src/client-registry.ts
@@ -1,0 +1,62 @@
+import type { XmtpClient } from "./xmtp-client-factory.js";
+
+/** Runtime state for a managed XMTP client. */
+export interface ManagedClient {
+  readonly identityId: string;
+  readonly inboxId: string;
+  readonly client: XmtpClient;
+  /** Groups this client is responsible for. Mutable during runtime. */
+  readonly groupIds: Set<string>;
+}
+
+/**
+ * Ephemeral in-memory registry of active XMTP clients.
+ *
+ * Keyed by identity ID. Rebuilt from the IdentityStore and XMTP network
+ * state on every broker startup. The IdentityStore is the durable source
+ * of truth for which identities exist; this registry is the runtime source
+ * of truth for active connections.
+ */
+export class ClientRegistry {
+  readonly #clients = new Map<string, ManagedClient>();
+
+  /** Register a managed client. Overwrites any existing entry. */
+  register(managed: ManagedClient): void {
+    this.#clients.set(managed.identityId, managed);
+  }
+
+  /** Get a managed client by identity ID. */
+  get(identityId: string): ManagedClient | undefined {
+    return this.#clients.get(identityId);
+  }
+
+  /** Get the managed client responsible for a given group. */
+  getByGroupId(groupId: string): ManagedClient | undefined {
+    for (const managed of this.#clients.values()) {
+      if (managed.groupIds.has(groupId)) {
+        return managed;
+      }
+    }
+    return undefined;
+  }
+
+  /** Remove a managed client. Returns true if it existed. */
+  unregister(identityId: string): boolean {
+    return this.#clients.delete(identityId);
+  }
+
+  /** List all managed clients. */
+  list(): readonly ManagedClient[] {
+    return [...this.#clients.values()];
+  }
+
+  /** Number of registered clients. */
+  get size(): number {
+    return this.#clients.size;
+  }
+
+  /** Remove all clients. */
+  clear(): void {
+    this.#clients.clear();
+  }
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+
+export const XmtpEnvSchema: z.ZodEnum<["local", "dev", "production"]> = z
+  .enum(["local", "dev", "production"])
+  .describe("XMTP network environment");
+
+export type XmtpEnv = z.infer<typeof XmtpEnvSchema>;
+
+export const IdentityModeSchema: z.ZodEnum<["per-group", "shared"]> = z
+  .enum(["per-group", "shared"])
+  .describe("Whether each group gets a unique identity or shares one");
+
+export type IdentityMode = z.infer<typeof IdentityModeSchema>;
+
+/** Parsed broker core configuration (all defaults applied). */
+export type BrokerCoreConfig = {
+  dataDir: string;
+  env: XmtpEnv;
+  identityMode: IdentityMode;
+  heartbeatIntervalMs: number;
+  syncTimeoutMs: number;
+  appVersion: string;
+};
+
+/** Input to BrokerCoreConfigSchema (fields with defaults are optional). */
+type BrokerCoreConfigInput = {
+  dataDir: string;
+  env?: XmtpEnv | undefined;
+  identityMode?: IdentityMode | undefined;
+  heartbeatIntervalMs?: number | undefined;
+  syncTimeoutMs?: number | undefined;
+  appVersion?: string | undefined;
+};
+
+export const BrokerCoreConfigSchema: z.ZodType<
+  BrokerCoreConfig,
+  z.ZodTypeDef,
+  BrokerCoreConfigInput
+> = z
+  .object({
+    dataDir: z.string().describe("Base directory for all broker data"),
+    env: XmtpEnvSchema.default("dev").describe("XMTP network environment"),
+    identityMode: IdentityModeSchema.default("per-group").describe(
+      "Identity isolation strategy",
+    ),
+    heartbeatIntervalMs: z
+      .number()
+      .int()
+      .positive()
+      .default(30_000)
+      .describe("Heartbeat emission interval in milliseconds"),
+    syncTimeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .default(30_000)
+      .describe("Maximum time to wait for initial sync"),
+    appVersion: z
+      .string()
+      .default("xmtp-broker/0.1.0")
+      .describe("App version string sent to XMTP network"),
+  })
+  .describe("Broker core configuration");

--- a/packages/core/src/core-context.ts
+++ b/packages/core/src/core-context.ts
@@ -1,0 +1,113 @@
+import { Result } from "better-result";
+import { NotFoundError, type BrokerError } from "@xmtp-broker/schemas";
+import type { ClientRegistry } from "./client-registry.js";
+import type { SqliteIdentityStore } from "./identity-store.js";
+import type { XmtpGroupInfo } from "./xmtp-client-factory.js";
+
+/**
+ * Sealed interface for performing actions through the broker core.
+ *
+ * Delegates to the client registry to find the correct XMTP client
+ * for each operation, and to the identity store for inbox ID lookups.
+ * Never exposes the raw client, conversations, or signer.
+ */
+export class BrokerCoreContext {
+  readonly #registry: ClientRegistry;
+  readonly #identityStore: SqliteIdentityStore;
+
+  constructor(registry: ClientRegistry, identityStore: SqliteIdentityStore) {
+    this.#registry = registry;
+    this.#identityStore = identityStore;
+  }
+
+  /** Send a message to a group. */
+  async sendMessage(
+    groupId: string,
+    _contentType: string,
+    content: unknown,
+  ): Promise<Result<{ messageId: string }, BrokerError>> {
+    const managed = this.#registry.getByGroupId(groupId);
+    if (!managed) {
+      return Result.err(NotFoundError.create("group", groupId));
+    }
+    const result = await managed.client.sendMessage(groupId, content);
+    if (result.isErr()) return result;
+    return Result.ok({ messageId: result.value });
+  }
+
+  /** Get group metadata. */
+  async getGroupInfo(
+    groupId: string,
+  ): Promise<Result<XmtpGroupInfo, BrokerError>> {
+    const managed = this.#registry.getByGroupId(groupId);
+    if (!managed) {
+      return Result.err(NotFoundError.create("group", groupId));
+    }
+    return managed.client.getGroupInfo(groupId);
+  }
+
+  /** List all groups the broker is a member of. */
+  async listGroups(): Promise<Result<readonly XmtpGroupInfo[], BrokerError>> {
+    const allGroups: XmtpGroupInfo[] = [];
+    for (const managed of this.#registry.list()) {
+      const result = await managed.client.listGroups();
+      if (result.isErr()) return result;
+      allGroups.push(...result.value);
+    }
+    return Result.ok(allGroups);
+  }
+
+  /** Add members to a group by inbox ID. */
+  async addMembers(
+    groupId: string,
+    inboxIds: readonly string[],
+  ): Promise<Result<void, BrokerError>> {
+    const managed = this.#registry.getByGroupId(groupId);
+    if (!managed) {
+      return Result.err(NotFoundError.create("group", groupId));
+    }
+    return managed.client.addMembers(groupId, inboxIds);
+  }
+
+  /** Remove members from a group. */
+  async removeMembers(
+    groupId: string,
+    inboxIds: readonly string[],
+  ): Promise<Result<void, BrokerError>> {
+    const managed = this.#registry.getByGroupId(groupId);
+    if (!managed) {
+      return Result.err(NotFoundError.create("group", groupId));
+    }
+    return managed.client.removeMembers(groupId, inboxIds);
+  }
+
+  /** Get the inbox ID for a given group's identity. */
+  async getInboxId(groupId: string): Promise<Result<string, BrokerError>> {
+    // Check the runtime registry first — shared-mode identities are
+    // persisted with group_id = NULL, so the identity store lookup
+    // would miss them. The registry is hydrated at startup.
+    const managed = this.#registry.getByGroupId(groupId);
+    if (managed) {
+      return Result.ok(managed.inboxId);
+    }
+
+    // Fall back to persisted per-group identities.
+    const identity = await this.#identityStore.getByGroupId(groupId);
+    if (!identity) {
+      return Result.err(NotFoundError.create("identity", groupId));
+    }
+    if (!identity.inboxId) {
+      return Result.err(NotFoundError.create("inboxId", groupId));
+    }
+    return Result.ok(identity.inboxId);
+  }
+
+  /** Force a sync for a specific group. */
+  async syncGroup(groupId: string): Promise<Result<void, BrokerError>> {
+    const managed = this.#registry.getByGroupId(groupId);
+    if (!managed) {
+      return Result.err(NotFoundError.create("group", groupId));
+    }
+    return managed.client.syncGroup(groupId);
+  }
+}

--- a/packages/core/src/event-emitter.ts
+++ b/packages/core/src/event-emitter.ts
@@ -1,0 +1,44 @@
+import type { CoreRawEvent, RawEventHandler } from "./raw-events.js";
+
+/**
+ * Typed event emitter for core raw events.
+ *
+ * Subscribers are called synchronously in registration order.
+ * A throwing subscriber does not prevent delivery to subsequent subscribers.
+ */
+export class CoreEventEmitter {
+  readonly #handlers = new Set<RawEventHandler>();
+
+  /** Subscribe to all raw events. Returns an unsubscribe function. */
+  on(handler: RawEventHandler): () => void {
+    this.#handlers.add(handler);
+    let removed = false;
+    return () => {
+      if (removed) return;
+      removed = true;
+      this.#handlers.delete(handler);
+    };
+  }
+
+  /** Emit an event to all subscribers. */
+  emit(event: CoreRawEvent): void {
+    for (const handler of this.#handlers) {
+      try {
+        handler(event);
+      } catch {
+        // Subscriber errors are swallowed to prevent cascade failures.
+        // In production, these would be logged.
+      }
+    }
+  }
+
+  /** Remove all subscribers. */
+  removeAll(): void {
+    this.#handlers.clear();
+  }
+
+  /** Number of active subscribers. */
+  get listenerCount(): number {
+    return this.#handlers.size;
+  }
+}

--- a/packages/core/src/identity-store.ts
+++ b/packages/core/src/identity-store.ts
@@ -1,0 +1,152 @@
+import { Database } from "bun:sqlite";
+import { Result } from "better-result";
+import { InternalError, NotFoundError } from "@xmtp-broker/schemas";
+
+/** Represents a single agent identity managed by the broker. */
+export interface AgentIdentity {
+  readonly id: string;
+  readonly inboxId: string | null;
+  readonly groupId: string | null;
+  readonly createdAt: string;
+}
+
+/** Row shape from SQLite. */
+interface IdentityRow {
+  id: string;
+  inbox_id: string | null;
+  group_id: string | null;
+  created_at: string;
+}
+
+function rowToIdentity(row: IdentityRow): AgentIdentity {
+  return {
+    id: row.id,
+    inboxId: row.inbox_id,
+    groupId: row.group_id,
+    createdAt: row.created_at,
+  };
+}
+
+/** Generate a random 32-byte hex string for identity IDs. */
+function generateId(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * SQLite-backed persistent store for agent identity material.
+ *
+ * Each identity record tracks: a unique ID, optional XMTP inbox ID (set after
+ * registration), optional group binding, and creation timestamp.
+ */
+export class SqliteIdentityStore {
+  readonly #db: Database;
+
+  constructor(dbPath: string) {
+    this.#db = new Database(dbPath);
+    this.#db.run("PRAGMA journal_mode = WAL");
+    this.#db.run("PRAGMA foreign_keys = ON");
+    this.#migrate();
+  }
+
+  #migrate(): void {
+    this.#db.run(`
+      CREATE TABLE IF NOT EXISTS identities (
+        id TEXT PRIMARY KEY,
+        inbox_id TEXT,
+        group_id TEXT UNIQUE,
+        created_at TEXT NOT NULL
+      )
+    `);
+  }
+
+  /** Create a new identity with fresh key material. */
+  async create(
+    groupId: string | null,
+  ): Promise<Result<AgentIdentity, InternalError>> {
+    const id = generateId();
+    const createdAt = new Date().toISOString();
+
+    try {
+      this.#db
+        .prepare(
+          "INSERT INTO identities (id, inbox_id, group_id, created_at) VALUES (?, ?, ?, ?)",
+        )
+        .run(id, null, groupId, createdAt);
+
+      return Result.ok({
+        id,
+        inboxId: null,
+        groupId,
+        createdAt,
+      });
+    } catch (cause) {
+      return Result.err(
+        InternalError.create("Failed to create identity", {
+          cause: String(cause),
+        }),
+      );
+    }
+  }
+
+  /** Look up the identity for a given group. */
+  async getByGroupId(groupId: string): Promise<AgentIdentity | null> {
+    const row = this.#db
+      .prepare("SELECT * FROM identities WHERE group_id = ?")
+      .get(groupId) as IdentityRow | null;
+    return row ? rowToIdentity(row) : null;
+  }
+
+  /** Look up an identity by its ID. */
+  async getById(id: string): Promise<AgentIdentity | null> {
+    const row = this.#db
+      .prepare("SELECT * FROM identities WHERE id = ?")
+      .get(id) as IdentityRow | null;
+    return row ? rowToIdentity(row) : null;
+  }
+
+  /** List all identities. */
+  async list(): Promise<readonly AgentIdentity[]> {
+    const rows = this.#db
+      .prepare("SELECT * FROM identities ORDER BY created_at ASC")
+      .all() as IdentityRow[];
+    return rows.map(rowToIdentity);
+  }
+
+  /** Update the inboxId after XMTP registration. */
+  async setInboxId(
+    id: string,
+    inboxId: string,
+  ): Promise<Result<AgentIdentity, NotFoundError>> {
+    const existing = await this.getById(id);
+    if (existing === null) {
+      return Result.err(NotFoundError.create("identity", id));
+    }
+
+    this.#db
+      .prepare("UPDATE identities SET inbox_id = ? WHERE id = ?")
+      .run(inboxId, id);
+
+    return Result.ok({
+      ...existing,
+      inboxId,
+    });
+  }
+
+  /** Remove an identity and its associated data. */
+  async remove(id: string): Promise<Result<void, NotFoundError>> {
+    const existing = await this.getById(id);
+    if (existing === null) {
+      return Result.err(NotFoundError.create("identity", id));
+    }
+
+    this.#db.prepare("DELETE FROM identities WHERE id = ?").run(id);
+    return Result.ok();
+  }
+
+  /** Close the database connection. */
+  close(): void {
+    this.#db.close();
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,50 @@
-// Placeholder — real exports added by subsequent specs.
-export {};
+// Config
+export {
+  BrokerCoreConfigSchema,
+  XmtpEnvSchema,
+  IdentityModeSchema,
+} from "./config.js";
+export type { BrokerCoreConfig, XmtpEnv, IdentityMode } from "./config.js";
+
+// Broker core
+export { BrokerCoreImpl } from "./broker-core.js";
+export type { BrokerState, SignerProviderFactory } from "./broker-core.js";
+
+// Core context
+export { BrokerCoreContext } from "./core-context.js";
+
+// Identity store
+export { SqliteIdentityStore } from "./identity-store.js";
+export type { AgentIdentity } from "./identity-store.js";
+
+// Client registry
+export { ClientRegistry } from "./client-registry.js";
+export type { ManagedClient } from "./client-registry.js";
+
+// Event emitter
+export { CoreEventEmitter } from "./event-emitter.js";
+
+// Raw events
+export type {
+  CoreRawEvent,
+  RawEventHandler,
+  RawMessageEvent,
+  RawGroupJoinedEvent,
+  RawGroupUpdatedEvent,
+  RawCoreStartedEvent,
+  RawCoreStoppedEvent,
+  RawHeartbeatEvent,
+} from "./raw-events.js";
+
+// XMTP client abstraction
+export type {
+  XmtpClient,
+  XmtpClientFactory,
+  XmtpClientCreateOptions,
+  XmtpGroupInfo,
+  XmtpDecodedMessage,
+  XmtpGroupEvent,
+  MessageStream,
+  GroupStream,
+  SignerProviderLike,
+} from "./xmtp-client-factory.js";

--- a/packages/core/src/raw-events.ts
+++ b/packages/core/src/raw-events.ts
@@ -1,0 +1,66 @@
+/**
+ * Internal raw event types emitted by BrokerCore.
+ *
+ * These are unfiltered events from the XMTP client, before any policy
+ * filtering. They carry enough metadata for the policy engine to apply
+ * views and grants. They are plain TypeScript interfaces, not Zod schemas,
+ * because they never cross a serialization boundary.
+ */
+
+/** Raw message received from XMTP, before any policy filtering. */
+export interface RawMessageEvent {
+  readonly type: "raw.message";
+  readonly messageId: string;
+  readonly groupId: string;
+  readonly senderInboxId: string;
+  readonly contentType: string;
+  readonly content: unknown;
+  readonly sentAt: string;
+  /** True if this message was received during recovery sync. */
+  readonly isHistorical: boolean;
+}
+
+/** A new group was discovered (joined or created). */
+export interface RawGroupJoinedEvent {
+  readonly type: "raw.group.joined";
+  readonly groupId: string;
+  readonly groupName: string;
+}
+
+/** Group membership changed. */
+export interface RawGroupUpdatedEvent {
+  readonly type: "raw.group.updated";
+  readonly groupId: string;
+  readonly update: unknown;
+}
+
+/** Core lifecycle: started. */
+export interface RawCoreStartedEvent {
+  readonly type: "raw.core.started";
+  readonly identityCount: number;
+  readonly syncedThrough: string;
+}
+
+/** Core lifecycle: stopped. */
+export interface RawCoreStoppedEvent {
+  readonly type: "raw.core.stopped";
+  readonly reason: string;
+}
+
+/** Core heartbeat. */
+export interface RawHeartbeatEvent {
+  readonly type: "raw.heartbeat";
+  readonly timestamp: string;
+}
+
+/** Union of all raw events emitted by the core. */
+export type CoreRawEvent =
+  | RawMessageEvent
+  | RawGroupJoinedEvent
+  | RawGroupUpdatedEvent
+  | RawCoreStartedEvent
+  | RawCoreStoppedEvent
+  | RawHeartbeatEvent;
+
+/** Handler function for raw events. */
+export type RawEventHandler = (event: CoreRawEvent) => void;

--- a/packages/core/src/xmtp-client-factory.ts
+++ b/packages/core/src/xmtp-client-factory.ts
@@ -1,0 +1,152 @@
+import type { Result } from "better-result";
+import type { BrokerError } from "@xmtp-broker/schemas";
+import type { XmtpEnv } from "./config.js";
+
+/**
+ * Abstract representation of an XMTP client instance.
+ *
+ * This interface decouples the core from the real `@xmtp/node-sdk` Client,
+ * allowing tests to provide stub implementations without pulling in the SDK.
+ */
+export interface XmtpClient {
+  /** The inbox ID assigned by the XMTP network. */
+  readonly inboxId: string;
+
+  /** Send a message to a group conversation. */
+  sendMessage(
+    groupId: string,
+    content: unknown,
+  ): Promise<Result<string, BrokerError>>;
+
+  /** Sync all conversations. */
+  syncAll(): Promise<Result<void, BrokerError>>;
+
+  /** Sync a specific group. */
+  syncGroup(groupId: string): Promise<Result<void, BrokerError>>;
+
+  /** Get group metadata. */
+  getGroupInfo(groupId: string): Promise<Result<XmtpGroupInfo, BrokerError>>;
+
+  /** List all groups the client is a member of. */
+  listGroups(): Promise<Result<readonly XmtpGroupInfo[], BrokerError>>;
+
+  /** Add members to a group by inbox ID. */
+  addMembers(
+    groupId: string,
+    inboxIds: readonly string[],
+  ): Promise<Result<void, BrokerError>>;
+
+  /** Remove members from a group. */
+  removeMembers(
+    groupId: string,
+    inboxIds: readonly string[],
+  ): Promise<Result<void, BrokerError>>;
+
+  /**
+   * Stream all messages across all groups.
+   * Returns an async iterable and an abort function.
+   */
+  streamAllMessages(): Promise<Result<MessageStream, BrokerError>>;
+
+  /**
+   * Stream group creation/join events.
+   * Returns an async iterable and an abort function.
+   */
+  streamGroups(): Promise<Result<GroupStream, BrokerError>>;
+}
+
+/** Group metadata returned by the XMTP client. */
+export interface XmtpGroupInfo {
+  readonly groupId: string;
+  readonly name: string;
+  readonly description: string;
+  readonly memberInboxIds: readonly string[];
+  readonly createdAt: string;
+}
+
+/** A decoded message from the XMTP stream. */
+export interface XmtpDecodedMessage {
+  readonly messageId: string;
+  readonly groupId: string;
+  readonly senderInboxId: string;
+  readonly contentType: string;
+  readonly content: unknown;
+  readonly sentAt: string;
+}
+
+/** A group event from the XMTP stream. */
+export interface XmtpGroupEvent {
+  readonly groupId: string;
+  readonly groupName: string;
+}
+
+/** Message stream with abort capability. */
+export interface MessageStream {
+  readonly messages: AsyncIterable<XmtpDecodedMessage>;
+  readonly abort: () => void;
+}
+
+/** Group stream with abort capability. */
+export interface GroupStream {
+  readonly groups: AsyncIterable<XmtpGroupEvent>;
+  readonly abort: () => void;
+}
+
+/** Options for creating an XMTP client. */
+export interface XmtpClientCreateOptions {
+  readonly identityId: string;
+  readonly dbPath: string;
+  readonly dbEncryptionKey: Uint8Array;
+  readonly env: XmtpEnv;
+  readonly appVersion: string;
+  /**
+   * Hex-encoded secp256k1 private key (0x-prefixed) for XMTP identity
+   * registration. Used once during `Client.create()` to produce an
+   * EIP-191 ECDSA signature. After registration, `Client.build()` is
+   * used instead and no signer is needed.
+   */
+  readonly signerPrivateKey: `0x${string}`;
+}
+
+/**
+ * Factory for creating XMTP client instances.
+ *
+ * Injected into BrokerCore to decouple from the real `@xmtp/node-sdk`.
+ * Tests provide a mock factory; production provides a factory that wraps
+ * `Client.create()` from the SDK.
+ */
+export interface XmtpClientFactory {
+  /** Create and register an XMTP client for the given identity. */
+  create(
+    options: XmtpClientCreateOptions,
+  ): Promise<Result<XmtpClient, BrokerError>>;
+}
+
+/**
+ * Minimal signer interface needed by the factory.
+ * Mirrors the shape of SignerProvider from contracts but avoids
+ * importing it to keep this file self-contained for the interface.
+ */
+export interface SignerProviderLike {
+  /** Sign data with the Ed25519 operational key. */
+  sign(data: Uint8Array): Promise<Result<Uint8Array, BrokerError>>;
+  /** Get the Ed25519 public key. */
+  getPublicKey(): Promise<Result<Uint8Array, BrokerError>>;
+  /** Get a fingerprint of the Ed25519 public key. */
+  getFingerprint(): Promise<Result<string, BrokerError>>;
+  /**
+   * Derive or retrieve a 32-byte encryption key for XMTP client databases.
+   * Must return the same key for a given identity across restarts.
+   */
+  getDbEncryptionKey(
+    identityId: string,
+  ): Promise<Result<Uint8Array, BrokerError>>;
+  /**
+   * Retrieve the secp256k1 private key for XMTP identity registration.
+   * Returns a hex-encoded 0x-prefixed key. Used once during
+   * `Client.create()` and persisted in the vault alongside Ed25519 keys.
+   */
+  getXmtpIdentityKey(
+    identityId: string,
+  ): Promise<Result<`0x${string}`, BrokerError>>;
+}


### PR DESCRIPTION
## Context
This branch adds the runtime core that owns XMTP clients and group/identity routing. Review this PR against `v0/contracts`, not `main`.

## What Changed
- implements broker startup, shutdown, sync, and client creation flow in `broker-core.ts`
- adds the identity store and client registry used to map groups to isolated or shared XMTP identities
- introduces the runtime context surface used by higher packages to send messages, inspect groups, and route operations
- emits raw broker events and defines the factory/config layer around XMTP client construction
- includes regression coverage for shared identity handling, startup sync, and context lookups

## Why This Branch Exists
This is the broker's raw plane. Policy, sessions, attestations, and transports all build on top of this lifecycle and routing behavior.

## Key Files
- `packages/core/src/broker-core.ts`
- `packages/core/src/identity-store.ts`
- `packages/core/src/client-registry.ts`
- `packages/core/src/core-context.ts`
- `packages/core/src/raw-events.ts`

## Verification
- `bun test packages/core/src/__tests__/broker-core.test.ts`
- `bun test packages/core/src/__tests__/core-context.test.ts`
- repo verification via pre-push stack checks (`lint`, `test`, `typecheck`)
