### PR TITLE
feat(keys): add root, operational, and session key management

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -58,6 +58,12 @@
     "packages/keys": {
       "name": "@xmtp-broker/keys",
       "version": "0.0.0",
+      "dependencies": {
+        "@xmtp-broker/contracts": "workspace:*",
+        "@xmtp-broker/schemas": "workspace:*",
+        "better-result": "catalog:",
+        "zod": "catalog:",
+      },
       "devDependencies": {
         "bun-types": "catalog:",
         "typescript": "catalog:",

--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -15,7 +15,12 @@
     "lint": "oxlint .",
     "test": "bun test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@xmtp-broker/contracts": "workspace:*",
+    "@xmtp-broker/schemas": "workspace:*",
+    "better-result": "catalog:",
+    "zod": "catalog:"
+  },
   "devDependencies": {
     "bun-types": "catalog:",
     "typescript": "catalog:"

--- a/packages/keys/src/__tests__/attestation-signer.test.ts
+++ b/packages/keys/src/__tests__/attestation-signer.test.ts
@@ -1,0 +1,97 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Result } from "better-result";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createKeyManager, type KeyManager } from "../key-manager.js";
+import { createAttestationSigner } from "../attestation-signer.js";
+import type { AttestationSigner } from "@xmtp-broker/contracts";
+import type { Attestation } from "@xmtp-broker/schemas";
+
+function makeTestAttestation(): Attestation {
+  return {
+    version: "0.1.0",
+    attestationId: "att_test_123",
+    agentAddress: "0xabc",
+    sessionId: "ses_test",
+    issuedAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    inference: {
+      mode: "client-side",
+      provider: null,
+      model: null,
+    },
+    contentEgress: {
+      scope: "none",
+      destinations: [],
+    },
+    retentionAtProvider: "none",
+    hostingMode: "self-hosted",
+    trustTier: "unverified",
+    buildProvenanceRef: null,
+    revocationRules: {
+      autoRevokeOnSessionEnd: true,
+      humanRevocable: true,
+      policyChangeRevokes: true,
+    },
+    extensions: null,
+  };
+}
+
+describe("AttestationSigner", () => {
+  let dataDir: string;
+  let manager: KeyManager;
+  let signer: AttestationSigner;
+
+  beforeEach(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "as-test-"));
+    const result = await createKeyManager({ dataDir });
+    if (Result.isError(result)) throw new Error("setup failed");
+    manager = result.value;
+    await manager.createOperationalKey("agent-1", null);
+    signer = createAttestationSigner(manager, "agent-1");
+  });
+
+  afterEach(() => {
+    manager.close();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  describe("sign", () => {
+    test("signs an attestation and returns a SignedAttestation", async () => {
+      const attestation = makeTestAttestation();
+      const result = await signer.sign(attestation);
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("sign failed");
+
+      const signed = result.value;
+      expect(signed.attestation).toEqual(attestation);
+      expect(signed.signature).toBeDefined();
+      expect(signed.signature.length).toBeGreaterThan(0);
+      expect(signed.signatureAlgorithm).toBe("Ed25519");
+      expect(signed.signerKeyRef).toBeDefined();
+    });
+  });
+
+  describe("signRevocation", () => {
+    test("signs a revocation attestation", async () => {
+      const revocation = {
+        attestationId: "rev_test_456",
+        previousAttestationId: "att_test_123",
+        agentInboxId: "0xabc",
+        groupId: "group-1",
+        reason: "owner-initiated" as const,
+        revokedAt: new Date().toISOString(),
+        issuer: "broker",
+      };
+      const result = await signer.signRevocation(revocation);
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("sign failed");
+
+      const signed = result.value;
+      expect(signed.revocation).toEqual(revocation);
+      expect(signed.signature).toBeDefined();
+      expect(signed.signatureAlgorithm).toBe("Ed25519");
+    });
+  });
+});

