### PR TITLE
feat(sessions): add session manager, token model, and policy hashing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -84,6 +84,12 @@
     "packages/sessions": {
       "name": "@xmtp-broker/sessions",
       "version": "0.0.0",
+      "dependencies": {
+        "@xmtp-broker/contracts": "workspace:*",
+        "@xmtp-broker/schemas": "workspace:*",
+        "better-result": "catalog:",
+        "zod": "catalog:",
+      },
       "devDependencies": {
         "bun-types": "catalog:",
         "typescript": "catalog:",

--- a/packages/sessions/package.json
+++ b/packages/sessions/package.json
@@ -15,7 +15,12 @@
     "lint": "oxlint .",
     "test": "bun test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@xmtp-broker/contracts": "workspace:*",
+    "@xmtp-broker/schemas": "workspace:*",
+    "better-result": "catalog:",
+    "zod": "catalog:"
+  },
   "devDependencies": {
     "bun-types": "catalog:",
     "typescript": "catalog:"

--- a/packages/sessions/src/__tests__/fixtures.ts
+++ b/packages/sessions/src/__tests__/fixtures.ts
@@ -1,0 +1,50 @@
+import type {
+  SessionConfig,
+  ViewConfig,
+  GrantConfig,
+} from "@xmtp-broker/schemas";
+
+export const baseView: ViewConfig = {
+  mode: "redacted",
+  threadScopes: [{ groupId: "group-1", threadId: null }],
+  contentTypes: ["text"],
+};
+
+export const baseGrant: GrantConfig = {
+  messaging: { send: false, reply: false, react: false, draftOnly: true },
+  groupManagement: {
+    addMembers: false,
+    removeMembers: false,
+    updateMetadata: false,
+    inviteUsers: false,
+  },
+  tools: { scopes: [] },
+  egress: {
+    storeExcerpts: false,
+    useForMemory: false,
+    forwardToProviders: false,
+    quoteRevealed: false,
+    summarize: false,
+  },
+};
+
+export function createTestSessionConfig(
+  overrides?: Partial<SessionConfig>,
+): SessionConfig {
+  return {
+    agentInboxId: "agent-inbox-1",
+    view: baseView,
+    grant: baseGrant,
+    ttlSeconds: 3600,
+    heartbeatInterval: 30,
+    ...overrides,
+  };
+}
+
+export function createTestView(overrides?: Partial<ViewConfig>): ViewConfig {
+  return { ...baseView, ...overrides };
+}
+
+export function createTestGrant(overrides?: Partial<GrantConfig>): GrantConfig {
+  return { ...baseGrant, ...overrides };
+}

--- a/packages/sessions/src/__tests__/materiality.test.ts
+++ b/packages/sessions/src/__tests__/materiality.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from "bun:test";
+import type { ViewConfig } from "@xmtp-broker/schemas";
+import { checkMateriality } from "../materiality.js";
+import { baseView, baseGrant, createTestGrant } from "./fixtures.js";
+
+describe("checkMateriality", () => {
+  describe("view mode escalation (material)", () => {
+    test("redacted -> full is material", () => {
+      const oldView: ViewConfig = { ...baseView, mode: "redacted" };
+      const newView: ViewConfig = { ...baseView, mode: "full" };
+      const result = checkMateriality(oldView, baseGrant, newView, baseGrant);
+      expect(result.isMaterial).toBe(true);
+      expect(result.changedFields).toContain("view.mode");
+    });
+
+    test("redacted -> thread-only is material", () => {
+      const oldView: ViewConfig = { ...baseView, mode: "redacted" };
+      const newView: ViewConfig = { ...baseView, mode: "thread-only" };
+      const result = checkMateriality(oldView, baseGrant, newView, baseGrant);
+      expect(result.isMaterial).toBe(true);
+    });
+
+    test("summary-only -> full is material", () => {
+      const oldView: ViewConfig = { ...baseView, mode: "summary-only" };
+      const newView: ViewConfig = { ...baseView, mode: "full" };
+      const result = checkMateriality(oldView, baseGrant, newView, baseGrant);
+      expect(result.isMaterial).toBe(true);
+    });
+
+    test("summary-only -> thread-only is material", () => {
+      const oldView: ViewConfig = { ...baseView, mode: "summary-only" };
+      const newView: ViewConfig = { ...baseView, mode: "thread-only" };
+      const result = checkMateriality(oldView, baseGrant, newView, baseGrant);
+      expect(result.isMaterial).toBe(true);
+    });
+
+    test("reveal-only -> full is material", () => {
+      const oldView: ViewConfig = { ...baseView, mode: "reveal-only" };
+      const newView: ViewConfig = { ...baseView, mode: "full" };
+      const result = checkMateriality(oldView, baseGrant, newView, baseGrant);
+      expect(result.isMaterial).toBe(true);
+    });
+
+    test("reveal-only -> redacted is material", () => {
+      const oldView: ViewConfig = { ...baseView, mode: "reveal-only" };
+      const newView: ViewConfig = { ...baseView, mode: "redacted" };
+      const result = checkMateriality(oldView, baseGrant, newView, baseGrant);
+      expect(result.isMaterial).toBe(true);
+    });
+
+    test("thread-only -> full is material", () => {
+      const oldView: ViewConfig = { ...baseView, mode: "thread-only" };
+      const newView: ViewConfig = { ...baseView, mode: "full" };
+      const result = checkMateriality(oldView, baseGrant, newView, baseGrant);
+      expect(result.isMaterial).toBe(true);
+    });
+  });
+
+  describe("view mode reduction (non-material)", () => {
+    test("full -> redacted is non-material", () => {
+      const oldView: ViewConfig = { ...baseView, mode: "full" };
+      const newView: ViewConfig = { ...baseView, mode: "redacted" };
+      const result = checkMateriality(oldView, baseGrant, newView, baseGrant);
+      expect(result.isMaterial).toBe(false);
+    });
+
+    test("full -> thread-only is non-material", () => {
+      const oldView: ViewConfig = { ...baseView, mode: "full" };
+      const newView: ViewConfig = { ...baseView, mode: "thread-only" };
+      const result = checkMateriality(oldView, baseGrant, newView, baseGrant);
+      expect(result.isMaterial).toBe(false);
+    });
+
+    test("redacted -> reveal-only is non-material", () => {
+      const oldView: ViewConfig = { ...baseView, mode: "redacted" };
+      const newView: ViewConfig = { ...baseView, mode: "reveal-only" };
+      const result = checkMateriality(oldView, baseGrant, newView, baseGrant);
+      expect(result.isMaterial).toBe(false);
+    });
+
+    test("same mode is non-material", () => {
+      const result = checkMateriality(baseView, baseGrant, baseView, baseGrant);
+      expect(result.isMaterial).toBe(false);
+      expect(result.changedFields).toHaveLength(0);
+    });
+  });
+
+  describe("grant escalation (material)", () => {
+    test("messaging.send false -> true is material", () => {
+      const newGrant = createTestGrant({
+        messaging: { ...baseGrant.messaging, send: true },
+      });
+      const result = checkMateriality(baseView, baseGrant, baseView, newGrant);
+      expect(result.isMaterial).toBe(true);
+      expect(result.changedFields).toContain("grant.messaging.send");
+    });
+
+    test("messaging.draftOnly true -> false is material", () => {
+      const newGrant = createTestGrant({
+        messaging: { ...baseGrant.messaging, draftOnly: false },
+      });
+      const result = checkMateriality(baseView, baseGrant, baseView, newGrant);
+      expect(result.isMaterial).toBe(true);
+      expect(result.changedFields).toContain("grant.messaging.draftOnly");
+    });
+
+    test("groupManagement.addMembers false -> true is material", () => {
+      const newGrant = createTestGrant({
+        groupManagement: {
+          ...baseGrant.groupManagement,
+          addMembers: true,
+        },
+      });
+      const result = checkMateriality(baseView, baseGrant, baseView, newGrant);
+      expect(result.isMaterial).toBe(true);
+      expect(result.changedFields).toContain(
+        "grant.groupManagement.addMembers",
+      );
+    });
+
+    test("egress.storeExcerpts false -> true is material", () => {
+      const newGrant = createTestGrant({
+        egress: { ...baseGrant.egress, storeExcerpts: true },
+      });
+      const result = checkMateriality(baseView, baseGrant, baseView, newGrant);
+      expect(result.isMaterial).toBe(true);
+      expect(result.changedFields).toContain("grant.egress.storeExcerpts");
+    });
+
+    test("new tool scope added is material", () => {
+      const newGrant = createTestGrant({
+        tools: {
+          scopes: [{ toolId: "tool-1", allowed: true, parameters: null }],
+        },
+      });
+      const result = checkMateriality(baseView, baseGrant, baseView, newGrant);
+      expect(result.isMaterial).toBe(true);
+      expect(result.changedFields).toContain("grant.tools.scopes");
+    });
+
+    test("tool allowed false -> true is material", () => {
+      const oldGrant = createTestGrant({
+        tools: {
+          scopes: [{ toolId: "tool-1", allowed: false, parameters: null }],
+        },
+      });
+      const newGrant = createTestGrant({
+        tools: {
+          scopes: [{ toolId: "tool-1", allowed: true, parameters: null }],
+        },
+      });
+      const result = checkMateriality(baseView, oldGrant, baseView, newGrant);
+      expect(result.isMaterial).toBe(true);
+      expect(result.changedFields).toContain("grant.tools.scopes");
+    });
+  });
+
+  describe("grant reduction (non-material)", () => {
+    test("messaging.send true -> false is non-material", () => {
+      const oldGrant = createTestGrant({
+        messaging: { ...baseGrant.messaging, send: true },
+      });
+      const result = checkMateriality(baseView, oldGrant, baseView, baseGrant);
+      expect(result.isMaterial).toBe(false);
+    });
+
+    test("egress.storeExcerpts true -> false is non-material", () => {
+      const oldGrant = createTestGrant({
+        egress: { ...baseGrant.egress, storeExcerpts: true },
+      });
+      const result = checkMateriality(baseView, oldGrant, baseView, baseGrant);
+      expect(result.isMaterial).toBe(false);
+    });
+  });
+
+  describe("non-material changes", () => {
+    test("adding thread scopes is non-material", () => {
+      const newView: ViewConfig = {
+        ...baseView,
+        threadScopes: [
+          ...baseView.threadScopes,
+          { groupId: "group-2", threadId: "thread-1" },
+        ],
+      };
+      const result = checkMateriality(baseView, baseGrant, newView, baseGrant);
+      expect(result.isMaterial).toBe(false);
+    });
+
+    test("adding content types is non-material", () => {
+      const newView: ViewConfig = {
+        ...baseView,
+        contentTypes: [...baseView.contentTypes, "reaction"],
+      };
+      const result = checkMateriality(baseView, baseGrant, newView, baseGrant);
+      expect(result.isMaterial).toBe(false);
+    });
+
+    test("messaging.react false -> true is non-material", () => {
+      const newGrant = createTestGrant({
+        messaging: { ...baseGrant.messaging, react: true },
+      });
+      const result = checkMateriality(baseView, baseGrant, baseView, newGrant);
+      expect(result.isMaterial).toBe(false);
+    });
+
+    test("messaging.reply false -> true is non-material", () => {
+      const newGrant = createTestGrant({
+        messaging: { ...baseGrant.messaging, reply: true },
+      });
+      const result = checkMateriality(baseView, baseGrant, baseView, newGrant);
+      expect(result.isMaterial).toBe(false);
+    });
+  });
+
+  describe("multiple changes", () => {
+    test("material + non-material = material", () => {
+      const newView: ViewConfig = {
+        ...baseView,
+        mode: "full",
+        contentTypes: [...baseView.contentTypes, "reaction"],
+      };
+      const result = checkMateriality(baseView, baseGrant, newView, baseGrant);
+      expect(result.isMaterial).toBe(true);
+      expect(result.changedFields).toContain("view.mode");
+    });
+
+    test("reason is null when non-material", () => {
+      const result = checkMateriality(baseView, baseGrant, baseView, baseGrant);
+      expect(result.reason).toBeNull();
+    });
+
+    test("reason is set when material", () => {
+      const newView: ViewConfig = { ...baseView, mode: "full" };
+      const result = checkMateriality(baseView, baseGrant, newView, baseGrant);
+      expect(result.reason).not.toBeNull();
+      expect(typeof result.reason).toBe("string");
+    });
+  });
+});

--- a/packages/sessions/src/__tests__/policy-hash.test.ts
+++ b/packages/sessions/src/__tests__/policy-hash.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import type { ViewConfig, GrantConfig } from "@xmtp-broker/schemas";
+import { computePolicyHash } from "../policy-hash.js";
+
+const baseView: ViewConfig = {
+  mode: "full",
+  threadScopes: [{ groupId: "group-1", threadId: null }],
+  contentTypes: ["text"],
+};
+
+const baseGrant: GrantConfig = {
+  messaging: { send: true, reply: true, react: true, draftOnly: false },
+  groupManagement: {
+    addMembers: false,
+    removeMembers: false,
+    updateMetadata: false,
+    inviteUsers: false,
+  },
+  tools: { scopes: [] },
+  egress: {
+    storeExcerpts: false,
+    useForMemory: false,
+    forwardToProviders: false,
+    quoteRevealed: false,
+    summarize: false,
+  },
+};
+
+describe("computePolicyHash", () => {
+  test("returns a string", () => {
+    const hash = computePolicyHash(baseView, baseGrant);
+    expect(typeof hash).toBe("string");
+    expect(hash.length).toBeGreaterThan(0);
+  });
+
+  test("same input produces same hash", () => {
+    const hash1 = computePolicyHash(baseView, baseGrant);
+    const hash2 = computePolicyHash(baseView, baseGrant);
+    expect(hash1).toBe(hash2);
+  });
+
+  test("different key order produces same hash (canonical)", () => {
+    // Construct grant with keys in different order
+    const reorderedGrant = {
+      egress: baseGrant.egress,
+      tools: baseGrant.tools,
+      groupManagement: baseGrant.groupManagement,
+      messaging: baseGrant.messaging,
+    } as GrantConfig;
+
+    const hash1 = computePolicyHash(baseView, baseGrant);
+    const hash2 = computePolicyHash(baseView, reorderedGrant);
+    expect(hash1).toBe(hash2);
+  });
+
+  test("different view mode produces different hash", () => {
+    const differentView: ViewConfig = { ...baseView, mode: "redacted" };
+    const hash1 = computePolicyHash(baseView, baseGrant);
+    const hash2 = computePolicyHash(differentView, baseGrant);
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test("different grant produces different hash", () => {
+    const differentGrant: GrantConfig = {
+      ...baseGrant,
+      messaging: { ...baseGrant.messaging, send: false },
+    };
+    const hash1 = computePolicyHash(baseView, baseGrant);
+    const hash2 = computePolicyHash(baseView, differentGrant);
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test("reordered content types produce the same hash", () => {
+    const firstView: ViewConfig = {
+      ...baseView,
+      contentTypes: ["text", "alpha", "zeta"],
+    };
+    const secondView: ViewConfig = {
+      ...baseView,
+      contentTypes: ["zeta", "text", "alpha"],
+    };
+
+    expect(computePolicyHash(firstView, baseGrant)).toBe(
+      computePolicyHash(secondView, baseGrant),
+    );
+  });
+
+  test("reordered thread scopes produce the same hash", () => {
+    const firstView: ViewConfig = {
+      ...baseView,
+      threadScopes: [
+        { groupId: "group-2", threadId: "thread-2" },
+        { groupId: "group-1", threadId: null },
+      ],
+    };
+    const secondView: ViewConfig = {
+      ...baseView,
+      threadScopes: [
+        { groupId: "group-1", threadId: null },
+        { groupId: "group-2", threadId: "thread-2" },
+      ],
+    };
+
+    expect(computePolicyHash(firstView, baseGrant)).toBe(
+      computePolicyHash(secondView, baseGrant),
+    );
+  });
+
+  test("reordered tool scopes produce the same hash", () => {
+    const firstGrant: GrantConfig = {
+      ...baseGrant,
+      tools: {
+        scopes: [
+          { toolId: "tool-b", allowed: true, parameters: null },
+          { toolId: "tool-a", allowed: false, parameters: null },
+        ],
+      },
+    };
+    const secondGrant: GrantConfig = {
+      ...baseGrant,
+      tools: {
+        scopes: [
+          { toolId: "tool-a", allowed: false, parameters: null },
+          { toolId: "tool-b", allowed: true, parameters: null },
+        ],
+      },
+    };
+
+    expect(computePolicyHash(baseView, firstGrant)).toBe(
+      computePolicyHash(baseView, secondGrant),
+    );
+  });
+});

--- a/packages/sessions/src/__tests__/session-manager.test.ts
+++ b/packages/sessions/src/__tests__/session-manager.test.ts
@@ -1,0 +1,572 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { createSessionManager } from "../session-manager.js";
+import type { InternalSessionManager } from "../session-manager.js";
+import { createTestSessionConfig, baseView, baseGrant } from "./fixtures.js";
+import type { ViewConfig } from "@xmtp-broker/schemas";
+
+let manager: InternalSessionManager;
+
+beforeEach(() => {
+  manager = createSessionManager({
+    defaultTtlSeconds: 60,
+    maxConcurrentPerAgent: 3,
+    renewalWindowSeconds: 10,
+    heartbeatGracePeriod: 3,
+  });
+});
+
+describe("createSession", () => {
+  test("creates a session with correct fields", async () => {
+    const config = createTestSessionConfig();
+    const result = await manager.createSession(config, "fp_abc123");
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    expect(result.value.state).toBe("active");
+    expect(result.value.agentInboxId).toBe("agent-inbox-1");
+    expect(result.value.sessionKeyFingerprint).toBe("fp_abc123");
+    expect(result.value.sessionId).toMatch(/^ses_[0-9a-f]{32}$/);
+  });
+
+  test("generates a 43-char base64url token", async () => {
+    const config = createTestSessionConfig();
+    const result = await manager.createSession(config, "fp_abc123");
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    expect(result.value.token).toHaveLength(43);
+    expect(result.value.token).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  test("sets correct timestamps", async () => {
+    const config = createTestSessionConfig({ ttlSeconds: 120 });
+    const before = new Date();
+    const result = await manager.createSession(config, "fp_abc");
+    const after = new Date();
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    const created = new Date(result.value.issuedAt);
+    const expires = new Date(result.value.expiresAt);
+    expect(created.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(created.getTime()).toBeLessThanOrEqual(after.getTime());
+    const diffMs = expires.getTime() - created.getTime();
+    expect(diffMs).toBeGreaterThanOrEqual(119_000);
+    expect(diffMs).toBeLessThanOrEqual(121_000);
+  });
+
+  test("stores ttlMs in session record", async () => {
+    const config = createTestSessionConfig({ ttlSeconds: 120 });
+    const result = await manager.createSession(config, "fp_abc");
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    expect(result.value.ttlMs).toBe(120_000);
+  });
+});
+
+describe("session deduplication", () => {
+  test("same agent + same policy returns existing session", async () => {
+    const config = createTestSessionConfig();
+    const s1 = await manager.createSession(config, "fp_1");
+    const s2 = await manager.createSession(config, "fp_1");
+    expect(s1.isOk()).toBe(true);
+    expect(s2.isOk()).toBe(true);
+    if (!s1.isOk() || !s2.isOk()) return;
+    expect(s1.value.sessionId).toBe(s2.value.sessionId);
+    expect(s1.value.token).toBe(s2.value.token);
+  });
+
+  test("same agent + different policy creates new session", async () => {
+    const config1 = createTestSessionConfig();
+    const config2 = createTestSessionConfig({
+      view: { ...baseView, mode: "full" },
+    });
+    const s1 = await manager.createSession(config1, "fp_1");
+    const s2 = await manager.createSession(config2, "fp_2");
+    expect(s1.isOk()).toBe(true);
+    expect(s2.isOk()).toBe(true);
+    if (!s1.isOk() || !s2.isOk()) return;
+    expect(s1.value.sessionId).not.toBe(s2.value.sessionId);
+  });
+
+  test("different agent + same policy creates new session", async () => {
+    const config1 = createTestSessionConfig({ agentInboxId: "agent-1" });
+    const config2 = createTestSessionConfig({ agentInboxId: "agent-2" });
+    const s1 = await manager.createSession(config1, "fp_1");
+    const s2 = await manager.createSession(config2, "fp_2");
+    expect(s1.isOk()).toBe(true);
+    expect(s2.isOk()).toBe(true);
+    if (!s1.isOk() || !s2.isOk()) return;
+    expect(s1.value.sessionId).not.toBe(s2.value.sessionId);
+  });
+});
+
+describe("getSessionByToken", () => {
+  test("returns session for valid token", async () => {
+    const config = createTestSessionConfig();
+    const created = await manager.createSession(config, "fp_1");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+    const lookup = manager.getSessionByToken(created.value.token);
+    expect(lookup.isOk()).toBe(true);
+    if (!lookup.isOk()) return;
+    expect(lookup.value.sessionId).toBe(created.value.sessionId);
+  });
+
+  test("returns NotFoundError for unknown token", () => {
+    const lookup = manager.getSessionByToken("nonexistent-token");
+    expect(lookup.isErr()).toBe(true);
+    if (!lookup.isErr()) return;
+    expect(lookup.error._tag).toBe("NotFoundError");
+  });
+
+  test("returns SessionExpiredError for expired session", async () => {
+    const config = createTestSessionConfig({ ttlSeconds: 1 });
+    const created = await manager.createSession(config, "fp_1");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+    await Bun.sleep(1100);
+    manager.sweepExpired();
+    const lookup = manager.getSessionByToken(created.value.token);
+    expect(lookup.isErr()).toBe(true);
+    if (!lookup.isErr()) return;
+    expect(lookup.error._tag).toBe("SessionExpiredError");
+  });
+
+  test("rejects expired sessions even before a sweep runs", async () => {
+    const config = createTestSessionConfig({ ttlSeconds: 1 });
+    const created = await manager.createSession(config, "fp_1");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+
+    await Bun.sleep(1100);
+
+    const lookup = manager.getSessionByToken(created.value.token);
+    expect(lookup.isErr()).toBe(true);
+    if (!lookup.isErr()) return;
+    expect(lookup.error._tag).toBe("SessionExpiredError");
+
+    const byId = manager.getSessionById(created.value.sessionId);
+    expect(byId.isOk()).toBe(true);
+    if (!byId.isOk()) return;
+    expect(byId.value.state).toBe("expired");
+  });
+
+  test("returns SessionExpiredError for revoked session", async () => {
+    const config = createTestSessionConfig();
+    const created = await manager.createSession(config, "fp_1");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+    manager.revokeSession(created.value.sessionId, "owner-initiated");
+    const lookup = manager.getSessionByToken(created.value.token);
+    expect(lookup.isErr()).toBe(true);
+    if (!lookup.isErr()) return;
+    expect(lookup.error._tag).toBe("SessionExpiredError");
+  });
+});
+
+describe("lookupByToken", () => {
+  test("returns session for valid token", async () => {
+    const config = createTestSessionConfig();
+    const created = await manager.createSession(config, "fp_1");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+    const lookup = manager.lookupByToken(created.value.token);
+    expect(lookup.isOk()).toBe(true);
+    if (!lookup.isOk()) return;
+    expect(lookup.value.sessionId).toBe(created.value.sessionId);
+  });
+
+  test("returns error for invalid token", () => {
+    const lookup = manager.lookupByToken("invalid-token");
+    expect(lookup.isErr()).toBe(true);
+    if (!lookup.isErr()) return;
+    expect(lookup.error._tag).toBe("NotFoundError");
+  });
+});
+
+describe("getSessionById", () => {
+  test("returns session for valid ID", async () => {
+    const config = createTestSessionConfig();
+    const created = await manager.createSession(config, "fp_1");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+    const lookup = manager.getSessionById(created.value.sessionId);
+    expect(lookup.isOk()).toBe(true);
+  });
+
+  test("returns NotFoundError for unknown ID", () => {
+    const lookup = manager.getSessionById("ses_nonexistent");
+    expect(lookup.isErr()).toBe(true);
+    if (!lookup.isErr()) return;
+    expect(lookup.error._tag).toBe("NotFoundError");
+  });
+});
+
+describe("getActiveSessions", () => {
+  test("returns empty array for agent with no sessions", () => {
+    const sessions = manager.getActiveSessions("no-agent");
+    expect(sessions).toHaveLength(0);
+  });
+
+  test("returns only active sessions", async () => {
+    const config1 = createTestSessionConfig({
+      view: { ...baseView, mode: "full" },
+    });
+    const config2 = createTestSessionConfig({
+      view: { ...baseView, mode: "thread-only" },
+    });
+    await manager.createSession(config1, "fp_1");
+    const s2 = await manager.createSession(config2, "fp_2");
+    expect(s2.isOk()).toBe(true);
+    if (!s2.isOk()) return;
+    manager.revokeSession(s2.value.sessionId, "owner-initiated");
+    const sessions = manager.getActiveSessions("agent-inbox-1");
+    expect(sessions).toHaveLength(1);
+  });
+});
+
+describe("concurrent session limits", () => {
+  test("checks concurrent limit before dedup", async () => {
+    // Fill to max with 3 distinct policies
+    const mgr = createSessionManager({
+      defaultTtlSeconds: 60,
+      maxConcurrentPerAgent: 3,
+      renewalWindowSeconds: 10,
+      heartbeatGracePeriod: 3,
+    });
+    const sessions = [];
+    for (let i = 0; i < 3; i++) {
+      const c = createTestSessionConfig({
+        view: { ...baseView, contentTypes: [`type-${i}`] },
+      });
+      const r = await mgr.createSession(c, `fp_${i}`);
+      expect(r.isOk()).toBe(true);
+      if (r.isOk()) sessions.push(r.value);
+    }
+    // Now create a 4th with the SAME policy as session[0] (the oldest)
+    // Concurrent limit should evict session[0] first,
+    // then dedup should NOT match (session[0] is now revoked)
+    const dupConfig = createTestSessionConfig({
+      view: { ...baseView, contentTypes: ["type-0"] },
+    });
+    const result = await mgr.createSession(dupConfig, "fp_new");
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    // Should be a NEW session, not the old one (which was evicted)
+    expect(result.value.sessionId).not.toBe(sessions[0]!.sessionId);
+    expect(result.value.sessionKeyFingerprint).toBe("fp_new");
+  });
+
+  test("oldest session is revoked when limit exceeded", async () => {
+    const configs = Array.from({ length: 4 }, (_, i) =>
+      createTestSessionConfig({
+        view: {
+          ...baseView,
+          mode: i % 2 === 0 ? "full" : "redacted",
+          contentTypes: [`type-${i}`],
+        },
+      }),
+    );
+    const sessions = [];
+    for (const config of configs) {
+      const result = await manager.createSession(
+        config,
+        `fp_${sessions.length}`,
+      );
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) sessions.push(result.value);
+    }
+    const active = manager.getActiveSessions("agent-inbox-1");
+    expect(active).toHaveLength(3);
+    // First session should have been evicted
+    const firstLookup = manager.getSessionById(sessions[0]!.sessionId);
+    expect(firstLookup.isOk()).toBe(true);
+    if (!firstLookup.isOk()) return;
+    expect(firstLookup.value.state).toBe("revoked");
+  });
+});
+
+describe("renewSession", () => {
+  test("renews session within renewal window", async () => {
+    // TTL = 15s, renewal window = 10s, so after 6s it should be in window
+    const shortManager = createSessionManager({
+      defaultTtlSeconds: 15,
+      renewalWindowSeconds: 10,
+      maxConcurrentPerAgent: 3,
+      heartbeatGracePeriod: 3,
+    });
+    const config = createTestSessionConfig({ ttlSeconds: 15 });
+    const created = await shortManager.createSession(config, "fp_1");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+
+    // Wait to enter renewal window
+    await Bun.sleep(6_000);
+    const renewed = await shortManager.renewSession(created.value.sessionId);
+    expect(renewed.isOk()).toBe(true);
+    if (!renewed.isOk()) return;
+    expect(renewed.value.sessionId).toBe(created.value.sessionId);
+    const newExpiry = new Date(renewed.value.expiresAt).getTime();
+    const oldExpiry = new Date(created.value.expiresAt).getTime();
+    expect(newExpiry).toBeGreaterThan(oldExpiry);
+  }, 10_000);
+
+  test("rejects renewal outside window (too early)", async () => {
+    const config = createTestSessionConfig({ ttlSeconds: 60 });
+    const created = await manager.createSession(config, "fp_1");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+    const renewed = await manager.renewSession(created.value.sessionId);
+    expect(renewed.isErr()).toBe(true);
+    if (!renewed.isErr()) return;
+    expect(renewed.error._tag).toBe("AuthError");
+  });
+
+  test("rejects renewal on revoked session", async () => {
+    const config = createTestSessionConfig();
+    const created = await manager.createSession(config, "fp_1");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+    manager.revokeSession(created.value.sessionId, "owner-initiated");
+    const renewed = await manager.renewSession(created.value.sessionId);
+    expect(renewed.isErr()).toBe(true);
+    if (!renewed.isErr()) return;
+    expect(renewed.error._tag).toBe("SessionExpiredError");
+  });
+
+  test("rejects renewal on expired session", async () => {
+    const config = createTestSessionConfig({ ttlSeconds: 1 });
+    const created = await manager.createSession(config, "fp_1");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+    await Bun.sleep(1100);
+    manager.sweepExpired();
+    const renewed = await manager.renewSession(created.value.sessionId);
+    expect(renewed.isErr()).toBe(true);
+    if (!renewed.isErr()) return;
+    expect(renewed.error._tag).toBe("SessionExpiredError");
+  });
+});
+
+describe("revokeSession", () => {
+  test("sets state to revoked with reason", async () => {
+    const config = createTestSessionConfig();
+    const created = await manager.createSession(config, "fp_1");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+    const revoked = manager.revokeSession(
+      created.value.sessionId,
+      "owner-initiated",
+    );
+    expect(revoked.isOk()).toBe(true);
+    if (!revoked.isOk()) return;
+    expect(revoked.value.state).toBe("revoked");
+    expect(revoked.value.revocationReason).toBe("owner-initiated");
+    expect(revoked.value.revokedAt).not.toBeNull();
+  });
+
+  test("returns NotFoundError for unknown session", () => {
+    const result = manager.revokeSession("ses_unknown", "owner-initiated");
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+    expect(result.error._tag).toBe("NotFoundError");
+  });
+});
+
+describe("revokeAllSessions", () => {
+  test("revokes all active sessions for an agent", async () => {
+    const config1 = createTestSessionConfig({
+      view: { ...baseView, mode: "full" },
+    });
+    const config2 = createTestSessionConfig({
+      view: { ...baseView, mode: "thread-only" },
+    });
+    await manager.createSession(config1, "fp_1");
+    await manager.createSession(config2, "fp_2");
+    const revoked = manager.revokeAllSessions(
+      "agent-inbox-1",
+      "owner-initiated",
+    );
+    expect(revoked).toHaveLength(2);
+    const active = manager.getActiveSessions("agent-inbox-1");
+    expect(active).toHaveLength(0);
+  });
+});
+
+describe("recordHeartbeat", () => {
+  test("updates lastHeartbeat timestamp", async () => {
+    const config = createTestSessionConfig();
+    const created = await manager.createSession(config, "fp_1");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+    await Bun.sleep(50);
+    const result = manager.recordHeartbeat(created.value.sessionId);
+    expect(result.isOk()).toBe(true);
+    const lookup = manager.getSessionById(created.value.sessionId);
+    expect(lookup.isOk()).toBe(true);
+    if (!lookup.isOk()) return;
+    const hbTime = new Date(lookup.value.lastHeartbeat).getTime();
+    const createdTime = new Date(created.value.issuedAt).getTime();
+    expect(hbTime).toBeGreaterThanOrEqual(createdTime);
+  });
+
+  test("fails on non-active session", async () => {
+    const config = createTestSessionConfig();
+    const created = await manager.createSession(config, "fp_1");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+    manager.revokeSession(created.value.sessionId, "owner-initiated");
+    const result = manager.recordHeartbeat(created.value.sessionId);
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+    expect(result.error._tag).toBe("SessionExpiredError");
+  });
+
+  test("fails on unknown session", () => {
+    const result = manager.recordHeartbeat("ses_unknown");
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+    expect(result.error._tag).toBe("NotFoundError");
+  });
+});
+
+describe("sweepExpired", () => {
+  test("marks expired sessions with state expired, no revokedAt", async () => {
+    const config = createTestSessionConfig({ ttlSeconds: 1 });
+    const created = await manager.createSession(config, "fp_1");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+    await Bun.sleep(1100);
+    const swept = manager.sweepExpired();
+    expect(swept).toHaveLength(1);
+    expect(swept[0]!.state).toBe("expired");
+    // Expiry is distinct from revocation: no revokedAt or revocationReason
+    expect(swept[0]!.revokedAt).toBeNull();
+    expect(swept[0]!.revocationReason).toBeNull();
+  });
+
+  test("does not sweep active sessions", async () => {
+    const config = createTestSessionConfig({ ttlSeconds: 3600 });
+    await manager.createSession(config, "fp_1");
+    const swept = manager.sweepExpired();
+    expect(swept).toHaveLength(0);
+  });
+
+  test("revokes sessions with heartbeat timeout", async () => {
+    // heartbeatInterval=1s, gracePeriod=1s => timeout after 2s of no heartbeat
+    const hbManager = createSessionManager({
+      defaultTtlSeconds: 3600,
+      maxConcurrentPerAgent: 3,
+      renewalWindowSeconds: 10,
+      heartbeatGracePeriod: 1,
+    });
+    const config = createTestSessionConfig({ heartbeatInterval: 1 });
+    const created = await hbManager.createSession(config, "fp_1");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+    // Wait past heartbeat + grace period
+    await Bun.sleep(2100);
+    const swept = hbManager.sweepExpired();
+    expect(swept).toHaveLength(1);
+    expect(swept[0]!.state).toBe("revoked");
+    expect(swept[0]!.revocationReason).toBe("heartbeat-timeout");
+    expect(swept[0]!.revokedAt).not.toBeNull();
+  });
+
+  test("does not timeout sessions with recent heartbeat", async () => {
+    const hbManager = createSessionManager({
+      defaultTtlSeconds: 3600,
+      maxConcurrentPerAgent: 3,
+      renewalWindowSeconds: 10,
+      heartbeatGracePeriod: 1,
+    });
+    const config = createTestSessionConfig({ heartbeatInterval: 1 });
+    const created = await hbManager.createSession(config, "fp_1");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+    // Send a heartbeat within the window
+    await Bun.sleep(500);
+    hbManager.recordHeartbeat(created.value.sessionId);
+    await Bun.sleep(500);
+    const swept = hbManager.sweepExpired();
+    expect(swept).toHaveLength(0);
+  });
+});
+
+describe("checkMateriality", () => {
+  test("delegates to materiality checker", async () => {
+    const config = createTestSessionConfig();
+    const created = await manager.createSession(config, "fp_1");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+    const newView: ViewConfig = { ...baseView, mode: "full" };
+    const result = manager.checkMateriality(
+      created.value.sessionId,
+      newView,
+      baseGrant,
+    );
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    expect(result.value.isMaterial).toBe(true);
+  });
+
+  test("returns NotFoundError for unknown session", () => {
+    const result = manager.checkMateriality("ses_unknown", baseView, baseGrant);
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+    expect(result.error._tag).toBe("NotFoundError");
+  });
+
+  test("treats reveal-only as narrower than redacted", async () => {
+    const config = createTestSessionConfig({
+      view: { ...baseView, mode: "redacted" },
+    });
+    const created = await manager.createSession(config, "fp_1");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+
+    const result = manager.checkMateriality(
+      created.value.sessionId,
+      { ...baseView, mode: "reveal-only" },
+      baseGrant,
+    );
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    expect(result.value.isMaterial).toBe(false);
+  });
+});
+
+describe("updateSessionPolicy", () => {
+  test("updates view and grant on active session", async () => {
+    const config = createTestSessionConfig();
+    const created = await manager.createSession(config, "fp_1");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+    const newView: ViewConfig = {
+      ...baseView,
+      contentTypes: [...baseView.contentTypes, "reaction"],
+    };
+    const result = manager.updateSessionPolicy(
+      created.value.sessionId,
+      newView,
+      baseGrant,
+    );
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    expect(result.value.view.contentTypes).toContain("reaction");
+  });
+
+  test("fails on non-active session", async () => {
+    const config = createTestSessionConfig();
+    const created = await manager.createSession(config, "fp_1");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+    manager.revokeSession(created.value.sessionId, "owner-initiated");
+    const result = manager.updateSessionPolicy(
+      created.value.sessionId,
+      baseView,
+      baseGrant,
+    );
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+    expect(result.error._tag).toBe("SessionExpiredError");
+  });
+});

--- a/packages/sessions/src/__tests__/smoke.test.ts
+++ b/packages/sessions/src/__tests__/smoke.test.ts
@@ -1,7 +1,0 @@
-import { describe, expect, it } from "bun:test";
-
-describe("workspace", () => {
-  it("test runner works", () => {
-    expect(true).toBe(true);
-  });
-});

--- a/packages/sessions/src/__tests__/token.test.ts
+++ b/packages/sessions/src/__tests__/token.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { generateToken, generateSessionId } from "../token.js";
+
+describe("generateToken", () => {
+  test("returns a base64url-encoded string of 43 characters", () => {
+    const token = generateToken();
+    expect(token).toHaveLength(43);
+  });
+
+  test("contains only base64url-safe characters", () => {
+    const token = generateToken();
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  test("generates unique tokens on each call", () => {
+    const tokens = new Set(Array.from({ length: 100 }, () => generateToken()));
+    expect(tokens.size).toBe(100);
+  });
+
+  test("can be decoded back to 32 bytes", () => {
+    const token = generateToken();
+    // base64url decode
+    const padded = token.replace(/-/g, "+").replace(/_/g, "/");
+    const decoded = Buffer.from(padded, "base64");
+    expect(decoded).toHaveLength(32);
+  });
+});
+
+describe("generateSessionId", () => {
+  test("starts with ses_ prefix", () => {
+    const id = generateSessionId();
+    expect(id.startsWith("ses_")).toBe(true);
+  });
+
+  test("has total length of 36 characters", () => {
+    const id = generateSessionId();
+    expect(id).toHaveLength(36);
+  });
+
+  test("hex portion contains only hex characters", () => {
+    const id = generateSessionId();
+    const hex = id.slice(4);
+    expect(hex).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  test("generates unique IDs on each call", () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateSessionId()));
+    expect(ids.size).toBe(100);
+  });
+});

--- a/packages/sessions/src/index.ts
+++ b/packages/sessions/src/index.ts
@@ -1,4 +1,14 @@
-// Placeholder — real exports added by subsequent specs.
-export {};
+export { generateToken, generateSessionId } from "./token.js";
+export { computePolicyHash } from "./policy-hash.js";
+export { checkMateriality } from "./materiality.js";
+export type { DetailedMaterialityCheck } from "./materiality.js";
+export { createSessionManager } from "./session-manager.js";
+export { createSessionService } from "./service.js";
+export { createSessionActions } from "./actions.js";
+export type {
+  SessionManagerConfig,
+  InternalSessionRecord,
+  InternalSessionManager,
+} from "./session-manager.js";
 export type { SessionServiceDeps } from "./service.js";
 export type { SessionActionDeps } from "./actions.js";

--- a/packages/sessions/src/materiality.ts
+++ b/packages/sessions/src/materiality.ts
@@ -1,0 +1,163 @@
+/**
+ * Materiality check logic.
+ *
+ * Determines whether a policy change between two view/grant
+ * configurations constitutes a material escalation (requiring
+ * session reauthorization) or a non-material update (applied
+ * in-place).
+ */
+
+import type { ViewConfig, GrantConfig, ViewMode } from "@xmtp-broker/schemas";
+import type { MaterialityCheck } from "@xmtp-broker/contracts";
+
+/** Extended materiality result with changed field names for diagnostics. */
+export interface DetailedMaterialityCheck extends MaterialityCheck {
+  readonly changedFields: readonly string[];
+}
+
+/**
+ * View mode access levels, ordered from least to most access.
+ * Escalation = moving to a higher index.
+ */
+const VIEW_MODE_LEVEL: Record<ViewMode, number> = {
+  "reveal-only": 0,
+  "summary-only": 1,
+  redacted: 2,
+  "thread-only": 3,
+  full: 4,
+};
+
+/** Check whether a policy change is material. */
+export function checkMateriality(
+  oldView: ViewConfig,
+  oldGrant: GrantConfig,
+  newView: ViewConfig,
+  newGrant: GrantConfig,
+): DetailedMaterialityCheck {
+  const changedFields: string[] = [];
+
+  // View mode escalation
+  if (oldView.mode !== newView.mode) {
+    const oldLevel = VIEW_MODE_LEVEL[oldView.mode];
+    const newLevel = VIEW_MODE_LEVEL[newView.mode];
+    if (newLevel > oldLevel) {
+      changedFields.push("view.mode");
+    }
+  }
+
+  // Messaging grant escalation
+  checkBoolEscalation(
+    oldGrant.messaging.send,
+    newGrant.messaging.send,
+    "grant.messaging.send",
+    changedFields,
+  );
+  // draftOnly: true -> false is escalation (removing guardrail)
+  if (oldGrant.messaging.draftOnly && !newGrant.messaging.draftOnly) {
+    changedFields.push("grant.messaging.draftOnly");
+  }
+
+  // Group management escalation (any false -> true)
+  checkBoolEscalation(
+    oldGrant.groupManagement.addMembers,
+    newGrant.groupManagement.addMembers,
+    "grant.groupManagement.addMembers",
+    changedFields,
+  );
+  checkBoolEscalation(
+    oldGrant.groupManagement.removeMembers,
+    newGrant.groupManagement.removeMembers,
+    "grant.groupManagement.removeMembers",
+    changedFields,
+  );
+  checkBoolEscalation(
+    oldGrant.groupManagement.updateMetadata,
+    newGrant.groupManagement.updateMetadata,
+    "grant.groupManagement.updateMetadata",
+    changedFields,
+  );
+  checkBoolEscalation(
+    oldGrant.groupManagement.inviteUsers,
+    newGrant.groupManagement.inviteUsers,
+    "grant.groupManagement.inviteUsers",
+    changedFields,
+  );
+
+  // Egress escalation (any false -> true)
+  checkBoolEscalation(
+    oldGrant.egress.storeExcerpts,
+    newGrant.egress.storeExcerpts,
+    "grant.egress.storeExcerpts",
+    changedFields,
+  );
+  checkBoolEscalation(
+    oldGrant.egress.useForMemory,
+    newGrant.egress.useForMemory,
+    "grant.egress.useForMemory",
+    changedFields,
+  );
+  checkBoolEscalation(
+    oldGrant.egress.forwardToProviders,
+    newGrant.egress.forwardToProviders,
+    "grant.egress.forwardToProviders",
+    changedFields,
+  );
+  checkBoolEscalation(
+    oldGrant.egress.quoteRevealed,
+    newGrant.egress.quoteRevealed,
+    "grant.egress.quoteRevealed",
+    changedFields,
+  );
+  checkBoolEscalation(
+    oldGrant.egress.summarize,
+    newGrant.egress.summarize,
+    "grant.egress.summarize",
+    changedFields,
+  );
+
+  // Tool scope escalation
+  if (hasToolEscalation(oldGrant.tools.scopes, newGrant.tools.scopes)) {
+    changedFields.push("grant.tools.scopes");
+  }
+
+  const isMaterial = changedFields.length > 0;
+  return {
+    isMaterial,
+    reason: isMaterial
+      ? `Material change in: ${changedFields.join(", ")}`
+      : null,
+    delta: null,
+    changedFields,
+  };
+}
+
+/** Check if a boolean field escalated from false to true. */
+function checkBoolEscalation(
+  oldVal: boolean,
+  newVal: boolean,
+  field: string,
+  out: string[],
+): void {
+  if (!oldVal && newVal) {
+    out.push(field);
+  }
+}
+
+/** Check if any tool scope was added or escalated from disallowed to allowed. */
+function hasToolEscalation(
+  oldScopes: GrantConfig["tools"]["scopes"],
+  newScopes: GrantConfig["tools"]["scopes"],
+): boolean {
+  const oldMap = new Map(oldScopes.map((s) => [s.toolId, s.allowed]));
+  for (const newScope of newScopes) {
+    const oldAllowed = oldMap.get(newScope.toolId);
+    // New tool added, or existing tool escalated from false to true
+    if (oldAllowed === undefined && newScope.allowed) {
+      return true;
+    }
+    if (oldAllowed === false && newScope.allowed) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/sessions/src/policy-hash.ts
+++ b/packages/sessions/src/policy-hash.ts
@@ -1,0 +1,47 @@
+/**
+ * Deterministic policy hashing for session deduplication.
+ *
+ * Computes a hash from the canonical JSON representation of a
+ * view + grant configuration. Two sessions with the same policy
+ * hash have identical effective policies.
+ */
+
+import type { ViewConfig, GrantConfig } from "@xmtp-broker/schemas";
+
+/** Compute a deterministic hash of the view + grant policy. */
+export function computePolicyHash(
+  view: ViewConfig,
+  grant: GrantConfig,
+): string {
+  const canonical = canonicalize({ view, grant });
+  // Bun.hash returns a bigint; convert to hex string
+  return Bun.hash(canonical).toString(16);
+}
+
+/** Produce a canonical JSON string with sorted keys at all levels. */
+function canonicalize(value: unknown): string {
+  return JSON.stringify(normalize(value));
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+function normalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    const normalizedItems = value.map((item) => normalize(item));
+    return normalizedItems.sort((left, right) =>
+      JSON.stringify(left).localeCompare(JSON.stringify(right)),
+    );
+  }
+
+  if (isRecord(value)) {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value).sort()) {
+      sorted[key] = normalize(value[key]);
+    }
+    return sorted;
+  }
+
+  return value;
+}

--- a/packages/sessions/src/session-manager.ts
+++ b/packages/sessions/src/session-manager.ts
@@ -1,0 +1,460 @@
+/**
+ * Session manager implementation.
+ *
+ * Manages the lifecycle of agent sessions: creation, lookup,
+ * renewal, revocation, heartbeat processing, and expiry sweeps.
+ * Uses an in-memory Map store for v0.
+ */
+
+import { Result } from "better-result";
+import type {
+  SessionConfig,
+  SessionRevocationReason,
+  ViewConfig,
+  GrantConfig,
+} from "@xmtp-broker/schemas";
+import {
+  AuthError,
+  SessionExpiredError,
+  NotFoundError,
+  InternalError,
+  ValidationError,
+} from "@xmtp-broker/schemas";
+import type { MaterialityCheck } from "@xmtp-broker/contracts";
+import { generateToken, generateSessionId } from "./token.js";
+import { computePolicyHash } from "./policy-hash.js";
+import { checkMateriality as checkMaterialityImpl } from "./materiality.js";
+
+/** Configuration for the session manager. */
+export interface SessionManagerConfig {
+  readonly defaultTtlSeconds: number;
+  readonly maxConcurrentPerAgent: number;
+  readonly tokenByteLength: number;
+  readonly renewalWindowSeconds: number;
+  readonly heartbeatGracePeriod: number;
+}
+
+const DEFAULT_CONFIG: SessionManagerConfig = {
+  defaultTtlSeconds: 3600,
+  maxConcurrentPerAgent: 3,
+  tokenByteLength: 32,
+  renewalWindowSeconds: 300,
+  heartbeatGracePeriod: 3,
+};
+
+/** Internal session record with all broker-side fields. */
+export interface InternalSessionRecord {
+  readonly sessionId: string;
+  readonly token: string;
+  readonly agentInboxId: string;
+  readonly view: ViewConfig;
+  readonly grant: GrantConfig;
+  readonly policyHash: string;
+  readonly sessionKeyFingerprint: string;
+  readonly state: "active" | "expired" | "revoked" | "reauthorization-required";
+  readonly heartbeatInterval: number;
+  readonly lastHeartbeat: string;
+  readonly issuedAt: string;
+  readonly expiresAt: string;
+  readonly ttlMs: number;
+  readonly revokedAt: string | null;
+  readonly revocationReason: SessionRevocationReason | null;
+}
+
+/** Extended session manager interface (superset of contract). */
+export interface InternalSessionManager {
+  createSession(
+    config: SessionConfig,
+    sessionKeyFingerprint: string,
+    options?: { sessionId?: string },
+  ): Promise<Result<InternalSessionRecord, ValidationError | InternalError>>;
+  getSessionByToken(
+    token: string,
+  ): Result<InternalSessionRecord, SessionExpiredError | NotFoundError>;
+  getSessionById(
+    sessionId: string,
+  ): Result<InternalSessionRecord, NotFoundError>;
+  getActiveSessions(agentInboxId: string): readonly InternalSessionRecord[];
+  listSessions(agentInboxId?: string): readonly InternalSessionRecord[];
+  recordHeartbeat(
+    sessionId: string,
+  ): Result<void, SessionExpiredError | NotFoundError>;
+  renewSession(
+    sessionId: string,
+  ): Promise<
+    Result<
+      InternalSessionRecord,
+      SessionExpiredError | NotFoundError | AuthError
+    >
+  >;
+  updateSessionPolicy(
+    sessionId: string,
+    view: ViewConfig,
+    grant: GrantConfig,
+  ): Result<InternalSessionRecord, SessionExpiredError | NotFoundError>;
+  revokeSession(
+    sessionId: string,
+    reason: SessionRevocationReason,
+  ): Result<InternalSessionRecord, NotFoundError>;
+  revokeAllSessions(
+    agentInboxId: string,
+    reason: SessionRevocationReason,
+  ): readonly InternalSessionRecord[];
+  lookupByToken(
+    token: string,
+  ): Result<InternalSessionRecord, SessionExpiredError | NotFoundError>;
+  checkMateriality(
+    sessionId: string,
+    newView: ViewConfig,
+    newGrant: GrantConfig,
+  ): Result<MaterialityCheck, NotFoundError>;
+  sweepExpired(): readonly InternalSessionRecord[];
+}
+
+/** Create a new session manager with the given configuration. */
+export function createSessionManager(
+  overrides?: Partial<SessionManagerConfig>,
+): InternalSessionManager {
+  const config = { ...DEFAULT_CONFIG, ...overrides };
+
+  // In-memory stores
+  const byId = new Map<string, InternalSessionRecord>();
+  const byToken = new Map<string, string>(); // token -> sessionId
+  const byAgent = new Map<string, Set<string>>(); // agentInboxId -> sessionIds
+
+  function now(): string {
+    return new Date().toISOString();
+  }
+
+  function upsertRecord(record: InternalSessionRecord): void {
+    byId.set(record.sessionId, record);
+    byToken.set(record.token, record.sessionId);
+    let agentSessions = byAgent.get(record.agentInboxId);
+    if (!agentSessions) {
+      agentSessions = new Set();
+      byAgent.set(record.agentInboxId, agentSessions);
+    }
+    agentSessions.add(record.sessionId);
+  }
+
+  function mutateRecord(
+    sessionId: string,
+    updates: Partial<InternalSessionRecord>,
+  ): Result<InternalSessionRecord, InternalError> {
+    const existing = byId.get(sessionId);
+    if (!existing) {
+      return Result.err(
+        InternalError.create(`Session ${sessionId} not found in store`),
+      );
+    }
+    const updated: InternalSessionRecord = {
+      sessionId: updates.sessionId ?? existing.sessionId,
+      token: updates.token ?? existing.token,
+      agentInboxId: updates.agentInboxId ?? existing.agentInboxId,
+      view: updates.view ?? existing.view,
+      grant: updates.grant ?? existing.grant,
+      policyHash: updates.policyHash ?? existing.policyHash,
+      sessionKeyFingerprint:
+        updates.sessionKeyFingerprint ?? existing.sessionKeyFingerprint,
+      state: updates.state ?? existing.state,
+      heartbeatInterval:
+        updates.heartbeatInterval ?? existing.heartbeatInterval,
+      lastHeartbeat: updates.lastHeartbeat ?? existing.lastHeartbeat,
+      issuedAt: updates.issuedAt ?? existing.issuedAt,
+      expiresAt: updates.expiresAt ?? existing.expiresAt,
+      ttlMs: updates.ttlMs ?? existing.ttlMs,
+      revokedAt:
+        updates.revokedAt !== undefined
+          ? updates.revokedAt
+          : existing.revokedAt,
+      revocationReason:
+        updates.revocationReason !== undefined
+          ? updates.revocationReason
+          : existing.revocationReason,
+    };
+    byId.set(sessionId, updated);
+    return Result.ok(updated);
+  }
+
+  function getActiveForAgent(agentInboxId: string): InternalSessionRecord[] {
+    const ids = byAgent.get(agentInboxId);
+    if (!ids) return [];
+    const active: InternalSessionRecord[] = [];
+    for (const id of ids) {
+      const record = byId.get(id);
+      if (record?.state === "active") {
+        active.push(record);
+      }
+    }
+    return active;
+  }
+
+  function revokeRecord(
+    sessionId: string,
+    reason: SessionRevocationReason,
+  ): Result<InternalSessionRecord, InternalError> {
+    return mutateRecord(sessionId, {
+      state: "revoked",
+      revokedAt: now(),
+      revocationReason: reason,
+    });
+  }
+
+  const manager: InternalSessionManager = {
+    async createSession(sessionConfig, sessionKeyFingerprint, options) {
+      const policyHash = computePolicyHash(
+        sessionConfig.view,
+        sessionConfig.grant,
+      );
+
+      const activeSessions = getActiveForAgent(sessionConfig.agentInboxId);
+
+      // Concurrent session limit: revoke oldest if at max (check before dedup)
+      if (activeSessions.length >= config.maxConcurrentPerAgent) {
+        const sorted = [...activeSessions].sort(
+          (a, b) =>
+            new Date(a.issuedAt).getTime() - new Date(b.issuedAt).getTime(),
+        );
+        const oldest = sorted[0];
+        if (oldest) {
+          // "policy-violation" is the closest valid SessionRevocationReason
+          // for max-sessions eviction (no dedicated enum value exists)
+          const revokeResult = revokeRecord(
+            oldest.sessionId,
+            "policy-violation",
+          );
+          if (!revokeResult.isOk()) {
+            return Result.err(revokeResult.error);
+          }
+        }
+      }
+
+      // Dedup check: same agent + same policy hash (after eviction)
+      const currentActive = getActiveForAgent(sessionConfig.agentInboxId);
+      const existing = currentActive.find((s) => s.policyHash === policyHash);
+      if (existing) {
+        return Result.ok(existing);
+      }
+
+      const currentTime = now();
+      const ttl = sessionConfig.ttlSeconds ?? config.defaultTtlSeconds;
+      const ttlMs = ttl * 1000;
+      const expiresAt = new Date(Date.now() + ttlMs).toISOString();
+
+      const record: InternalSessionRecord = {
+        sessionId: options?.sessionId ?? generateSessionId(),
+        token: generateToken(config.tokenByteLength),
+        agentInboxId: sessionConfig.agentInboxId,
+        view: sessionConfig.view,
+        grant: sessionConfig.grant,
+        policyHash,
+        sessionKeyFingerprint,
+        state: "active",
+        heartbeatInterval: sessionConfig.heartbeatInterval ?? 30,
+        lastHeartbeat: currentTime,
+        issuedAt: currentTime,
+        expiresAt,
+        ttlMs,
+        revokedAt: null,
+        revocationReason: null,
+      };
+
+      upsertRecord(record);
+      return Result.ok(record);
+    },
+
+    getSessionByToken(token) {
+      const sessionId = byToken.get(token);
+      if (!sessionId) {
+        return Result.err(NotFoundError.create("session", token));
+      }
+      const record = byId.get(sessionId);
+      if (!record) {
+        return Result.err(NotFoundError.create("session", token));
+      }
+      if (Date.now() >= new Date(record.expiresAt).getTime()) {
+        const expireResult = mutateRecord(sessionId, { state: "expired" });
+        if (!expireResult.isOk()) {
+          return Result.err(SessionExpiredError.create(sessionId));
+        }
+        return Result.err(SessionExpiredError.create(sessionId));
+      }
+      if (record.state !== "active") {
+        return Result.err(SessionExpiredError.create(sessionId));
+      }
+      return Result.ok(record);
+    },
+
+    lookupByToken(token) {
+      return manager.getSessionByToken(token);
+    },
+
+    getSessionById(sessionId) {
+      const record = byId.get(sessionId);
+      if (!record) {
+        return Result.err(NotFoundError.create("session", sessionId));
+      }
+      return Result.ok(record);
+    },
+
+    getActiveSessions(agentInboxId) {
+      return getActiveForAgent(agentInboxId);
+    },
+
+    listSessions(agentInboxId) {
+      if (agentInboxId !== undefined) {
+        return getActiveForAgent(agentInboxId);
+      }
+      const active: InternalSessionRecord[] = [];
+      for (const record of byId.values()) {
+        if (record.state === "active") {
+          active.push(record);
+        }
+      }
+      return active;
+    },
+
+    recordHeartbeat(sessionId) {
+      const record = byId.get(sessionId);
+      if (!record) {
+        return Result.err(NotFoundError.create("session", sessionId));
+      }
+      if (record.state !== "active") {
+        return Result.err(SessionExpiredError.create(sessionId));
+      }
+      const heartbeatResult = mutateRecord(sessionId, {
+        lastHeartbeat: now(),
+      });
+      if (!heartbeatResult.isOk()) {
+        return Result.err(NotFoundError.create("session", sessionId));
+      }
+      return Result.ok(undefined);
+    },
+
+    async renewSession(sessionId) {
+      const record = byId.get(sessionId);
+      if (!record) {
+        return Result.err(NotFoundError.create("session", sessionId));
+      }
+      if (record.state !== "active") {
+        return Result.err(SessionExpiredError.create(sessionId));
+      }
+      // Check renewal window
+      const expiresAt = new Date(record.expiresAt).getTime();
+      const remaining = (expiresAt - Date.now()) / 1000;
+      if (remaining > config.renewalWindowSeconds) {
+        return Result.err(
+          AuthError.create("Not in renewal window", {
+            sessionId,
+            remainingSeconds: remaining,
+            renewalWindowSeconds: config.renewalWindowSeconds,
+          }),
+        );
+      }
+      // Renew: reset expiry using stored TTL (avoids compounding)
+      const newExpiresAt = new Date(Date.now() + record.ttlMs).toISOString();
+      const renewResult = mutateRecord(sessionId, { expiresAt: newExpiresAt });
+      if (!renewResult.isOk()) {
+        return Result.err(NotFoundError.create("session", sessionId));
+      }
+      return Result.ok(renewResult.value);
+    },
+
+    updateSessionPolicy(sessionId, view, grant) {
+      const record = byId.get(sessionId);
+      if (!record) {
+        return Result.err(NotFoundError.create("session", sessionId));
+      }
+      if (record.state !== "active") {
+        return Result.err(SessionExpiredError.create(sessionId));
+      }
+      const policyHash = computePolicyHash(view, grant);
+      const updateResult = mutateRecord(sessionId, {
+        view,
+        grant,
+        policyHash,
+      });
+      if (!updateResult.isOk()) {
+        return Result.err(NotFoundError.create("session", sessionId));
+      }
+      return Result.ok(updateResult.value);
+    },
+
+    revokeSession(sessionId, reason) {
+      const record = byId.get(sessionId);
+      if (!record) {
+        return Result.err(NotFoundError.create("session", sessionId));
+      }
+      const revokeResult = revokeRecord(sessionId, reason);
+      if (!revokeResult.isOk()) {
+        return Result.err(NotFoundError.create("session", sessionId));
+      }
+      return Result.ok(revokeResult.value);
+    },
+
+    revokeAllSessions(agentInboxId, reason) {
+      const activeSessions = getActiveForAgent(agentInboxId);
+      const revoked: InternalSessionRecord[] = [];
+      for (const session of activeSessions) {
+        const revokeResult = revokeRecord(session.sessionId, reason);
+        if (revokeResult.isOk()) {
+          revoked.push(revokeResult.value);
+        }
+      }
+      return revoked;
+    },
+
+    checkMateriality(sessionId, newView, newGrant) {
+      const record = byId.get(sessionId);
+      if (!record) {
+        return Result.err(NotFoundError.create("session", sessionId));
+      }
+      const result = checkMaterialityImpl(
+        record.view,
+        record.grant,
+        newView,
+        newGrant,
+      );
+      return Result.ok(result);
+    },
+
+    sweepExpired() {
+      const swept: InternalSessionRecord[] = [];
+      const currentTime = Date.now();
+      for (const record of byId.values()) {
+        if (record.state !== "active") continue;
+
+        // TTL expiry: transition to "expired" (distinct from revocation)
+        const expiresAt = new Date(record.expiresAt).getTime();
+        if (currentTime >= expiresAt) {
+          const expireResult = mutateRecord(record.sessionId, {
+            state: "expired",
+          });
+          if (expireResult.isOk()) {
+            swept.push(expireResult.value);
+          }
+          continue;
+        }
+
+        // Heartbeat timeout: revoke if heartbeat overdue
+        const lastHb = new Date(record.lastHeartbeat).getTime();
+        const heartbeatDeadline =
+          lastHb +
+          record.heartbeatInterval * 1000 +
+          config.heartbeatGracePeriod * 1000;
+        if (currentTime >= heartbeatDeadline) {
+          const revokeResult = revokeRecord(
+            record.sessionId,
+            "heartbeat-timeout",
+          );
+          if (revokeResult.isOk()) {
+            swept.push(revokeResult.value);
+          }
+        }
+      }
+      return swept;
+    },
+  };
+
+  return manager;
+}

--- a/packages/sessions/src/token.ts
+++ b/packages/sessions/src/token.ts
@@ -1,0 +1,28 @@
+/**
+ * Cryptographic token and session ID generation.
+ *
+ * Tokens are 32 random bytes, base64url-encoded (no padding) = 43 chars.
+ * Session IDs are "ses_" + 16 random bytes, hex-encoded = 36 chars.
+ */
+
+/** Generate a cryptographically random session bearer token. */
+export function generateToken(byteLength: number = 32): string {
+  const bytes = new Uint8Array(byteLength);
+  crypto.getRandomValues(bytes);
+  return base64UrlEncode(bytes);
+}
+
+/** Generate a unique session ID with "ses_" prefix. */
+export function generateSessionId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join(
+    "",
+  );
+  return `ses_${hex}`;
+}
+
+/** Encode bytes as base64url without padding. */
+function base64UrlEncode(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64url");
+}


### PR DESCRIPTION
## Context
This branch adds harness session lifecycle management on top of the policy layer. Review this PR against `v0/policy-engine`, not `main`.

## What Changed
- implements session creation, refresh, expiry, and lifecycle handling in `session-manager.ts`
- adds token generation and validation helpers for broker-issued session credentials
- introduces policy hashing and materiality checks so sessions can detect meaningful permission changes
- covers token semantics, policy hash stability, and session transitions with focused tests

## Why This Branch Exists
Harnesses need a scoped, revocable session layer above raw policy decisions. This PR provides that broker-facing auth lifecycle.

## Key Files
- `packages/sessions/src/session-manager.ts`
- `packages/sessions/src/token.ts`
- `packages/sessions/src/policy-hash.ts`
- `packages/sessions/src/materiality.ts`

## Verification
- session package test suite under `packages/sessions/src/__tests__`
- repo verification via pre-push stack checks (`lint`, `test`, `typecheck`)
