### PR TITLE
feat(policy): add projection pipeline and grant validation engine

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,11 @@
     "packages/policy": {
       "name": "@xmtp-broker/policy",
       "version": "0.0.0",
+      "dependencies": {
+        "@xmtp-broker/contracts": "workspace:*",
+        "@xmtp-broker/schemas": "workspace:*",
+        "better-result": "catalog:",
+      },
       "devDependencies": {
         "bun-types": "catalog:",
         "typescript": "catalog:",

--- a/packages/policy/package.json
+++ b/packages/policy/package.json
@@ -15,7 +15,11 @@
     "lint": "oxlint .",
     "test": "bun test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@xmtp-broker/contracts": "workspace:*",
+    "@xmtp-broker/schemas": "workspace:*",
+    "better-result": "catalog:"
+  },
   "devDependencies": {
     "bun-types": "catalog:",
     "typescript": "catalog:"

--- a/packages/policy/src/__tests__/allowlist.test.ts
+++ b/packages/policy/src/__tests__/allowlist.test.ts
@@ -1,0 +1,111 @@
+import { describe, test, expect } from "bun:test";
+import { resolveEffectiveAllowlist } from "../allowlist.js";
+import { BASELINE_CONTENT_TYPES } from "@xmtp-broker/schemas";
+import type { ContentTypeId } from "@xmtp-broker/schemas";
+import { Result } from "better-result";
+
+describe("resolveEffectiveAllowlist", () => {
+  test("intersection of all three tiers", () => {
+    const broker = {
+      allowlist: new Set([
+        "xmtp.org/text:1.0" as ContentTypeId,
+        "xmtp.org/reaction:1.0" as ContentTypeId,
+        "xmtp.org/reply:1.0" as ContentTypeId,
+      ]),
+    };
+    const agent = [
+      "xmtp.org/text:1.0" as ContentTypeId,
+      "xmtp.org/reaction:1.0" as ContentTypeId,
+    ];
+
+    const result = resolveEffectiveAllowlist(
+      BASELINE_CONTENT_TYPES,
+      broker,
+      agent,
+    );
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isOk(result)) {
+      expect(result.value.size).toBe(2);
+      expect(result.value.has("xmtp.org/text:1.0" as ContentTypeId)).toBe(true);
+      expect(result.value.has("xmtp.org/reaction:1.0" as ContentTypeId)).toBe(
+        true,
+      );
+    }
+  });
+
+  test("broker superset of baseline still bounded by baseline", () => {
+    const broker = {
+      allowlist: new Set([
+        ...BASELINE_CONTENT_TYPES,
+        "custom.org/special:1.0" as ContentTypeId,
+      ]),
+    };
+    const agent = [
+      ...BASELINE_CONTENT_TYPES,
+      "custom.org/special:1.0" as ContentTypeId,
+    ];
+
+    const result = resolveEffectiveAllowlist(
+      BASELINE_CONTENT_TYPES,
+      broker,
+      agent,
+    );
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isOk(result)) {
+      expect(result.value.size).toBe(BASELINE_CONTENT_TYPES.length);
+      expect(result.value.has("custom.org/special:1.0" as ContentTypeId)).toBe(
+        false,
+      );
+    }
+  });
+
+  test("agent requests types broker does not allow -- silently excluded", () => {
+    const broker = {
+      allowlist: new Set(["xmtp.org/text:1.0" as ContentTypeId]),
+    };
+    const agent = [
+      "xmtp.org/text:1.0" as ContentTypeId,
+      "xmtp.org/reaction:1.0" as ContentTypeId,
+    ];
+
+    const result = resolveEffectiveAllowlist(
+      BASELINE_CONTENT_TYPES,
+      broker,
+      agent,
+    );
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isOk(result)) {
+      expect(result.value.size).toBe(1);
+      expect(result.value.has("xmtp.org/text:1.0" as ContentTypeId)).toBe(true);
+    }
+  });
+
+  test("empty intersection returns ValidationError", () => {
+    const broker = {
+      allowlist: new Set(["xmtp.org/text:1.0" as ContentTypeId]),
+    };
+    const agent = ["xmtp.org/reaction:1.0" as ContentTypeId];
+
+    const result = resolveEffectiveAllowlist(
+      BASELINE_CONTENT_TYPES,
+      broker,
+      agent,
+    );
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error._tag).toBe("ValidationError");
+    }
+  });
+
+  test("empty agent allowlist returns ValidationError", () => {
+    const broker = {
+      allowlist: new Set(BASELINE_CONTENT_TYPES),
+    };
+    const result = resolveEffectiveAllowlist(
+      BASELINE_CONTENT_TYPES,
+      broker,
+      [],
+    );
+    expect(Result.isError(result)).toBe(true);
+  });
+});

--- a/packages/policy/src/__tests__/content-projector.test.ts
+++ b/packages/policy/src/__tests__/content-projector.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from "bun:test";
+import { projectContent } from "../pipeline/content-projector.js";
+import type { ContentTypeId } from "@xmtp-broker/schemas";
+
+describe("projectContent", () => {
+  const content = { text: "hello world" };
+  const contentType = "xmtp.org/text:1.0" as ContentTypeId;
+
+  test("visible passes content through unchanged", () => {
+    expect(projectContent(content, contentType, "visible")).toEqual(content);
+  });
+
+  test("historical passes content through unchanged", () => {
+    expect(projectContent(content, contentType, "historical")).toEqual(content);
+  });
+
+  test("revealed passes content through unchanged", () => {
+    expect(projectContent(content, contentType, "revealed")).toEqual(content);
+  });
+
+  test("redacted replaces content with null", () => {
+    expect(projectContent(content, contentType, "redacted")).toBeNull();
+  });
+
+  test("hidden is unreachable but returns null defensively", () => {
+    expect(projectContent(content, contentType, "hidden")).toBeNull();
+  });
+});

--- a/packages/policy/src/__tests__/content-type-filter.test.ts
+++ b/packages/policy/src/__tests__/content-type-filter.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from "bun:test";
+import { isContentTypeAllowed } from "../pipeline/content-type-filter.js";
+import type { ContentTypeId } from "@xmtp-broker/schemas";
+
+describe("isContentTypeAllowed", () => {
+  test("returns true when content type is in allowlist", () => {
+    const allowlist = new Set([
+      "xmtp.org/text:1.0" as ContentTypeId,
+      "xmtp.org/reaction:1.0" as ContentTypeId,
+    ]);
+    expect(
+      isContentTypeAllowed("xmtp.org/text:1.0" as ContentTypeId, allowlist),
+    ).toBe(true);
+  });
+
+  test("returns false when content type is not in allowlist", () => {
+    const allowlist = new Set(["xmtp.org/text:1.0" as ContentTypeId]);
+    expect(
+      isContentTypeAllowed("xmtp.org/reaction:1.0" as ContentTypeId, allowlist),
+    ).toBe(false);
+  });
+
+  test("returns false for unknown content types (default-deny)", () => {
+    const allowlist = new Set(["xmtp.org/text:1.0" as ContentTypeId]);
+    expect(
+      isContentTypeAllowed(
+        "custom.org/unknown:1.0" as ContentTypeId,
+        allowlist,
+      ),
+    ).toBe(false);
+  });
+
+  test("returns false for empty allowlist", () => {
+    const allowlist = new Set<ContentTypeId>();
+    expect(
+      isContentTypeAllowed("xmtp.org/text:1.0" as ContentTypeId, allowlist),
+    ).toBe(false);
+  });
+});

--- a/packages/policy/src/__tests__/fixtures.ts
+++ b/packages/policy/src/__tests__/fixtures.ts
@@ -1,0 +1,113 @@
+import type {
+  ContentTypeId,
+  ViewConfig,
+  GrantConfig,
+} from "@xmtp-broker/schemas";
+import type { RevealStateSnapshot } from "../reveal-state.js";
+import type { RawMessage, BrokerContentTypeConfig } from "../types.js";
+
+/** Creates a RawMessage fixture. */
+export function createTestRawMessage(
+  overrides?: Partial<RawMessage>,
+): RawMessage {
+  return {
+    messageId: "msg-1",
+    groupId: "group-1",
+    senderInboxId: "sender-1",
+    contentType: "xmtp.org/text:1.0" as ContentTypeId,
+    content: { text: "hello" },
+    sentAt: "2024-01-01T00:00:00Z",
+    threadId: null,
+    attestationId: null,
+    ...overrides,
+  };
+}
+
+/** Creates a minimal ViewConfig that passes all messages. */
+export function createPassthroughView(groupId: string): ViewConfig {
+  return {
+    mode: "full",
+    threadScopes: [{ groupId, threadId: null }],
+    contentTypes: [
+      "xmtp.org/text:1.0" as ContentTypeId,
+      "xmtp.org/reaction:1.0" as ContentTypeId,
+      "xmtp.org/reply:1.0" as ContentTypeId,
+      "xmtp.org/readReceipt:1.0" as ContentTypeId,
+      "xmtp.org/groupUpdated:1.0" as ContentTypeId,
+    ],
+  };
+}
+
+/** Creates a GrantConfig with all permissions enabled. */
+export function createFullGrant(): GrantConfig {
+  return {
+    messaging: {
+      send: true,
+      reply: true,
+      react: true,
+      draftOnly: false,
+    },
+    groupManagement: {
+      addMembers: true,
+      removeMembers: true,
+      updateMetadata: true,
+      inviteUsers: true,
+    },
+    tools: {
+      scopes: [],
+    },
+    egress: {
+      storeExcerpts: true,
+      useForMemory: true,
+      forwardToProviders: true,
+      quoteRevealed: true,
+      summarize: true,
+    },
+  };
+}
+
+/** Creates a GrantConfig with all permissions denied. */
+export function createDenyAllGrant(): GrantConfig {
+  return {
+    messaging: {
+      send: false,
+      reply: false,
+      react: false,
+      draftOnly: false,
+    },
+    groupManagement: {
+      addMembers: false,
+      removeMembers: false,
+      updateMetadata: false,
+      inviteUsers: false,
+    },
+    tools: {
+      scopes: [],
+    },
+    egress: {
+      storeExcerpts: false,
+      useForMemory: false,
+      forwardToProviders: false,
+      quoteRevealed: false,
+      summarize: false,
+    },
+  };
+}
+
+/** Creates a broker content type config with all baseline types. */
+export function createBaselineBrokerConfig(): BrokerContentTypeConfig {
+  return {
+    allowlist: new Set([
+      "xmtp.org/text:1.0" as ContentTypeId,
+      "xmtp.org/reaction:1.0" as ContentTypeId,
+      "xmtp.org/reply:1.0" as ContentTypeId,
+      "xmtp.org/readReceipt:1.0" as ContentTypeId,
+      "xmtp.org/groupUpdated:1.0" as ContentTypeId,
+    ]),
+  };
+}
+
+/** Creates an empty RevealStateSnapshot. */
+export function createEmptyRevealState(): RevealStateSnapshot {
+  return { activeReveals: [] };
+}