--- a/packages/keys/src/__tests__/config.test.ts
+++ b/packages/keys/src/__tests__/config.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect } from "bun:test";
+import {
+  KeyManagerConfigSchema,
+  KeyPolicySchema,
+  PlatformCapabilitySchema,
+} from "../config.js";
+
+describe("KeyPolicySchema", () => {
+  test("accepts valid policies", () => {
+    expect(KeyPolicySchema.parse("biometric")).toBe("biometric");
+    expect(KeyPolicySchema.parse("passcode")).toBe("passcode");
+    expect(KeyPolicySchema.parse("open")).toBe("open");
+  });
+
+  test("rejects invalid policy", () => {
+    const result = KeyPolicySchema.safeParse("invalid");
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("PlatformCapabilitySchema", () => {
+  test("accepts valid capabilities", () => {
+    expect(PlatformCapabilitySchema.parse("secure-enclave")).toBe(
+      "secure-enclave",
+    );
+    expect(PlatformCapabilitySchema.parse("keychain-software")).toBe(
+      "keychain-software",
+    );
+    expect(PlatformCapabilitySchema.parse("tpm")).toBe("tpm");
+    expect(PlatformCapabilitySchema.parse("software-vault")).toBe(
+      "software-vault",
+    );
+  });
+
+  test("rejects invalid capability", () => {
+    const result = PlatformCapabilitySchema.safeParse("magic");
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("KeyManagerConfigSchema", () => {
+  test("parses valid config with defaults", () => {
+    const config = KeyManagerConfigSchema.parse({ dataDir: "/tmp/keys" });
+    expect(config.dataDir).toBe("/tmp/keys");
+    expect(config.rootKeyPolicy).toBe("biometric");
+    expect(config.operationalKeyPolicy).toBe("open");
+    expect(config.sessionKeyTtlSeconds).toBe(3600);
+  });
+
+  test("accepts overridden values", () => {
+    const config = KeyManagerConfigSchema.parse({
+      dataDir: "/tmp/keys",
+      rootKeyPolicy: "open",
+      operationalKeyPolicy: "passcode",
+      sessionKeyTtlSeconds: 7200,
+    });
+    expect(config.rootKeyPolicy).toBe("open");
+    expect(config.operationalKeyPolicy).toBe("passcode");
+    expect(config.sessionKeyTtlSeconds).toBe(7200);
+  });
+
+  test("rejects missing dataDir", () => {
+    const result = KeyManagerConfigSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-positive sessionKeyTtlSeconds", () => {
+    const result = KeyManagerConfigSchema.safeParse({
+      dataDir: "/tmp",
+      sessionKeyTtlSeconds: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/keys/src/__tests__/crypto-keys.test.ts
+++ b/packages/keys/src/__tests__/crypto-keys.test.ts
@@ -1,0 +1,150 @@
+import { describe, test, expect } from "bun:test";
+import { Result } from "better-result";
+import {
+  generateP256KeyPair,
+  generateEd25519KeyPair,
+  signP256,
+  verifyP256,
+  signEd25519,
+  verifyEd25519,
+  exportPublicKey,
+  exportPrivateKey,
+  importEd25519PrivateKey,
+  fingerprint,
+} from "../crypto-keys.js";
+
+describe("P-256 keys", () => {
+  test("generates a key pair", async () => {
+    const result = await generateP256KeyPair();
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result)) throw new Error("gen failed");
+    expect(result.value.publicKey).toBeDefined();
+    expect(result.value.privateKey).toBeDefined();
+  });
+
+  test("signs and verifies data", async () => {
+    const kp = await generateP256KeyPair();
+    if (Result.isError(kp)) throw new Error("gen failed");
+
+    const data = new Uint8Array([1, 2, 3, 4]);
+    const sig = await signP256(kp.value.privateKey, data);
+    expect(Result.isOk(sig)).toBe(true);
+    if (Result.isError(sig)) throw new Error("sign failed");
+
+    const valid = await verifyP256(kp.value.publicKey, data, sig.value);
+    expect(Result.isOk(valid)).toBe(true);
+    if (Result.isError(valid)) throw new Error("verify failed");
+    expect(valid.value).toBe(true);
+  });
+
+  test("rejects tampered data", async () => {
+    const kp = await generateP256KeyPair();
+    if (Result.isError(kp)) throw new Error("gen failed");
+
+    const data = new Uint8Array([1, 2, 3]);
+    const sig = await signP256(kp.value.privateKey, data);
+    if (Result.isError(sig)) throw new Error("sign failed");
+
+    const tampered = new Uint8Array([1, 2, 4]);
+    const valid = await verifyP256(kp.value.publicKey, tampered, sig.value);
+    expect(Result.isOk(valid)).toBe(true);
+    if (Result.isError(valid)) throw new Error("verify failed");
+    expect(valid.value).toBe(false);
+  });
+});
+
+describe("Ed25519 keys", () => {
+  test("generates a key pair", async () => {
+    const result = await generateEd25519KeyPair();
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result)) throw new Error("gen failed");
+    expect(result.value.publicKey).toBeDefined();
+    expect(result.value.privateKey).toBeDefined();
+  });
+
+  test("signs and verifies data", async () => {
+    const kp = await generateEd25519KeyPair();
+    if (Result.isError(kp)) throw new Error("gen failed");
+
+    const data = new Uint8Array([10, 20, 30]);
+    const sig = await signEd25519(kp.value.privateKey, data);
+    expect(Result.isOk(sig)).toBe(true);
+    if (Result.isError(sig)) throw new Error("sign failed");
+
+    const valid = await verifyEd25519(kp.value.publicKey, data, sig.value);
+    expect(Result.isOk(valid)).toBe(true);
+    if (Result.isError(valid)) throw new Error("verify failed");
+    expect(valid.value).toBe(true);
+  });
+
+  test("exports and re-imports private key", async () => {
+    const kp = await generateEd25519KeyPair();
+    if (Result.isError(kp)) throw new Error("gen failed");
+
+    const exported = await exportPrivateKey(kp.value.privateKey);
+    expect(Result.isOk(exported)).toBe(true);
+    if (Result.isError(exported)) throw new Error("export failed");
+
+    const reimported = await importEd25519PrivateKey(exported.value);
+    expect(Result.isOk(reimported)).toBe(true);
+    if (Result.isError(reimported)) throw new Error("import failed");
+
+    // Sign with reimported key, verify with original public key
+    const data = new Uint8Array([99]);
+    const sig = await signEd25519(reimported.value, data);
+    if (Result.isError(sig)) throw new Error("sign failed");
+    const valid = await verifyEd25519(kp.value.publicKey, data, sig.value);
+    if (Result.isError(valid)) throw new Error("verify failed");
+    expect(valid.value).toBe(true);
+  });
+});
+
+describe("exportPublicKey", () => {
+  test("exports P-256 public key as bytes", async () => {
+    const kp = await generateP256KeyPair();
+    if (Result.isError(kp)) throw new Error("gen failed");
+
+    const exported = await exportPublicKey(kp.value.publicKey);
+    expect(Result.isOk(exported)).toBe(true);
+    if (Result.isError(exported)) throw new Error("export failed");
+    // P-256 uncompressed public key is 65 bytes (0x04 + 32 + 32)
+    expect(exported.value.byteLength).toBe(65);
+    expect(exported.value[0]).toBe(0x04);
+  });
+
+  test("exports Ed25519 public key as bytes", async () => {
+    const kp = await generateEd25519KeyPair();
+    if (Result.isError(kp)) throw new Error("gen failed");
+
+    const exported = await exportPublicKey(kp.value.publicKey);
+    expect(Result.isOk(exported)).toBe(true);
+    if (Result.isError(exported)) throw new Error("export failed");
+    // Ed25519 public key is 32 bytes
+    expect(exported.value.byteLength).toBe(32);
+  });
+});
+
+describe("fingerprint", () => {
+  test("produces a hex-encoded SHA-256 fingerprint", async () => {
+    const kp = await generateEd25519KeyPair();
+    if (Result.isError(kp)) throw new Error("gen failed");
+
+    const fp = await fingerprint(kp.value.publicKey);
+    expect(Result.isOk(fp)).toBe(true);
+    if (Result.isError(fp)) throw new Error("fingerprint failed");
+    // SHA-256 hex = 64 characters
+    expect(fp.value).toHaveLength(64);
+    expect(fp.value).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("same key produces same fingerprint", async () => {
+    const kp = await generateEd25519KeyPair();
+    if (Result.isError(kp)) throw new Error("gen failed");
+
+    const fp1 = await fingerprint(kp.value.publicKey);
+    const fp2 = await fingerprint(kp.value.publicKey);
+    if (Result.isError(fp1) || Result.isError(fp2))
+      throw new Error("fp failed");
+    expect(fp1.value).toBe(fp2.value);
+  });
+});

--- a/packages/keys/src/__tests__/key-manager.test.ts
+++ b/packages/keys/src/__tests__/key-manager.test.ts
@@ -1,0 +1,198 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Result } from "better-result";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createKeyManager, type KeyManager } from "../key-manager.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+describe("KeyManager", () => {
+  let dataDir: string;
+  let manager: KeyManager;
+
+  beforeEach(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "km-test-"));
+    const result = await createKeyManager({ dataDir });
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result)) throw new Error("setup failed");
+    manager = result.value;
+  });
+
+  afterEach(() => {
+    manager.close();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  describe("initialize", () => {
+    test("detects platform as software-vault for v0", () => {
+      expect(manager.platform).toBe("software-vault");
+    });
+
+    test("maps software-vault to unverified trust tier", () => {
+      expect(manager.trustTier).toBe("unverified");
+    });
+
+    test("creates a root key handle on initialization", async () => {
+      const result = await manager.initialize();
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("init failed");
+      expect(result.value.keyRef).toBeDefined();
+      expect(result.value.publicKey).toBeDefined();
+      expect(result.value.platform).toBe("software-vault");
+    });
+
+    test("returns existing root key on re-initialization", async () => {
+      const r1 = await manager.initialize();
+      const r2 = await manager.initialize();
+      if (Result.isError(r1) || Result.isError(r2))
+        throw new Error("init failed");
+      expect(r1.value.keyRef).toBe(r2.value.keyRef);
+    });
+  });
+
+  describe("operational keys", () => {
+    test("creates an operational key", async () => {
+      const result = await manager.createOperationalKey("agent-1", null);
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("create failed");
+      expect(result.value.identityId).toBe("agent-1");
+    });
+
+    test("retrieves an operational key by identity", async () => {
+      await manager.createOperationalKey("agent-1", null);
+      const result = manager.getOperationalKey("agent-1");
+      expect(Result.isOk(result)).toBe(true);
+    });
+
+    test("retrieves an operational key by group ID", async () => {
+      await manager.createOperationalKey("agent-1", "group-a");
+      const result = manager.getOperationalKeyByGroupId("group-a");
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("get failed");
+      expect(result.value.groupId).toBe("group-a");
+    });
+
+    test("rotates an operational key", async () => {
+      const original = await manager.createOperationalKey("agent-1", null);
+      if (Result.isError(original)) throw new Error("create failed");
+
+      const rotated = await manager.rotateOperationalKey("agent-1");
+      expect(Result.isOk(rotated)).toBe(true);
+      if (Result.isError(rotated)) throw new Error("rotate failed");
+      expect(rotated.value.publicKey).not.toBe(original.value.publicKey);
+    });
+
+    test("lists all operational keys", async () => {
+      await manager.createOperationalKey("agent-1", null);
+      await manager.createOperationalKey("agent-2", "group-b");
+      expect(manager.listOperationalKeys()).toHaveLength(2);
+    });
+  });
+
+  describe("session keys", () => {
+    test("issues a session key", async () => {
+      const result = await manager.issueSessionKey("ses_1", 3600);
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("issue failed");
+      expect(result.value.sessionId).toBe("ses_1");
+    });
+
+    test("revokes a session key", async () => {
+      const issued = await manager.issueSessionKey("ses_2", 3600);
+      if (Result.isError(issued)) throw new Error("issue failed");
+      const result = manager.revokeSessionKey(issued.value.keyId);
+      expect(Result.isOk(result)).toBe(true);
+    });
+  });
+
+  describe("signing", () => {
+    test("signs with operational key", async () => {
+      await manager.createOperationalKey("agent-1", null);
+      const result = await manager.signWithOperationalKey(
+        "agent-1",
+        new Uint8Array([1, 2, 3]),
+      );
+      expect(Result.isOk(result)).toBe(true);
+    });
+
+    test("signs with session key", async () => {
+      const issued = await manager.issueSessionKey("ses_3", 3600);
+      if (Result.isError(issued)) throw new Error("issue failed");
+      const result = await manager.signWithSessionKey(
+        issued.value.keyId,
+        new Uint8Array([4, 5, 6]),
+      );
+      expect(Result.isOk(result)).toBe(true);
+    });
+  });
+
+  describe("vault operations", () => {
+    test("stores and retrieves a secret", async () => {
+      const setResult = await manager.vaultSet(
+        "api-key",
+        encoder.encode("secret"),
+      );
+      expect(Result.isOk(setResult)).toBe(true);
+
+      const getResult = await manager.vaultGet("api-key");
+      expect(Result.isOk(getResult)).toBe(true);
+      if (Result.isError(getResult)) throw new Error("get failed");
+      expect(decoder.decode(getResult.value)).toBe("secret");
+    });
+
+    test("deletes a secret", async () => {
+      await manager.vaultSet("key", encoder.encode("val"));
+      const result = await manager.vaultDelete("key");
+      expect(Result.isOk(result)).toBe(true);
+    });
+
+    test("lists vault secrets", async () => {
+      await manager.vaultSet("a", encoder.encode("1"));
+      await manager.vaultSet("b", encoder.encode("2"));
+      const names = manager.vaultList();
+      expect(names).toHaveLength(2);
+    });
+  });
+
+  describe("getOrCreateDbKey", () => {
+    test("returns a 32-byte key", async () => {
+      const result = await manager.getOrCreateDbKey("agent-1");
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("getOrCreateDbKey failed");
+      expect(result.value.byteLength).toBe(32);
+    });
+
+    test("returns the same key on repeated calls", async () => {
+      const r1 = await manager.getOrCreateDbKey("agent-1");
+      const r2 = await manager.getOrCreateDbKey("agent-1");
+      if (Result.isError(r1) || Result.isError(r2))
+        throw new Error("getOrCreateDbKey failed");
+      expect(r1.value).toEqual(r2.value);
+    });
+
+    test("returns different keys for different identities", async () => {
+      const r1 = await manager.getOrCreateDbKey("agent-1");
+      const r2 = await manager.getOrCreateDbKey("agent-2");
+      if (Result.isError(r1) || Result.isError(r2))
+        throw new Error("getOrCreateDbKey failed");
+      const same = r1.value.every((b, i) => b === r2.value[i]);
+      expect(same).toBe(false);
+    });
+
+    test("persists key across close and reopen", async () => {
+      const r1 = await manager.getOrCreateDbKey("agent-1");
+      if (Result.isError(r1)) throw new Error("getOrCreateDbKey failed");
+
+      manager.close();
+      const reopened = await createKeyManager({ dataDir });
+      if (Result.isError(reopened)) throw new Error("reopen failed");
+      manager = reopened.value;
+
+      const r2 = await manager.getOrCreateDbKey("agent-1");
+      if (Result.isError(r2)) throw new Error("getOrCreateDbKey failed");
+      expect(r1.value).toEqual(r2.value);
+    });
+  });
+});

--- a/packages/keys/src/__tests__/operational-key.test.ts
+++ b/packages/keys/src/__tests__/operational-key.test.ts
@@ -1,0 +1,159 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Result } from "better-result";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createVault, type Vault } from "../vault.js";
+import {
+  createOperationalKeyManager,
+  type OperationalKeyManager,
+} from "../operational-key.js";
+
+describe("OperationalKeyManager", () => {
+  let dataDir: string;
+  let vault: Vault;
+  let opKeys: OperationalKeyManager;
+
+  beforeEach(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "opkey-test-"));
+    const vaultResult = await createVault(dataDir);
+    if (Result.isError(vaultResult)) throw new Error("vault setup failed");
+    vault = vaultResult.value;
+    opKeys = createOperationalKeyManager(vault);
+  });
+
+  afterEach(() => {
+    vault.close();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  describe("create", () => {
+    test("creates an operational key for an identity", async () => {
+      const result = await opKeys.create("agent-1", null);
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("create failed");
+
+      const key = result.value;
+      expect(key.keyId).toBeDefined();
+      expect(key.identityId).toBe("agent-1");
+      expect(key.groupId).toBeNull();
+      expect(key.publicKey).toMatch(/^[0-9a-f]+$/);
+      expect(key.fingerprint).toMatch(/^[0-9a-f]{64}$/);
+      expect(key.createdAt).toBeDefined();
+      expect(key.rotatedAt).toBeNull();
+    });
+
+    test("creates a per-group operational key", async () => {
+      const result = await opKeys.create("agent-1", "group-a");
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("create failed");
+      expect(result.value.groupId).toBe("group-a");
+    });
+
+    test("creates separate keys for different identities", async () => {
+      const r1 = await opKeys.create("agent-1", null);
+      const r2 = await opKeys.create("agent-2", null);
+      if (Result.isError(r1) || Result.isError(r2))
+        throw new Error("create failed");
+      expect(r1.value.publicKey).not.toBe(r2.value.publicKey);
+    });
+  });
+
+  describe("get", () => {
+    test("retrieves an existing key by identity", async () => {
+      const created = await opKeys.create("agent-1", null);
+      if (Result.isError(created)) throw new Error("create failed");
+
+      const result = opKeys.get("agent-1");
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("get failed");
+      expect(result.value.keyId).toBe(created.value.keyId);
+    });
+
+    test("returns NotFoundError for unknown identity", () => {
+      const result = opKeys.get("unknown");
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isOk(result)) throw new Error("expected error");
+      expect(result.error._tag).toBe("NotFoundError");
+    });
+  });
+
+  describe("getByGroupId", () => {
+    test("retrieves a key by group ID", async () => {
+      await opKeys.create("agent-1", "group-a");
+      const result = opKeys.getByGroupId("group-a");
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("get failed");
+      expect(result.value.groupId).toBe("group-a");
+    });
+
+    test("returns NotFoundError for unknown group", () => {
+      const result = opKeys.getByGroupId("unknown-group");
+      expect(Result.isError(result)).toBe(true);
+    });
+  });
+
+  describe("rotate", () => {
+    test("replaces the key material for an identity", async () => {
+      const original = await opKeys.create("agent-1", null);
+      if (Result.isError(original)) throw new Error("create failed");
+
+      const rotated = await opKeys.rotate("agent-1");
+      expect(Result.isOk(rotated)).toBe(true);
+      if (Result.isError(rotated)) throw new Error("rotate failed");
+
+      expect(rotated.value.keyId).not.toBe(original.value.keyId);
+      expect(rotated.value.publicKey).not.toBe(original.value.publicKey);
+      expect(rotated.value.rotatedAt).not.toBeNull();
+    });
+
+    test("returns NotFoundError for unknown identity", async () => {
+      const result = await opKeys.rotate("unknown");
+      expect(Result.isError(result)).toBe(true);
+    });
+  });
+
+  describe("list", () => {
+    test("returns empty list initially", () => {
+      expect(opKeys.list()).toEqual([]);
+    });
+
+    test("lists all operational keys", async () => {
+      await opKeys.create("agent-1", null);
+      await opKeys.create("agent-2", "group-b");
+
+      const keys = opKeys.list();
+      expect(keys).toHaveLength(2);
+    });
+  });
+
+  describe("sign", () => {
+    test("signs data with an operational key", async () => {
+      await opKeys.create("agent-1", null);
+      const data = new Uint8Array([1, 2, 3]);
+      const result = await opKeys.sign("agent-1", data);
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("sign failed");
+      expect(result.value.byteLength).toBeGreaterThan(0);
+    });
+
+    test("returns NotFoundError for unknown identity", async () => {
+      const result = await opKeys.sign("unknown", new Uint8Array([1]));
+      expect(Result.isError(result)).toBe(true);
+    });
+
+    test("signs with persisted key material after manager recreation", async () => {
+      await opKeys.create("agent-1", null);
+
+      const reloadedManager = createOperationalKeyManager(vault);
+      const result = await reloadedManager.sign(
+        "agent-1",
+        new Uint8Array([1, 2, 3]),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("sign failed");
+      expect(result.value.byteLength).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/keys/src/__tests__/platform.test.ts
+++ b/packages/keys/src/__tests__/platform.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from "bun:test";
+import { detectPlatform, platformToTrustTier } from "../platform.js";
+
+describe("detectPlatform", () => {
+  test("returns a valid PlatformCapability", () => {
+    const platform = detectPlatform();
+    const valid: readonly string[] = [
+      "secure-enclave",
+      "keychain-software",
+      "tpm",
+      "software-vault",
+    ];
+    expect(valid).toContain(platform);
+  });
+
+  test("returns software-vault for v0", () => {
+    // v0 always returns software-vault since no Swift bridge
+    const platform = detectPlatform();
+    expect(platform).toBe("software-vault");
+  });
+});
+
+describe("platformToTrustTier", () => {
+  test("maps secure-enclave to source-verified", () => {
+    expect(platformToTrustTier("secure-enclave")).toBe("source-verified");
+  });
+
+  test("maps keychain-software to source-verified", () => {
+    expect(platformToTrustTier("keychain-software")).toBe("source-verified");
+  });
+
+  test("maps tpm to source-verified", () => {
+    expect(platformToTrustTier("tpm")).toBe("source-verified");
+  });
+
+  test("maps software-vault to unverified", () => {
+    expect(platformToTrustTier("software-vault")).toBe("unverified");
+  });
+});

--- a/packages/keys/src/__tests__/session-key.test.ts
+++ b/packages/keys/src/__tests__/session-key.test.ts
@@ -1,0 +1,130 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { Result } from "better-result";
+import {
+  createSessionKeyManager,
+  type SessionKeyManager,
+} from "../session-key.js";
+
+describe("SessionKeyManager", () => {
+  let sessions: SessionKeyManager;
+
+  beforeEach(() => {
+    sessions = createSessionKeyManager();
+  });
+
+  describe("issue", () => {
+    test("issues a session key bound to a session ID", async () => {
+      const result = await sessions.issue("ses_abc", 3600);
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("issue failed");
+
+      const key = result.value;
+      expect(key.keyId).toBeDefined();
+      expect(key.sessionId).toBe("ses_abc");
+      expect(key.fingerprint).toMatch(/^[0-9a-f]{64}$/);
+      expect(key.expiresAt).toBeDefined();
+      expect(key.createdAt).toBeDefined();
+    });
+
+    test("issues unique keys for different sessions", async () => {
+      const r1 = await sessions.issue("ses_1", 3600);
+      const r2 = await sessions.issue("ses_2", 3600);
+      if (Result.isError(r1) || Result.isError(r2))
+        throw new Error("issue failed");
+      expect(r1.value.keyId).not.toBe(r2.value.keyId);
+    });
+
+    test("sets expiry based on TTL", async () => {
+      const before = Date.now();
+      const result = await sessions.issue("ses_ttl", 60);
+      if (Result.isError(result)) throw new Error("issue failed");
+
+      const expiresAt = new Date(result.value.expiresAt).getTime();
+      // Should be roughly now + 60 seconds
+      expect(expiresAt).toBeGreaterThanOrEqual(before + 59_000);
+      expect(expiresAt).toBeLessThanOrEqual(before + 61_000);
+    });
+  });
+
+  describe("sign", () => {
+    test("signs data with a session key", async () => {
+      const issued = await sessions.issue("ses_sign", 3600);
+      if (Result.isError(issued)) throw new Error("issue failed");
+
+      const data = new Uint8Array([1, 2, 3]);
+      const sig = await sessions.sign(issued.value.keyId, data);
+      expect(Result.isOk(sig)).toBe(true);
+      if (Result.isError(sig)) throw new Error("sign failed");
+      expect(sig.value.byteLength).toBeGreaterThan(0);
+    });
+
+    test("returns NotFoundError for unknown key ID", async () => {
+      const result = await sessions.sign("unknown-key", new Uint8Array([1]));
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isOk(result)) throw new Error("expected error");
+      expect(result.error._tag).toBe("NotFoundError");
+    });
+
+    test("rejects signing with an expired key", async () => {
+      // Issue with 0-second TTL so it expires immediately
+      const issued = await sessions.issue("ses_expired", 0);
+      if (Result.isError(issued)) throw new Error("issue failed");
+
+      const result = await sessions.sign(
+        issued.value.keyId,
+        new Uint8Array([1]),
+      );
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isOk(result)) throw new Error("expected error");
+      expect(result.error._tag).toBe("NotFoundError");
+    });
+
+    test("deletes expired key on sign attempt", async () => {
+      const issued = await sessions.issue("ses_expired2", 0);
+      if (Result.isError(issued)) throw new Error("issue failed");
+
+      // First sign attempt triggers expiry cleanup
+      await sessions.sign(issued.value.keyId, new Uint8Array([1]));
+
+      // Revoke should also fail since the key was deleted
+      const revokeResult = sessions.revoke(issued.value.keyId);
+      expect(Result.isError(revokeResult)).toBe(true);
+    });
+  });
+
+  describe("revoke", () => {
+    test("revokes an issued session key", async () => {
+      const issued = await sessions.issue("ses_revoke", 3600);
+      if (Result.isError(issued)) throw new Error("issue failed");
+
+      const revokeResult = sessions.revoke(issued.value.keyId);
+      expect(Result.isOk(revokeResult)).toBe(true);
+    });
+
+    test("signing after revoke fails", async () => {
+      const issued = await sessions.issue("ses_revoke2", 3600);
+      if (Result.isError(issued)) throw new Error("issue failed");
+
+      sessions.revoke(issued.value.keyId);
+
+      const sig = await sessions.sign(issued.value.keyId, new Uint8Array([1]));
+      expect(Result.isError(sig)).toBe(true);
+    });
+
+    test("returns NotFoundError for unknown key", () => {
+      const result = sessions.revoke("nonexistent");
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isOk(result)) throw new Error("expected error");
+      expect(result.error._tag).toBe("NotFoundError");
+    });
+
+    test("double revoke returns NotFoundError", async () => {
+      const issued = await sessions.issue("ses_double", 3600);
+      if (Result.isError(issued)) throw new Error("issue failed");
+
+      sessions.revoke(issued.value.keyId);
+      const result = sessions.revoke(issued.value.keyId);
+      expect(Result.isError(result)).toBe(true);
+    });
+  });
+});

--- a/packages/keys/src/__tests__/signer-provider.test.ts
+++ b/packages/keys/src/__tests__/signer-provider.test.ts
@@ -1,0 +1,141 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Result } from "better-result";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createKeyManager, type KeyManager } from "../key-manager.js";
+import { createSignerProvider } from "../signer-provider.js";
+import type { SignerProvider } from "@xmtp-broker/contracts";
+
+describe("SignerProvider", () => {
+  let dataDir: string;
+  let manager: KeyManager;
+  let provider: SignerProvider;
+
+  beforeEach(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "sp-test-"));
+    const result = await createKeyManager({ dataDir });
+    if (Result.isError(result)) throw new Error("setup failed");
+    manager = result.value;
+    await manager.createOperationalKey("agent-1", null);
+    provider = createSignerProvider(manager, "agent-1");
+  });
+
+  afterEach(() => {
+    manager.close();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  describe("sign", () => {
+    test("signs data and returns bytes", async () => {
+      const result = await provider.sign(new Uint8Array([1, 2, 3]));
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("sign failed");
+      expect(result.value.byteLength).toBeGreaterThan(0);
+    });
+  });
+
+  describe("getPublicKey", () => {
+    test("returns public key bytes", async () => {
+      const result = await provider.getPublicKey();
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("getPublicKey failed");
+      // Ed25519 public key is 32 bytes
+      expect(result.value.byteLength).toBe(32);
+    });
+  });
+
+  describe("getFingerprint", () => {
+    test("returns hex SHA-256 fingerprint", async () => {
+      const result = await provider.getFingerprint();
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("getFingerprint failed");
+      expect(result.value).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    test("matches the operational key fingerprint", async () => {
+      const fp = await provider.getFingerprint();
+      if (Result.isError(fp)) throw new Error("getFingerprint failed");
+
+      const opKey = manager.getOperationalKey("agent-1");
+      if (Result.isError(opKey)) throw new Error("getOperationalKey failed");
+      expect(fp.value).toBe(opKey.value.fingerprint);
+    });
+  });
+
+  describe("getDbEncryptionKey", () => {
+    test("returns a 32-byte key", async () => {
+      const result = await provider.getDbEncryptionKey();
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("getDbEncryptionKey failed");
+      expect(result.value.byteLength).toBe(32);
+    });
+
+    test("returns the same key for the same identity", async () => {
+      const r1 = await provider.getDbEncryptionKey();
+      const r2 = await provider.getDbEncryptionKey();
+      if (Result.isError(r1) || Result.isError(r2))
+        throw new Error("getDbEncryptionKey failed");
+      expect(r1.value).toEqual(r2.value);
+    });
+
+    test("returns different keys for different identities", async () => {
+      await manager.createOperationalKey("agent-2", null);
+      const provider2 = createSignerProvider(manager, "agent-2");
+
+      const r1 = await provider.getDbEncryptionKey();
+      const r2 = await provider2.getDbEncryptionKey();
+      if (Result.isError(r1) || Result.isError(r2))
+        throw new Error("getDbEncryptionKey failed");
+
+      // Keys should be different for different identities
+      const same = r1.value.every((b, i) => b === r2.value[i]);
+      expect(same).toBe(false);
+    });
+
+    test("key is NOT derivable from public key and identity ID", async () => {
+      // Two managers with the same identity but different vaults must
+      // produce different DB encryption keys — proving the key is
+      // vault-backed random material, not derived from public inputs.
+      const dataDir2 = mkdtempSync(join(tmpdir(), "sp-test-2-"));
+      const result2 = await createKeyManager({ dataDir: dataDir2 });
+      if (Result.isError(result2)) throw new Error("setup failed");
+      const manager2 = result2.value;
+
+      try {
+        await manager2.createOperationalKey("agent-1", null);
+        const provider2 = createSignerProvider(manager2, "agent-1");
+
+        const r1 = await provider.getDbEncryptionKey();
+        const r2 = await provider2.getDbEncryptionKey();
+        if (Result.isError(r1) || Result.isError(r2))
+          throw new Error("getDbEncryptionKey failed");
+
+        // Same identity, different vaults => different keys
+        const same = r1.value.every((b, i) => b === r2.value[i]);
+        expect(same).toBe(false);
+      } finally {
+        manager2.close();
+        rmSync(dataDir2, { recursive: true, force: true });
+      }
+    });
+
+    test("key survives vault close and reopen", async () => {
+      const r1 = await provider.getDbEncryptionKey();
+      if (Result.isError(r1)) throw new Error("getDbEncryptionKey failed");
+
+      // Close and reopen manager with the same dataDir
+      manager.close();
+      const reopened = await createKeyManager({ dataDir });
+      if (Result.isError(reopened)) throw new Error("reopen failed");
+      manager = reopened.value;
+
+      await manager.createOperationalKey("agent-1", null);
+      const provider2 = createSignerProvider(manager, "agent-1");
+      const r2 = await provider2.getDbEncryptionKey();
+      if (Result.isError(r2)) throw new Error("getDbEncryptionKey failed");
+
+      expect(r1.value).toEqual(r2.value);
+    });
+  });
+});

--- a/packages/keys/src/__tests__/smoke.test.ts
+++ b/packages/keys/src/__tests__/smoke.test.ts
@@ -1,7 +1,0 @@
-import { describe, expect, it } from "bun:test";
-
-describe("workspace", () => {
-  it("test runner works", () => {
-    expect(true).toBe(true);
-  });
-});

--- a/packages/keys/src/__tests__/vault.test.ts
+++ b/packages/keys/src/__tests__/vault.test.ts
@@ -1,0 +1,145 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Result } from "better-result";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createVault, type Vault } from "../vault.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+describe("Vault", () => {
+  let dataDir: string;
+  let vault: Vault;
+
+  beforeEach(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "vault-test-"));
+    const result = await createVault(dataDir);
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result)) throw new Error("setup failed");
+    vault = result.value;
+  });
+
+  afterEach(() => {
+    vault.close();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  describe("set and get", () => {
+    test("stores and retrieves a secret", async () => {
+      const data = encoder.encode("my-secret-value");
+      const setResult = await vault.set("api-key", data);
+      expect(Result.isOk(setResult)).toBe(true);
+
+      const getResult = await vault.get("api-key");
+      expect(Result.isOk(getResult)).toBe(true);
+      if (Result.isError(getResult)) throw new Error("get failed");
+      expect(decoder.decode(getResult.value)).toBe("my-secret-value");
+    });
+
+    test("overwrites existing secret", async () => {
+      await vault.set("key", encoder.encode("v1"));
+      await vault.set("key", encoder.encode("v2"));
+
+      const result = await vault.get("key");
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("get failed");
+      expect(decoder.decode(result.value)).toBe("v2");
+    });
+
+    test("returns NotFoundError for missing secret", async () => {
+      const result = await vault.get("nonexistent");
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isOk(result)) throw new Error("expected error");
+      expect(result.error._tag).toBe("NotFoundError");
+    });
+  });
+
+  describe("delete", () => {
+    test("removes an existing secret", async () => {
+      await vault.set("key", encoder.encode("val"));
+      const delResult = await vault.delete("key");
+      expect(Result.isOk(delResult)).toBe(true);
+
+      const getResult = await vault.get("key");
+      expect(Result.isError(getResult)).toBe(true);
+    });
+
+    test("returns NotFoundError for missing secret", async () => {
+      const result = await vault.delete("nonexistent");
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isOk(result)) throw new Error("expected error");
+      expect(result.error._tag).toBe("NotFoundError");
+    });
+  });
+
+  describe("list", () => {
+    test("returns empty list initially", () => {
+      expect(vault.list()).toEqual([]);
+    });
+
+    test("lists stored secret names", async () => {
+      await vault.set("a", encoder.encode("1"));
+      await vault.set("b", encoder.encode("2"));
+      await vault.set("c", encoder.encode("3"));
+
+      const names = vault.list();
+      expect(names).toHaveLength(3);
+      expect([...names].sort()).toEqual(["a", "b", "c"]);
+    });
+
+    test("does not include deleted secrets", async () => {
+      await vault.set("a", encoder.encode("1"));
+      await vault.set("b", encoder.encode("2"));
+      await vault.delete("a");
+
+      expect(vault.list()).toEqual(["b"]);
+    });
+  });
+
+  describe("encryption at rest", () => {
+    test("stored data is not plaintext in the database", async () => {
+      const secret = "super-secret-password-12345";
+      await vault.set("test-enc", encoder.encode(secret));
+
+      // Read the raw database file and check the secret is not in plaintext
+      const dbPath = join(dataDir, "vault.db");
+      const raw = await Bun.file(dbPath).arrayBuffer();
+      const rawStr = decoder.decode(raw);
+      expect(rawStr).not.toContain(secret);
+    });
+
+    test("creates a vault.key file with 32 random bytes", async () => {
+      const keyPath = join(dataDir, "vault.key");
+      const keyFile = Bun.file(keyPath);
+      expect(await keyFile.exists()).toBe(true);
+      const keyBytes = new Uint8Array(await keyFile.arrayBuffer());
+      expect(keyBytes.byteLength).toBe(32);
+    });
+
+    test("vault.key is not all zeros", async () => {
+      const keyPath = join(dataDir, "vault.key");
+      const keyBytes = new Uint8Array(await Bun.file(keyPath).arrayBuffer());
+      const allZero = keyBytes.every((b) => b === 0);
+      expect(allZero).toBe(false);
+    });
+  });
+
+  describe("persistence", () => {
+    test("survives close and reopen", async () => {
+      await vault.set("persist-key", encoder.encode("persist-value"));
+      vault.close();
+
+      const result2 = await createVault(dataDir);
+      expect(Result.isOk(result2)).toBe(true);
+      if (Result.isError(result2)) throw new Error("reopen failed");
+      const vault2 = result2.value;
+
+      const getResult = await vault2.get("persist-key");
+      expect(Result.isOk(getResult)).toBe(true);
+      if (Result.isError(getResult)) throw new Error("get failed");
+      expect(decoder.decode(getResult.value)).toBe("persist-value");
+      vault2.close();
+    });
+  });
+});

