### PR TITLE
feat(ws): add Bun.serve WebSocket transport and event replay

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -119,6 +119,12 @@
     "packages/ws": {
       "name": "@xmtp-broker/ws",
       "version": "0.0.0",
+      "dependencies": {
+        "@xmtp-broker/contracts": "workspace:*",
+        "@xmtp-broker/schemas": "workspace:*",
+        "better-result": "catalog:",
+        "zod": "catalog:",
+      },
       "devDependencies": {
         "bun-types": "catalog:",
         "typescript": "catalog:",

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -15,7 +15,12 @@
     "lint": "oxlint .",
     "test": "bun test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@xmtp-broker/contracts": "workspace:*",
+    "@xmtp-broker/schemas": "workspace:*",
+    "better-result": "catalog:",
+    "zod": "catalog:"
+  },
   "devDependencies": {
     "bun-types": "catalog:",
     "typescript": "catalog:"

--- a/packages/ws/src/__tests__/auth-handler.test.ts
+++ b/packages/ws/src/__tests__/auth-handler.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import { handleAuth } from "../auth-handler.js";
+import { AuthError } from "@xmtp-broker/schemas";
+import type { SessionRecord } from "@xmtp-broker/contracts";
+import type { AuthFrame } from "../frames.js";
+
+function makeSessionRecord(
+  overrides: Partial<SessionRecord> = {},
+): SessionRecord {
+  return {
+    sessionId: "sess_123",
+    agentInboxId: "agent_1",
+    sessionKeyFingerprint: "fp_abc",
+    view: {
+      mode: "full",
+      threadScopes: [{ groupId: "g1", threadId: null }],
+      contentTypes: ["xmtp.org/text:1.0"],
+    },
+    grant: {
+      messaging: { send: true, reply: true, react: true, draftOnly: false },
+      groupManagement: {
+        addMembers: false,
+        removeMembers: false,
+        updateMetadata: false,
+        inviteUsers: false,
+      },
+      tools: { scopes: [] },
+      egress: {
+        storeExcerpts: false,
+        useForMemory: false,
+        forwardToProviders: false,
+        quoteRevealed: false,
+        summarize: false,
+      },
+    },
+    state: "active",
+    issuedAt: "2024-01-01T00:00:00Z",
+    expiresAt: "2024-01-02T00:00:00Z",
+    lastHeartbeat: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("handleAuth", () => {
+  const validFrame: AuthFrame = {
+    type: "auth",
+    token: "valid_token",
+    lastSeenSeq: null,
+  };
+
+  test("returns session record on valid token", async () => {
+    const lookup = async (_token: string) => Result.ok(makeSessionRecord());
+    const result = await handleAuth(validFrame, lookup);
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.sessionId).toBe("sess_123");
+    }
+  });
+
+  test("returns error when lookup fails", async () => {
+    const lookup = async (_token: string) =>
+      Result.err(AuthError.create("Invalid token"));
+    const result = await handleAuth(validFrame, lookup);
+    expect(result.isErr()).toBe(true);
+  });
+
+  test("returns error when session is expired", async () => {
+    const lookup = async (_token: string) =>
+      Result.ok(makeSessionRecord({ state: "expired" }));
+    const result = await handleAuth(validFrame, lookup);
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("not active");
+    }
+  });
+
+  test("returns error when session is revoked", async () => {
+    const lookup = async (_token: string) =>
+      Result.ok(makeSessionRecord({ state: "revoked" }));
+    const result = await handleAuth(validFrame, lookup);
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/packages/ws/src/__tests__/backpressure.test.ts
+++ b/packages/ws/src/__tests__/backpressure.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { BackpressureTracker } from "../backpressure.js";
+
+describe("BackpressureTracker", () => {
+  test("starts at zero depth", () => {
+    const bp = new BackpressureTracker(64, 256);
+    expect(bp.depth).toBe(0);
+    expect(bp.state).toBe("ok");
+  });
+
+  test("increment increases depth", () => {
+    const bp = new BackpressureTracker(2, 4);
+    bp.increment();
+    expect(bp.depth).toBe(1);
+    expect(bp.state).toBe("ok");
+  });
+
+  test("decrement decreases depth", () => {
+    const bp = new BackpressureTracker(2, 4);
+    bp.increment();
+    bp.increment();
+    bp.decrement();
+    expect(bp.depth).toBe(1);
+  });
+
+  test("decrement does not go below zero", () => {
+    const bp = new BackpressureTracker(2, 4);
+    bp.decrement();
+    expect(bp.depth).toBe(0);
+  });
+
+  test("returns warning state at soft limit", () => {
+    const bp = new BackpressureTracker(2, 4);
+    bp.increment();
+    bp.increment();
+    expect(bp.state).toBe("warning");
+  });
+
+  test("returns exceeded state at hard limit", () => {
+    const bp = new BackpressureTracker(2, 4);
+    bp.increment();
+    bp.increment();
+    bp.increment();
+    bp.increment();
+    expect(bp.state).toBe("exceeded");
+  });
+
+  test("transitions back from warning to ok on drain", () => {
+    const bp = new BackpressureTracker(2, 4);
+    bp.increment();
+    bp.increment();
+    expect(bp.state).toBe("warning");
+    bp.decrement();
+    expect(bp.state).toBe("ok");
+  });
+
+  test("notified flag tracks whether warning has been sent", () => {
+    const bp = new BackpressureTracker(2, 4);
+    expect(bp.notified).toBe(false);
+    bp.markNotified();
+    expect(bp.notified).toBe(true);
+    bp.clearNotified();
+    expect(bp.notified).toBe(false);
+  });
+
+  test("reset clears depth and notified", () => {
+    const bp = new BackpressureTracker(2, 4);
+    bp.increment();
+    bp.increment();
+    bp.markNotified();
+    bp.reset();
+    expect(bp.depth).toBe(0);
+    expect(bp.notified).toBe(false);
+    expect(bp.state).toBe("ok");
+  });
+});

--- a/packages/ws/src/__tests__/close-codes.test.ts
+++ b/packages/ws/src/__tests__/close-codes.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { WS_CLOSE_CODES } from "../close-codes.js";
+
+describe("WS_CLOSE_CODES", () => {
+  test("defines standard close codes", () => {
+    expect(WS_CLOSE_CODES.NORMAL).toBe(1000);
+    expect(WS_CLOSE_CODES.GOING_AWAY).toBe(1001);
+  });
+
+  test("defines custom close codes in 4000 range", () => {
+    expect(WS_CLOSE_CODES.AUTH_FAILED).toBe(4001);
+    expect(WS_CLOSE_CODES.AUTH_TIMEOUT).toBe(4002);
+    expect(WS_CLOSE_CODES.SESSION_EXPIRED).toBe(4003);
+    expect(WS_CLOSE_CODES.SESSION_REVOKED).toBe(4004);
+    expect(WS_CLOSE_CODES.POLICY_CHANGE).toBe(4005);
+    expect(WS_CLOSE_CODES.BACKPRESSURE).toBe(4008);
+    expect(WS_CLOSE_CODES.PROTOCOL_ERROR).toBe(4009);
+    expect(WS_CLOSE_CODES.DEAD_CONNECTION).toBe(4010);
+  });
+
+  test("defines rate limit close code (standard 1008)", () => {
+    expect(WS_CLOSE_CODES.RATE_LIMITED).toBe(1008);
+  });
+});

--- a/packages/ws/src/__tests__/config.test.ts
+++ b/packages/ws/src/__tests__/config.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { WsServerConfigSchema } from "../config.js";
+
+describe("WsServerConfigSchema", () => {
+  test("applies all defaults for empty object", () => {
+    const result = WsServerConfigSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.port).toBe(8393);
+      expect(result.data.host).toBe("127.0.0.1");
+      expect(result.data.heartbeatIntervalMs).toBe(30_000);
+      expect(result.data.missedHeartbeatsBeforeDead).toBe(3);
+      expect(result.data.authTimeoutMs).toBe(5_000);
+      expect(result.data.requestTimeoutMs).toBe(30_000);
+      expect(result.data.replayBufferSize).toBe(1_000);
+      expect(result.data.sendBufferSoftLimit).toBe(64);
+      expect(result.data.sendBufferHardLimit).toBe(256);
+      expect(result.data.drainTimeoutMs).toBe(5_000);
+      expect(result.data.maxFrameSizeBytes).toBe(1_048_576);
+      expect(result.data.rateLimitWindowMs).toBe(1_000);
+      expect(result.data.rateLimitMaxMessages).toBeNull();
+    }
+  });
+
+  test("accepts custom values", () => {
+    const result = WsServerConfigSchema.safeParse({
+      port: 9000,
+      host: "0.0.0.0",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.port).toBe(9000);
+      expect(result.data.host).toBe("0.0.0.0");
+    }
+  });
+
+  test("allows port 0 for random assignment", () => {
+    const result = WsServerConfigSchema.safeParse({ port: 0 });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects negative port", () => {
+    const result = WsServerConfigSchema.safeParse({ port: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-integer port", () => {
+    const result = WsServerConfigSchema.safeParse({ port: 3.14 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rate limiting is disabled by default (null)", () => {
+    const result = WsServerConfigSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.rateLimitMaxMessages).toBeNull();
+    }
+  });
+
+  test("accepts rate limit configuration", () => {
+    const result = WsServerConfigSchema.safeParse({
+      rateLimitWindowMs: 2_000,
+      rateLimitMaxMessages: 50,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.rateLimitWindowMs).toBe(2_000);
+      expect(result.data.rateLimitMaxMessages).toBe(50);
+    }
+  });
+
+  test("rejects non-positive rateLimitWindowMs", () => {
+    const result = WsServerConfigSchema.safeParse({ rateLimitWindowMs: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-positive rateLimitMaxMessages", () => {
+    const result = WsServerConfigSchema.safeParse({ rateLimitMaxMessages: 0 });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/ws/src/__tests__/connection-registry.test.ts
+++ b/packages/ws/src/__tests__/connection-registry.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { ConnectionRegistry } from "../connection-registry.js";
+import type { ConnectionData } from "../connection-state.js";
+
+/** Minimal mock of ServerWebSocket for registry tests. */
+function mockWs(data: ConnectionData): {
+  data: ConnectionData;
+  send: (msg: string) => number;
+} {
+  return {
+    data,
+    send: (_msg: string) => 0,
+  };
+}
+
+function makeData(overrides: Partial<ConnectionData> = {}): ConnectionData {
+  return {
+    connectionId: `conn_${Math.random().toString(36).slice(2, 8)}`,
+    phase: "active",
+    sessionId: "sess_default",
+    agentInboxId: "agent_default",
+    ...overrides,
+  } as ConnectionData;
+}
+
+describe("ConnectionRegistry", () => {
+  let registry: ConnectionRegistry;
+
+  beforeEach(() => {
+    registry = new ConnectionRegistry();
+  });
+
+  test("starts empty", () => {
+    expect(registry.size).toBe(0);
+  });
+
+  test("add increments size", () => {
+    const ws = mockWs(makeData());
+    registry.add(ws as never);
+    expect(registry.size).toBe(1);
+  });
+
+  test("remove decrements size", () => {
+    const data = makeData();
+    const ws = mockWs(data);
+    registry.add(ws as never);
+    registry.remove(data.connectionId);
+    expect(registry.size).toBe(0);
+  });
+
+  test("remove is idempotent for unknown ID", () => {
+    registry.remove("nonexistent");
+    expect(registry.size).toBe(0);
+  });
+
+  test("getBySessionId returns matching connections", () => {
+    const ws1 = mockWs(makeData({ sessionId: "sess_a" }));
+    const ws2 = mockWs(makeData({ sessionId: "sess_a" }));
+    const ws3 = mockWs(makeData({ sessionId: "sess_b" }));
+    registry.add(ws1 as never);
+    registry.add(ws2 as never);
+    registry.add(ws3 as never);
+
+    const result = registry.getBySessionId("sess_a");
+    expect(result).toHaveLength(2);
+  });
+
+  test("getBySessionId returns empty for unknown session", () => {
+    expect(registry.getBySessionId("nonexistent")).toHaveLength(0);
+  });
+
+  test("getByAgentInboxId returns matching connections", () => {
+    const ws1 = mockWs(makeData({ agentInboxId: "agent_x" }));
+    const ws2 = mockWs(makeData({ agentInboxId: "agent_y" }));
+    registry.add(ws1 as never);
+    registry.add(ws2 as never);
+
+    const result = registry.getByAgentInboxId("agent_x");
+    expect(result).toHaveLength(1);
+  });
+
+  test("getAll returns all connections", () => {
+    const ws1 = mockWs(makeData());
+    const ws2 = mockWs(makeData());
+    registry.add(ws1 as never);
+    registry.add(ws2 as never);
+    expect(registry.getAll()).toHaveLength(2);
+  });
+});

--- a/packages/ws/src/__tests__/connection-state.test.ts
+++ b/packages/ws/src/__tests__/connection-state.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type ConnectionPhase,
+  createConnectionState,
+  canTransition,
+  transition,
+} from "../connection-state.js";
+
+describe("createConnectionState", () => {
+  test("creates state in authenticating phase", () => {
+    const state = createConnectionState();
+    expect(state.phase).toBe("authenticating");
+    expect(state.connectionId).toBeTruthy();
+    expect(state.sessionRecord).toBeNull();
+    expect(state.sessionReplayState).toBeNull();
+    expect(state.inFlightRequests.size).toBe(0);
+  });
+
+  test("generates unique connection IDs", () => {
+    const a = createConnectionState();
+    const b = createConnectionState();
+    expect(a.connectionId).not.toBe(b.connectionId);
+  });
+});
+
+describe("canTransition", () => {
+  const valid: Array<[ConnectionPhase, ConnectionPhase]> = [
+    ["authenticating", "active"],
+    ["authenticating", "closed"],
+    ["active", "draining"],
+    ["active", "closed"],
+    ["draining", "closed"],
+  ];
+
+  for (const [from, to] of valid) {
+    test(`allows ${from} -> ${to}`, () => {
+      expect(canTransition(from, to)).toBe(true);
+    });
+  }
+
+  const invalid: Array<[ConnectionPhase, ConnectionPhase]> = [
+    ["authenticating", "draining"],
+    ["active", "authenticating"],
+    ["draining", "active"],
+    ["draining", "authenticating"],
+    ["closed", "authenticating"],
+    ["closed", "active"],
+    ["closed", "draining"],
+  ];
+
+  for (const [from, to] of invalid) {
+    test(`rejects ${from} -> ${to}`, () => {
+      expect(canTransition(from, to)).toBe(false);
+    });
+  }
+});
+
+describe("transition", () => {
+  test("transitions from authenticating to active", () => {
+    const state = createConnectionState();
+    const result = transition(state, "active");
+    expect(result).toBe(true);
+    expect(state.phase).toBe("active");
+  });
+
+  test("rejects invalid transition and keeps current phase", () => {
+    const state = createConnectionState();
+    const result = transition(state, "draining");
+    expect(result).toBe(false);
+    expect(state.phase).toBe("authenticating");
+  });
+
+  test("transitions active -> draining -> closed", () => {
+    const state = createConnectionState();
+    transition(state, "active");
+    expect(transition(state, "draining")).toBe(true);
+    expect(state.phase).toBe("draining");
+    expect(transition(state, "closed")).toBe(true);
+    expect(state.phase).toBe("closed");
+  });
+});

--- a/packages/ws/src/__tests__/event-broadcaster.test.ts
+++ b/packages/ws/src/__tests__/event-broadcaster.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { sequenceEvent } from "../event-broadcaster.js";
+import { CircularBuffer } from "../replay-buffer.js";
+import type { SessionReplayState } from "../connection-state.js";
+import type { BrokerEvent } from "@xmtp-broker/schemas";
+import type { SequencedFrame } from "../frames.js";
+
+function makeSessionState(bufferSize = 100): SessionReplayState {
+  return {
+    buffer: new CircularBuffer<SequencedFrame>(bufferSize),
+    nextSeq: 1,
+  };
+}
+
+describe("sequenceEvent", () => {
+  const heartbeatEvent: BrokerEvent = {
+    type: "heartbeat",
+    sessionId: "sess_1",
+    timestamp: "2024-01-01T00:00:00Z",
+  };
+
+  let sessionState: SessionReplayState;
+
+  beforeEach(() => {
+    sessionState = makeSessionState();
+  });
+
+  test("assigns monotonically increasing seq", () => {
+    const frame1 = sequenceEvent(sessionState, heartbeatEvent);
+    const frame2 = sequenceEvent(sessionState, heartbeatEvent);
+    const frame3 = sequenceEvent(sessionState, heartbeatEvent);
+    expect(frame1.seq).toBe(1);
+    expect(frame2.seq).toBe(2);
+    expect(frame3.seq).toBe(3);
+  });
+
+  test("advances session nextSeq", () => {
+    expect(sessionState.nextSeq).toBe(1);
+    sequenceEvent(sessionState, heartbeatEvent);
+    expect(sessionState.nextSeq).toBe(2);
+  });
+
+  test("pushes frame into session replay buffer", () => {
+    const frame = sequenceEvent(sessionState, heartbeatEvent);
+    expect(sessionState.buffer.size).toBe(1);
+    expect(sessionState.buffer.oldest()).toEqual(frame);
+  });
+
+  test("independent seq counters per session", () => {
+    const session1 = makeSessionState();
+    const session2 = makeSessionState();
+    const frame1 = sequenceEvent(session1, heartbeatEvent);
+    const frame2 = sequenceEvent(session2, heartbeatEvent);
+    expect(frame1.seq).toBe(1);
+    expect(frame2.seq).toBe(1);
+  });
+
+  test("resumes from custom nextSeq", () => {
+    sessionState.nextSeq = 42;
+    const frame = sequenceEvent(sessionState, heartbeatEvent);
+    expect(frame.seq).toBe(42);
+    expect(sessionState.nextSeq).toBe(43);
+  });
+});

--- a/packages/ws/src/__tests__/fixtures.ts
+++ b/packages/ws/src/__tests__/fixtures.ts
@@ -1,0 +1,298 @@
+import { Result } from "better-result";
+import type {
+  HarnessRequest,
+  IssuedSession,
+  SessionToken,
+} from "@xmtp-broker/schemas";
+import { AuthError, NotFoundError } from "@xmtp-broker/schemas";
+import type {
+  BrokerCore,
+  SessionManager,
+  AttestationManager,
+  SessionRecord,
+} from "@xmtp-broker/contracts";
+import type { WsServerDeps } from "../server.js";
+
+/** Default session record used in tests. */
+export function makeSessionRecord(
+  overrides: Partial<SessionRecord> = {},
+): SessionRecord {
+  return {
+    sessionId: "sess_test",
+    agentInboxId: "agent_test",
+    sessionKeyFingerprint: "fp_test",
+    view: {
+      mode: "full",
+      threadScopes: [{ groupId: "g1", threadId: null }],
+      contentTypes: ["xmtp.org/text:1.0"],
+    },
+    grant: {
+      messaging: { send: true, reply: true, react: true, draftOnly: false },
+      groupManagement: {
+        addMembers: false,
+        removeMembers: false,
+        updateMetadata: false,
+        inviteUsers: false,
+      },
+      tools: { scopes: [] },
+      egress: {
+        storeExcerpts: false,
+        useForMemory: false,
+        forwardToProviders: false,
+        quoteRevealed: false,
+        summarize: false,
+      },
+    },
+    state: "active",
+    issuedAt: "2024-01-01T00:00:00Z",
+    expiresAt: "2024-01-02T00:00:00Z",
+    lastHeartbeat: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+export function makeSessionToken(
+  record: SessionRecord = makeSessionRecord(),
+): SessionToken {
+  return {
+    sessionId: record.sessionId,
+    agentInboxId: record.agentInboxId,
+    sessionKeyFingerprint: record.sessionKeyFingerprint,
+    issuedAt: record.issuedAt,
+    expiresAt: record.expiresAt,
+  };
+}
+
+export function makeIssuedSession(
+  token = "valid_token",
+  record: SessionRecord = makeSessionRecord(),
+): IssuedSession {
+  return {
+    token,
+    session: makeSessionToken(record),
+  };
+}
+
+/** Creates a mock SessionManager that recognizes one token. */
+export function createMockSessionManager(
+  validToken = "valid_token",
+  record: SessionRecord = makeSessionRecord(),
+): SessionManager {
+  const sessions = new Map<string, SessionRecord>();
+  sessions.set(record.sessionId, record);
+
+  return {
+    async issue() {
+      return Result.ok(makeIssuedSession(validToken, record));
+    },
+    async list(agentInboxId?: string) {
+      return Result.ok(
+        [...sessions.values()].filter(
+          (session) =>
+            agentInboxId === undefined || session.agentInboxId === agentInboxId,
+        ),
+      );
+    },
+    async lookup(sessionId: string) {
+      const s = sessions.get(sessionId);
+      if (!s) return Result.err(NotFoundError.create("session", sessionId));
+      return Result.ok(s);
+    },
+    async lookupByToken(token: string) {
+      if (token !== validToken) {
+        return Result.err(NotFoundError.create("session", token));
+      }
+      return Result.ok(record);
+    },
+    async revoke() {
+      return Result.ok(undefined);
+    },
+    async heartbeat() {
+      return Result.ok(undefined);
+    },
+    async isActive(sessionId: string) {
+      const s = sessions.get(sessionId);
+      return Result.ok(s?.state === "active");
+    },
+    // Non-standard: token lookup for the WS layer
+    _validToken: validToken,
+    _record: record,
+  } as SessionManager & { _validToken: string; _record: SessionRecord };
+}
+
+/** Creates a mock BrokerCore. */
+export function createMockBrokerCore(): BrokerCore {
+  return {
+    state: "ready",
+    async initializeLocal() {
+      return Result.ok(undefined);
+    },
+    async initialize() {
+      return Result.ok(undefined);
+    },
+    async shutdown() {
+      return Result.ok(undefined);
+    },
+    async sendMessage() {
+      return Result.ok({ messageId: "msg_test" });
+    },
+    async getGroupInfo() {
+      return Result.ok({
+        groupId: "g1",
+        identityKeyFingerprint: "fp_g1",
+        memberInboxIds: ["agent_test"],
+        createdAt: "2024-01-01T00:00:00Z",
+      });
+    },
+  };
+}
+
+/** Creates a mock AttestationManager. */
+export function createMockAttestationManager(): AttestationManager {
+  return {
+    async issue() {
+      return Result.ok({
+        envelope: {
+          attestation: {},
+          signature: new Uint8Array(),
+          publicKey: new Uint8Array(),
+        },
+      } as never);
+    },
+    async refresh() {
+      return Result.ok({} as never);
+    },
+    async revoke() {
+      return Result.ok(undefined);
+    },
+    async current() {
+      return Result.ok(null);
+    },
+  };
+}
+
+/** Creates a full WsServerDeps mock. */
+export function createMockDeps(validToken = "valid_token"): {
+  deps: WsServerDeps;
+  sessionRecord: SessionRecord;
+} {
+  const sessionRecord = makeSessionRecord();
+  const sessionManager = createMockSessionManager(validToken, sessionRecord);
+  return {
+    deps: {
+      sessionManager,
+      core: createMockBrokerCore(),
+      attestationManager: createMockAttestationManager(),
+      tokenLookup: async (token: string) => {
+        if (
+          token ===
+          (sessionManager as SessionManager & { _validToken: string })
+            ._validToken
+        ) {
+          return Result.ok(sessionRecord);
+        }
+        return Result.err(AuthError.create("Invalid token"));
+      },
+      requestHandler: async (
+        request: HarnessRequest,
+        _session: SessionRecord,
+      ) => {
+        if (request.type === "heartbeat") {
+          return Result.ok(null);
+        }
+        return Result.ok({ messageId: "msg_test" });
+      },
+    },
+    sessionRecord,
+  };
+}
+
+/** Wait for a WebSocket message, parsed as JSON. */
+export function nextMessage(ws: WebSocket, timeoutMs = 5000): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error("Timeout waiting for message")),
+      timeoutMs,
+    );
+
+    const handler = (event: MessageEvent) => {
+      clearTimeout(timer);
+      ws.removeEventListener("message", handler);
+      resolve(JSON.parse(event.data as string));
+    };
+
+    ws.addEventListener("message", handler);
+  });
+}
+
+/** Wait for WebSocket close event. */
+export function waitForClose(
+  ws: WebSocket,
+  timeoutMs = 5000,
+): Promise<{ code: number; reason: string }> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error("Timeout waiting for close")),
+      timeoutMs,
+    );
+
+    const handler = (event: CloseEvent) => {
+      clearTimeout(timer);
+      ws.removeEventListener("close", handler);
+      resolve({ code: event.code, reason: event.reason });
+    };
+
+    ws.addEventListener("close", handler);
+  });
+}
+
+/** Wait for WebSocket to open. */
+export function waitForOpen(ws: WebSocket, timeoutMs = 5000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (ws.readyState === WebSocket.OPEN) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(
+      () => reject(new Error("Timeout waiting for open")),
+      timeoutMs,
+    );
+
+    const handler = () => {
+      clearTimeout(timer);
+      ws.removeEventListener("open", handler);
+      resolve();
+    };
+
+    ws.addEventListener("open", handler);
+  });
+}
+
+/** Collect N messages from a WebSocket. */
+export function collectMessages(
+  ws: WebSocket,
+  count: number,
+  timeoutMs = 5000,
+): Promise<unknown[]> {
+  return new Promise((resolve, reject) => {
+    const messages: unknown[] = [];
+    const timer = setTimeout(
+      () =>
+        reject(
+          new Error(`Timeout: collected ${messages.length}/${count} messages`),
+        ),
+      timeoutMs,
+    );
+
+    const handler = (event: MessageEvent) => {
+      messages.push(JSON.parse(event.data as string));
+      if (messages.length >= count) {
+        clearTimeout(timer);
+        ws.removeEventListener("message", handler);
+        resolve(messages);
+      }
+    };
+
+    ws.addEventListener("message", handler);
+  });
+}