--- a/packages/policy/src/__tests__/materiality.test.ts
+++ b/packages/policy/src/__tests__/materiality.test.ts
@@ -1,0 +1,233 @@
+import { describe, test, expect } from "bun:test";
+import { isMaterialChange, requiresReauthorization } from "../materiality.js";
+import type { PolicyDelta } from "@xmtp-broker/contracts";
+
+function emptyDelta(): PolicyDelta {
+  return {
+    viewChanges: [],
+    grantChanges: [],
+    contentTypeChanges: { added: [], removed: [] },
+  };
+}
+
+describe("isMaterialChange", () => {
+  test("accepts an array of deltas", () => {
+    const deltas: readonly PolicyDelta[] = [
+      {
+        ...emptyDelta(),
+        viewChanges: [{ field: "view.mode", from: "redacted", to: "full" }],
+      },
+      emptyDelta(),
+    ];
+    expect(isMaterialChange(deltas)).toBe(true);
+  });
+
+  test("returns false for array of empty deltas", () => {
+    expect(isMaterialChange([emptyDelta(), emptyDelta()])).toBe(false);
+  });
+
+  test("view.mode change is material", () => {
+    const delta: PolicyDelta = {
+      ...emptyDelta(),
+      viewChanges: [{ field: "view.mode", from: "redacted", to: "full" }],
+    };
+    expect(isMaterialChange([delta])).toBe(true);
+  });
+
+  test("view.threadScopes change is material", () => {
+    const delta: PolicyDelta = {
+      ...emptyDelta(),
+      viewChanges: [
+        {
+          field: "view.threadScopes",
+          from: [{ groupId: "g1", threadId: null }],
+          to: [
+            { groupId: "g1", threadId: null },
+            { groupId: "g2", threadId: null },
+          ],
+        },
+      ],
+    };
+    expect(isMaterialChange([delta])).toBe(true);
+  });
+
+  test("grant.messaging.send change is material", () => {
+    const delta: PolicyDelta = {
+      ...emptyDelta(),
+      grantChanges: [{ field: "grant.messaging.send", from: false, to: true }],
+    };
+    expect(isMaterialChange([delta])).toBe(true);
+  });
+
+  test("grant.egress change is material", () => {
+    const delta: PolicyDelta = {
+      ...emptyDelta(),
+      grantChanges: [
+        { field: "grant.egress.storeExcerpts", from: false, to: true },
+      ],
+    };
+    expect(isMaterialChange([delta])).toBe(true);
+  });
+
+  test("grant.groupManagement change is material", () => {
+    const delta: PolicyDelta = {
+      ...emptyDelta(),
+      grantChanges: [
+        { field: "grant.groupManagement.addMembers", from: false, to: true },
+      ],
+    };
+    expect(isMaterialChange([delta])).toBe(true);
+  });
+
+  test("grant.tools.scopes change is material", () => {
+    const delta: PolicyDelta = {
+      ...emptyDelta(),
+      grantChanges: [
+        { field: "grant.tools.scopes", from: [], to: [{ toolId: "x" }] },
+      ],
+    };
+    expect(isMaterialChange([delta])).toBe(true);
+  });
+
+  test("content type additions are material", () => {
+    const delta: PolicyDelta = {
+      ...emptyDelta(),
+      contentTypeChanges: { added: ["xmtp.org/text:1.0"], removed: [] },
+    };
+    expect(isMaterialChange([delta])).toBe(true);
+  });
+
+  test("content type removals are material", () => {
+    const delta: PolicyDelta = {
+      ...emptyDelta(),
+      contentTypeChanges: { added: [], removed: ["xmtp.org/text:1.0"] },
+    };
+    expect(isMaterialChange([delta])).toBe(true);
+  });
+
+  test("empty delta (session rotation) is not material", () => {
+    expect(isMaterialChange([emptyDelta()])).toBe(false);
+  });
+
+  test("routine field changes are not material", () => {
+    const delta: PolicyDelta = {
+      ...emptyDelta(),
+      viewChanges: [{ field: "session.heartbeatInterval", from: 30, to: 60 }],
+    };
+    expect(isMaterialChange([delta])).toBe(false);
+  });
+});
+
+describe("requiresReauthorization", () => {
+  test("view.mode escalation requires reauthorization", () => {
+    const delta: PolicyDelta = {
+      ...emptyDelta(),
+      viewChanges: [{ field: "view.mode", from: "redacted", to: "full" }],
+    };
+    expect(requiresReauthorization([delta])).toBe(true);
+  });
+
+  test("view.mode reduction does not require reauthorization", () => {
+    const delta: PolicyDelta = {
+      ...emptyDelta(),
+      viewChanges: [{ field: "view.mode", from: "full", to: "redacted" }],
+    };
+    expect(requiresReauthorization([delta])).toBe(false);
+  });
+
+  test("grant escalation (false to true) requires reauthorization", () => {
+    const delta: PolicyDelta = {
+      ...emptyDelta(),
+      grantChanges: [
+        { field: "grant.egress.forwardToProviders", from: false, to: true },
+      ],
+    };
+    expect(requiresReauthorization([delta])).toBe(true);
+  });
+
+  test("grant reduction (true to false) does not require reauthorization", () => {
+    const delta: PolicyDelta = {
+      ...emptyDelta(),
+      grantChanges: [{ field: "grant.messaging.send", from: true, to: false }],
+    };
+    expect(requiresReauthorization([delta])).toBe(false);
+  });
+
+  test("draftOnly guardrails do not count as false-to-true escalation", () => {
+    const delta: PolicyDelta = {
+      ...emptyDelta(),
+      grantChanges: [
+        { field: "grant.messaging.draftOnly", from: false, to: true },
+      ],
+    };
+    expect(requiresReauthorization([delta])).toBe(false);
+  });
+
+  test("groupManagement escalation requires reauthorization", () => {
+    const delta: PolicyDelta = {
+      ...emptyDelta(),
+      grantChanges: [
+        { field: "grant.groupManagement.removeMembers", from: false, to: true },
+      ],
+    };
+    expect(requiresReauthorization([delta])).toBe(true);
+  });
+
+  test("mode ordering: reveal-only < summary-only < redacted < thread-only < full", () => {
+    // reveal-only -> summary-only is escalation
+    const d1: PolicyDelta = {
+      ...emptyDelta(),
+      viewChanges: [
+        { field: "view.mode", from: "reveal-only", to: "summary-only" },
+      ],
+    };
+    expect(requiresReauthorization([d1])).toBe(true);
+
+    // summary-only -> redacted is escalation
+    const d2: PolicyDelta = {
+      ...emptyDelta(),
+      viewChanges: [
+        { field: "view.mode", from: "summary-only", to: "redacted" },
+      ],
+    };
+    expect(requiresReauthorization([d2])).toBe(true);
+
+    // full -> reveal-only is reduction
+    const d3: PolicyDelta = {
+      ...emptyDelta(),
+      viewChanges: [{ field: "view.mode", from: "full", to: "reveal-only" }],
+    };
+    expect(requiresReauthorization([d3])).toBe(false);
+  });
+
+  test("empty delta does not require reauthorization", () => {
+    expect(requiresReauthorization([emptyDelta()])).toBe(false);
+  });
+
+  test("accepts an array of deltas and returns true if any requires reauth", () => {
+    const deltas: readonly PolicyDelta[] = [
+      emptyDelta(),
+      {
+        ...emptyDelta(),
+        grantChanges: [
+          { field: "grant.egress.forwardToProviders", from: false, to: true },
+        ],
+      },
+    ];
+    expect(requiresReauthorization(deltas)).toBe(true);
+  });
+
+  test("tool scope additions modeled as array diffs require reauthorization", () => {
+    const delta: PolicyDelta = {
+      ...emptyDelta(),
+      grantChanges: [
+        {
+          field: "grant.tools.scopes",
+          from: [{ toolId: "tool-1", allowed: false }],
+          to: [{ toolId: "tool-1", allowed: true }],
+        },
+      ],
+    };
+    expect(requiresReauthorization([delta])).toBe(true);
+  });
+});