--- a/packages/keys/src/attestation-signer.ts
+++ b/packages/keys/src/attestation-signer.ts
@@ -1,0 +1,86 @@
+import { Result } from "better-result";
+import type {
+  Attestation,
+  BrokerError,
+  RevocationAttestation,
+} from "@xmtp-broker/schemas";
+import type {
+  AttestationSigner,
+  SignedAttestation,
+  SignedRevocationEnvelope,
+} from "@xmtp-broker/contracts";
+import type { KeyManager } from "./key-manager.js";
+
+/**
+ * Create an AttestationSigner backed by a KeyManager's operational key.
+ * Signs attestation and revocation payloads with Ed25519.
+ */
+export function createAttestationSigner(
+  manager: KeyManager,
+  identityId: string,
+): AttestationSigner {
+  return {
+    async sign(
+      payload: Attestation,
+    ): Promise<Result<SignedAttestation, BrokerError>> {
+      const canonical = canonicalize(payload);
+      const sig = await manager.signWithOperationalKey(identityId, canonical);
+      if (Result.isError(sig)) return sig;
+
+      const opKey = manager.getOperationalKey(identityId);
+      if (Result.isError(opKey)) return opKey;
+
+      const signed: SignedAttestation = {
+        attestation: payload,
+        signature: toBase64(sig.value),
+        signatureAlgorithm: "Ed25519",
+        signerKeyRef: opKey.value.fingerprint,
+      };
+      return Result.ok(signed);
+    },
+
+    async signRevocation(
+      payload: RevocationAttestation,
+    ): Promise<Result<SignedRevocationEnvelope, BrokerError>> {
+      const canonical = canonicalize(payload);
+      const sig = await manager.signWithOperationalKey(identityId, canonical);
+      if (Result.isError(sig)) return sig;
+
+      const opKey = manager.getOperationalKey(identityId);
+      if (Result.isError(opKey)) return opKey;
+
+      const signed: SignedRevocationEnvelope = {
+        revocation: payload,
+        signature: toBase64(sig.value),
+        signatureAlgorithm: "Ed25519",
+        signerKeyRef: opKey.value.fingerprint,
+      };
+      return Result.ok(signed);
+    },
+  };
+}
+
+function toBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64");
+}
+
+/** Deterministic JSON serialization with sorted keys, encoded as UTF-8. */
+function canonicalize(value: unknown): Uint8Array {
+  const json = JSON.stringify(sortKeys(value));
+  return new TextEncoder().encode(json);
+}
+
+function sortKeys(value: unknown): unknown {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(sortKeys);
+  }
+  const sorted: Record<string, unknown> = {};
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  for (const key of keys) {
+    sorted[key] = sortKeys((value as Record<string, unknown>)[key]);
+  }
+  return sorted;
+}