--- a/packages/ws/src/__tests__/frames.test.ts
+++ b/packages/ws/src/__tests__/frames.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "bun:test";
+import {
+  AuthFrame,
+  AuthenticatedFrame,
+  AuthErrorFrame,
+  BackpressureFrame,
+  SequencedFrame,
+} from "../frames.js";
+
+describe("AuthFrame", () => {
+  test("parses valid auth frame", () => {
+    const result = AuthFrame.safeParse({
+      type: "auth",
+      token: "tok_abc123",
+      lastSeenSeq: null,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.type).toBe("auth");
+      expect(result.data.token).toBe("tok_abc123");
+      expect(result.data.lastSeenSeq).toBeNull();
+    }
+  });
+
+  test("parses auth frame with lastSeenSeq", () => {
+    const result = AuthFrame.safeParse({
+      type: "auth",
+      token: "tok_abc123",
+      lastSeenSeq: 42,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.lastSeenSeq).toBe(42);
+    }
+  });
+
+  test("rejects negative lastSeenSeq", () => {
+    const result = AuthFrame.safeParse({
+      type: "auth",
+      token: "tok_abc123",
+      lastSeenSeq: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing token", () => {
+    const result = AuthFrame.safeParse({
+      type: "auth",
+      lastSeenSeq: null,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects wrong type", () => {
+    const result = AuthFrame.safeParse({
+      type: "wrong",
+      token: "tok",
+      lastSeenSeq: null,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("AuthErrorFrame", () => {
+  test("parses valid auth error frame", () => {
+    const result = AuthErrorFrame.safeParse({
+      type: "auth_error",
+      code: 4001,
+      message: "Invalid token",
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("BackpressureFrame", () => {
+  test("parses valid backpressure frame", () => {
+    const result = BackpressureFrame.safeParse({
+      type: "backpressure",
+      buffered: 100,
+      limit: 256,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("SequencedFrame", () => {
+  test("parses valid sequenced frame with heartbeat event", () => {
+    const result = SequencedFrame.safeParse({
+      seq: 1,
+      event: {
+        type: "heartbeat",
+        sessionId: "sess_123",
+        timestamp: "2024-01-01T00:00:00Z",
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.seq).toBe(1);
+      expect(result.data.event.type).toBe("heartbeat");
+    }
+  });
+
+  test("rejects zero seq", () => {
+    const result = SequencedFrame.safeParse({
+      seq: 0,
+      event: {
+        type: "heartbeat",
+        sessionId: "sess_123",
+        timestamp: "2024-01-01T00:00:00Z",
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects negative seq", () => {
+    const result = SequencedFrame.safeParse({
+      seq: -1,
+      event: {
+        type: "heartbeat",
+        sessionId: "sess_123",
+        timestamp: "2024-01-01T00:00:00Z",
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("AuthenticatedFrame", () => {
+  test("parses valid authenticated frame", () => {
+    const result = AuthenticatedFrame.safeParse({
+      type: "authenticated",
+      connectionId: "conn_abc",
+      session: {
+        sessionId: "sess_123",
+        agentInboxId: "agent_1",
+        sessionKeyFingerprint: "fp_abc",
+        issuedAt: "2024-01-01T00:00:00Z",
+        expiresAt: "2024-01-02T00:00:00Z",
+      },
+      view: {
+        mode: "full",
+        threadScopes: [{ groupId: "g1", threadId: null }],
+        contentTypes: ["xmtp.org/text:1.0"],
+      },
+      grant: {
+        messaging: {
+          send: true,
+          reply: true,
+          react: true,
+          draftOnly: false,
+        },
+        groupManagement: {
+          addMembers: false,
+          removeMembers: false,
+          updateMetadata: false,
+          inviteUsers: false,
+        },
+        tools: { scopes: [] },
+        egress: {
+          storeExcerpts: false,
+          useForMemory: false,
+          forwardToProviders: false,
+          quoteRevealed: false,
+          summarize: false,
+        },
+      },
+      resumedFromSeq: null,
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/ws/src/__tests__/replay-buffer.test.ts
+++ b/packages/ws/src/__tests__/replay-buffer.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import { CircularBuffer } from "../replay-buffer.js";
+
+describe("CircularBuffer", () => {
+  test("starts empty", () => {
+    const buf = new CircularBuffer<number>(5);
+    expect(buf.size).toBe(0);
+    expect(buf.toArray()).toEqual([]);
+  });
+
+  test("push adds items up to capacity", () => {
+    const buf = new CircularBuffer<number>(3);
+    buf.push(1);
+    buf.push(2);
+    buf.push(3);
+    expect(buf.size).toBe(3);
+    expect(buf.toArray()).toEqual([1, 2, 3]);
+  });
+
+  test("overwrites oldest when full", () => {
+    const buf = new CircularBuffer<number>(3);
+    buf.push(1);
+    buf.push(2);
+    buf.push(3);
+    buf.push(4);
+    expect(buf.size).toBe(3);
+    expect(buf.toArray()).toEqual([2, 3, 4]);
+  });
+
+  test("overwrites multiple rounds", () => {
+    const buf = new CircularBuffer<number>(2);
+    buf.push(1);
+    buf.push(2);
+    buf.push(3);
+    buf.push(4);
+    buf.push(5);
+    expect(buf.toArray()).toEqual([4, 5]);
+  });
+
+  test("itemsSince returns items after given predicate", () => {
+    const buf = new CircularBuffer<{ seq: number; value: string }>(5);
+    buf.push({ seq: 1, value: "a" });
+    buf.push({ seq: 2, value: "b" });
+    buf.push({ seq: 3, value: "c" });
+    buf.push({ seq: 4, value: "d" });
+
+    const result = buf.itemsSince((item) => item.seq > 2);
+    expect(result).toEqual([
+      { seq: 3, value: "c" },
+      { seq: 4, value: "d" },
+    ]);
+  });
+
+  test("itemsSince returns empty when nothing matches", () => {
+    const buf = new CircularBuffer<number>(3);
+    buf.push(1);
+    buf.push(2);
+    const result = buf.itemsSince((n) => n > 10);
+    expect(result).toEqual([]);
+  });
+
+  test("itemsSince works after wrap-around", () => {
+    const buf = new CircularBuffer<{ seq: number }>(3);
+    buf.push({ seq: 1 });
+    buf.push({ seq: 2 });
+    buf.push({ seq: 3 });
+    buf.push({ seq: 4 });
+    buf.push({ seq: 5 });
+    // Buffer now has [3, 4, 5]
+    const result = buf.itemsSince((item) => item.seq > 3);
+    expect(result).toEqual([{ seq: 4 }, { seq: 5 }]);
+  });
+
+  test("oldest returns the oldest item in buffer", () => {
+    const buf = new CircularBuffer<number>(3);
+    buf.push(10);
+    buf.push(20);
+    buf.push(30);
+    expect(buf.oldest()).toBe(10);
+    buf.push(40);
+    expect(buf.oldest()).toBe(20);
+  });
+
+  test("oldest returns undefined when empty", () => {
+    const buf = new CircularBuffer<number>(3);
+    expect(buf.oldest()).toBeUndefined();
+  });
+
+  test("clear empties the buffer", () => {
+    const buf = new CircularBuffer<number>(3);
+    buf.push(1);
+    buf.push(2);
+    buf.clear();
+    expect(buf.size).toBe(0);
+    expect(buf.toArray()).toEqual([]);
+  });
+
+  test("capacity returns configured capacity", () => {
+    const buf = new CircularBuffer<number>(42);
+    expect(buf.capacity).toBe(42);
+  });
+});

--- a/packages/ws/src/__tests__/request-router.test.ts
+++ b/packages/ws/src/__tests__/request-router.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import { routeRequest } from "../request-router.js";
+import type { HarnessRequest } from "@xmtp-broker/schemas";
+import { PermissionError } from "@xmtp-broker/schemas";
+import type { SessionRecord } from "@xmtp-broker/contracts";
+
+function makeSessionRecord(): SessionRecord {
+  return {
+    sessionId: "sess_123",
+    agentInboxId: "agent_1",
+    sessionKeyFingerprint: "fp_abc",
+    view: {
+      mode: "full",
+      threadScopes: [{ groupId: "g1", threadId: null }],
+      contentTypes: ["xmtp.org/text:1.0"],
+    },
+    grant: {
+      messaging: { send: true, reply: true, react: true, draftOnly: false },
+      groupManagement: {
+        addMembers: false,
+        removeMembers: false,
+        updateMetadata: false,
+        inviteUsers: false,
+      },
+      tools: { scopes: [] },
+      egress: {
+        storeExcerpts: false,
+        useForMemory: false,
+        forwardToProviders: false,
+        quoteRevealed: false,
+        summarize: false,
+      },
+    },
+    state: "active",
+    issuedAt: "2024-01-01T00:00:00Z",
+    expiresAt: "2024-01-02T00:00:00Z",
+    lastHeartbeat: "2024-01-01T00:00:00Z",
+  };
+}
+
+describe("routeRequest", () => {
+  test("routes send_message to handler and returns success", async () => {
+    const request: HarnessRequest = {
+      type: "send_message",
+      requestId: "req_1",
+      groupId: "g1",
+      contentType: "xmtp.org/text:1.0",
+      content: { text: "hello" },
+    };
+
+    const handler = async () => Result.ok({ messageId: "msg_1" } as unknown);
+
+    const result = await routeRequest(request, makeSessionRecord(), handler);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.requestId).toBe("req_1");
+    }
+  });
+
+  test("returns failure when handler errors", async () => {
+    const request: HarnessRequest = {
+      type: "send_message",
+      requestId: "req_2",
+      groupId: "g1",
+      contentType: "xmtp.org/text:1.0",
+      content: { text: "hello" },
+    };
+
+    const handler = async () =>
+      Result.err(PermissionError.create("send_message", "not allowed"));
+
+    const result = await routeRequest(request, makeSessionRecord(), handler);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.requestId).toBe("req_2");
+      expect(result.error.category).toBe("permission");
+    }
+  });
+
+  test("routes heartbeat requests", async () => {
+    const request: HarnessRequest = {
+      type: "heartbeat",
+      requestId: "req_3",
+      sessionId: "sess_123",
+    };
+
+    const handler = async () => Result.ok(null as unknown);
+
+    const result = await routeRequest(request, makeSessionRecord(), handler);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.requestId).toBe("req_3");
+    }
+  });
+});

--- a/packages/ws/src/__tests__/server.integration.test.ts
+++ b/packages/ws/src/__tests__/server.integration.test.ts
@@ -1,0 +1,588 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { Result } from "better-result";
+import { createWsServer, type WsServer, type WsServerDeps } from "../server.js";
+import { SequencedFrame } from "../frames.js";
+import {
+  createMockDeps,
+  nextMessage,
+  waitForClose,
+  waitForOpen,
+  collectMessages,
+} from "./fixtures.js";
+
+let server: WsServer;
+let port: number;
+
+async function startServer(
+  overrides: Record<string, unknown> = {},
+  validToken = "valid_token",
+  depsOverrides: Partial<WsServerDeps> = {},
+) {
+  const { deps } = createMockDeps(validToken);
+  server = createWsServer(
+    { port: 0, ...overrides },
+    { ...deps, ...depsOverrides },
+  );
+  const result = await server.start();
+  if (!result.isOk()) throw new Error("Failed to start server");
+  port = result.value.port;
+}
+
+async function connectAndAuth(
+  token = "valid_token",
+  lastSeenSeq: number | null = null,
+): Promise<WebSocket> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/v1/agent`);
+  await waitForOpen(ws);
+  ws.send(JSON.stringify({ type: "auth", token, lastSeenSeq }));
+  return ws;
+}
+
+describe("WsServer lifecycle", () => {
+  afterEach(async () => {
+    if (server && server.state === "listening") {
+      await server.stop();
+    }
+  });
+
+  test("starts and stops cleanly", async () => {
+    await startServer();
+    expect(server.state).toBe("listening");
+    expect(server.connectionCount).toBe(0);
+
+    const stopResult = await server.stop();
+    expect(stopResult.isOk()).toBe(true);
+    expect(server.state).toBe("stopped");
+  });
+
+  test("rejects start when not idle", async () => {
+    await startServer();
+    const result = await server.start();
+    expect(result.isErr()).toBe(true);
+  });
+
+  test("returns 404 for non-upgrade paths", async () => {
+    await startServer();
+    const resp = await fetch(`http://127.0.0.1:${port}/health`);
+    expect(resp.status).toBe(404);
+  });
+});
+
+describe("Auth handshake", () => {
+  afterEach(async () => {
+    if (server && server.state === "listening") {
+      await server.stop();
+    }
+  });
+
+  test("authenticates with valid token", async () => {
+    await startServer();
+    const ws = await connectAndAuth();
+
+    const frame = (await nextMessage(ws)) as Record<string, unknown>;
+    expect(frame["type"]).toBe("authenticated");
+    expect(frame["connectionId"]).toBeTruthy();
+    expect(frame["resumedFromSeq"]).toBeNull();
+
+    const session = frame["session"] as Record<string, unknown>;
+    expect(session["sessionId"]).toBe("sess_test");
+
+    ws.close();
+  });
+
+  test("rejects invalid token with 4001", async () => {
+    await startServer();
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/v1/agent`);
+    await waitForOpen(ws);
+    ws.send(
+      JSON.stringify({
+        type: "auth",
+        token: "bad_token",
+        lastSeenSeq: null,
+      }),
+    );
+
+    const errorFrame = (await nextMessage(ws)) as Record<string, unknown>;
+    expect(errorFrame["type"]).toBe("auth_error");
+
+    const { code } = await waitForClose(ws);
+    expect(code).toBe(4001);
+  });
+
+  test("times out auth with 4002", async () => {
+    await startServer({ authTimeoutMs: 200 });
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/v1/agent`);
+    await waitForOpen(ws);
+    // Don't send auth frame
+
+    const errorFrame = (await nextMessage(ws, 2000)) as Record<string, unknown>;
+    expect(errorFrame["type"]).toBe("auth_error");
+    expect(errorFrame["code"]).toBe(4002);
+
+    const { code } = await waitForClose(ws, 2000);
+    expect(code).toBe(4002);
+  });
+
+  test("rejects malformed auth frame with 4009", async () => {
+    await startServer();
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/v1/agent`);
+    await waitForOpen(ws);
+    ws.send(JSON.stringify({ type: "auth" })); // missing token
+
+    const errorFrame = (await nextMessage(ws)) as Record<string, unknown>;
+    expect(errorFrame["type"]).toBe("auth_error");
+
+    const { code } = await waitForClose(ws);
+    expect(code).toBe(4009);
+  });
+
+  test("rejects invalid JSON with 4009", async () => {
+    await startServer();
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/v1/agent`);
+    await waitForOpen(ws);
+    ws.send("not json {{{");
+
+    const { code } = await waitForClose(ws);
+    expect(code).toBe(4009);
+  });
+});
+
+describe("Request/Response", () => {
+  afterEach(async () => {
+    if (server && server.state === "listening") {
+      await server.stop();
+    }
+  });
+
+  test("handles send_message request", async () => {
+    await startServer();
+    const ws = await connectAndAuth();
+    await nextMessage(ws); // consume auth response
+
+    ws.send(
+      JSON.stringify({
+        type: "send_message",
+        requestId: "req_1",
+        groupId: "g1",
+        contentType: "xmtp.org/text:1.0",
+        content: { text: "hello" },
+      }),
+    );
+
+    const resp = (await nextMessage(ws)) as Record<string, unknown>;
+    expect(resp["ok"]).toBe(true);
+    expect(resp["requestId"]).toBe("req_1");
+
+    ws.close();
+  });
+
+  test("handles heartbeat request", async () => {
+    await startServer();
+    const ws = await connectAndAuth();
+    await nextMessage(ws); // consume auth response
+
+    ws.send(
+      JSON.stringify({
+        type: "heartbeat",
+        requestId: "req_hb",
+        sessionId: "sess_test",
+      }),
+    );
+
+    const resp = (await nextMessage(ws)) as Record<string, unknown>;
+    expect(resp["ok"]).toBe(true);
+    expect(resp["requestId"]).toBe("req_hb");
+
+    ws.close();
+  });
+
+  test("returns error for invalid request with requestId", async () => {
+    await startServer();
+    const ws = await connectAndAuth();
+    await nextMessage(ws); // consume auth response
+
+    ws.send(
+      JSON.stringify({
+        type: "unknown_type",
+        requestId: "req_bad",
+      }),
+    );
+
+    const resp = (await nextMessage(ws)) as Record<string, unknown>;
+    expect(resp["ok"]).toBe(false);
+    expect(resp["requestId"]).toBe("req_bad");
+
+    ws.close();
+  });
+
+  test("suppresses late handler responses after timing out a request", async () => {
+    await startServer({ requestTimeoutMs: 50 }, "valid_token", {
+      requestHandler: async () => {
+        await Bun.sleep(100);
+        return Result.ok({ messageId: "late-message" });
+      },
+    });
+
+    const ws = await connectAndAuth();
+    await nextMessage(ws); // consume auth response
+
+    const messages: Array<Record<string, unknown>> = [];
+    ws.addEventListener("message", (event) => {
+      messages.push(
+        JSON.parse(event.data as string) as Record<string, unknown>,
+      );
+    });
+
+    ws.send(
+      JSON.stringify({
+        type: "send_message",
+        requestId: "req_timeout",
+        groupId: "g1",
+        contentType: "xmtp.org/text:1.0",
+        content: { text: "slow" },
+      }),
+    );
+
+    await Bun.sleep(200);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.ok).toBe(false);
+    expect(messages[0]?.requestId).toBe("req_timeout");
+    expect(
+      (messages[0]?.error as Record<string, unknown> | undefined)?.category,
+    ).toBe("timeout");
+
+    ws.close();
+  });
+});
+
+describe("Event broadcasting", () => {
+  afterEach(async () => {
+    if (server && server.state === "listening") {
+      await server.stop();
+    }
+  });
+
+  test("broadcasts sequenced events to connected sessions", async () => {
+    await startServer();
+    const ws = await connectAndAuth();
+    await nextMessage(ws); // consume auth response
+
+    // Broadcast an event
+    server.broadcast("sess_test", {
+      type: "heartbeat",
+      sessionId: "sess_test",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+
+    const frame = (await nextMessage(ws)) as Record<string, unknown>;
+    expect(frame["seq"]).toBe(1);
+    expect((frame["event"] as Record<string, unknown>)["type"]).toBe(
+      "heartbeat",
+    );
+
+    ws.close();
+  });
+
+  test("assigns monotonically increasing seq numbers", async () => {
+    await startServer();
+    const ws = await connectAndAuth();
+    await nextMessage(ws); // consume auth response
+
+    server.broadcast("sess_test", {
+      type: "heartbeat",
+      sessionId: "sess_test",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+    server.broadcast("sess_test", {
+      type: "heartbeat",
+      sessionId: "sess_test",
+      timestamp: "2024-01-01T00:00:01Z",
+    });
+
+    const frames = await collectMessages(ws, 2);
+    const f1 = frames[0] as Record<string, unknown>;
+    const f2 = frames[1] as Record<string, unknown>;
+    expect(f1["seq"]).toBe(1);
+    expect(f2["seq"]).toBe(2);
+
+    ws.close();
+  });
+
+  test("keeps healthy connections open under normal traffic with low limits", async () => {
+    await startServer({
+      sendBufferSoftLimit: 1,
+      sendBufferHardLimit: 2,
+    });
+    const ws = await connectAndAuth();
+    await nextMessage(ws); // consume auth response
+
+    server.broadcast("sess_test", {
+      type: "heartbeat",
+      sessionId: "sess_test",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+
+    const eventFrame = (await nextMessage(ws)) as Record<string, unknown>;
+    expect(eventFrame["seq"]).toBe(1);
+
+    ws.send(
+      JSON.stringify({
+        type: "heartbeat",
+        requestId: "req_after_event",
+        sessionId: "sess_test",
+      }),
+    );
+
+    const response = (await nextMessage(ws)) as Record<string, unknown>;
+    expect(response["ok"]).toBe(true);
+    expect(response["requestId"]).toBe("req_after_event");
+
+    ws.close();
+  });
+
+  test("emits a sequenced recovery event when replay buffer cannot satisfy resume", async () => {
+    await startServer({ replayBufferSize: 1 });
+    const first = await connectAndAuth();
+    await nextMessage(first); // consume auth response
+
+    server.broadcast("sess_test", {
+      type: "heartbeat",
+      sessionId: "sess_test",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+    await nextMessage(first);
+
+    server.broadcast("sess_test", {
+      type: "heartbeat",
+      sessionId: "sess_test",
+      timestamp: "2024-01-01T00:00:01Z",
+    });
+    await nextMessage(first);
+    first.close();
+
+    const resumed = await connectAndAuth("valid_token", 0);
+    const authFrame = (await nextMessage(resumed)) as Record<string, unknown>;
+    expect(authFrame["type"]).toBe("authenticated");
+    expect(authFrame["resumedFromSeq"]).toBeNull();
+
+    const recoveryFrame = await nextMessage(resumed);
+    const parsed = SequencedFrame.safeParse(recoveryFrame);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.event.type).toBe("broker.recovery.complete");
+      expect(parsed.data.event.caughtUpThrough).toBeTruthy();
+    }
+
+    resumed.close();
+  });
+});
+
+describe("Connection tracking", () => {
+  afterEach(async () => {
+    if (server && server.state === "listening") {
+      await server.stop();
+    }
+  });
+
+  test("tracks connection count", async () => {
+    await startServer();
+    expect(server.connectionCount).toBe(0);
+
+    const ws = await connectAndAuth();
+    await nextMessage(ws); // consume auth response
+    expect(server.connectionCount).toBe(1);
+
+    ws.close();
+    // Give time for close to propagate
+    await new Promise((r) => setTimeout(r, 100));
+    expect(server.connectionCount).toBe(0);
+  });
+});
+
+describe("Dead-connection detection", () => {
+  afterEach(async () => {
+    if (server && server.state === "listening") {
+      await server.stop();
+    }
+  });
+
+  test("closes connection when no client activity within threshold", async () => {
+    // heartbeatIntervalMs=100, missedHeartbeatsBeforeDead=2
+    // => dead threshold = 200ms, checked every 100ms
+    await startServer({
+      heartbeatIntervalMs: 100,
+      missedHeartbeatsBeforeDead: 2,
+    });
+    const ws = await connectAndAuth();
+    await nextMessage(ws); // consume auth response
+
+    // Do NOT send any messages — let the dead check fire
+    const { code } = await waitForClose(ws, 2000);
+    expect(code).toBe(4010);
+  });
+
+  test("keeps connection alive when client sends messages", async () => {
+    await startServer({
+      heartbeatIntervalMs: 100,
+      missedHeartbeatsBeforeDead: 2,
+    });
+    const ws = await connectAndAuth();
+    await nextMessage(ws); // consume auth response
+
+    // Send a heartbeat request every 50ms to stay active
+    const interval = setInterval(() => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(
+          JSON.stringify({
+            type: "heartbeat",
+            requestId: `req_keep_alive_${Date.now()}`,
+            sessionId: "sess_test",
+          }),
+        );
+      }
+    }, 50);
+
+    // Wait past the dead threshold
+    await Bun.sleep(350);
+
+    clearInterval(interval);
+
+    // Connection should still be open
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+    ws.close();
+  });
+});
+
+describe("Rate limiting", () => {
+  afterEach(async () => {
+    if (server && server.state === "listening") {
+      await server.stop();
+    }
+  });
+
+  test("does not limit when rateLimitMaxMessages is null (default)", async () => {
+    await startServer();
+    const ws = await connectAndAuth();
+    await nextMessage(ws); // consume auth response
+
+    // Send many messages rapidly
+    for (let i = 0; i < 20; i++) {
+      ws.send(
+        JSON.stringify({
+          type: "heartbeat",
+          requestId: `req_${i}`,
+          sessionId: "sess_test",
+        }),
+      );
+    }
+
+    // Wait for responses
+    await Bun.sleep(200);
+
+    // Connection should still be open
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+    ws.close();
+  });
+
+  test("closes connection with 1008 when rate limit exceeded", async () => {
+    await startServer({
+      rateLimitWindowMs: 1_000,
+      rateLimitMaxMessages: 3,
+    });
+    const ws = await connectAndAuth();
+    await nextMessage(ws); // consume auth response
+
+    // Send messages exceeding the limit (auth frame already counted as 1)
+    // Window: auth=1, msg1=2, msg2=3, msg3=4 => exceeds 3
+    for (let i = 0; i < 3; i++) {
+      ws.send(
+        JSON.stringify({
+          type: "heartbeat",
+          requestId: `req_${i}`,
+          sessionId: "sess_test",
+        }),
+      );
+    }
+
+    const { code } = await waitForClose(ws, 2000);
+    expect(code).toBe(1008);
+  });
+
+  test("resets rate limit counter after window expires", async () => {
+    await startServer({
+      rateLimitWindowMs: 200,
+      rateLimitMaxMessages: 3,
+    });
+    const ws = await connectAndAuth();
+    await nextMessage(ws); // consume auth response
+
+    // Send 2 messages (auth=1 + 2 = 3, at the limit)
+    ws.send(
+      JSON.stringify({
+        type: "heartbeat",
+        requestId: "req_a",
+        sessionId: "sess_test",
+      }),
+    );
+    ws.send(
+      JSON.stringify({
+        type: "heartbeat",
+        requestId: "req_b",
+        sessionId: "sess_test",
+      }),
+    );
+
+    // Wait for window to expire
+    await Bun.sleep(250);
+
+    // Should be able to send again
+    ws.send(
+      JSON.stringify({
+        type: "heartbeat",
+        requestId: "req_c",
+        sessionId: "sess_test",
+      }),
+    );
+
+    const resp = (await nextMessage(ws)) as Record<string, unknown>;
+    expect(resp["requestId"]).toBeTruthy();
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+    ws.close();
+  });
+});
+
+describe("Graceful shutdown", () => {
+  test("sends session.expired event before closing", async () => {
+    await startServer();
+    const ws = await connectAndAuth();
+    await nextMessage(ws); // consume auth response
+
+    // Collect the session.expired event sent during drain
+    const msgPromise = nextMessage(ws, 10000);
+    const closePromise = waitForClose(ws, 10000);
+    await server.stop();
+
+    // Should receive a sequenced session.expired event
+    const frame = msgPromise
+      .then((f) => f as Record<string, unknown>)
+      .catch(() => null);
+    const msg = await frame;
+    if (msg !== null) {
+      const event = msg["event"] as Record<string, unknown> | undefined;
+      if (event) {
+        expect(event["type"]).toBe("session.expired");
+        expect(event["reason"]).toBe("broker_shutdown");
+      }
+    }
+
+    await closePromise;
+    expect(server.state).toBe("stopped");
+  });
+
+  test("transitions to stopped state after stop", async () => {
+    await startServer();
+    await server.stop();
+    expect(server.state).toBe("stopped");
+  });
+});

--- a/packages/ws/src/__tests__/smoke.test.ts
+++ b/packages/ws/src/__tests__/smoke.test.ts
@@ -1,7 +1,0 @@
-import { describe, expect, it } from "bun:test";
-
-describe("workspace", () => {
-  it("test runner works", () => {
-    expect(true).toBe(true);
-  });
-});

--- a/packages/ws/src/auth-handler.ts
+++ b/packages/ws/src/auth-handler.ts
@@ -1,0 +1,38 @@
+import { Result } from "better-result";
+import type { BrokerError } from "@xmtp-broker/schemas";
+import { AuthError } from "@xmtp-broker/schemas";
+import type { SessionRecord } from "@xmtp-broker/contracts";
+import type { AuthFrame } from "./frames.js";
+
+/**
+ * Callback to look up a session by bearer token.
+ * Injected by the server -- the auth handler doesn't know about
+ * the SessionManager directly.
+ */
+export type TokenLookup = (
+  token: string,
+) => Promise<Result<SessionRecord, BrokerError>>;
+
+/**
+ * Validates an auth frame by looking up the token and checking
+ * the session is in an active state.
+ */
+export async function handleAuth(
+  frame: AuthFrame,
+  lookup: TokenLookup,
+): Promise<Result<SessionRecord, BrokerError>> {
+  const result = await lookup(frame.token);
+  if (!result.isOk()) return result;
+
+  const session = result.value;
+  if (session.state !== "active") {
+    return Result.err(
+      AuthError.create(`Session ${session.sessionId} is not active`, {
+        sessionId: session.sessionId,
+        state: session.state,
+      }),
+    );
+  }
+
+  return Result.ok(session);
+}

--- a/packages/ws/src/backpressure.ts
+++ b/packages/ws/src/backpressure.ts
@@ -1,0 +1,51 @@
+export type BackpressureState = "ok" | "warning" | "exceeded";
+
+/**
+ * Tracks per-connection send buffer depth and determines backpressure state.
+ */
+export class BackpressureTracker {
+  private _depth = 0;
+  private _notified = false;
+
+  constructor(
+    private readonly softLimit: number,
+    private readonly hardLimit: number,
+  ) {}
+
+  get depth(): number {
+    return this._depth;
+  }
+
+  get notified(): boolean {
+    return this._notified;
+  }
+
+  get state(): BackpressureState {
+    if (this._depth >= this.hardLimit) return "exceeded";
+    if (this._depth >= this.softLimit) return "warning";
+    return "ok";
+  }
+
+  increment(): void {
+    this._depth++;
+  }
+
+  decrement(): void {
+    if (this._depth > 0) {
+      this._depth--;
+    }
+  }
+
+  markNotified(): void {
+    this._notified = true;
+  }
+
+  clearNotified(): void {
+    this._notified = false;
+  }
+
+  reset(): void {
+    this._depth = 0;
+    this._notified = false;
+  }
+}

--- a/packages/ws/src/close-codes.ts
+++ b/packages/ws/src/close-codes.ts
@@ -1,0 +1,27 @@
+/** WebSocket close codes used by the broker. */
+export const WS_CLOSE_CODES = {
+  /** Clean client disconnect. */
+  NORMAL: 1000,
+  /** Server shutdown. */
+  GOING_AWAY: 1001,
+  /** Invalid or expired token. */
+  AUTH_FAILED: 4001,
+  /** No auth frame within timeout. */
+  AUTH_TIMEOUT: 4002,
+  /** Session TTL exceeded. */
+  SESSION_EXPIRED: 4003,
+  /** Explicit revocation. */
+  SESSION_REVOKED: 4004,
+  /** Material change requires reauth. */
+  POLICY_CHANGE: 4005,
+  /** Send buffer hard limit exceeded. */
+  BACKPRESSURE: 4008,
+  /** Connection detected as dead (missed heartbeats). */
+  DEAD_CONNECTION: 4010,
+  /** Rate limit exceeded (policy violation). */
+  RATE_LIMITED: 1008,
+  /** Malformed frame or unknown type. */
+  PROTOCOL_ERROR: 4009,
+} as const;
+
+export type WsCloseCode = (typeof WS_CLOSE_CODES)[keyof typeof WS_CLOSE_CODES];

--- a/packages/ws/src/config.ts
+++ b/packages/ws/src/config.ts
@@ -1,0 +1,128 @@
+import { z } from "zod";
+
+/** Parsed WebSocket server configuration (all defaults applied). */
+export type WsServerConfig = {
+  port: number;
+  host: string;
+  heartbeatIntervalMs: number;
+  missedHeartbeatsBeforeDead: number;
+  authTimeoutMs: number;
+  requestTimeoutMs: number;
+  replayBufferSize: number;
+  sendBufferSoftLimit: number;
+  sendBufferHardLimit: number;
+  drainTimeoutMs: number;
+  maxFrameSizeBytes: number;
+  rateLimitWindowMs: number;
+  rateLimitMaxMessages: number | null;
+};
+
+/** Input to WsServerConfigSchema (fields with defaults are optional). */
+type WsServerConfigInput = {
+  port?: number | undefined;
+  host?: string | undefined;
+  heartbeatIntervalMs?: number | undefined;
+  missedHeartbeatsBeforeDead?: number | undefined;
+  authTimeoutMs?: number | undefined;
+  requestTimeoutMs?: number | undefined;
+  replayBufferSize?: number | undefined;
+  sendBufferSoftLimit?: number | undefined;
+  sendBufferHardLimit?: number | undefined;
+  drainTimeoutMs?: number | undefined;
+  maxFrameSizeBytes?: number | undefined;
+  rateLimitWindowMs?: number | undefined;
+  rateLimitMaxMessages?: number | null | undefined;
+};
+
+export const WsServerConfigSchema: z.ZodType<
+  WsServerConfig,
+  z.ZodTypeDef,
+  WsServerConfigInput
+> = z
+  .object({
+    port: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(8393)
+      .describe("Port to listen on (0 for random)"),
+    host: z.string().default("127.0.0.1").describe("Host to bind to"),
+    heartbeatIntervalMs: z
+      .number()
+      .int()
+      .positive()
+      .default(30_000)
+      .describe("Interval between heartbeat frames in milliseconds"),
+    missedHeartbeatsBeforeDead: z
+      .number()
+      .int()
+      .positive()
+      .default(3)
+      .describe(
+        "Consecutive missed heartbeats before connection is considered dead",
+      ),
+    authTimeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .default(5_000)
+      .describe("Time allowed for auth handshake after connect"),
+    requestTimeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .default(30_000)
+      .describe("Time allowed for an individual request handler to finish"),
+    replayBufferSize: z
+      .number()
+      .int()
+      .positive()
+      .default(1_000)
+      .describe("Max events buffered per connection for reconnection replay"),
+    sendBufferSoftLimit: z
+      .number()
+      .int()
+      .positive()
+      .default(64)
+      .describe("Send buffer depth that triggers backpressure warning"),
+    sendBufferHardLimit: z
+      .number()
+      .int()
+      .positive()
+      .default(256)
+      .describe("Send buffer depth that triggers forced disconnect"),
+    drainTimeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .default(5_000)
+      .describe(
+        "Time to wait for in-flight responses during graceful shutdown",
+      ),
+    maxFrameSizeBytes: z
+      .number()
+      .int()
+      .positive()
+      .default(1_048_576)
+      .describe("Maximum accepted frame size (1 MiB default)"),
+    rateLimitWindowMs: z
+      .number()
+      .int()
+      .positive()
+      .default(1_000)
+      .describe("Rate limit window in milliseconds"),
+    rateLimitMaxMessages: z
+      .number()
+      .int()
+      .positive()
+      .nullable()
+      .default(null)
+      .describe(
+        "Max messages per window per connection. null = unlimited (default)",
+      ),
+  })
+  .refine(
+    (c) => c.sendBufferSoftLimit < c.sendBufferHardLimit,
+    { message: "sendBufferSoftLimit must be less than sendBufferHardLimit" },
+  )
+  .describe("WebSocket server configuration");

--- a/packages/ws/src/connection-registry.ts
+++ b/packages/ws/src/connection-registry.ts
@@ -1,0 +1,57 @@
+import type { ServerWebSocket } from "bun";
+import type { ConnectionData } from "./connection-state.js";
+
+/**
+ * Tracks authenticated WebSocket connections.
+ * Provides lookups by connection ID, session ID, and agent inbox ID.
+ */
+export class ConnectionRegistry {
+  private readonly connections = new Map<
+    string,
+    ServerWebSocket<ConnectionData>
+  >();
+
+  get size(): number {
+    return this.connections.size;
+  }
+
+  add(ws: ServerWebSocket<ConnectionData>): void {
+    this.connections.set(ws.data.connectionId, ws);
+  }
+
+  remove(connectionId: string): void {
+    this.connections.delete(connectionId);
+  }
+
+  get(connectionId: string): ServerWebSocket<ConnectionData> | undefined {
+    return this.connections.get(connectionId);
+  }
+
+  getBySessionId(
+    sessionId: string,
+  ): readonly ServerWebSocket<ConnectionData>[] {
+    const result: ServerWebSocket<ConnectionData>[] = [];
+    for (const ws of this.connections.values()) {
+      if (ws.data.sessionId === sessionId) {
+        result.push(ws);
+      }
+    }
+    return result;
+  }
+
+  getByAgentInboxId(
+    agentInboxId: string,
+  ): readonly ServerWebSocket<ConnectionData>[] {
+    const result: ServerWebSocket<ConnectionData>[] = [];
+    for (const ws of this.connections.values()) {
+      if (ws.data.agentInboxId === agentInboxId) {
+        result.push(ws);
+      }
+    }
+    return result;
+  }
+
+  getAll(): readonly ServerWebSocket<ConnectionData>[] {
+    return Array.from(this.connections.values());
+  }
+}

--- a/packages/ws/src/connection-state.ts
+++ b/packages/ws/src/connection-state.ts
@@ -1,0 +1,99 @@
+import type { SessionRecord } from "@xmtp-broker/contracts";
+import { CircularBuffer } from "./replay-buffer.js";
+import { BackpressureTracker } from "./backpressure.js";
+import type { SequencedFrame } from "./frames.js";
+
+export type ConnectionPhase =
+  | "authenticating"
+  | "active"
+  | "draining"
+  | "closed";
+
+/** Valid state transitions for the connection lifecycle. */
+const VALID_TRANSITIONS: Record<ConnectionPhase, readonly ConnectionPhase[]> = {
+  authenticating: ["active", "closed"],
+  active: ["draining", "closed"],
+  draining: ["closed"],
+  closed: [],
+};
+
+/**
+ * Per-session replay state: buffer + seq counter.
+ * Shared across reconnections of the same session.
+ */
+export interface SessionReplayState {
+  buffer: CircularBuffer<SequencedFrame>;
+  nextSeq: number;
+}
+
+/**
+ * Per-connection state stored in `ws.data`.
+ * Also used as the type parameter for Bun's `ServerWebSocket<ConnectionData>`.
+ */
+export interface ConnectionData {
+  readonly connectionId: string;
+  phase: ConnectionPhase;
+  sessionRecord: SessionRecord | null;
+  sessionId: string | null;
+  agentInboxId: string | null;
+  /** Attached after auth succeeds; shared across reconnections. */
+  sessionReplayState: SessionReplayState | null;
+  backpressure: BackpressureTracker;
+  authTimer: ReturnType<typeof setTimeout> | null;
+  heartbeatTimer: ReturnType<typeof setInterval> | null;
+  inFlightRequests: Map<
+    string,
+    { timer: ReturnType<typeof setTimeout>; sentAt: number }
+  >;
+  /** Timestamp of last inbound message from client (for dead-connection detection). */
+  lastClientActivity: number;
+  /** Rate limiting: message count in current window. */
+  messageCount: number;
+  /** Rate limiting: start of current window (ms since epoch). */
+  messageWindowStart: number;
+}
+
+let connectionCounter = 0;
+
+export function createConnectionState(
+  softLimit = 64,
+  hardLimit = 256,
+): ConnectionData {
+  connectionCounter++;
+  const now = Date.now();
+  return {
+    connectionId: `conn_${now}_${connectionCounter}`,
+    phase: "authenticating",
+    sessionRecord: null,
+    sessionId: null,
+    agentInboxId: null,
+    sessionReplayState: null,
+    backpressure: new BackpressureTracker(softLimit, hardLimit),
+    authTimer: null,
+    heartbeatTimer: null,
+    inFlightRequests: new Map(),
+    lastClientActivity: now,
+    messageCount: 0,
+    messageWindowStart: now,
+  };
+}
+
+export function canTransition(
+  from: ConnectionPhase,
+  to: ConnectionPhase,
+): boolean {
+  return VALID_TRANSITIONS[from].includes(to);
+}
+
+/**
+ * Attempt a phase transition. Returns true if successful, false if invalid.
+ * Mutates state.phase on success.
+ */
+export function transition(
+  state: ConnectionData,
+  to: ConnectionPhase,
+): boolean {
+  if (!canTransition(state.phase, to)) return false;
+  state.phase = to;
+  return true;
+}

--- a/packages/ws/src/event-broadcaster.ts
+++ b/packages/ws/src/event-broadcaster.ts
@@ -1,0 +1,18 @@
+import type { BrokerEvent } from "@xmtp-broker/schemas";
+import type { SequencedFrame } from "./frames.js";
+import type { SessionReplayState } from "./connection-state.js";
+
+/**
+ * Wraps an event in a SequencedFrame using the session's replay state.
+ * Advances the session's seq counter and pushes to the replay buffer.
+ */
+export function sequenceEvent(
+  sessionState: SessionReplayState,
+  event: BrokerEvent,
+): SequencedFrame {
+  const seq = sessionState.nextSeq;
+  sessionState.nextSeq = seq + 1;
+  const frame: SequencedFrame = { seq, event };
+  sessionState.buffer.push(frame);
+  return frame;
+}

--- a/packages/ws/src/frames.ts
+++ b/packages/ws/src/frames.ts
@@ -1,0 +1,117 @@
+import { z } from "zod";
+import {
+  SessionToken,
+  ViewConfig,
+  GrantConfig,
+  BrokerEvent,
+} from "@xmtp-broker/schemas";
+import type { BrokerEvent as BrokerEventType } from "@xmtp-broker/schemas";
+
+export type AuthFrame = {
+  type: "auth";
+  token: string;
+  lastSeenSeq: number | null;
+};
+
+/** Auth frame sent by harness as first message. */
+const _AuthFrame = z
+  .object({
+    type: z.literal("auth"),
+    token: z.string().describe("Session bearer token"),
+    lastSeenSeq: z
+      .number()
+      .int()
+      .nonnegative()
+      .nullable()
+      .describe("Last sequence number seen, null for fresh connection"),
+  })
+  .describe("Authentication frame from harness");
+
+export const AuthFrame: z.ZodType<AuthFrame> = _AuthFrame;
+
+export type AuthenticatedFrame = {
+  type: "authenticated";
+  connectionId: string;
+  session: z.infer<typeof SessionToken>;
+  view: z.infer<typeof ViewConfig>;
+  grant: z.infer<typeof GrantConfig>;
+  resumedFromSeq: number | null;
+};
+
+/** Authenticated confirmation from broker. */
+export const AuthenticatedFrame: z.ZodType<AuthenticatedFrame> = z
+  .object({
+    type: z.literal("authenticated"),
+    connectionId: z.string().describe("Broker-assigned connection identifier"),
+    session: SessionToken.describe("Session info"),
+    view: ViewConfig.describe("Active view configuration"),
+    grant: GrantConfig.describe("Active grant configuration"),
+    resumedFromSeq: z
+      .number()
+      .int()
+      .nonnegative()
+      .nullable()
+      .describe("Sequence number resume started from, null if fresh"),
+  })
+  .describe("Authentication success response from broker");
+
+export type AuthErrorFrame = {
+  type: "auth_error";
+  code: number;
+  message: string;
+};
+
+/** Auth error from broker, sent before close. */
+export const AuthErrorFrame: z.ZodType<AuthErrorFrame> = z
+  .object({
+    type: z.literal("auth_error"),
+    code: z.number().int().describe("Error code"),
+    message: z.string().describe("Human-readable error description"),
+  })
+  .describe("Authentication failure response from broker");
+
+export type BackpressureFrame = {
+  type: "backpressure";
+  buffered: number;
+  limit: number;
+};
+
+/** Backpressure warning from broker. */
+export const BackpressureFrame: z.ZodType<BackpressureFrame> = z
+  .object({
+    type: z.literal("backpressure"),
+    buffered: z.number().int().describe("Current buffer depth"),
+    limit: z.number().int().describe("Hard limit before disconnect"),
+  })
+  .describe("Backpressure warning from broker");
+
+export type SequencedFrame = {
+  seq: number;
+  event: BrokerEventType;
+};
+
+/** Sequenced event envelope for replay support. */
+export const SequencedFrame: z.ZodType<SequencedFrame> = z
+  .object({
+    seq: z
+      .number()
+      .int()
+      .positive()
+      .describe(
+        "Monotonically increasing sequence number, scoped to connection",
+      ),
+    event: BrokerEvent.describe("The event payload"),
+  })
+  .describe("Sequenced event envelope for replay support");
+
+/**
+ * Discriminated union of all inbound frame types from harness.
+ * The auth frame is the only non-request frame; requests use HarnessRequest
+ * from schemas.
+ */
+export const InboundFrame: z.ZodType<AuthFrame> = z.discriminatedUnion(
+  "type",
+  [_AuthFrame],
+);
+
+export type InboundFrame = z.infer<typeof InboundFrame>;

--- a/packages/ws/src/index.ts
+++ b/packages/ws/src/index.ts
@@ -1,2 +1,51 @@
-// Placeholder — real exports added by subsequent specs.
-export {};
+// Configuration
+export { WsServerConfigSchema, type WsServerConfig } from "./config.js";
+
+// Close codes
+export { WS_CLOSE_CODES, type WsCloseCode } from "./close-codes.js";
+
+// Frame schemas
+export {
+  AuthFrame,
+  AuthenticatedFrame,
+  AuthErrorFrame,
+  BackpressureFrame,
+  SequencedFrame,
+  InboundFrame,
+} from "./frames.js";
+
+// Connection state
+export {
+  type ConnectionPhase,
+  type ConnectionData,
+  type SessionReplayState,
+  createConnectionState,
+  canTransition,
+  transition,
+} from "./connection-state.js";
+
+// Connection registry
+export { ConnectionRegistry } from "./connection-registry.js";
+
+// Replay buffer
+export { CircularBuffer } from "./replay-buffer.js";
+
+// Backpressure
+export { BackpressureTracker, type BackpressureState } from "./backpressure.js";
+
+// Auth handler
+export { handleAuth, type TokenLookup } from "./auth-handler.js";
+
+// Request router
+export { routeRequest, type RequestHandler } from "./request-router.js";
+
+// Event broadcaster
+export { sequenceEvent } from "./event-broadcaster.js";
+
+// Server
+export {
+  createWsServer,
+  type WsServer,
+  type WsServerState,
+  type WsServerDeps,
+} from "./server.js";

--- a/packages/ws/src/replay-buffer.ts
+++ b/packages/ws/src/replay-buffer.ts
@@ -1,0 +1,76 @@
+/**
+ * Fixed-capacity circular buffer. Overwrites oldest entries when full.
+ * Used for per-session event replay on reconnection.
+ */
+export class CircularBuffer<T> {
+  private readonly buffer: Array<T | undefined>;
+  private head = 0;
+  private count = 0;
+
+  constructor(private readonly cap: number) {
+    this.buffer = Array.from<T | undefined>({ length: cap });
+  }
+
+  get capacity(): number {
+    return this.cap;
+  }
+
+  get size(): number {
+    return this.count;
+  }
+
+  push(item: T): void {
+    this.buffer[this.head] = item;
+    this.head = (this.head + 1) % this.cap;
+    if (this.count < this.cap) {
+      this.count++;
+    }
+  }
+
+  /**
+   * Returns the oldest item in the buffer, or undefined if empty.
+   */
+  oldest(): T | undefined {
+    if (this.count === 0) return undefined;
+    const start = this.count < this.cap ? 0 : this.head;
+    return this.buffer[start];
+  }
+
+  /**
+   * Returns all items matching the predicate, preserving insertion order.
+   */
+  itemsSince(predicate: (item: T) => boolean): T[] {
+    const result: T[] = [];
+    const start = this.count < this.cap ? 0 : this.head;
+    for (let i = 0; i < this.count; i++) {
+      const idx = (start + i) % this.cap;
+      const item = this.buffer[idx];
+      if (item !== undefined && predicate(item)) {
+        result.push(item);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Returns all items in insertion order.
+   */
+  toArray(): T[] {
+    const result: T[] = [];
+    const start = this.count < this.cap ? 0 : this.head;
+    for (let i = 0; i < this.count; i++) {
+      const idx = (start + i) % this.cap;
+      const item = this.buffer[idx];
+      if (item !== undefined) {
+        result.push(item);
+      }
+    }
+    return result;
+  }
+
+  clear(): void {
+    this.buffer.fill(undefined);
+    this.head = 0;
+    this.count = 0;
+  }
+}

--- a/packages/ws/src/request-router.ts
+++ b/packages/ws/src/request-router.ts
@@ -1,0 +1,49 @@
+import type { Result } from "better-result";
+import type {
+  HarnessRequest,
+  RequestResponse,
+  BrokerError,
+} from "@xmtp-broker/schemas";
+import type { SessionRecord } from "@xmtp-broker/contracts";
+
+/**
+ * Callback to handle a validated harness request.
+ * Injected by the server -- the router doesn't know about
+ * core/policy/sessions directly.
+ */
+export type RequestHandler = (
+  request: HarnessRequest,
+  session: SessionRecord,
+) => Promise<Result<unknown, BrokerError>>;
+
+/**
+ * Routes a parsed request through the handler and converts
+ * the Result into a RequestResponse envelope.
+ */
+export async function routeRequest(
+  request: HarnessRequest,
+  session: SessionRecord,
+  handler: RequestHandler,
+): Promise<RequestResponse> {
+  const result = await handler(request, session);
+
+  if (result.isOk()) {
+    return {
+      ok: true,
+      requestId: request.requestId,
+      data: result.value,
+    };
+  }
+
+  const error = result.error;
+  return {
+    ok: false,
+    requestId: request.requestId,
+    error: {
+      code: error.code,
+      category: error.category,
+      message: error.message,
+      context: error.context,
+    },
+  };
+}

--- a/packages/ws/src/server.ts
+++ b/packages/ws/src/server.ts
@@ -1,0 +1,612 @@
+import type { ServerWebSocket } from "bun";
+import { z } from "zod";
+import { Result } from "better-result";
+import type { BrokerEvent, BrokerError } from "@xmtp-broker/schemas";
+import {
+  HarnessRequest as HarnessRequestSchema,
+  InternalError as InternalErrorClass,
+} from "@xmtp-broker/schemas";
+import type {
+  BrokerCore,
+  SessionManager,
+  AttestationManager,
+} from "@xmtp-broker/contracts";
+import type { WsServerConfig } from "./config.js";
+import { WsServerConfigSchema } from "./config.js";
+import {
+  type ConnectionData,
+  type SessionReplayState,
+  createConnectionState,
+  transition,
+} from "./connection-state.js";
+import { ConnectionRegistry } from "./connection-registry.js";
+import { CircularBuffer } from "./replay-buffer.js";
+import {
+  AuthFrame,
+  type AuthErrorFrame,
+  type SequencedFrame,
+} from "./frames.js";
+import { handleAuth, type TokenLookup } from "./auth-handler.js";
+import { routeRequest, type RequestHandler } from "./request-router.js";
+import { sequenceEvent } from "./event-broadcaster.js";
+import { WS_CLOSE_CODES } from "./close-codes.js";
+
+export type WsServerState = "idle" | "listening" | "draining" | "stopped";
+
+export interface WsServerDeps {
+  readonly core: BrokerCore;
+  readonly sessionManager: SessionManager;
+  readonly attestationManager: AttestationManager;
+  readonly tokenLookup: TokenLookup;
+  readonly requestHandler: RequestHandler;
+}
+
+export interface WsServer {
+  start(): Promise<Result<{ port: number }, BrokerError>>;
+  stop(): Promise<Result<void, BrokerError>>;
+  readonly state: WsServerState;
+  readonly connectionCount: number;
+  /** Broadcast an event to all connections for a session. */
+  broadcast(sessionId: string, event: BrokerEvent): void;
+}
+
+export function createWsServer(
+  rawConfig: Partial<WsServerConfig>,
+  deps: WsServerDeps,
+): WsServer {
+  const config = WsServerConfigSchema.parse(rawConfig);
+  const registry = new ConnectionRegistry();
+  /** Per-session replay state: survives reconnections. */
+  const sessionStates = new Map<string, SessionReplayState>();
+  let serverState: WsServerState = "idle";
+  let bunServer: ReturnType<typeof Bun.serve<ConnectionData>> | null = null;
+
+  function getOrCreateSessionState(sessionId: string): SessionReplayState {
+    let state = sessionStates.get(sessionId);
+    if (!state) {
+      state = {
+        buffer: new CircularBuffer<SequencedFrame>(config.replayBufferSize),
+        nextSeq: 1,
+      };
+      sessionStates.set(sessionId, state);
+    }
+    return state;
+  }
+
+  function sendJson(
+    ws: ServerWebSocket<ConnectionData>,
+    data: unknown,
+  ): number {
+    const msg = JSON.stringify(data);
+    const sendResult = ws.send(msg);
+    if (sendResult === -1) {
+      ws.data.backpressure.increment();
+    }
+    return sendResult;
+  }
+
+  function sendSequenced(
+    ws: ServerWebSocket<ConnectionData>,
+    event: BrokerEvent,
+  ): void {
+    const sessionState = ws.data.sessionReplayState;
+    if (!sessionState) return;
+
+    const frame = sequenceEvent(sessionState, event);
+    sendJson(ws, frame);
+
+    // Check backpressure
+    const bpState = ws.data.backpressure.state;
+    if (bpState === "exceeded") {
+      ws.close(WS_CLOSE_CODES.BACKPRESSURE, "Send buffer hard limit exceeded");
+      return;
+    }
+    if (bpState === "warning" && !ws.data.backpressure.notified) {
+      ws.data.backpressure.markNotified();
+      sendJson(ws, {
+        type: "backpressure",
+        buffered: ws.data.backpressure.depth,
+        limit: config.sendBufferHardLimit,
+      });
+      // Re-check after warning send -- the warning itself may push us over
+      if (ws.data.backpressure.state === "exceeded") {
+        ws.close(
+          WS_CLOSE_CODES.BACKPRESSURE,
+          "Send buffer hard limit exceeded",
+        );
+        return;
+      }
+    }
+  }
+
+  function cleanupConnection(ws: ServerWebSocket<ConnectionData>): void {
+    const data = ws.data;
+
+    // Clear timers
+    if (data.authTimer !== null) {
+      clearTimeout(data.authTimer);
+      data.authTimer = null;
+    }
+    if (data.heartbeatTimer !== null) {
+      clearInterval(data.heartbeatTimer);
+      data.heartbeatTimer = null;
+    }
+
+    // Clear in-flight request timers
+    for (const [, entry] of data.inFlightRequests) {
+      clearTimeout(entry.timer);
+    }
+    data.inFlightRequests.clear();
+
+    // Remove from registry
+    registry.remove(data.connectionId);
+
+    transition(data, "closed");
+  }
+
+  function startHeartbeat(ws: ServerWebSocket<ConnectionData>): void {
+    const sessionRecord = ws.data.sessionRecord;
+    if (!sessionRecord) return;
+
+    const deadThresholdMs =
+      config.missedHeartbeatsBeforeDead * config.heartbeatIntervalMs;
+
+    ws.data.heartbeatTimer = setInterval(() => {
+      if (ws.data.phase !== "active") return;
+
+      // Dead-connection detection: close if no inbound activity
+      const elapsed = Date.now() - ws.data.lastClientActivity;
+      if (elapsed > deadThresholdMs) {
+        ws.close(
+          WS_CLOSE_CODES.DEAD_CONNECTION,
+          "Dead connection: no client activity",
+        );
+        return;
+      }
+
+      sendSequenced(ws, {
+        type: "heartbeat",
+        sessionId: sessionRecord.sessionId,
+        timestamp: new Date().toISOString(),
+      });
+    }, config.heartbeatIntervalMs);
+  }
+
+  async function handleAuthFrame(
+    ws: ServerWebSocket<ConnectionData>,
+    frame: unknown,
+  ): Promise<void> {
+    // Guard: timer may have already fired and closed the connection
+    if (ws.data.phase !== "authenticating") return;
+
+    // Clear auth timer
+    if (ws.data.authTimer !== null) {
+      clearTimeout(ws.data.authTimer);
+      ws.data.authTimer = null;
+    }
+
+    // Parse the auth frame
+    const parsed = AuthFrame.safeParse(frame);
+    if (!parsed.success) {
+      sendJson(ws, {
+        type: "auth_error",
+        code: WS_CLOSE_CODES.PROTOCOL_ERROR,
+        message: "Invalid auth frame",
+      } satisfies AuthErrorFrame);
+      ws.close(WS_CLOSE_CODES.PROTOCOL_ERROR, "Invalid auth frame");
+      return;
+    }
+
+    const authFrame = parsed.data;
+    const result = await handleAuth(authFrame, deps.tokenLookup);
+
+    if (!result.isOk()) {
+      sendJson(ws, {
+        type: "auth_error",
+        code: WS_CLOSE_CODES.AUTH_FAILED,
+        message: result.error.message,
+      } satisfies AuthErrorFrame);
+      ws.close(WS_CLOSE_CODES.AUTH_FAILED, "Auth failed");
+      return;
+    }
+
+    const session = result.value;
+
+    // Transition to active
+    ws.data.sessionRecord = session;
+    ws.data.sessionId = session.sessionId;
+    ws.data.agentInboxId = session.agentInboxId;
+    transition(ws.data, "active");
+
+    // Attach session replay state (shared across reconnections)
+    const sessionState = getOrCreateSessionState(session.sessionId);
+    ws.data.sessionReplayState = sessionState;
+
+    // Register connection
+    registry.add(ws);
+
+    // Handle replay
+    let resumedFromSeq: number | null = null;
+    let needsRecovery = false;
+    let replayFrames: readonly SequencedFrame[] = [];
+
+    if (authFrame.lastSeenSeq !== null) {
+      const lastSeen = authFrame.lastSeenSeq;
+      const oldestFrame = sessionState.buffer.oldest();
+      if (
+        oldestFrame !== undefined &&
+        oldestFrame.seq > lastSeen + 1
+      ) {
+        needsRecovery = true;
+      } else {
+        replayFrames = sessionState.buffer.itemsSince(
+          (f: SequencedFrame) => f.seq > lastSeen,
+        );
+
+        if (replayFrames.length > 0) {
+          resumedFromSeq = lastSeen;
+        }
+      }
+    }
+
+    // Send authenticated frame
+    sendJson(ws, {
+      type: "authenticated",
+      connectionId: ws.data.connectionId,
+      session: {
+        sessionId: session.sessionId,
+        agentInboxId: session.agentInboxId,
+        sessionKeyFingerprint: session.sessionKeyFingerprint,
+        issuedAt: session.issuedAt,
+        expiresAt: session.expiresAt,
+      },
+      view: session.view,
+      grant: session.grant,
+      resumedFromSeq,
+    });
+
+    // Send recovery event if client is too far behind
+    if (needsRecovery) {
+      sendSequenced(ws, {
+        type: "broker.recovery.complete",
+        caughtUpThrough: new Date().toISOString(),
+      });
+    }
+
+    // Replay buffered events
+    if (!needsRecovery) {
+      for (const replayFrame of replayFrames) {
+        sendJson(ws, replayFrame);
+      }
+    }
+
+    // Start heartbeat
+    startHeartbeat(ws);
+  }
+
+  async function handleRequestFrame(
+    ws: ServerWebSocket<ConnectionData>,
+    frame: unknown,
+  ): Promise<void> {
+    const session = ws.data.sessionRecord;
+    if (!session) {
+      ws.close(WS_CLOSE_CODES.PROTOCOL_ERROR, "Not authenticated");
+      return;
+    }
+
+    // Parse request
+    const parsed = HarnessRequestSchema.safeParse(frame);
+    if (!parsed.success) {
+      // Try to extract requestId for error response
+      const FrameWithRequestId = z
+        .object({ requestId: z.string() })
+        .passthrough();
+      const requestIdParsed = FrameWithRequestId.safeParse(frame);
+      const maybeId = requestIdParsed.success
+        ? requestIdParsed.data.requestId
+        : undefined;
+
+      if (typeof maybeId === "string") {
+        sendJson(ws, {
+          ok: false,
+          requestId: maybeId,
+          error: {
+            code: 1000,
+            category: "validation",
+            message: "Invalid request frame",
+            context: null,
+          },
+        });
+      } else {
+        ws.close(WS_CLOSE_CODES.PROTOCOL_ERROR, "Malformed frame");
+      }
+      return;
+    }
+
+    const request = parsed.data;
+    const requestId = request.requestId;
+
+    // Set up timeout
+    const timeoutTimer = setTimeout(() => {
+      ws.data.inFlightRequests.delete(requestId);
+      sendJson(ws, {
+        ok: false,
+        requestId,
+        error: {
+          code: 1500,
+          category: "timeout",
+          message: "Request timed out",
+          context: {
+            operation: request.type,
+            timeoutMs: config.requestTimeoutMs,
+          },
+        },
+      });
+    }, config.requestTimeoutMs);
+
+    ws.data.inFlightRequests.set(requestId, {
+      timer: timeoutTimer,
+      sentAt: Date.now(),
+    });
+
+    try {
+      const response = await routeRequest(
+        request,
+        session,
+        deps.requestHandler,
+      );
+
+      const inflight = ws.data.inFlightRequests.get(requestId);
+      if (!inflight) {
+        return;
+      }
+      clearTimeout(inflight.timer);
+      ws.data.inFlightRequests.delete(requestId);
+
+      sendJson(ws, response);
+    } catch {
+      const inflight = ws.data.inFlightRequests.get(requestId);
+      if (!inflight) {
+        return;
+      }
+      clearTimeout(inflight.timer);
+      ws.data.inFlightRequests.delete(requestId);
+
+      sendJson(ws, {
+        ok: false,
+        requestId,
+        error: {
+          code: 1400,
+          category: "internal",
+          message: "Internal error",
+          context: null,
+        },
+      });
+    }
+  }
+
+  function broadcastToSession(sessionId: string, event: BrokerEvent): void {
+    const connections = registry.getBySessionId(sessionId);
+    for (const ws of connections) {
+      if (ws.data.phase === "active") {
+        sendSequenced(ws, event);
+      }
+    }
+  }
+
+  const server: WsServer = {
+    get state() {
+      return serverState;
+    },
+
+    get connectionCount() {
+      return registry.size;
+    },
+
+    broadcast: broadcastToSession,
+
+    async start() {
+      if (serverState !== "idle") {
+        return Result.err(
+          InternalErrorClass.create("Server is not in idle state"),
+        );
+      }
+
+      try {
+        bunServer = Bun.serve<ConnectionData>({
+          port: config.port,
+          hostname: config.host,
+          fetch(req, srv) {
+            const url = new URL(req.url);
+            if (url.pathname === "/v1/agent") {
+              const data = createConnectionState(
+                config.sendBufferSoftLimit,
+                config.sendBufferHardLimit,
+              );
+              const upgraded = srv.upgrade(req, { data });
+              if (!upgraded) {
+                return new Response("Upgrade failed", { status: 400 });
+              }
+              return undefined;
+            }
+            return new Response("Not found", { status: 404 });
+          },
+          websocket: {
+            open(ws) {
+              if (serverState === "draining" || serverState === "stopped") {
+                ws.close(WS_CLOSE_CODES.GOING_AWAY, "Server shutting down");
+                return;
+              }
+
+              // Start auth timeout
+              ws.data.authTimer = setTimeout(() => {
+                if (ws.data.phase === "authenticating") {
+                  sendJson(ws, {
+                    type: "auth_error",
+                    code: WS_CLOSE_CODES.AUTH_TIMEOUT,
+                    message: "Auth timeout",
+                  } satisfies AuthErrorFrame);
+                  ws.close(WS_CLOSE_CODES.AUTH_TIMEOUT, "Auth timeout");
+                }
+              }, config.authTimeoutMs);
+            },
+
+            message(ws, message) {
+              if (ws.data.phase === "closed") return;
+
+              // Track client activity for dead-connection detection
+              const now = Date.now();
+              ws.data.lastClientActivity = now;
+
+              // Rate limiting (when enabled)
+              if (config.rateLimitMaxMessages !== null) {
+                if (now - ws.data.messageWindowStart >= config.rateLimitWindowMs) {
+                  // Window expired, reset
+                  ws.data.messageCount = 1;
+                  ws.data.messageWindowStart = now;
+                } else {
+                  ws.data.messageCount++;
+                  if (ws.data.messageCount > config.rateLimitMaxMessages) {
+                    ws.close(
+                      WS_CLOSE_CODES.RATE_LIMITED,
+                      "Rate limit exceeded",
+                    );
+                    return;
+                  }
+                }
+              }
+
+              let frame: unknown;
+              try {
+                frame = JSON.parse(
+                  typeof message === "string"
+                    ? message
+                    : new TextDecoder().decode(message),
+                );
+              } catch {
+                ws.close(WS_CLOSE_CODES.PROTOCOL_ERROR, "Invalid JSON");
+                return;
+              }
+
+              if (ws.data.phase === "authenticating") {
+                void handleAuthFrame(ws, frame);
+                return;
+              }
+
+              if (ws.data.phase === "active") {
+                void handleRequestFrame(ws, frame);
+                return;
+              }
+
+              // draining: ignore new requests
+            },
+
+            close(ws, _code, _reason) {
+              cleanupConnection(ws);
+            },
+
+            drain(ws) {
+              // Bun fires drain once when the kernel buffer drains,
+              // not once per send -- reset depth to 0.
+              ws.data.backpressure.reset();
+            },
+
+            maxPayloadLength: config.maxFrameSizeBytes,
+            idleTimeout: Math.ceil(
+              (config.missedHeartbeatsBeforeDead * config.heartbeatIntervalMs) /
+                1_000,
+            ),
+          },
+        });
+
+        serverState = "listening";
+        const assignedPort = bunServer.port;
+        if (assignedPort === undefined) {
+          return Result.err(
+            InternalErrorClass.create("Server started but port is undefined"),
+          );
+        }
+        return Result.ok({ port: assignedPort });
+      } catch (error: unknown) {
+        return Result.err(
+          InternalErrorClass.create(
+            `Failed to start server: ${error instanceof Error ? error.message : String(error)}`,
+          ),
+        );
+      }
+    },
+
+    async stop() {
+      if (serverState !== "listening") {
+        return Result.err(InternalErrorClass.create("Server is not listening"));
+      }
+
+      serverState = "draining";
+
+      // Send session.expired to all active connections
+      const allConnections = registry.getAll();
+      for (const ws of allConnections) {
+        if (ws.data.phase === "active" && ws.data.sessionRecord) {
+          sendSequenced(ws, {
+            type: "session.expired",
+            sessionId: ws.data.sessionRecord.sessionId,
+            reason: "broker_shutdown",
+          });
+          transition(ws.data, "draining");
+        }
+      }
+
+      // Wait for in-flight requests to complete
+      await new Promise<void>((resolve) => {
+        const deadline = setTimeout(() => {
+          resolve();
+        }, config.drainTimeoutMs);
+
+        const checkInflight = () => {
+          let hasInflight = false;
+          for (const ws of registry.getAll()) {
+            if (ws.data.inFlightRequests.size > 0) {
+              hasInflight = true;
+              break;
+            }
+          }
+          if (!hasInflight) {
+            clearTimeout(deadline);
+            resolve();
+          } else {
+            setTimeout(checkInflight, 50);
+          }
+        };
+
+        checkInflight();
+      });
+
+      // Close all connections (close before cleanup so close code is sent)
+      const remaining = registry.getAll();
+      for (const ws of remaining) {
+        ws.close(WS_CLOSE_CODES.GOING_AWAY, "Server shutting down");
+      }
+
+      // Allow close frames to flush before stopping the server
+      await new Promise((r) => setTimeout(r, 50));
+
+      for (const ws of remaining) {
+        cleanupConnection(ws);
+      }
+
+      // Clean up session states
+      sessionStates.clear();
+
+      // Stop the server (false = don't force-close remaining connections)
+      if (bunServer) {
+        bunServer.stop(false);
+        bunServer = null;
+      }
+
+      serverState = "stopped";
+      return Result.ok(undefined);
+    },
+  };
+
+  return server;
+}


### PR DESCRIPTION
## Context
This branch exposes the broker over a WebSocket transport. Review this PR against `v0/key-management`, not `main`.

## What Changed
- implements the Bun.serve-based WebSocket server, request router, and auth handler
- adds connection state, registry, close-code handling, and backpressure controls
- introduces event broadcasting and replay buffer behavior so reconnecting clients can recover recent broker events
- adds integration and unit coverage for framing, routing, auth, replay, and server lifecycle behavior

## Why This Branch Exists
WebSocket is the primary phase-one transport for agent harnesses. This PR turns the broker runtime into a network-accessible service.

## Key Files
- `packages/ws/src/server.ts`
- `packages/ws/src/request-router.ts`
- `packages/ws/src/auth-handler.ts`
- `packages/ws/src/event-broadcaster.ts`
- `packages/ws/src/replay-buffer.ts`

## Verification
- `bun test packages/ws/src/__tests__/server.integration.test.ts`
- ws package test suite under `packages/ws/src/__tests__`
- repo verification via pre-push stack checks (`lint`, `test`, `typecheck`)