--- a/packages/policy/src/__tests__/project-message.test.ts
+++ b/packages/policy/src/__tests__/project-message.test.ts
@@ -1,0 +1,104 @@
+import { describe, test, expect } from "bun:test";
+import { projectMessage } from "../pipeline/project-message.js";
+import type { ContentTypeId, ViewConfig } from "@xmtp-broker/schemas";
+import { createTestRawMessage, createPassthroughView } from "./fixtures.js";
+
+describe("projectMessage", () => {
+  const baseAllowlist = new Set([
+    "xmtp.org/text:1.0" as ContentTypeId,
+    "xmtp.org/reaction:1.0" as ContentTypeId,
+  ]);
+
+  test("emits message when all stages pass with full mode", () => {
+    const message = createTestRawMessage();
+    const view = createPassthroughView("group-1");
+    const result = projectMessage(message, view, baseAllowlist, false);
+
+    expect(result.action).toBe("emit");
+    if (result.action === "emit") {
+      expect(result.event.messageId).toBe("msg-1");
+      expect(result.event.visibility).toBe("visible");
+      expect(result.event.content).toEqual({ text: "hello" });
+    }
+  });
+
+  test("drops message when group is out of scope", () => {
+    const message = createTestRawMessage({ groupId: "group-other" });
+    const view = createPassthroughView("group-1");
+    const result = projectMessage(message, view, baseAllowlist, false);
+
+    expect(result.action).toBe("drop");
+  });
+
+  test("drops message when content type is not allowed", () => {
+    const message = createTestRawMessage({
+      contentType: "xmtp.org/readReceipt:1.0" as ContentTypeId,
+    });
+    const view = createPassthroughView("group-1");
+    const allowlist = new Set(["xmtp.org/text:1.0" as ContentTypeId]);
+    const result = projectMessage(message, view, allowlist, false);
+
+    expect(result.action).toBe("drop");
+  });
+
+  test("drops message when visibility resolves to hidden (reveal-only, no reveal)", () => {
+    const message = createTestRawMessage();
+    const view: ViewConfig = {
+      mode: "reveal-only",
+      threadScopes: [{ groupId: "group-1", threadId: null }],
+      contentTypes: ["xmtp.org/text:1.0" as ContentTypeId],
+    };
+    const result = projectMessage(message, view, baseAllowlist, false);
+
+    expect(result.action).toBe("drop");
+  });
+
+  test("emits revealed message when reveal-only mode with reveal", () => {
+    const message = createTestRawMessage();
+    const view: ViewConfig = {
+      mode: "reveal-only",
+      threadScopes: [{ groupId: "group-1", threadId: null }],
+      contentTypes: ["xmtp.org/text:1.0" as ContentTypeId],
+    };
+    const result = projectMessage(message, view, baseAllowlist, true);
+
+    expect(result.action).toBe("emit");
+    if (result.action === "emit") {
+      expect(result.event.visibility).toBe("revealed");
+      expect(result.event.content).toEqual({ text: "hello" });
+    }
+  });
+
+  test("emits redacted message with null content in redacted mode", () => {
+    const message = createTestRawMessage();
+    const view: ViewConfig = {
+      mode: "redacted",
+      threadScopes: [{ groupId: "group-1", threadId: null }],
+      contentTypes: ["xmtp.org/text:1.0" as ContentTypeId],
+    };
+    const result = projectMessage(message, view, baseAllowlist, false);
+
+    expect(result.action).toBe("emit");
+    if (result.action === "emit") {
+      expect(result.event.visibility).toBe("redacted");
+      expect(result.event.content).toBeNull();
+    }
+  });
+
+  test("preserves metadata in redacted messages", () => {
+    const message = createTestRawMessage();
+    const view: ViewConfig = {
+      mode: "redacted",
+      threadScopes: [{ groupId: "group-1", threadId: null }],
+      contentTypes: ["xmtp.org/text:1.0" as ContentTypeId],
+    };
+    const result = projectMessage(message, view, baseAllowlist, false);
+
+    expect(result.action).toBe("emit");
+    if (result.action === "emit") {
+      expect(result.event.senderInboxId).toBe("sender-1");
+      expect(result.event.contentType).toBe("xmtp.org/text:1.0");
+      expect(result.event.sentAt).toBe("2024-01-01T00:00:00Z");
+    }
+  });
+});