--- a/packages/keys/src/config.ts
+++ b/packages/keys/src/config.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+export const KeyPolicySchema: z.ZodEnum<
+  ["biometric", "passcode", "open"]
+> = z
+  .enum(["biometric", "passcode", "open"])
+  .describe("Access control policy for a key tier");
+
+export type KeyPolicy = z.infer<typeof KeyPolicySchema>;
+
+export const PlatformCapabilitySchema: z.ZodEnum<
+  ["secure-enclave", "keychain-software", "tpm", "software-vault"]
+> = z
+  .enum(["secure-enclave", "keychain-software", "tpm", "software-vault"])
+  .describe("Actual hardware security capability detected");
+
+export type PlatformCapability = z.infer<typeof PlatformCapabilitySchema>;
+
+/** Parsed key manager configuration (all defaults applied). */
+export type KeyManagerConfig = {
+  dataDir: string;
+  rootKeyPolicy: KeyPolicy;
+  operationalKeyPolicy: KeyPolicy;
+  sessionKeyTtlSeconds: number;
+};
+
+/** Input to KeyManagerConfigSchema (fields with defaults are optional). */
+type KeyManagerConfigInput = {
+  dataDir: string;
+  rootKeyPolicy?: KeyPolicy | undefined;
+  operationalKeyPolicy?: KeyPolicy | undefined;
+  sessionKeyTtlSeconds?: number | undefined;
+};
+
+export const KeyManagerConfigSchema: z.ZodType<
+  KeyManagerConfig,
+  z.ZodTypeDef,
+  KeyManagerConfigInput
+> = z
+  .object({
+    dataDir: z.string().describe("Base directory for key storage"),
+    rootKeyPolicy: KeyPolicySchema.default("biometric").describe(
+      "Access policy for root key operations",
+    ),
+    operationalKeyPolicy: KeyPolicySchema.default("open").describe(
+      "Access policy for routine operations",
+    ),
+    sessionKeyTtlSeconds: z
+      .number()
+      .int()
+      .positive()
+      .default(3600)
+      .describe("Default TTL for session keys"),
+  })
+  .describe("Key manager configuration");

--- a/packages/keys/src/crypto-keys.ts
+++ b/packages/keys/src/crypto-keys.ts
@@ -1,0 +1,244 @@
+import { Result } from "better-result";
+import { InternalError } from "@xmtp-broker/schemas";
+
+/**
+ * Helper to convert Uint8Array to a BufferSource compatible with
+ * Bun's strict WebCrypto types.
+ */
+function asBuffer(data: Uint8Array): ArrayBuffer {
+  return data.buffer.slice(
+    data.byteOffset,
+    data.byteOffset + data.byteLength,
+  ) as ArrayBuffer;
+}
+
+/** Generate a P-256 ECDSA key pair. */
+export async function generateP256KeyPair(): Promise<
+  Result<CryptoKeyPair, InternalError>
+> {
+  try {
+    const keyPair = await crypto.subtle.generateKey(
+      { name: "ECDSA", namedCurve: "P-256" },
+      true,
+      ["sign", "verify"],
+    );
+    return Result.ok(keyPair);
+  } catch (e) {
+    return Result.err(
+      InternalError.create("Failed to generate P-256 key pair", {
+        cause: String(e),
+      }),
+    );
+  }
+}
+
+/** Generate an Ed25519 key pair. */
+export async function generateEd25519KeyPair(): Promise<
+  Result<CryptoKeyPair, InternalError>
+> {
+  try {
+    const keyPair = await crypto.subtle.generateKey({ name: "Ed25519" }, true, [
+      "sign",
+      "verify",
+    ]);
+    return Result.ok(keyPair);
+  } catch (e) {
+    return Result.err(
+      InternalError.create("Failed to generate Ed25519 key pair", {
+        cause: String(e),
+      }),
+    );
+  }
+}
+
+/** Sign data with P-256 ECDSA (SHA-256). */
+export async function signP256(
+  privateKey: CryptoKey,
+  data: Uint8Array,
+): Promise<Result<Uint8Array, InternalError>> {
+  try {
+    const sig = await crypto.subtle.sign(
+      { name: "ECDSA", hash: "SHA-256" },
+      privateKey,
+      asBuffer(data),
+    );
+    return Result.ok(new Uint8Array(sig));
+  } catch (e) {
+    return Result.err(
+      InternalError.create("P-256 signing failed", { cause: String(e) }),
+    );
+  }
+}
+
+/** Verify a P-256 ECDSA signature. */
+export async function verifyP256(
+  publicKey: CryptoKey,
+  data: Uint8Array,
+  signature: Uint8Array,
+): Promise<Result<boolean, InternalError>> {
+  try {
+    const valid = await crypto.subtle.verify(
+      { name: "ECDSA", hash: "SHA-256" },
+      publicKey,
+      asBuffer(signature),
+      asBuffer(data),
+    );
+    return Result.ok(valid);
+  } catch (e) {
+    return Result.err(
+      InternalError.create("P-256 verification failed", {
+        cause: String(e),
+      }),
+    );
+  }
+}
+
+/** Sign data with Ed25519. */
+export async function signEd25519(
+  privateKey: CryptoKey,
+  data: Uint8Array,
+): Promise<Result<Uint8Array, InternalError>> {
+  try {
+    const sig = await crypto.subtle.sign(
+      { name: "Ed25519" },
+      privateKey,
+      asBuffer(data),
+    );
+    return Result.ok(new Uint8Array(sig));
+  } catch (e) {
+    return Result.err(
+      InternalError.create("Ed25519 signing failed", { cause: String(e) }),
+    );
+  }
+}
+
+/** Verify an Ed25519 signature. */
+export async function verifyEd25519(
+  publicKey: CryptoKey,
+  data: Uint8Array,
+  signature: Uint8Array,
+): Promise<Result<boolean, InternalError>> {
+  try {
+    const valid = await crypto.subtle.verify(
+      { name: "Ed25519" },
+      publicKey,
+      asBuffer(signature),
+      asBuffer(data),
+    );
+    return Result.ok(valid);
+  } catch (e) {
+    return Result.err(
+      InternalError.create("Ed25519 verification failed", {
+        cause: String(e),
+      }),
+    );
+  }
+}
+
+/** Export a public key as raw bytes. */
+export async function exportPublicKey(
+  key: CryptoKey,
+): Promise<Result<Uint8Array, InternalError>> {
+  try {
+    const raw = await crypto.subtle.exportKey("raw", key);
+    return Result.ok(new Uint8Array(raw));
+  } catch (e) {
+    return Result.err(
+      InternalError.create("Failed to export public key", {
+        cause: String(e),
+      }),
+    );
+  }
+}
+
+/** Export a private key as PKCS8 bytes. */
+export async function exportPrivateKey(
+  key: CryptoKey,
+): Promise<Result<Uint8Array, InternalError>> {
+  try {
+    const pkcs8 = await crypto.subtle.exportKey("pkcs8", key);
+    return Result.ok(new Uint8Array(pkcs8));
+  } catch (e) {
+    return Result.err(
+      InternalError.create("Failed to export private key", {
+        cause: String(e),
+      }),
+    );
+  }
+}
+
+/** Import Ed25519 private key from PKCS8 bytes. */
+export async function importEd25519PrivateKey(
+  pkcs8: Uint8Array,
+): Promise<Result<CryptoKey, InternalError>> {
+  try {
+    const key = await crypto.subtle.importKey(
+      "pkcs8",
+      asBuffer(pkcs8),
+      { name: "Ed25519" },
+      true,
+      ["sign"],
+    );
+    return Result.ok(key);
+  } catch (e) {
+    return Result.err(
+      InternalError.create("Failed to import Ed25519 private key", {
+        cause: String(e),
+      }),
+    );
+  }
+}
+
+/** Import P-256 ECDSA private key from PKCS8 bytes. */
+export async function importP256PrivateKey(
+  pkcs8: Uint8Array,
+): Promise<Result<CryptoKey, InternalError>> {
+  try {
+    const key = await crypto.subtle.importKey(
+      "pkcs8",
+      asBuffer(pkcs8),
+      { name: "ECDSA", namedCurve: "P-256" },
+      true,
+      ["sign"],
+    );
+    return Result.ok(key);
+  } catch (e) {
+    return Result.err(
+      InternalError.create("Failed to import P-256 private key", {
+        cause: String(e),
+      }),
+    );
+  }
+}
+
+/** Compute SHA-256 fingerprint of a public key (hex-encoded). */
+export async function fingerprint(
+  publicKey: CryptoKey,
+): Promise<Result<string, InternalError>> {
+  const exported = await exportPublicKey(publicKey);
+  if (Result.isError(exported)) return exported;
+
+  try {
+    const hash = await crypto.subtle.digest(
+      "SHA-256",
+      asBuffer(exported.value),
+    );
+    const hex = Array.from(new Uint8Array(hash))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+    return Result.ok(hex);
+  } catch (e) {
+    return Result.err(
+      InternalError.create("Failed to compute fingerprint", {
+        cause: String(e),
+      }),
+    );
+  }
+}
+
+/** Convert bytes to hex string. */
+export function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/packages/keys/src/index.ts
+++ b/packages/keys/src/index.ts
@@ -1,2 +1,60 @@
-// Placeholder — real exports added by subsequent specs.
-export {};
+// Config and schemas
+export {
+  KeyPolicySchema,
+  PlatformCapabilitySchema,
+  KeyManagerConfigSchema,
+} from "./config.js";
+export type {
+  KeyPolicy,
+  PlatformCapability,
+  KeyManagerConfig,
+} from "./config.js";
+
+// Types
+export type { RootKeyHandle, OperationalKey, SessionKey } from "./types.js";
+
+// Platform detection
+export { detectPlatform, platformToTrustTier } from "./platform.js";
+
+// Key manager
+export { createKeyManager } from "./key-manager.js";
+export type { KeyManager } from "./key-manager.js";
+
+// Vault
+export { createVault } from "./vault.js";
+export type { Vault } from "./vault.js";
+
+// Signer provider
+export { createSignerProvider } from "./signer-provider.js";
+
+// Attestation signer
+export { createAttestationSigner } from "./attestation-signer.js";
+
+// Operational key manager
+export { createOperationalKeyManager } from "./operational-key.js";
+export type { OperationalKeyManager } from "./operational-key.js";
+
+// Session key manager
+export { createSessionKeyManager } from "./session-key.js";
+export type { SessionKeyManager } from "./session-key.js";
+
+// Crypto utilities
+// Root key
+export { initializeRootKey, signWithRootKey } from "./root-key.js";
+export type { RootKeyResult } from "./root-key.js";
+
+// Crypto utilities
+export {
+  generateP256KeyPair,
+  generateEd25519KeyPair,
+  signP256,
+  verifyP256,
+  signEd25519,
+  verifyEd25519,
+  exportPublicKey,
+  exportPrivateKey,
+  importEd25519PrivateKey,
+  importP256PrivateKey,
+  fingerprint,
+  toHex,
+} from "./crypto-keys.js";