--- a/packages/policy/src/__tests__/reveal-state.test.ts
+++ b/packages/policy/src/__tests__/reveal-state.test.ts
@@ -1,0 +1,355 @@
+import { describe, test, expect } from "bun:test";
+import { createRevealStateStore } from "../reveal-state.js";
+import type {
+  ContentTypeId,
+  RevealGrant,
+  RevealRequest,
+} from "@xmtp-broker/schemas";
+
+function makeRequest(overrides?: Partial<RevealRequest>): RevealRequest {
+  return {
+    revealId: "rev-1",
+    groupId: "group-1",
+    scope: "message",
+    targetId: "msg-1",
+    requestedBy: "owner-1",
+    expiresAt: null,
+    ...overrides,
+  };
+}
+
+function makeGrant(overrides?: Partial<RevealGrant>): RevealGrant {
+  return {
+    revealId: "rev-1",
+    grantedAt: "2024-01-01T00:00:00Z",
+    grantedBy: "owner-1",
+    expiresAt: null,
+    ...overrides,
+  };
+}
+
+describe("RevealStateStore", () => {
+  test("grant and query: message scope", () => {
+    const store = createRevealStateStore();
+    store.grant(
+      makeGrant(),
+      makeRequest({ scope: "message", targetId: "msg-1" }),
+    );
+
+    expect(
+      store.isRevealed(
+        "msg-1",
+        "group-1",
+        null,
+        "sender-1",
+        "xmtp.org/text:1.0" as ContentTypeId,
+      ),
+    ).toBe(true);
+  });
+
+  test("message scope does not match different message", () => {
+    const store = createRevealStateStore();
+    store.grant(
+      makeGrant(),
+      makeRequest({ scope: "message", targetId: "msg-1" }),
+    );
+
+    expect(
+      store.isRevealed(
+        "msg-2",
+        "group-1",
+        null,
+        "sender-1",
+        "xmtp.org/text:1.0" as ContentTypeId,
+      ),
+    ).toBe(false);
+  });
+
+  test("thread scope reveals all messages in thread", () => {
+    const store = createRevealStateStore();
+    store.grant(
+      makeGrant({ revealId: "rev-thread" }),
+      makeRequest({
+        revealId: "rev-thread",
+        scope: "thread",
+        targetId: "thread-1",
+      }),
+    );
+
+    expect(
+      store.isRevealed(
+        "msg-1",
+        "group-1",
+        "thread-1",
+        "sender-1",
+        "xmtp.org/text:1.0" as ContentTypeId,
+      ),
+    ).toBe(true);
+
+    expect(
+      store.isRevealed(
+        "msg-2",
+        "group-1",
+        "thread-1",
+        "sender-2",
+        "xmtp.org/text:1.0" as ContentTypeId,
+      ),
+    ).toBe(true);
+
+    // Different thread not revealed
+    expect(
+      store.isRevealed(
+        "msg-3",
+        "group-1",
+        "thread-2",
+        "sender-1",
+        "xmtp.org/text:1.0" as ContentTypeId,
+      ),
+    ).toBe(false);
+  });
+
+  test("sender scope reveals all messages from sender in group", () => {
+    const store = createRevealStateStore();
+    store.grant(
+      makeGrant({ revealId: "rev-sender" }),
+      makeRequest({
+        revealId: "rev-sender",
+        scope: "sender",
+        targetId: "sender-1",
+      }),
+    );
+
+    expect(
+      store.isRevealed(
+        "msg-1",
+        "group-1",
+        null,
+        "sender-1",
+        "xmtp.org/text:1.0" as ContentTypeId,
+      ),
+    ).toBe(true);
+
+    expect(
+      store.isRevealed(
+        "msg-2",
+        "group-1",
+        null,
+        "sender-2",
+        "xmtp.org/text:1.0" as ContentTypeId,
+      ),
+    ).toBe(false);
+  });
+
+  test("content-type scope reveals all messages of that type in group", () => {
+    const store = createRevealStateStore();
+    store.grant(
+      makeGrant({ revealId: "rev-ct" }),
+      makeRequest({
+        revealId: "rev-ct",
+        scope: "content-type",
+        targetId: "xmtp.org/text:1.0",
+      }),
+    );
+
+    expect(
+      store.isRevealed(
+        "msg-1",
+        "group-1",
+        null,
+        "sender-1",
+        "xmtp.org/text:1.0" as ContentTypeId,
+      ),
+    ).toBe(true);
+
+    expect(
+      store.isRevealed(
+        "msg-2",
+        "group-1",
+        null,
+        "sender-1",
+        "xmtp.org/reaction:1.0" as ContentTypeId,
+      ),
+    ).toBe(false);
+  });
+
+  test("expired reveal returns false from isRevealed and is cleaned by expireStale", () => {
+    const store = createRevealStateStore();
+    const pastDate = "2024-01-01T00:00:00Z";
+    store.grant(
+      makeGrant({ expiresAt: pastDate }),
+      makeRequest({ expiresAt: pastDate }),
+    );
+
+    // isRevealed checks expiry inline -- already-expired grant returns false
+    expect(
+      store.isRevealed(
+        "msg-1",
+        "group-1",
+        null,
+        "sender-1",
+        "xmtp.org/text:1.0" as ContentTypeId,
+      ),
+    ).toBe(false);
+
+    // expireStale removes the entry from the store entirely
+    const removed = store.expireStale(new Date("2025-01-01T00:00:00Z"));
+    expect(removed).toBe(1);
+
+    // Still false after cleanup
+    expect(
+      store.isRevealed(
+        "msg-1",
+        "group-1",
+        null,
+        "sender-1",
+        "xmtp.org/text:1.0" as ContentTypeId,
+      ),
+    ).toBe(false);
+  });
+
+  test("permanent reveal (expiresAt null) is not expired", () => {
+    const store = createRevealStateStore();
+    store.grant(makeGrant({ expiresAt: null }), makeRequest());
+
+    const removed = store.expireStale(new Date("2099-01-01T00:00:00Z"));
+    expect(removed).toBe(0);
+
+    expect(
+      store.isRevealed(
+        "msg-1",
+        "group-1",
+        null,
+        "sender-1",
+        "xmtp.org/text:1.0" as ContentTypeId,
+      ),
+    ).toBe(true);
+  });
+
+  test("snapshot and restore round-trip preserves isRevealed behavior", () => {
+    const store = createRevealStateStore();
+    store.grant(
+      makeGrant(),
+      makeRequest({ scope: "message", targetId: "msg-1", groupId: "group-1" }),
+    );
+    store.grant(
+      makeGrant({ revealId: "rev-thread" }),
+      makeRequest({
+        revealId: "rev-thread",
+        scope: "thread",
+        targetId: "thread-1",
+        groupId: "group-1",
+      }),
+    );
+
+    const snapshot = store.snapshot();
+    expect(snapshot.activeReveals.length).toBe(2);
+
+    const store2 = createRevealStateStore();
+    store2.restore(snapshot);
+
+    // After restore, isRevealed must still work correctly
+    expect(
+      store2.isRevealed(
+        "msg-1",
+        "group-1",
+        null,
+        "sender-1",
+        "xmtp.org/text:1.0" as ContentTypeId,
+      ),
+    ).toBe(true);
+
+    expect(
+      store2.isRevealed(
+        "msg-99",
+        "group-1",
+        "thread-1",
+        "sender-1",
+        "xmtp.org/text:1.0" as ContentTypeId,
+      ),
+    ).toBe(true);
+
+    // Non-matching still returns false
+    expect(
+      store2.isRevealed(
+        "msg-99",
+        "group-1",
+        null,
+        "sender-1",
+        "xmtp.org/text:1.0" as ContentTypeId,
+      ),
+    ).toBe(false);
+  });
+
+  test("snapshot includes request data for each reveal", () => {
+    const store = createRevealStateStore();
+    store.grant(
+      makeGrant(),
+      makeRequest({ groupId: "group-1", scope: "sender", targetId: "s-1" }),
+    );
+
+    const snapshot = store.snapshot();
+    expect(snapshot.activeReveals.length).toBe(1);
+    const entry = snapshot.activeReveals[0];
+    expect(entry).toBeDefined();
+    expect(entry!.request.groupId).toBe("group-1");
+    expect(entry!.request.scope).toBe("sender");
+    expect(entry!.request.targetId).toBe("s-1");
+  });
+
+  test("isRevealed returns false for expired grant without calling expireStale", () => {
+    const store = createRevealStateStore();
+    const pastDate = "2020-01-01T00:00:00Z";
+    store.grant(
+      makeGrant({ expiresAt: pastDate }),
+      makeRequest({ scope: "message", targetId: "msg-1" }),
+    );
+
+    // The grant is expired — isRevealed should check expiry inline
+    expect(
+      store.isRevealed(
+        "msg-1",
+        "group-1",
+        null,
+        "sender-1",
+        "xmtp.org/text:1.0" as ContentTypeId,
+      ),
+    ).toBe(false);
+  });
+
+  test("isRevealed returns true for non-expired grant with future expiry", () => {
+    const store = createRevealStateStore();
+    const futureDate = "2099-01-01T00:00:00Z";
+    store.grant(
+      makeGrant({ expiresAt: futureDate }),
+      makeRequest({ scope: "message", targetId: "msg-1" }),
+    );
+
+    expect(
+      store.isRevealed(
+        "msg-1",
+        "group-1",
+        null,
+        "sender-1",
+        "xmtp.org/text:1.0" as ContentTypeId,
+      ),
+    ).toBe(true);
+  });
+
+  test("grant scoped to different group does not match", () => {
+    const store = createRevealStateStore();
+    store.grant(
+      makeGrant(),
+      makeRequest({ groupId: "group-2", scope: "message", targetId: "msg-1" }),
+    );
+
+    expect(
+      store.isRevealed(
+        "msg-1",
+        "group-1",
+        null,
+        "sender-1",
+        "xmtp.org/text:1.0" as ContentTypeId,
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/policy/src/__tests__/scope-filter.test.ts
+++ b/packages/policy/src/__tests__/scope-filter.test.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect } from "bun:test";
+import { isInScope } from "../pipeline/scope-filter.js";
+import type { ThreadScope } from "@xmtp-broker/schemas";
+
+describe("isInScope", () => {
+  test("returns true when message groupId matches a scope with null threadId", () => {
+    const scopes: readonly ThreadScope[] = [
+      { groupId: "group-1", threadId: null },
+    ];
+    expect(isInScope({ groupId: "group-1", threadId: null }, scopes)).toBe(
+      true,
+    );
+  });
+
+  test("returns true when message groupId and threadId match a scope", () => {
+    const scopes: readonly ThreadScope[] = [
+      { groupId: "group-1", threadId: "thread-1" },
+    ];
+    expect(
+      isInScope({ groupId: "group-1", threadId: "thread-1" }, scopes),
+    ).toBe(true);
+  });
+
+  test("returns false when message groupId does not match any scope", () => {
+    const scopes: readonly ThreadScope[] = [
+      { groupId: "group-1", threadId: null },
+    ];
+    expect(isInScope({ groupId: "group-2", threadId: null }, scopes)).toBe(
+      false,
+    );
+  });
+
+  test("null threadId scope matches any thread in that group", () => {
+    const scopes: readonly ThreadScope[] = [
+      { groupId: "group-1", threadId: null },
+    ];
+    expect(
+      isInScope({ groupId: "group-1", threadId: "thread-42" }, scopes),
+    ).toBe(true);
+  });
+
+  test("specific threadId scope does not match a different thread", () => {
+    const scopes: readonly ThreadScope[] = [
+      { groupId: "group-1", threadId: "thread-1" },
+    ];
+    expect(
+      isInScope({ groupId: "group-1", threadId: "thread-2" }, scopes),
+    ).toBe(false);
+  });
+
+  test("specific threadId scope does not match null threadId message", () => {
+    const scopes: readonly ThreadScope[] = [
+      { groupId: "group-1", threadId: "thread-1" },
+    ];
+    expect(isInScope({ groupId: "group-1", threadId: null }, scopes)).toBe(
+      false,
+    );
+  });
+
+  test("returns true when any of multiple scopes match", () => {
+    const scopes: readonly ThreadScope[] = [
+      { groupId: "group-1", threadId: "thread-1" },
+      { groupId: "group-2", threadId: null },
+    ];
+    expect(
+      isInScope({ groupId: "group-2", threadId: "thread-5" }, scopes),
+    ).toBe(true);
+  });
+
+  test("returns false for empty scopes array", () => {
+    expect(isInScope({ groupId: "group-1", threadId: null }, [])).toBe(false);
+  });
+});

--- a/packages/policy/src/__tests__/smoke.test.ts
+++ b/packages/policy/src/__tests__/smoke.test.ts
@@ -1,7 +1,0 @@
-import { describe, expect, it } from "bun:test";
-
-describe("workspace", () => {
-  it("test runner works", () => {
-    expect(true).toBe(true);
-  });
-});

--- a/packages/policy/src/__tests__/validate-egress.test.ts
+++ b/packages/policy/src/__tests__/validate-egress.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from "bun:test";
+import { validateEgress } from "../grant/validate-egress.js";
+import { Result } from "better-result";
+import { createFullGrant, createDenyAllGrant } from "./fixtures.js";
+
+describe("validateEgress", () => {
+  const actions = [
+    "storeExcerpts",
+    "useForMemory",
+    "forwardToProviders",
+    "quoteRevealed",
+    "summarize",
+  ] as const;
+
+  for (const action of actions) {
+    test(`succeeds when egress.${action} is true`, () => {
+      const result = validateEgress(action, createFullGrant());
+      expect(Result.isOk(result)).toBe(true);
+    });
+
+    test(`returns GrantDeniedError when egress.${action} is false`, () => {
+      const result = validateEgress(action, createDenyAllGrant());
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error._tag).toBe("GrantDeniedError");
+      }
+    });
+  }
+});

--- a/packages/policy/src/__tests__/validate-group-management.test.ts
+++ b/packages/policy/src/__tests__/validate-group-management.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from "bun:test";
+import { validateGroupManagement } from "../grant/validate-group-management.js";
+import { Result } from "better-result";
+import {
+  createFullGrant,
+  createDenyAllGrant,
+  createPassthroughView,
+} from "./fixtures.js";
+
+describe("validateGroupManagement", () => {
+  const actions = [
+    "addMembers",
+    "removeMembers",
+    "updateMetadata",
+    "inviteUsers",
+  ] as const;
+
+  for (const action of actions) {
+    test(`succeeds when groupManagement.${action} is true`, () => {
+      const result = validateGroupManagement(
+        action,
+        { groupId: "group-1" },
+        createFullGrant(),
+        createPassthroughView("group-1"),
+      );
+      expect(Result.isOk(result)).toBe(true);
+    });
+
+    test(`returns GrantDeniedError when groupManagement.${action} is false`, () => {
+      const result = validateGroupManagement(
+        action,
+        { groupId: "group-1" },
+        createDenyAllGrant(),
+        createPassthroughView("group-1"),
+      );
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error._tag).toBe("GrantDeniedError");
+      }
+    });
+  }
+
+  test("returns PermissionError when group not in view", () => {
+    const result = validateGroupManagement(
+      "addMembers",
+      { groupId: "group-other" },
+      createFullGrant(),
+      createPassthroughView("group-1"),
+    );
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error._tag).toBe("PermissionError");
+    }
+  });
+});