--- a/packages/keys/src/key-manager.ts
+++ b/packages/keys/src/key-manager.ts
@@ -1,0 +1,271 @@
+import { Result } from "better-result";
+import type { TrustTier } from "@xmtp-broker/schemas";
+import {
+  InternalError,
+  NotFoundError,
+  type AuthError,
+} from "@xmtp-broker/schemas";
+import {
+  KeyManagerConfigSchema,
+  type KeyManagerConfig,
+  type PlatformCapability,
+} from "./config.js";
+import { detectPlatform, platformToTrustTier } from "./platform.js";
+import { createVault } from "./vault.js";
+import {
+  createOperationalKeyManager,
+  type OperationalKeyManager,
+} from "./operational-key.js";
+import {
+  createSessionKeyManager,
+  type SessionKeyManager,
+} from "./session-key.js";
+import { initializeRootKey } from "./root-key.js";
+import type { RootKeyHandle, OperationalKey, SessionKey } from "./types.js";
+
+export interface KeyManager {
+  initialize(): Promise<Result<RootKeyHandle, InternalError | AuthError>>;
+
+  readonly platform: PlatformCapability;
+  readonly trustTier: TrustTier;
+
+  createOperationalKey(
+    identityId: string,
+    groupId: string | null,
+  ): Promise<Result<OperationalKey, InternalError>>;
+
+  getOperationalKey(identityId: string): Result<OperationalKey, NotFoundError>;
+
+  getOperationalKeyByGroupId(
+    groupId: string,
+  ): Result<OperationalKey, NotFoundError>;
+
+  rotateOperationalKey(
+    identityId: string,
+  ): Promise<Result<OperationalKey, InternalError | NotFoundError>>;
+
+  listOperationalKeys(): readonly OperationalKey[];
+
+  issueSessionKey(
+    sessionId: string,
+    ttlSeconds: number,
+  ): Promise<Result<SessionKey, InternalError>>;
+
+  revokeSessionKey(keyId: string): Result<void, NotFoundError>;
+
+  signWithOperationalKey(
+    identityId: string,
+    data: Uint8Array,
+  ): Promise<Result<Uint8Array, InternalError | NotFoundError>>;
+
+  signWithSessionKey(
+    keyId: string,
+    data: Uint8Array,
+  ): Promise<Result<Uint8Array, InternalError | NotFoundError>>;
+
+  getOrCreateDbKey(
+    identityId: string,
+  ): Promise<Result<Uint8Array, InternalError>>;
+
+  /**
+   * Retrieve or generate a secp256k1 private key for XMTP identity
+   * registration. The key is persisted in the vault so the same key
+   * is returned across restarts.
+   */
+  getOrCreateXmtpIdentityKey(
+    identityId: string,
+  ): Promise<Result<`0x${string}`, InternalError>>;
+
+  vaultSet(
+    name: string,
+    value: Uint8Array,
+  ): Promise<Result<void, InternalError>>;
+
+  vaultGet(
+    name: string,
+  ): Promise<Result<Uint8Array, NotFoundError | InternalError>>;
+
+  vaultDelete(name: string): Promise<Result<void, NotFoundError>>;
+
+  vaultList(): readonly string[];
+
+  close(): void;
+}
+
+export async function createKeyManager(
+  rawConfig: Partial<KeyManagerConfig> & { dataDir: string },
+): Promise<Result<KeyManager, InternalError>> {
+  const parsed = KeyManagerConfigSchema.safeParse(rawConfig);
+  if (!parsed.success) {
+    return Result.err(
+      InternalError.create("Invalid key manager config", {
+        issues: parsed.error.issues,
+      }),
+    );
+  }
+  const config = parsed.data;
+
+  const detectedPlatform = detectPlatform();
+  const trustTier = platformToTrustTier(detectedPlatform);
+
+  const vaultResult = await createVault(config.dataDir);
+  if (Result.isError(vaultResult)) return vaultResult;
+  const vault = vaultResult.value;
+
+  const opKeys: OperationalKeyManager = createOperationalKeyManager(vault);
+  const sessionKeys: SessionKeyManager = createSessionKeyManager();
+
+  let rootKeyHandle: RootKeyHandle | null = null;
+
+  const manager: KeyManager = {
+    get platform(): PlatformCapability {
+      return detectedPlatform;
+    },
+
+    get trustTier(): TrustTier {
+      return trustTier;
+    },
+
+    async initialize(): Promise<
+      Result<RootKeyHandle, InternalError | AuthError>
+    > {
+      if (rootKeyHandle) {
+        return Result.ok(rootKeyHandle);
+      }
+      const result = await initializeRootKey(
+        vault,
+        config.rootKeyPolicy,
+        detectedPlatform,
+      );
+      if (Result.isError(result)) return result;
+      rootKeyHandle = result.value;
+      return Result.ok(rootKeyHandle);
+    },
+
+    async createOperationalKey(
+      identityId: string,
+      groupId: string | null,
+    ): Promise<Result<OperationalKey, InternalError>> {
+      return opKeys.create(identityId, groupId);
+    },
+
+    getOperationalKey(
+      identityId: string,
+    ): Result<OperationalKey, NotFoundError> {
+      return opKeys.get(identityId);
+    },
+
+    getOperationalKeyByGroupId(
+      groupId: string,
+    ): Result<OperationalKey, NotFoundError> {
+      return opKeys.getByGroupId(groupId);
+    },
+
+    async rotateOperationalKey(
+      identityId: string,
+    ): Promise<Result<OperationalKey, InternalError | NotFoundError>> {
+      return opKeys.rotate(identityId);
+    },
+
+    listOperationalKeys(): readonly OperationalKey[] {
+      return opKeys.list();
+    },
+
+    async issueSessionKey(
+      sessionId: string,
+      ttlSeconds: number,
+    ): Promise<Result<SessionKey, InternalError>> {
+      return sessionKeys.issue(sessionId, ttlSeconds);
+    },
+
+    revokeSessionKey(keyId: string): Result<void, NotFoundError> {
+      return sessionKeys.revoke(keyId);
+    },
+
+    async signWithOperationalKey(
+      identityId: string,
+      data: Uint8Array,
+    ): Promise<Result<Uint8Array, InternalError | NotFoundError>> {
+      return opKeys.sign(identityId, data);
+    },
+
+    async signWithSessionKey(
+      keyId: string,
+      data: Uint8Array,
+    ): Promise<Result<Uint8Array, InternalError | NotFoundError>> {
+      return sessionKeys.sign(keyId, data);
+    },
+
+    async getOrCreateDbKey(
+      identityId: string,
+    ): Promise<Result<Uint8Array, InternalError>> {
+      const vaultKey = `db-key:${identityId}`;
+      const existing = await vault.get(vaultKey);
+      if (Result.isOk(existing)) {
+        return Result.ok(existing.value);
+      }
+      // Propagate internal errors; NotFoundError means key doesn't exist yet
+      if (existing.error._tag !== "NotFoundError") {
+        return existing as Result<Uint8Array, InternalError>;
+      }
+      // Generate and persist a new random 32-byte key
+      const newKey = crypto.getRandomValues(new Uint8Array(32));
+      const setResult = await vault.set(vaultKey, newKey);
+      if (Result.isError(setResult)) return setResult;
+      return Result.ok(newKey);
+    },
+
+    async getOrCreateXmtpIdentityKey(
+      identityId: string,
+    ): Promise<Result<`0x${string}`, InternalError>> {
+      const vaultKey = `xmtp-identity-key:${identityId}`;
+      const existing = await vault.get(vaultKey);
+      if (Result.isOk(existing)) {
+        // Decode stored bytes back to hex
+        const hex = Array.from(existing.value)
+          .map((b) => b.toString(16).padStart(2, "0"))
+          .join("");
+        return Result.ok(`0x${hex}` as `0x${string}`);
+      }
+      // Propagate internal errors; NotFoundError means key doesn't exist yet
+      if (existing.error._tag !== "NotFoundError") {
+        return existing as Result<`0x${string}`, InternalError>;
+      }
+      // Generate a new random 32-byte secp256k1 private key
+      const newKey = crypto.getRandomValues(new Uint8Array(32));
+      const setResult = await vault.set(vaultKey, newKey);
+      if (Result.isError(setResult)) return setResult;
+      const hex = Array.from(newKey)
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+      return Result.ok(`0x${hex}` as `0x${string}`);
+    },
+
+    async vaultSet(
+      name: string,
+      value: Uint8Array,
+    ): Promise<Result<void, InternalError>> {
+      return vault.set(name, value);
+    },
+
+    async vaultGet(
+      name: string,
+    ): Promise<Result<Uint8Array, NotFoundError | InternalError>> {
+      return vault.get(name);
+    },
+
+    async vaultDelete(name: string): Promise<Result<void, NotFoundError>> {
+      return vault.delete(name);
+    },
+
+    vaultList(): readonly string[] {
+      return vault.list();
+    },
+
+    close(): void {
+      vault.close();
+    },
+  };
+
+  return Result.ok(manager);
+}

--- a/packages/keys/src/operational-key.ts
+++ b/packages/keys/src/operational-key.ts
@@ -1,0 +1,186 @@
+import { Result } from "better-result";
+import { InternalError, NotFoundError } from "@xmtp-broker/schemas";
+import type { Vault } from "./vault.js";
+import type { OperationalKey } from "./types.js";
+import {
+  generateEd25519KeyPair,
+  exportPublicKey,
+  exportPrivateKey,
+  importEd25519PrivateKey,
+  signEd25519,
+  fingerprint as computeFingerprint,
+  toHex,
+} from "./crypto-keys.js";
+
+export interface OperationalKeyManager {
+  create(
+    identityId: string,
+    groupId: string | null,
+  ): Promise<Result<OperationalKey, InternalError>>;
+
+  get(identityId: string): Result<OperationalKey, NotFoundError>;
+
+  getByGroupId(groupId: string): Result<OperationalKey, NotFoundError>;
+
+  rotate(
+    identityId: string,
+  ): Promise<Result<OperationalKey, InternalError | NotFoundError>>;
+
+  list(): readonly OperationalKey[];
+
+  sign(
+    identityId: string,
+    data: Uint8Array,
+  ): Promise<Result<Uint8Array, InternalError | NotFoundError>>;
+}
+
+/** Vault key prefix for operational key material. */
+const OP_KEY_PREFIX = "op-key:";
+
+export function createOperationalKeyManager(
+  vault: Vault,
+): OperationalKeyManager {
+  const keys = new Map<string, OperationalKey>();
+  const groupIndex = new Map<string, string>();
+
+  async function storeKeyMaterial(
+    identityId: string,
+    privateKey: CryptoKey,
+  ): Promise<Result<void, InternalError>> {
+    const exported = await exportPrivateKey(privateKey);
+    if (Result.isError(exported)) return exported;
+    const result = await vault.set(
+      `${OP_KEY_PREFIX}${identityId}`,
+      exported.value,
+    );
+    // Zeroize exported private key bytes after vault storage
+    exported.value.fill(0);
+    return result;
+  }
+
+  async function loadAndSign(
+    identityId: string,
+    data: Uint8Array,
+  ): Promise<Result<Uint8Array, InternalError | NotFoundError>> {
+    const vaultResult = await vault.get(`${OP_KEY_PREFIX}${identityId}`);
+    if (Result.isError(vaultResult)) {
+      if (vaultResult.error._tag === "NotFoundError") {
+        return Result.err(NotFoundError.create("OperationalKey", identityId));
+      }
+      return vaultResult;
+    }
+
+    const imported = await importEd25519PrivateKey(vaultResult.value);
+    if (Result.isError(imported)) return imported;
+
+    return signEd25519(imported.value, data);
+  }
+
+  return {
+    async create(
+      identityId: string,
+      groupId: string | null,
+    ): Promise<Result<OperationalKey, InternalError>> {
+      const keyPair = await generateEd25519KeyPair();
+      if (Result.isError(keyPair)) return keyPair;
+
+      const pubBytes = await exportPublicKey(keyPair.value.publicKey);
+      if (Result.isError(pubBytes)) return pubBytes;
+
+      const fp = await computeFingerprint(keyPair.value.publicKey);
+      if (Result.isError(fp)) return fp;
+
+      const storeResult = await storeKeyMaterial(
+        identityId,
+        keyPair.value.privateKey,
+      );
+      if (Result.isError(storeResult)) return storeResult;
+
+      const keyId = crypto.randomUUID();
+      const now = new Date().toISOString();
+
+      const opKey: OperationalKey = {
+        keyId,
+        identityId,
+        groupId,
+        publicKey: toHex(pubBytes.value),
+        fingerprint: fp.value,
+        createdAt: now,
+        rotatedAt: null,
+      };
+
+      keys.set(identityId, opKey);
+      if (groupId !== null) {
+        groupIndex.set(groupId, identityId);
+      }
+
+      return Result.ok(opKey);
+    },
+
+    get(identityId: string): Result<OperationalKey, NotFoundError> {
+      const key = keys.get(identityId);
+      if (!key) {
+        return Result.err(NotFoundError.create("OperationalKey", identityId));
+      }
+      return Result.ok(key);
+    },
+
+    getByGroupId(groupId: string): Result<OperationalKey, NotFoundError> {
+      const identityId = groupIndex.get(groupId);
+      if (!identityId) {
+        return Result.err(NotFoundError.create("OperationalKey", groupId));
+      }
+      const key = keys.get(identityId);
+      if (!key) {
+        return Result.err(NotFoundError.create("OperationalKey", groupId));
+      }
+      return Result.ok(key);
+    },
+
+    async rotate(
+      identityId: string,
+    ): Promise<Result<OperationalKey, InternalError | NotFoundError>> {
+      const existing = keys.get(identityId);
+      if (!existing) {
+        return Result.err(NotFoundError.create("OperationalKey", identityId));
+      }
+
+      const keyPair = await generateEd25519KeyPair();
+      if (Result.isError(keyPair)) return keyPair;
+
+      const pubBytes = await exportPublicKey(keyPair.value.publicKey);
+      if (Result.isError(pubBytes)) return pubBytes;
+
+      const fp = await computeFingerprint(keyPair.value.publicKey);
+      if (Result.isError(fp)) return fp;
+
+      const storeResult = await storeKeyMaterial(
+        identityId,
+        keyPair.value.privateKey,
+      );
+      if (Result.isError(storeResult)) return storeResult;
+
+      const rotated: OperationalKey = {
+        ...existing,
+        keyId: crypto.randomUUID(),
+        publicKey: toHex(pubBytes.value),
+        fingerprint: fp.value,
+        rotatedAt: new Date().toISOString(),
+      };
+
+      keys.set(identityId, rotated);
+      return Result.ok(rotated);
+    },
+
+    list(): readonly OperationalKey[] {
+      return [...keys.values()];
+    },
+
+    async sign(
+      identityId: string,
+      data: Uint8Array,
+    ): Promise<Result<Uint8Array, InternalError | NotFoundError>> {
+      return loadAndSign(identityId, data);
+    },
+  };
+}

--- a/packages/keys/src/platform.ts
+++ b/packages/keys/src/platform.ts
@@ -1,0 +1,24 @@
+import type { TrustTier } from "@xmtp-broker/schemas";
+import type { PlatformCapability } from "./config.js";
+
+/**
+ * Detect the current platform's key storage capability.
+ * v0: always returns "software-vault" since the Swift CLI bridge is not yet implemented.
+ */
+export function detectPlatform(): PlatformCapability {
+  // v0: software fallback only.
+  // Future: check for Secure Enclave via broker-signer subprocess.
+  return "software-vault";
+}
+
+/** Map platform capability to the corresponding trust tier. */
+export function platformToTrustTier(platform: PlatformCapability): TrustTier {
+  switch (platform) {
+    case "secure-enclave":
+    case "keychain-software":
+    case "tpm":
+      return "source-verified";
+    case "software-vault":
+      return "unverified";
+  }
+}

--- a/packages/keys/src/root-key.ts
+++ b/packages/keys/src/root-key.ts
@@ -1,0 +1,128 @@
+import { z } from "zod";
+import { Result } from "better-result";
+import { InternalError } from "@xmtp-broker/schemas";
+import {
+  KeyPolicySchema,
+  PlatformCapabilitySchema,
+} from "./config.js";
+import type { KeyPolicy, PlatformCapability } from "./config.js";
+import type { RootKeyHandle } from "./types.js";
+import type { Vault } from "./vault.js";
+import {
+  generateP256KeyPair,
+  exportPublicKey,
+  exportPrivateKey,
+  importP256PrivateKey,
+  signP256,
+  toHex,
+} from "./crypto-keys.js";
+
+const RootKeyHandleSchema = z.object({
+  keyRef: z.string(),
+  publicKey: z.string(),
+  policy: KeyPolicySchema,
+  platform: PlatformCapabilitySchema,
+  createdAt: z.string(),
+});
+
+const ROOT_KEY_REF = "root-key-ref";
+const ROOT_KEY_PRIVATE = "root-key:private";
+
+/** Result of root key initialization: opaque handle only. */
+export type RootKeyResult = RootKeyHandle;
+
+/**
+ * Initialize or load the root key.
+ * v0: software P-256 key stored in the vault.
+ * Future: Secure Enclave via Swift subprocess.
+ */
+export async function initializeRootKey(
+  vault: Vault,
+  policy: KeyPolicy,
+  platform: PlatformCapability,
+): Promise<Result<RootKeyResult, InternalError>> {
+  // Check if root key already exists in vault
+  const existing = await vault.get(ROOT_KEY_REF);
+  if (Result.isError(existing)) {
+    if (existing.error._tag !== "NotFoundError") {
+      return Result.err(existing.error);
+    }
+  } else {
+    try {
+      const parsed = RootKeyHandleSchema.safeParse(
+        JSON.parse(new TextDecoder().decode(existing.value)),
+      );
+      if (!parsed.success) {
+        return Result.err(
+          InternalError.create("Invalid root key handle data", {
+            cause: parsed.error.message,
+          }),
+        );
+      }
+      const stored: RootKeyHandle = parsed.data;
+      return Result.ok(stored);
+    } catch (e) {
+      return Result.err(
+        InternalError.create("Corrupt root key data", {
+          cause: String(e),
+        }),
+      );
+    }
+  }
+
+  // Generate new root key
+  const keyPair = await generateP256KeyPair();
+  if (Result.isError(keyPair)) return keyPair;
+
+  const pubBytes = await exportPublicKey(keyPair.value.publicKey);
+  if (Result.isError(pubBytes)) return pubBytes;
+
+  // Export and store the private key
+  const privBytes = await exportPrivateKey(keyPair.value.privateKey);
+  if (Result.isError(privBytes)) return privBytes;
+
+  const storePrivateResult = await vault.set(ROOT_KEY_PRIVATE, privBytes.value);
+  if (Result.isError(storePrivateResult)) return storePrivateResult;
+
+  // Zeroize exported private key bytes after vault storage
+  privBytes.value.fill(0);
+
+  const keyRef = crypto.randomUUID();
+  const handle: RootKeyHandle = {
+    keyRef,
+    publicKey: toHex(pubBytes.value),
+    policy,
+    platform,
+    createdAt: new Date().toISOString(),
+  };
+
+  // Store root key handle metadata in vault
+  const storeResult = await vault.set(
+    ROOT_KEY_REF,
+    new TextEncoder().encode(JSON.stringify(handle)),
+  );
+  if (Result.isError(storeResult)) return storeResult;
+
+  return Result.ok(handle);
+}
+
+/**
+ * Sign data with the root key. Loads private material from vault on-demand,
+ * signs, then lets the CryptoKey be garbage collected.
+ */
+export async function signWithRootKey(
+  vault: Vault,
+  data: Uint8Array,
+): Promise<Result<Uint8Array, InternalError>> {
+  const privateBytes = await vault.get(ROOT_KEY_PRIVATE);
+  if (Result.isError(privateBytes)) {
+    return Result.err(
+      InternalError.create("Root key private material not found in vault"),
+    );
+  }
+
+  const imported = await importP256PrivateKey(privateBytes.value);
+  if (Result.isError(imported)) return imported;
+
+  return signP256(imported.value, data);
+}

--- a/packages/keys/src/session-key.ts
+++ b/packages/keys/src/session-key.ts
@@ -1,0 +1,95 @@
+import { Result } from "better-result";
+import { InternalError, NotFoundError } from "@xmtp-broker/schemas";
+import type { SessionKey } from "./types.js";
+import {
+  generateEd25519KeyPair,
+  signEd25519,
+  fingerprint as computeFingerprint,
+} from "./crypto-keys.js";
+
+/**
+ * Internal record with key material (never exposed).
+ * Note: CryptoKey objects cannot be zeroized via the Web Crypto API.
+ * The private key material remains in memory until garbage-collected.
+ * This is a known limitation of the Web Crypto specification.
+ */
+interface SessionKeyEntry {
+  readonly meta: SessionKey;
+  readonly privateKey: CryptoKey;
+}
+
+export interface SessionKeyManager {
+  issue(
+    sessionId: string,
+    ttlSeconds: number,
+  ): Promise<Result<SessionKey, InternalError>>;
+
+  sign(
+    keyId: string,
+    data: Uint8Array,
+  ): Promise<Result<Uint8Array, InternalError | NotFoundError>>;
+
+  revoke(keyId: string): Result<void, NotFoundError>;
+}
+
+export function createSessionKeyManager(): SessionKeyManager {
+  const entries = new Map<string, SessionKeyEntry>();
+
+  return {
+    async issue(
+      sessionId: string,
+      ttlSeconds: number,
+    ): Promise<Result<SessionKey, InternalError>> {
+      const keyPair = await generateEd25519KeyPair();
+      if (Result.isError(keyPair)) return keyPair;
+
+      const fp = await computeFingerprint(keyPair.value.publicKey);
+      if (Result.isError(fp)) return fp;
+
+      const keyId = crypto.randomUUID();
+      const now = new Date();
+      const expiresAt = new Date(now.getTime() + ttlSeconds * 1000);
+
+      const meta: SessionKey = {
+        keyId,
+        sessionId,
+        fingerprint: fp.value,
+        expiresAt: expiresAt.toISOString(),
+        createdAt: now.toISOString(),
+      };
+
+      entries.set(keyId, {
+        meta,
+        privateKey: keyPair.value.privateKey,
+      });
+
+      return Result.ok(meta);
+    },
+
+    async sign(
+      keyId: string,
+      data: Uint8Array,
+    ): Promise<Result<Uint8Array, InternalError | NotFoundError>> {
+      const entry = entries.get(keyId);
+      if (!entry) {
+        return Result.err(NotFoundError.create("SessionKey", keyId));
+      }
+
+      // Enforce expiry: delete expired keys and reject signing
+      if (new Date(entry.meta.expiresAt).getTime() <= Date.now()) {
+        entries.delete(keyId);
+        return Result.err(NotFoundError.create("SessionKey", keyId));
+      }
+
+      return signEd25519(entry.privateKey, data);
+    },
+
+    revoke(keyId: string): Result<void, NotFoundError> {
+      if (!entries.has(keyId)) {
+        return Result.err(NotFoundError.create("SessionKey", keyId));
+      }
+      entries.delete(keyId);
+      return Result.ok();
+    },
+  };
+}