--- a/packages/policy/src/__tests__/validate-reaction.test.ts
+++ b/packages/policy/src/__tests__/validate-reaction.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from "bun:test";
+import { validateSendReaction } from "../grant/validate-reaction.js";
+import { Result } from "better-result";
+import {
+  createFullGrant,
+  createDenyAllGrant,
+  createPassthroughView,
+} from "./fixtures.js";
+
+describe("validateSendReaction", () => {
+  test("succeeds when messaging.react is true", () => {
+    const result = validateSendReaction(
+      { groupId: "group-1", messageId: "msg-1" },
+      createFullGrant(),
+      createPassthroughView("group-1"),
+    );
+    expect(Result.isOk(result)).toBe(true);
+  });
+
+  test("returns GrantDeniedError when messaging.react is false", () => {
+    const result = validateSendReaction(
+      { groupId: "group-1", messageId: "msg-1" },
+      createDenyAllGrant(),
+      createPassthroughView("group-1"),
+    );
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error._tag).toBe("GrantDeniedError");
+    }
+  });
+
+  test("returns PermissionError when group not in view", () => {
+    const result = validateSendReaction(
+      { groupId: "group-other", messageId: "msg-1" },
+      createFullGrant(),
+      createPassthroughView("group-1"),
+    );
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error._tag).toBe("PermissionError");
+    }
+  });
+});

--- a/packages/policy/src/__tests__/validate-send.test.ts
+++ b/packages/policy/src/__tests__/validate-send.test.ts
@@ -1,0 +1,123 @@
+import { describe, test, expect } from "bun:test";
+import {
+  validateSendMessage,
+  validateSendReply,
+} from "../grant/validate-send.js";
+import { Result } from "better-result";
+import type { ContentTypeId } from "@xmtp-broker/schemas";
+import {
+  createFullGrant,
+  createDenyAllGrant,
+  createPassthroughView,
+} from "./fixtures.js";
+
+describe("validateSendMessage", () => {
+  test("succeeds when messaging.send is true", () => {
+    const result = validateSendMessage(
+      { groupId: "group-1", contentType: "xmtp.org/text:1.0" as ContentTypeId },
+      createFullGrant(),
+      createPassthroughView("group-1"),
+    );
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isOk(result)) {
+      expect(result.value.draftOnly).toBe(false);
+    }
+  });
+
+  test("returns GrantDeniedError when messaging.send is false", () => {
+    const result = validateSendMessage(
+      { groupId: "group-1", contentType: "xmtp.org/text:1.0" as ContentTypeId },
+      createDenyAllGrant(),
+      createPassthroughView("group-1"),
+    );
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error._tag).toBe("GrantDeniedError");
+    }
+  });
+
+  test("returns PermissionError when group not in view", () => {
+    const result = validateSendMessage(
+      {
+        groupId: "group-other",
+        contentType: "xmtp.org/text:1.0" as ContentTypeId,
+      },
+      createFullGrant(),
+      createPassthroughView("group-1"),
+    );
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error._tag).toBe("PermissionError");
+    }
+  });
+
+  test("returns draftOnly true when messaging.draftOnly is true", () => {
+    const grant = {
+      ...createFullGrant(),
+      messaging: { send: true, reply: true, react: true, draftOnly: true },
+    };
+    const result = validateSendMessage(
+      { groupId: "group-1", contentType: "xmtp.org/text:1.0" as ContentTypeId },
+      grant,
+      createPassthroughView("group-1"),
+    );
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isOk(result)) {
+      expect(result.value.draftOnly).toBe(true);
+    }
+  });
+});
+
+describe("validateSendReply", () => {
+  test("succeeds when messaging.reply is true", () => {
+    const result = validateSendReply(
+      {
+        groupId: "group-1",
+        messageId: "msg-1",
+        contentType: "xmtp.org/text:1.0" as ContentTypeId,
+      },
+      createFullGrant(),
+      createPassthroughView("group-1"),
+    );
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isOk(result)) {
+      expect(result.value.draftOnly).toBe(false);
+    }
+  });
+
+  test("returns GrantDeniedError when messaging.reply is false", () => {
+    const result = validateSendReply(
+      {
+        groupId: "group-1",
+        messageId: "msg-1",
+        contentType: "xmtp.org/text:1.0" as ContentTypeId,
+      },
+      createDenyAllGrant(),
+      createPassthroughView("group-1"),
+    );
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error._tag).toBe("GrantDeniedError");
+    }
+  });
+
+  test("returns draftOnly true when messaging.draftOnly is true", () => {
+    const grant = {
+      ...createFullGrant(),
+      messaging: { send: true, reply: true, react: true, draftOnly: true },
+    };
+    const result = validateSendReply(
+      {
+        groupId: "group-1",
+        messageId: "msg-1",
+        contentType: "xmtp.org/text:1.0" as ContentTypeId,
+      },
+      grant,
+      createPassthroughView("group-1"),
+    );
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isOk(result)) {
+      expect(result.value.draftOnly).toBe(true);
+    }
+  });
+});

--- a/packages/policy/src/__tests__/validate-tool.test.ts
+++ b/packages/policy/src/__tests__/validate-tool.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect } from "bun:test";
+import { validateToolUse } from "../grant/validate-tool.js";
+import { Result } from "better-result";
+import { createFullGrant } from "./fixtures.js";
+import type { GrantConfig } from "@xmtp-broker/schemas";
+
+describe("validateToolUse", () => {
+  test("succeeds when toolId is in scopes with allowed: true", () => {
+    const grant: GrantConfig = {
+      ...createFullGrant(),
+      tools: {
+        scopes: [{ toolId: "web-search", allowed: true, parameters: null }],
+      },
+    };
+    const result = validateToolUse("web-search", null, grant);
+    expect(Result.isOk(result)).toBe(true);
+  });
+
+  test("returns GrantDeniedError when toolId is not in scopes", () => {
+    const grant: GrantConfig = {
+      ...createFullGrant(),
+      tools: { scopes: [] },
+    };
+    const result = validateToolUse("web-search", null, grant);
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error._tag).toBe("GrantDeniedError");
+    }
+  });
+
+  test("returns GrantDeniedError when toolId is in scopes but allowed: false", () => {
+    const grant: GrantConfig = {
+      ...createFullGrant(),
+      tools: {
+        scopes: [{ toolId: "web-search", allowed: false, parameters: null }],
+      },
+    };
+    const result = validateToolUse("web-search", null, grant);
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isError(result)) {
+      expect(result.error._tag).toBe("GrantDeniedError");
+    }
+  });
+
+  test("succeeds when tool has parameter constraints and request params are provided", () => {
+    const grant: GrantConfig = {
+      ...createFullGrant(),
+      tools: {
+        scopes: [
+          {
+            toolId: "web-search",
+            allowed: true,
+            parameters: { maxResults: 10 },
+          },
+        ],
+      },
+    };
+    const result = validateToolUse("web-search", { maxResults: 5 }, grant);
+    expect(Result.isOk(result)).toBe(true);
+  });
+
+  test("succeeds when tool has null parameters (unconstrained)", () => {
+    const grant: GrantConfig = {
+      ...createFullGrant(),
+      tools: {
+        scopes: [{ toolId: "web-search", allowed: true, parameters: null }],
+      },
+    };
+    const result = validateToolUse("web-search", { anything: "goes" }, grant);
+    expect(Result.isOk(result)).toBe(true);
+  });
+});