--- a/packages/keys/src/signer-provider.ts
+++ b/packages/keys/src/signer-provider.ts
@@ -1,0 +1,55 @@
+import { Result } from "better-result";
+import type { BrokerError } from "@xmtp-broker/schemas";
+import type { SignerProvider } from "@xmtp-broker/contracts";
+import type { KeyManager } from "./key-manager.js";
+
+/**
+ * Create a SignerProvider backed by a KeyManager for a specific identity.
+ * The provider signs with the identity's operational key and retrieves
+ * a vault-backed random DB encryption key.
+ */
+export function createSignerProvider(
+  manager: KeyManager,
+  identityId: string,
+): SignerProvider {
+  return {
+    async sign(data: Uint8Array): Promise<Result<Uint8Array, BrokerError>> {
+      return manager.signWithOperationalKey(identityId, data);
+    },
+
+    async getPublicKey(): Promise<Result<Uint8Array, BrokerError>> {
+      const opKey = manager.getOperationalKey(identityId);
+      if (Result.isError(opKey)) return opKey;
+
+      // Convert hex public key back to bytes
+      const hex = opKey.value.publicKey;
+      const bytes = hexToBytes(hex);
+      return Result.ok(bytes);
+    },
+
+    async getFingerprint(): Promise<Result<string, BrokerError>> {
+      const opKey = manager.getOperationalKey(identityId);
+      if (Result.isError(opKey)) return opKey;
+      return Result.ok(opKey.value.fingerprint);
+    },
+
+    async getDbEncryptionKey(): Promise<Result<Uint8Array, BrokerError>> {
+      return manager.getOrCreateDbKey(identityId);
+    },
+
+    async getXmtpIdentityKey(): Promise<
+      Result<`0x${string}`, BrokerError>
+    > {
+      return manager.getOrCreateXmtpIdentityKey(identityId);
+    },
+  };
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const length = hex.length / 2;
+  const bytes = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    bytes[i] = parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}

--- a/packages/keys/src/types.ts
+++ b/packages/keys/src/types.ts
@@ -1,0 +1,30 @@
+import type { KeyPolicy, PlatformCapability } from "./config.js";
+
+/** Opaque handle to the root key. Never contains raw key bytes. */
+export interface RootKeyHandle {
+  readonly keyRef: string;
+  readonly publicKey: string;
+  readonly policy: KeyPolicy;
+  readonly platform: PlatformCapability;
+  readonly createdAt: string;
+}
+
+/** Ed25519 operational key for an agent identity. */
+export interface OperationalKey {
+  readonly keyId: string;
+  readonly identityId: string;
+  readonly groupId: string | null;
+  readonly publicKey: string;
+  readonly fingerprint: string;
+  readonly createdAt: string;
+  readonly rotatedAt: string | null;
+}
+
+/** Ephemeral session key, in-memory only. */
+export interface SessionKey {
+  readonly keyId: string;
+  readonly sessionId: string;
+  readonly fingerprint: string;
+  readonly expiresAt: string;
+  readonly createdAt: string;
+}

--- a/packages/keys/src/vault.ts
+++ b/packages/keys/src/vault.ts
@@ -1,0 +1,207 @@
+import { Database } from "bun:sqlite";
+import { Result } from "better-result";
+import { InternalError, NotFoundError } from "@xmtp-broker/schemas";
+import { join } from "node:path";
+import { chmodSync } from "node:fs";
+
+/** Encrypted vault backed by bun:sqlite with AES-GCM encryption. */
+export interface Vault {
+  set(name: string, value: Uint8Array): Promise<Result<void, InternalError>>;
+  get(name: string): Promise<Result<Uint8Array, NotFoundError | InternalError>>;
+  delete(name: string): Promise<Result<void, NotFoundError>>;
+  list(): readonly string[];
+  close(): void;
+}
+
+/** AES-GCM IV length in bytes. */
+const IV_BYTES = 12;
+
+function asBuffer(data: Uint8Array): ArrayBuffer {
+  return data.buffer.slice(
+    data.byteOffset,
+    data.byteOffset + data.byteLength,
+  ) as ArrayBuffer;
+}
+
+/**
+ * Get or create a random 256-bit vault encryption key.
+ * For file-backed vaults, the key is stored in `<dataDir>/vault.key`.
+ * For `:memory:` vaults (tests), an ephemeral random key is generated.
+ */
+async function getOrCreateVaultKey(dataDir: string): Promise<CryptoKey> {
+  // In-memory vaults get an ephemeral key
+  if (dataDir === ":memory:") {
+    const raw = crypto.getRandomValues(new Uint8Array(32));
+    return crypto.subtle.importKey("raw", raw, { name: "AES-GCM" }, false, [
+      "encrypt",
+      "decrypt",
+    ]);
+  }
+
+  const keyPath = join(dataDir, "vault.key");
+  const file = Bun.file(keyPath);
+
+  if (await file.exists()) {
+    const raw = new Uint8Array(await file.arrayBuffer());
+    if (raw.byteLength !== 32) {
+      throw new Error(
+        `Vault key file has invalid length: expected 32 bytes, got ${raw.byteLength}`,
+      );
+    }
+    return crypto.subtle.importKey("raw", raw, { name: "AES-GCM" }, false, [
+      "encrypt",
+      "decrypt",
+    ]);
+  }
+
+  const raw = crypto.getRandomValues(new Uint8Array(32));
+  await Bun.write(keyPath, raw);
+  chmodSync(keyPath, 0o600);
+  return crypto.subtle.importKey("raw", raw, { name: "AES-GCM" }, false, [
+    "encrypt",
+    "decrypt",
+  ]);
+}
+
+async function encrypt(
+  key: CryptoKey,
+  plaintext: Uint8Array,
+): Promise<Uint8Array> {
+  const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    asBuffer(plaintext),
+  );
+  // Prepend IV to ciphertext
+  const result = new Uint8Array(IV_BYTES + ciphertext.byteLength);
+  result.set(iv, 0);
+  result.set(new Uint8Array(ciphertext), IV_BYTES);
+  return result;
+}
+
+async function decrypt(key: CryptoKey, data: Uint8Array): Promise<Uint8Array> {
+  const iv = data.slice(0, IV_BYTES);
+  const ciphertext = data.slice(IV_BYTES);
+  const plaintext = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv },
+    key,
+    ciphertext,
+  );
+  return new Uint8Array(plaintext);
+}
+
+export async function createVault(
+  dataDir: string,
+): Promise<Result<Vault, InternalError>> {
+  try {
+    const dbPath = join(dataDir, "vault.db");
+    const db = new Database(dbPath);
+    db.run("PRAGMA journal_mode = WAL");
+    db.run(`
+      CREATE TABLE IF NOT EXISTS secrets (
+        name TEXT PRIMARY KEY,
+        encrypted_value BLOB NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+
+    // Restrict vault database file permissions
+    if (dataDir !== ":memory:") {
+      chmodSync(dbPath, 0o600);
+    }
+
+    const encKey = await getOrCreateVaultKey(dataDir);
+
+    const stmtGet = db.prepare<{ encrypted_value: Uint8Array }, [string]>(
+      "SELECT encrypted_value FROM secrets WHERE name = ?",
+    );
+
+    const stmtUpsert = db.prepare<void, [string, Uint8Array]>(
+      `INSERT INTO secrets (name, encrypted_value)
+       VALUES (?, ?)
+       ON CONFLICT(name) DO UPDATE SET
+         encrypted_value = excluded.encrypted_value,
+         updated_at = datetime('now')`,
+    );
+
+    const stmtDelete = db.prepare<void, [string]>(
+      "DELETE FROM secrets WHERE name = ?",
+    );
+
+    const stmtList = db.prepare<{ name: string }, []>(
+      "SELECT name FROM secrets ORDER BY name",
+    );
+
+    const stmtExists = db.prepare<{ cnt: number }, [string]>(
+      "SELECT COUNT(*) as cnt FROM secrets WHERE name = ?",
+    );
+
+    const vault: Vault = {
+      async set(
+        name: string,
+        value: Uint8Array,
+      ): Promise<Result<void, InternalError>> {
+        try {
+          const encrypted = await encrypt(encKey, value);
+          stmtUpsert.run(name, encrypted);
+          return Result.ok();
+        } catch (e) {
+          return Result.err(
+            InternalError.create("Failed to set vault secret", {
+              name,
+              cause: String(e),
+            }),
+          );
+        }
+      },
+
+      async get(
+        name: string,
+      ): Promise<Result<Uint8Array, NotFoundError | InternalError>> {
+        try {
+          const row = stmtGet.get(name);
+          if (!row) {
+            return Result.err(NotFoundError.create("VaultSecret", name));
+          }
+          const plaintext = await decrypt(encKey, row.encrypted_value);
+          return Result.ok(plaintext);
+        } catch (e) {
+          return Result.err(
+            InternalError.create("Failed to get vault secret", {
+              name,
+              cause: String(e),
+            }),
+          );
+        }
+      },
+
+      async delete(name: string): Promise<Result<void, NotFoundError>> {
+        const exists = stmtExists.get(name);
+        if (!exists || exists.cnt === 0) {
+          return Result.err(NotFoundError.create("VaultSecret", name));
+        }
+        stmtDelete.run(name);
+        return Result.ok();
+      },
+
+      list(): readonly string[] {
+        return stmtList.all().map((row) => row.name);
+      },
+
+      close(): void {
+        db.close();
+      },
+    };
+
+    return Result.ok(vault);
+  } catch (e) {
+    return Result.err(
+      InternalError.create("Failed to create vault", {
+        dataDir,
+        cause: String(e),
+      }),
+    );
+  }
+}


### PR DESCRIPTION
## Context
This branch adds the broker key hierarchy and signer infrastructure. Review this PR against `v0/attestations`, not `main`.

## What Changed
- implements the root, operational, attestation, and session key flow used by the broker
- adds the encrypted vault, key manager, signer provider, and platform abstraction layers
- derives database encryption keys from secret material instead of public key data
- adds tests covering vault behavior, signer generation, operational key handling, and crypto helpers

## Why This Branch Exists
The broker cannot safely manage XMTP identities or sign attestations without a dedicated key layer. This PR establishes that security-sensitive foundation.

## Key Files
- `packages/keys/src/key-manager.ts`
- `packages/keys/src/vault.ts`
- `packages/keys/src/signer-provider.ts`
- `packages/keys/src/root-key.ts`
- `packages/keys/src/session-key.ts`

## Verification
- key-management package test suite under `packages/keys/src/__tests__`
- repo verification via pre-push stack checks (`lint`, `test`, `typecheck`)