--- a/packages/policy/src/__tests__/visibility-resolver.test.ts
+++ b/packages/policy/src/__tests__/visibility-resolver.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from "bun:test";
+import { resolveVisibility } from "../pipeline/visibility-resolver.js";
+
+describe("resolveVisibility", () => {
+  test("full mode returns visible regardless of reveal", () => {
+    expect(resolveVisibility("full", false)).toBe("visible");
+    expect(resolveVisibility("full", true)).toBe("visible");
+  });
+
+  test("thread-only mode returns visible (already passed scope filter)", () => {
+    expect(resolveVisibility("thread-only", false)).toBe("visible");
+    expect(resolveVisibility("thread-only", true)).toBe("visible");
+  });
+
+  test("redacted mode returns redacted without reveal", () => {
+    expect(resolveVisibility("redacted", false)).toBe("redacted");
+  });
+
+  test("redacted mode returns revealed with active reveal", () => {
+    expect(resolveVisibility("redacted", true)).toBe("revealed");
+  });
+
+  test("reveal-only mode returns hidden without reveal", () => {
+    expect(resolveVisibility("reveal-only", false)).toBe("hidden");
+  });
+
+  test("reveal-only mode returns revealed with active reveal", () => {
+    expect(resolveVisibility("reveal-only", true)).toBe("revealed");
+  });
+
+  test("summary-only mode returns redacted without reveal", () => {
+    expect(resolveVisibility("summary-only", false)).toBe("redacted");
+  });
+
+  test("summary-only mode returns revealed with active reveal", () => {
+    expect(resolveVisibility("summary-only", true)).toBe("revealed");
+  });
+});

--- a/packages/policy/src/allowlist.ts
+++ b/packages/policy/src/allowlist.ts
@@ -1,0 +1,60 @@
+import { Result } from "better-result";
+import {
+  type ContentTypeId,
+  type ViewMode,
+  ValidationError,
+} from "@xmtp-broker/schemas";
+import type { BrokerContentTypeConfig } from "./types.js";
+
+/**
+ * Validates that a view mode is supported in the current version.
+ * Rejects `summary-only` which is not implemented in v0.
+ */
+export function validateViewMode(
+  mode: ViewMode,
+): Result<void, ValidationError> {
+  if (mode === "summary-only") {
+    return Result.err(
+      ValidationError.create(
+        "viewMode",
+        "summary-only mode is not supported in v0",
+        { value: mode },
+      ),
+    );
+  }
+  return Result.ok(undefined);
+}
+
+/**
+ * Computes the effective allowlist as the intersection of
+ * baseline, broker-level, and agent view-level allowlists.
+ *
+ * effectiveAllowlist = baseline ∩ broker ∩ agent
+ *
+ * Returns ValidationError if the intersection is empty.
+ */
+export function resolveEffectiveAllowlist(
+  baseline: readonly ContentTypeId[],
+  brokerConfig: BrokerContentTypeConfig,
+  agentAllowlist: readonly ContentTypeId[],
+): Result<ReadonlySet<ContentTypeId>, ValidationError> {
+  const baselineSet = new Set(baseline);
+  const effective = new Set<ContentTypeId>();
+
+  for (const ct of agentAllowlist) {
+    if (baselineSet.has(ct) && brokerConfig.allowlist.has(ct)) {
+      effective.add(ct);
+    }
+  }
+
+  if (effective.size === 0) {
+    return Result.err(
+      ValidationError.create(
+        "contentTypes",
+        "Effective content type allowlist is empty: no types are permitted across baseline, broker, and agent allowlists",
+      ),
+    );
+  }
+
+  return Result.ok(effective);
+}

--- a/packages/policy/src/grant/scope-check.ts
+++ b/packages/policy/src/grant/scope-check.ts
@@ -1,0 +1,22 @@
+import { Result } from "better-result";
+import { type ViewConfig, PermissionError } from "@xmtp-broker/schemas";
+
+/**
+ * Checks that the request's groupId appears in at least one of the
+ * view's threadScopes. An agent cannot act on groups it cannot see.
+ */
+export function checkGroupInScope(
+  groupId: string,
+  view: ViewConfig,
+): Result<void, PermissionError> {
+  const inScope = view.threadScopes.some((scope) => scope.groupId === groupId);
+  if (!inScope) {
+    return Result.err(
+      PermissionError.create(
+        `Group '${groupId}' is not in the agent's view scopes`,
+        { groupId },
+      ),
+    );
+  }
+  return Result.ok();
+}

--- a/packages/policy/src/grant/validate-egress.ts
+++ b/packages/policy/src/grant/validate-egress.ts
@@ -1,0 +1,24 @@
+import { Result } from "better-result";
+import { type GrantConfig, GrantDeniedError } from "@xmtp-broker/schemas";
+import type { GrantError } from "@xmtp-broker/contracts";
+
+type EgressAction =
+  | "storeExcerpts"
+  | "useForMemory"
+  | "forwardToProviders"
+  | "quoteRevealed"
+  | "summarize";
+
+/**
+ * Validates an egress action against the active grant.
+ */
+export function validateEgress(
+  action: EgressAction,
+  grant: GrantConfig,
+): Result<void, GrantError> {
+  if (!grant.egress[action]) {
+    return Result.err(GrantDeniedError.create(action, `egress.${action}`));
+  }
+
+  return Result.ok();
+}

--- a/packages/policy/src/grant/validate-group-management.ts
+++ b/packages/policy/src/grant/validate-group-management.ts
@@ -1,0 +1,37 @@
+import { Result } from "better-result";
+import {
+  type GrantConfig,
+  type ViewConfig,
+  GrantDeniedError,
+} from "@xmtp-broker/schemas";
+import type { GrantError } from "@xmtp-broker/contracts";
+import { checkGroupInScope } from "./scope-check.js";
+
+type GroupManagementAction =
+  | "addMembers"
+  | "removeMembers"
+  | "updateMetadata"
+  | "inviteUsers";
+
+/**
+ * Validates a group management action against the active grant.
+ */
+export function validateGroupManagement(
+  action: GroupManagementAction,
+  request: { groupId: string },
+  grant: GrantConfig,
+  view: ViewConfig,
+): Result<void, GrantError> {
+  const scopeResult = checkGroupInScope(request.groupId, view);
+  if (scopeResult.isErr()) {
+    return Result.err(scopeResult.error);
+  }
+
+  if (!grant.groupManagement[action]) {
+    return Result.err(
+      GrantDeniedError.create(action, `groupManagement.${action}`),
+    );
+  }
+
+  return Result.ok();
+}

--- a/packages/policy/src/grant/validate-reaction.ts
+++ b/packages/policy/src/grant/validate-reaction.ts
@@ -1,0 +1,30 @@
+import { Result } from "better-result";
+import {
+  type GrantConfig,
+  type ViewConfig,
+  GrantDeniedError,
+} from "@xmtp-broker/schemas";
+import type { GrantError } from "@xmtp-broker/contracts";
+import { checkGroupInScope } from "./scope-check.js";
+
+/**
+ * Validates a send_reaction request against the active grant.
+ */
+export function validateSendReaction(
+  request: { groupId: string; messageId: string },
+  grant: GrantConfig,
+  view: ViewConfig,
+): Result<void, GrantError> {
+  const scopeResult = checkGroupInScope(request.groupId, view);
+  if (scopeResult.isErr()) {
+    return Result.err(scopeResult.error);
+  }
+
+  if (!grant.messaging.react) {
+    return Result.err(
+      GrantDeniedError.create("send_reaction", "messaging.react"),
+    );
+  }
+
+  return Result.ok();
+}

--- a/packages/policy/src/grant/validate-send.ts
+++ b/packages/policy/src/grant/validate-send.ts
@@ -1,0 +1,51 @@
+import { Result } from "better-result";
+import {
+  type ContentTypeId,
+  type GrantConfig,
+  type ViewConfig,
+  GrantDeniedError,
+} from "@xmtp-broker/schemas";
+import type { GrantError } from "@xmtp-broker/contracts";
+import { checkGroupInScope } from "./scope-check.js";
+
+/**
+ * Validates a send_message request against the active grant.
+ */
+export function validateSendMessage(
+  request: { groupId: string; contentType: ContentTypeId },
+  grant: GrantConfig,
+  view: ViewConfig,
+): Result<{ draftOnly: boolean }, GrantError> {
+  const scopeResult = checkGroupInScope(request.groupId, view);
+  if (scopeResult.isErr()) {
+    return Result.err(scopeResult.error);
+  }
+
+  if (!grant.messaging.send) {
+    return Result.err(
+      GrantDeniedError.create("send_message", "messaging.send"),
+    );
+  }
+
+  return Result.ok({ draftOnly: grant.messaging.draftOnly });
+}
+
+/**
+ * Validates a send_reply request against the active grant.
+ */
+export function validateSendReply(
+  request: { groupId: string; messageId: string; contentType: ContentTypeId },
+  grant: GrantConfig,
+  view: ViewConfig,
+): Result<{ draftOnly: boolean }, GrantError> {
+  const scopeResult = checkGroupInScope(request.groupId, view);
+  if (scopeResult.isErr()) {
+    return Result.err(scopeResult.error);
+  }
+
+  if (!grant.messaging.reply) {
+    return Result.err(GrantDeniedError.create("send_reply", "messaging.reply"));
+  }
+
+  return Result.ok({ draftOnly: grant.messaging.draftOnly });
+}

--- a/packages/policy/src/grant/validate-tool.ts
+++ b/packages/policy/src/grant/validate-tool.ts
@@ -1,0 +1,25 @@
+import { Result } from "better-result";
+import { type GrantConfig, GrantDeniedError } from "@xmtp-broker/schemas";
+import type { GrantError } from "@xmtp-broker/contracts";
+
+/**
+ * Validates a tool invocation against the active grant.
+ *
+ * The toolId must appear in grant.tools.scopes with allowed: true.
+ * Deep parameter constraint validation is deferred to Phase 2.
+ */
+export function validateToolUse(
+  toolId: string,
+  _parameters: Record<string, unknown> | null,
+  grant: GrantConfig,
+): Result<void, GrantError> {
+  const scope = grant.tools.scopes.find((s) => s.toolId === toolId);
+
+  if (!scope || !scope.allowed) {
+    return Result.err(
+      GrantDeniedError.create(`tool:${toolId}`, "tools.scopes"),
+    );
+  }
+
+  return Result.ok();
+}

--- a/packages/policy/src/index.ts
+++ b/packages/policy/src/index.ts
@@ -1,2 +1,38 @@
-// Placeholder — real exports added by subsequent specs.
-export {};
+// Types
+export type {
+  RawMessage,
+  ProjectionResult,
+  BrokerContentTypeConfig,
+} from "./types.js";
+
+// View projection pipeline
+export { projectMessage } from "./pipeline/project-message.js";
+export { isInScope } from "./pipeline/scope-filter.js";
+export { isContentTypeAllowed } from "./pipeline/content-type-filter.js";
+export { resolveVisibility } from "./pipeline/visibility-resolver.js";
+export { projectContent } from "./pipeline/content-projector.js";
+
+// Content type allowlist
+export { resolveEffectiveAllowlist, validateViewMode } from "./allowlist.js";
+
+// Grant validation
+export {
+  validateSendMessage,
+  validateSendReply,
+} from "./grant/validate-send.js";
+export { validateSendReaction } from "./grant/validate-reaction.js";
+export { validateGroupManagement } from "./grant/validate-group-management.js";
+export { validateToolUse } from "./grant/validate-tool.js";
+export { validateEgress } from "./grant/validate-egress.js";
+export { checkGroupInScope } from "./grant/scope-check.js";
+
+// Reveal state
+export { createRevealStateStore } from "./reveal-state.js";
+export type {
+  RevealStateStore,
+  RevealStateSnapshot,
+  RevealStateEntry,
+} from "./reveal-state.js";
+
+// Materiality classifier
+export { isMaterialChange, requiresReauthorization } from "./materiality.js";

--- a/packages/policy/src/materiality.ts
+++ b/packages/policy/src/materiality.ts
@@ -1,0 +1,162 @@
+import type { PolicyDelta } from "@xmtp-broker/contracts";
+
+/** Material field prefixes that trigger attestation. */
+const MATERIAL_FIELD_PREFIXES = [
+  "view.mode",
+  "view.threadScopes",
+  "view.contentTypes",
+  "grant.messaging",
+  "grant.groupManagement",
+  "grant.tools",
+  "grant.egress",
+] as const;
+
+/** View mode ordering from narrow to broad. */
+const VIEW_MODE_ORDER: Record<string, number> = {
+  "reveal-only": 0,
+  "summary-only": 1,
+  redacted: 2,
+  "thread-only": 3,
+  full: 4,
+};
+
+/** Fields where false -> true is a privilege escalation. */
+const ESCALATION_FIELD_PREFIXES = [
+  "grant.egress",
+  "grant.groupManagement",
+  "grant.messaging",
+  "grant.tools",
+] as const;
+
+function isMaterialField(field: string): boolean {
+  return MATERIAL_FIELD_PREFIXES.some((prefix) => field.startsWith(prefix));
+}
+
+/**
+ * Classifies whether any delta in a set of policy changes is material
+ * (triggers attestation) or routine (silent).
+ */
+export function isMaterialChange(deltas: readonly PolicyDelta[]): boolean {
+  return deltas.some((delta) => isSingleDeltaMaterial(delta));
+}
+
+function isSingleDeltaMaterial(delta: PolicyDelta): boolean {
+  // Content type changes are always material
+  if (
+    delta.contentTypeChanges.added.length > 0 ||
+    delta.contentTypeChanges.removed.length > 0
+  ) {
+    return true;
+  }
+
+  // Check view changes
+  for (const change of delta.viewChanges) {
+    if (isMaterialField(change.field)) {
+      return true;
+    }
+  }
+
+  // Check grant changes
+  for (const change of delta.grantChanges) {
+    if (isMaterialField(change.field)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Classifies whether any delta in a set of policy changes requires
+ * session reauthorization (privilege escalation).
+ *
+ * Stricter subset of material changes: only escalations
+ * (expanding from false to true or from narrower to broader mode).
+ */
+export function requiresReauthorization(
+  deltas: readonly PolicyDelta[],
+): boolean {
+  return deltas.some((delta) => isSingleDeltaEscalation(delta));
+}
+
+function isSingleDeltaEscalation(delta: PolicyDelta): boolean {
+  // Check view mode escalation
+  for (const change of delta.viewChanges) {
+    if (change.field === "view.mode") {
+      if (typeof change.from === "string" && typeof change.to === "string") {
+        const oldOrder = VIEW_MODE_ORDER[change.from];
+        const newOrder = VIEW_MODE_ORDER[change.to];
+        if (
+          oldOrder !== undefined &&
+          newOrder !== undefined &&
+          newOrder > oldOrder
+        ) {
+          return true;
+        }
+      }
+    }
+  }
+
+  // Check grant escalations (false -> true)
+  for (const change of delta.grantChanges) {
+    if (change.field === "grant.tools.scopes") {
+      if (hasToolScopeEscalation(change.from, change.to)) {
+        return true;
+      }
+      continue;
+    }
+
+    const isEscalationField = ESCALATION_FIELD_PREFIXES.some((prefix) =>
+      change.field.startsWith(prefix),
+    );
+    if (
+      isEscalationField &&
+      change.field !== "grant.messaging.draftOnly" &&
+      change.from === false &&
+      change.to === true
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasToolScopeEscalation(from: unknown, to: unknown): boolean {
+  if (!Array.isArray(to)) {
+    return false;
+  }
+
+  const previousAllowed = new Map<string, boolean>();
+  if (Array.isArray(from)) {
+    for (const scope of from) {
+      if (
+        scope &&
+        typeof scope === "object" &&
+        "toolId" in scope &&
+        typeof scope.toolId === "string" &&
+        "allowed" in scope &&
+        typeof scope.allowed === "boolean"
+      ) {
+        previousAllowed.set(scope.toolId, scope.allowed);
+      }
+    }
+  }
+
+  for (const scope of to) {
+    if (
+      scope &&
+      typeof scope === "object" &&
+      "toolId" in scope &&
+      typeof scope.toolId === "string" &&
+      "allowed" in scope &&
+      typeof scope.allowed === "boolean" &&
+      scope.allowed &&
+      previousAllowed.get(scope.toolId) !== true
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/packages/policy/src/pipeline/content-projector.ts
+++ b/packages/policy/src/pipeline/content-projector.ts
@@ -1,0 +1,24 @@
+import type { ContentTypeId, MessageVisibility } from "@xmtp-broker/schemas";
+
+/**
+ * Stage 4: Content projector. Applies redaction based on resolved visibility.
+ *
+ * - visible / historical / revealed: content passes through unchanged
+ * - redacted: content replaced with null (metadata preserved by caller)
+ * - hidden: unreachable in normal flow (dropped in stage 3), returns null defensively
+ */
+export function projectContent(
+  content: unknown,
+  _contentType: ContentTypeId,
+  visibility: MessageVisibility,
+): unknown {
+  switch (visibility) {
+    case "visible":
+    case "historical":
+    case "revealed":
+      return content;
+    case "redacted":
+    case "hidden":
+      return null;
+  }
+}

--- a/packages/policy/src/pipeline/content-type-filter.ts
+++ b/packages/policy/src/pipeline/content-type-filter.ts
@@ -1,0 +1,14 @@
+import type { ContentTypeId } from "@xmtp-broker/schemas";
+
+/**
+ * Stage 2: Content type filter. Returns true if the message's content
+ * type is in the effective allowlist.
+ *
+ * Unknown content types are dropped silently (default-deny).
+ */
+export function isContentTypeAllowed(
+  contentType: ContentTypeId,
+  allowlist: ReadonlySet<ContentTypeId>,
+): boolean {
+  return allowlist.has(contentType);
+}

--- a/packages/policy/src/pipeline/project-message.ts
+++ b/packages/policy/src/pipeline/project-message.ts
@@ -1,0 +1,67 @@
+import type {
+  ContentTypeId,
+  MessageEvent,
+  ViewConfig,
+} from "@xmtp-broker/schemas";
+import type { RawMessage, ProjectionResult } from "../types.js";
+import { isInScope } from "./scope-filter.js";
+import { isContentTypeAllowed } from "./content-type-filter.js";
+import { resolveVisibility } from "./visibility-resolver.js";
+import { projectContent } from "./content-projector.js";
+
+const DROP: ProjectionResult = { action: "drop" } as const;
+
+/**
+ * Projects a raw message through the view filter, content type filter,
+ * visibility logic, and content projection to produce a derived event or drop.
+ *
+ * Pure function. No side effects.
+ *
+ * @param message - The raw XMTP message, already decoded
+ * @param view - The active view configuration
+ * @param effectiveAllowlist - Pre-computed content type allowlist
+ * @param isRevealed - Whether this message has an active reveal grant
+ */
+export function projectMessage(
+  message: RawMessage,
+  view: ViewConfig,
+  effectiveAllowlist: ReadonlySet<ContentTypeId>,
+  isRevealed: boolean,
+): ProjectionResult {
+  // Stage 1: Scope filter
+  if (!isInScope(message, view.threadScopes)) {
+    return DROP;
+  }
+
+  // Stage 2: Content type filter
+  if (!isContentTypeAllowed(message.contentType, effectiveAllowlist)) {
+    return DROP;
+  }
+
+  // Stage 3: Visibility resolver
+  const visibility = resolveVisibility(view.mode, isRevealed);
+  if (visibility === "hidden") {
+    return DROP;
+  }
+
+  // Stage 4: Content projector
+  const content = projectContent(
+    message.content,
+    message.contentType,
+    visibility,
+  );
+
+  const event: MessageEvent = {
+    type: "message.visible",
+    messageId: message.messageId,
+    groupId: message.groupId,
+    senderInboxId: message.senderInboxId,
+    contentType: message.contentType,
+    content,
+    visibility,
+    sentAt: message.sentAt,
+    attestationId: message.attestationId,
+  };
+
+  return { action: "emit", event };
+}

--- a/packages/policy/src/pipeline/scope-filter.ts
+++ b/packages/policy/src/pipeline/scope-filter.ts
@@ -1,0 +1,27 @@
+import type { ThreadScope } from "@xmtp-broker/schemas";
+
+/**
+ * Stage 1: Scope filter. Returns true if the message falls within
+ * any of the view's thread scopes.
+ *
+ * A scope with `threadId: null` matches all threads in that group.
+ * A scope with a specific `threadId` matches only that thread.
+ */
+export function isInScope(
+  message: Pick<
+    { groupId: string; threadId: string | null },
+    "groupId" | "threadId"
+  >,
+  scopes: readonly ThreadScope[],
+): boolean {
+  return scopes.some((scope) => {
+    if (scope.groupId !== message.groupId) {
+      return false;
+    }
+    // null threadId in scope matches all threads in the group
+    if (scope.threadId === null) {
+      return true;
+    }
+    return scope.threadId === message.threadId;
+  });
+}

--- a/packages/policy/src/pipeline/visibility-resolver.ts
+++ b/packages/policy/src/pipeline/visibility-resolver.ts
@@ -1,0 +1,30 @@
+import type { MessageVisibility, ViewMode } from "@xmtp-broker/schemas";
+
+/**
+ * Stage 3: Visibility resolver. Determines the MessageVisibility
+ * for a message given the view mode and whether the message is revealed.
+ *
+ * | View Mode      | Default Visibility | With Active Reveal |
+ * |----------------|--------------------|--------------------|
+ * | full           | visible            | visible            |
+ * | thread-only    | visible            | visible            |
+ * | redacted       | redacted           | revealed           |
+ * | reveal-only    | hidden             | revealed           |
+ * | summary-only   | redacted           | revealed           |
+ */
+export function resolveVisibility(
+  mode: ViewMode,
+  isRevealed: boolean,
+): MessageVisibility {
+  switch (mode) {
+    case "full":
+    case "thread-only":
+      return "visible";
+    case "redacted":
+      return isRevealed ? "revealed" : "redacted";
+    case "reveal-only":
+      return isRevealed ? "revealed" : "hidden";
+    case "summary-only":
+      return isRevealed ? "revealed" : "redacted";
+  }
+}

--- a/packages/policy/src/reveal-state.ts
+++ b/packages/policy/src/reveal-state.ts
@@ -1,0 +1,139 @@
+import type {
+  ContentTypeId,
+  RevealGrant,
+  RevealRequest,
+} from "@xmtp-broker/schemas";
+
+/** Internal entry pairing a grant with its request context for matching. */
+interface RevealEntry {
+  readonly grant: RevealGrant;
+  readonly request: RevealRequest;
+}
+
+/** Serializable reveal entry that preserves request context for restore. */
+export interface RevealStateEntry {
+  readonly grant: RevealGrant;
+  readonly request: RevealRequest;
+}
+
+/** Snapshot format for the reveal state store. */
+export interface RevealStateSnapshot {
+  readonly activeReveals: readonly RevealStateEntry[];
+}
+
+/**
+ * In-memory reveal state store scoped to an agent session.
+ * Persisted by the session manager; the policy engine owns the logic.
+ */
+export interface RevealStateStore {
+  /** Add a reveal grant with its originating request. */
+  grant(reveal: RevealGrant, request: RevealRequest): void;
+
+  /** Check if a specific message is revealed by any active grant. */
+  isRevealed(
+    messageId: string,
+    groupId: string,
+    threadId: string | null,
+    senderInboxId: string,
+    contentType: ContentTypeId,
+  ): boolean;
+
+  /** Remove expired reveals. Returns count of removed grants. */
+  expireStale(now: Date): number;
+
+  /** Snapshot the current state for serialization. */
+  snapshot(): RevealStateSnapshot;
+
+  /** Restore from a serialized snapshot. */
+  restore(state: RevealStateSnapshot): void;
+}
+
+/**
+ * Creates a new in-memory reveal state store.
+ */
+export function createRevealStateStore(): RevealStateStore {
+  const entries: RevealEntry[] = [];
+
+  return {
+    grant(reveal: RevealGrant, request: RevealRequest): void {
+      entries.push({ grant: reveal, request });
+    },
+
+    isRevealed(
+      messageId: string,
+      groupId: string,
+      threadId: string | null,
+      senderInboxId: string,
+      contentType: ContentTypeId,
+    ): boolean {
+      const now = Date.now();
+
+      return entries.some((entry) => {
+        // Skip expired grants
+        if (
+          entry.grant.expiresAt !== null &&
+          new Date(entry.grant.expiresAt).getTime() <= now
+        ) {
+          return false;
+        }
+
+        // Must match the group
+        if (entry.request.groupId !== groupId) {
+          return false;
+        }
+
+        switch (entry.request.scope) {
+          case "message":
+            return entry.request.targetId === messageId;
+          case "thread":
+            return entry.request.targetId === threadId;
+          case "sender":
+            return entry.request.targetId === senderInboxId;
+          case "content-type":
+            return entry.request.targetId === contentType;
+          case "time-window":
+            // time-window not implemented in v0
+            return false;
+        }
+      });
+    },
+
+    expireStale(now: Date): number {
+      let removed = 0;
+      const nowMs = now.getTime();
+
+      for (let i = entries.length - 1; i >= 0; i--) {
+        const entry = entries[i];
+        if (entry === undefined) continue;
+        if (
+          entry.grant.expiresAt !== null &&
+          new Date(entry.grant.expiresAt).getTime() <= nowMs
+        ) {
+          entries.splice(i, 1);
+          removed++;
+        }
+      }
+
+      return removed;
+    },
+
+    snapshot(): RevealStateSnapshot {
+      return {
+        activeReveals: entries.map((e) => ({
+          grant: e.grant,
+          request: e.request,
+        })),
+      };
+    },
+
+    restore(state: RevealStateSnapshot): void {
+      entries.length = 0;
+      for (const entry of state.activeReveals) {
+        entries.push({
+          grant: entry.grant,
+          request: entry.request,
+        });
+      }
+    },
+  };
+}

--- a/packages/policy/src/types.ts
+++ b/packages/policy/src/types.ts
@@ -1,0 +1,27 @@
+import type { ContentTypeId, MessageEvent } from "@xmtp-broker/schemas";
+
+/**
+ * A raw message as received from the XMTP client, already decoded.
+ * Extends the contracts RawMessage with threadId and attestationId
+ * needed by the policy pipeline.
+ */
+export interface RawMessage {
+  readonly messageId: string;
+  readonly groupId: string;
+  readonly senderInboxId: string;
+  readonly contentType: ContentTypeId;
+  readonly content: unknown;
+  readonly sentAt: string;
+  readonly threadId: string | null;
+  readonly attestationId: string | null;
+}
+
+/** Result of projecting a raw message through the view pipeline. */
+export type ProjectionResult =
+  | { readonly action: "emit"; readonly event: MessageEvent }
+  | { readonly action: "drop" };
+
+/** Broker-level content type configuration. */
+export interface BrokerContentTypeConfig {
+  readonly allowlist: ReadonlySet<ContentTypeId>;
+}


### PR DESCRIPTION
## Context
This branch adds the policy layer that shapes what harnesses can see and do. Review this PR against `v0/broker-core`, not `main`.

## What Changed
- implements the projection pipeline for visibility resolution, scope filtering, content filtering, and message projection
- adds grant validators for send, reaction, egress, tool usage, and group management operations
- introduces reveal-state and allowlist helpers used to enforce broker policy decisions consistently
- adds materiality helpers used later by sessions and attestations to decide when policy changes matter
- includes targeted tests across the projection and validation surface

## Why This Branch Exists
The broker's value is controlled access, not raw XMTP passthrough. This PR defines the authorization and projection logic that makes that possible.

## Key Files
- `packages/policy/src/pipeline/*`
- `packages/policy/src/grant/*`
- `packages/policy/src/materiality.ts`
- `packages/policy/src/reveal-state.ts`
- `packages/policy/src/allowlist.ts`

## Verification
- policy package test suite under `packages/policy/src/__tests__`
- repo verification via pre-push stack checks (`lint`, `test`, `typecheck`)
