### PR TITLE
feat(verifier): add reference verifier service and trust checks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -111,6 +111,12 @@
     "packages/verifier": {
       "name": "@xmtp-broker/verifier",
       "version": "0.0.0",
+      "dependencies": {
+        "@xmtp-broker/contracts": "workspace:*",
+        "@xmtp-broker/schemas": "workspace:*",
+        "better-result": "catalog:",
+        "zod": "catalog:",
+      },
       "devDependencies": {
         "bun-types": "catalog:",
         "typescript": "catalog:",

--- a/packages/verifier/package.json
+++ b/packages/verifier/package.json
@@ -15,7 +15,12 @@
     "lint": "oxlint .",
     "test": "bun test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@xmtp-broker/contracts": "workspace:*",
+    "@xmtp-broker/schemas": "workspace:*",
+    "better-result": "catalog:",
+    "zod": "catalog:"
+  },
   "devDependencies": {
     "bun-types": "catalog:",
     "typescript": "catalog:"

--- a/packages/verifier/src/__tests__/attestation-chain.test.ts
+++ b/packages/verifier/src/__tests__/attestation-chain.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { createAttestationChainCheck } from "../checks/attestation-chain.js";
+import {
+  createTestVerificationRequest,
+  createTestAttestation,
+} from "./fixtures.js";
+
+describe("attestation_chain check", () => {
+  test("skips when no attestation provided", async () => {
+    const check = createAttestationChainCheck();
+    const result = await check.execute(
+      createTestVerificationRequest({ attestation: null }),
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.verdict).toBe("skip");
+      expect(result.value.checkId).toBe("attestation_chain");
+    }
+  });
+
+  test("passes for initial attestation (null previous)", async () => {
+    const check = createAttestationChainCheck();
+    const result = await check.execute(
+      createTestVerificationRequest({
+        attestation: createTestAttestation({
+          previousAttestationId: null,
+        }),
+      }),
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.verdict).toBe("pass");
+      expect(result.value.reason).toContain("Initial attestation");
+    }
+  });
+
+  test("passes for attestation with valid previous ID", async () => {
+    const check = createAttestationChainCheck();
+    const result = await check.execute(
+      createTestVerificationRequest({
+        attestation: createTestAttestation({
+          attestationId: "att-002",
+          previousAttestationId: "att-001",
+        }),
+      }),
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.verdict).toBe("pass");
+      expect(result.value.reason).toContain("structurally valid");
+    }
+  });
+
+  test("fails when attestation references itself", async () => {
+    const check = createAttestationChainCheck();
+    const result = await check.execute(
+      createTestVerificationRequest({
+        attestation: createTestAttestation({
+          attestationId: "att-001",
+          previousAttestationId: "att-001",
+        }),
+      }),
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.verdict).toBe("fail");
+      expect(result.value.reason).toContain("references itself");
+    }
+  });
+
+  test("includes chain evidence", async () => {
+    const check = createAttestationChainCheck();
+    const result = await check.execute(
+      createTestVerificationRequest({
+        attestation: createTestAttestation({
+          attestationId: "att-002",
+          previousAttestationId: "att-001",
+        }),
+      }),
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const evidence = result.value.evidence as Record<string, unknown>;
+      expect(evidence["previousId"]).toBe("att-001");
+      expect(evidence["chainValid"]).toBe(true);
+    }
+  });
+});

--- a/packages/verifier/src/__tests__/attestation-signature.test.ts
+++ b/packages/verifier/src/__tests__/attestation-signature.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { createAttestationSignatureCheck } from "../checks/attestation-signature.js";
+import {
+  createTestVerificationRequest,
+  createTestAttestation,
+} from "./fixtures.js";
+
+describe("attestation_signature check", () => {
+  test("skips when no attestation provided", async () => {
+    const check = createAttestationSignatureCheck();
+    const result = await check.execute(
+      createTestVerificationRequest({ attestation: null }),
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.verdict).toBe("skip");
+      expect(result.value.checkId).toBe("attestation_signature");
+    }
+  });
+
+  test("skips when attestation has valid structure (v0: no crypto verification)", async () => {
+    const check = createAttestationSignatureCheck();
+    const result = await check.execute(createTestVerificationRequest());
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.verdict).toBe("skip");
+    }
+  });
+
+  test("fails when attestation has empty issuer", async () => {
+    const check = createAttestationSignatureCheck();
+    const result = await check.execute(
+      createTestVerificationRequest({
+        attestation: createTestAttestation({ issuer: "" }),
+      }),
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.verdict).toBe("fail");
+      expect(result.value.reason).toContain("issuer");
+    }
+  });
+
+  test("fails when agentInboxId does not match", async () => {
+    const check = createAttestationSignatureCheck();
+    const result = await check.execute(
+      createTestVerificationRequest({
+        agentInboxId: "agent-inbox-001",
+        attestation: createTestAttestation({
+          agentInboxId: "different-agent",
+        }),
+      }),
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.verdict).toBe("fail");
+      expect(result.value.reason).toContain("does not match");
+    }
+  });
+});

--- a/packages/verifier/src/__tests__/build-provenance.test.ts
+++ b/packages/verifier/src/__tests__/build-provenance.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { createBuildProvenanceCheck } from "../checks/build-provenance.js";
+import { createTestVerificationRequest } from "./fixtures.js";
+
+describe("build_provenance check", () => {
+  test("skips when no bundle provided", async () => {
+    const check = createBuildProvenanceCheck();
+    const result = await check.execute(
+      createTestVerificationRequest({ buildProvenanceBundle: null }),
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.verdict).toBe("skip");
+      expect(result.value.checkId).toBe("build_provenance");
+    }
+  });
+
+  test("fails with v0 stub message when valid base64 JSON provided", async () => {
+    const check = createBuildProvenanceCheck();
+    const bundle = btoa(JSON.stringify({ type: "slsa-provenance" }));
+    const result = await check.execute(
+      createTestVerificationRequest({ buildProvenanceBundle: bundle }),
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.verdict).toBe("fail");
+      expect(result.value.reason).toContain("v0 stub");
+    }
+  });
+
+  test("fails when bundle is not valid base64", async () => {
+    const check = createBuildProvenanceCheck();
+    const result = await check.execute(
+      createTestVerificationRequest({
+        buildProvenanceBundle: "!!!not-base64!!!",
+      }),
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.verdict).toBe("fail");
+      expect(result.value.reason).toContain("not valid base64");
+    }
+  });
+});

--- a/packages/verifier/src/__tests__/fixtures.ts
+++ b/packages/verifier/src/__tests__/fixtures.ts
@@ -1,0 +1,104 @@
+import type { Attestation } from "@xmtp-broker/schemas";
+import type { VerificationRequest } from "../schemas/request.js";
+import type { VerifierConfig } from "../config.js";
+
+const BASE_TIME = new Date("2025-01-15T00:00:00.000Z");
+
+export function createTestAttestation(
+  overrides?: Partial<Attestation>,
+): Attestation {
+  return {
+    attestationId: "att-001",
+    previousAttestationId: null,
+    agentInboxId: "agent-inbox-001",
+    ownerInboxId: "owner-inbox-001",
+    groupId: "group-001",
+    threadScope: null,
+    viewMode: "full",
+    contentTypes: ["xmtp.org/text:1.0"],
+    grantedOps: ["send"],
+    toolScopes: [],
+    inferenceMode: "local",
+    inferenceProviders: [],
+    contentEgressScope: "none",
+    retentionAtProvider: "none",
+    hostingMode: "self-hosted",
+    trustTier: "source-verified",
+    buildProvenanceRef: null,
+    verifierStatementRef: null,
+    sessionKeyFingerprint: null,
+    policyHash: "abc123",
+    heartbeatInterval: 30,
+    issuedAt: BASE_TIME.toISOString(),
+    expiresAt: new Date(BASE_TIME.getTime() + 86_400_000).toISOString(),
+    revocationRules: {
+      maxTtlSeconds: 86400,
+      requireHeartbeat: false,
+      ownerCanRevoke: true,
+      adminCanRemove: true,
+    },
+    issuer: "broker-signer-001",
+    ...overrides,
+  };
+}
+
+export function createTestVerificationRequest(
+  overrides?: Partial<VerificationRequest>,
+): VerificationRequest {
+  return {
+    requestId: "req-001",
+    agentInboxId: "agent-inbox-001",
+    brokerInboxId: "broker-inbox-001",
+    groupId: "group-001",
+    attestation: createTestAttestation(),
+    artifactDigest:
+      "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    buildProvenanceBundle: null,
+    sourceRepoUrl: "https://github.com/xmtp/xmtp-broker",
+    releaseTag: null,
+    requestedTier: "source-verified",
+    challengeNonce: "deadbeef".repeat(8),
+    ...overrides,
+  };
+}
+
+export function createTestConfig(
+  overrides?: Partial<VerifierConfig>,
+): VerifierConfig {
+  return {
+    verifierInboxId: "verifier-inbox-001",
+    sourceRepoUrl: "https://github.com/xmtp/xmtp-verifier",
+    statementTtlSeconds: 86400,
+    maxRequestsPerRequesterPerHour: 10,
+    ...overrides,
+  };
+}
+
+/** A mock signer that returns a deterministic base64 "signature". */
+export async function mockSign(_bytes: Uint8Array): Promise<string> {
+  return "bW9jay1zaWduYXR1cmU="; // base64("mock-signature")
+}
+
+/** Creates a mock fetch that returns configured responses. */
+export function createTestFetcher(
+  responses: Record<string, { status: number; ok?: boolean }>,
+): typeof fetch {
+  return (async (input: string | URL | Request) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+
+    const config = responses[url];
+    if (config === undefined) {
+      return new Response(null, { status: 404 });
+    }
+
+    return new Response(null, {
+      status: config.status,
+      // Response.ok is based on status 200-299
+    });
+  }) as unknown as typeof fetch;
+}

--- a/packages/verifier/src/__tests__/rate-limiter.test.ts
+++ b/packages/verifier/src/__tests__/rate-limiter.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { createRateLimiter } from "../rate-limiter.js";
+
+describe("createRateLimiter", () => {
+  test("allows requests under the limit", () => {
+    const limiter = createRateLimiter({
+      maxRequests: 3,
+      windowMs: 60_000,
+    });
+
+    expect(limiter.check("user-1")).toBe(true);
+    expect(limiter.check("user-1")).toBe(true);
+    expect(limiter.check("user-1")).toBe(true);
+  });
+
+  test("rejects requests over the limit", () => {
+    const limiter = createRateLimiter({
+      maxRequests: 2,
+      windowMs: 60_000,
+    });
+
+    expect(limiter.check("user-1")).toBe(true);
+    expect(limiter.check("user-1")).toBe(true);
+    expect(limiter.check("user-1")).toBe(false);
+  });
+
+  test("tracks requesters independently", () => {
+    const limiter = createRateLimiter({
+      maxRequests: 1,
+      windowMs: 60_000,
+    });
+
+    expect(limiter.check("user-1")).toBe(true);
+    expect(limiter.check("user-2")).toBe(true);
+    expect(limiter.check("user-1")).toBe(false);
+    expect(limiter.check("user-2")).toBe(false);
+  });
+
+  test("sliding window evicts old entries", () => {
+    let currentTime = 1_000_000;
+    const limiter = createRateLimiter({
+      maxRequests: 2,
+      windowMs: 10_000,
+      now: () => currentTime,
+    });
+
+    expect(limiter.check("user-1")).toBe(true); // t=1000000
+    expect(limiter.check("user-1")).toBe(true); // t=1000000
+    expect(limiter.check("user-1")).toBe(false); // at limit
+
+    // Advance past window
+    currentTime = 1_011_000;
+    expect(limiter.check("user-1")).toBe(true); // old entries evicted
+  });
+
+  test("reset clears all state", () => {
+    const limiter = createRateLimiter({
+      maxRequests: 1,
+      windowMs: 60_000,
+    });
+
+    expect(limiter.check("user-1")).toBe(true);
+    expect(limiter.check("user-1")).toBe(false);
+
+    limiter.reset();
+
+    expect(limiter.check("user-1")).toBe(true);
+  });
+
+  test("partially expired entries are evicted correctly", () => {
+    let currentTime = 0;
+    const limiter = createRateLimiter({
+      maxRequests: 3,
+      windowMs: 10_000,
+      now: () => currentTime,
+    });
+
+    // Fill up
+    currentTime = 1000;
+    expect(limiter.check("user-1")).toBe(true);
+    currentTime = 5000;
+    expect(limiter.check("user-1")).toBe(true);
+    currentTime = 9000;
+    expect(limiter.check("user-1")).toBe(true);
+    expect(limiter.check("user-1")).toBe(false); // at limit
+
+    // Advance so first entry expires but second doesn't
+    currentTime = 12_000;
+    expect(limiter.check("user-1")).toBe(true); // one slot freed
+  });
+});

--- a/packages/verifier/src/__tests__/release-signing.test.ts
+++ b/packages/verifier/src/__tests__/release-signing.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { createReleaseSigningCheck } from "../checks/release-signing.js";
+import { createTestVerificationRequest } from "./fixtures.js";
+
+describe("release_signing check", () => {
+  test("skips when no release tag provided", async () => {
+    const check = createReleaseSigningCheck();
+    const result = await check.execute(
+      createTestVerificationRequest({ releaseTag: null }),
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.verdict).toBe("skip");
+      expect(result.value.checkId).toBe("release_signing");
+    }
+  });
+
+  test("skips with v0 stub message when tag provided", async () => {
+    const check = createReleaseSigningCheck();
+    const result = await check.execute(
+      createTestVerificationRequest({ releaseTag: "v0.1.0" }),
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.verdict).toBe("skip");
+      expect(result.value.reason).toContain("v0 stub");
+    }
+  });
+
+  test("includes release tag and repo url in evidence", async () => {
+    const check = createReleaseSigningCheck();
+    const result = await check.execute(
+      createTestVerificationRequest({ releaseTag: "v1.0.0" }),
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const evidence = result.value.evidence as Record<string, unknown>;
+      expect(evidence["releaseTag"]).toBe("v1.0.0");
+      expect(evidence["sourceRepoUrl"]).toBe(
+        "https://github.com/xmtp/xmtp-broker",
+      );
+    }
+  });
+});

--- a/packages/verifier/src/__tests__/request.test.ts
+++ b/packages/verifier/src/__tests__/request.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { VerificationRequestSchema } from "../schemas/request.js";
+import { createTestVerificationRequest } from "./fixtures.js";
+
+describe("VerificationRequestSchema", () => {
+  test("accepts a valid request with attestation", () => {
+    const request = createTestVerificationRequest();
+    const result = VerificationRequestSchema.safeParse(request);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts a valid request with null optional fields", () => {
+    const request = createTestVerificationRequest({
+      attestation: null,
+      groupId: null,
+      buildProvenanceBundle: null,
+      releaseTag: null,
+    });
+    const result = VerificationRequestSchema.safeParse(request);
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects request missing requestId", () => {
+    const { requestId: _, ...rest } = createTestVerificationRequest();
+    const result = VerificationRequestSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects request with invalid sourceRepoUrl", () => {
+    const request = createTestVerificationRequest({
+      sourceRepoUrl: "not-a-url",
+    });
+    const result = VerificationRequestSchema.safeParse(request);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects request with invalid requestedTier", () => {
+    const request = {
+      ...createTestVerificationRequest(),
+      requestedTier: "invalid-tier",
+    };
+    const result = VerificationRequestSchema.safeParse(request);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects request missing challengeNonce", () => {
+    const { challengeNonce: _, ...rest } = createTestVerificationRequest();
+    const result = VerificationRequestSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/verifier/src/__tests__/schema-compliance.test.ts
+++ b/packages/verifier/src/__tests__/schema-compliance.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { createSchemaComplianceCheck } from "../checks/schema-compliance.js";
+import {
+  createTestVerificationRequest,
+  createTestAttestation,
+} from "./fixtures.js";
+
+describe("schema_compliance check", () => {
+  test("skips when no attestation provided", async () => {
+    const check = createSchemaComplianceCheck();
+    const result = await check.execute(
+      createTestVerificationRequest({ attestation: null }),
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.verdict).toBe("skip");
+      expect(result.value.checkId).toBe("schema_compliance");
+    }
+  });
+
+  test("passes when attestation is schema-compliant", async () => {
+    const check = createSchemaComplianceCheck();
+    const result = await check.execute(createTestVerificationRequest());
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.verdict).toBe("pass");
+      expect(result.value.reason).toContain("conforms");
+    }
+  });
+
+  test("fails when attestation has invalid fields", async () => {
+    const check = createSchemaComplianceCheck();
+    // Create a request with a malformed attestation
+    const badAttestation = {
+      ...createTestAttestation(),
+      viewMode: "invalid-mode",
+    };
+
+    const result = await check.execute(
+      createTestVerificationRequest({
+        // Force the bad attestation through by bypassing the schema
+        attestation: badAttestation as ReturnType<typeof createTestAttestation>,
+      }),
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.verdict).toBe("fail");
+      expect(result.value.reason).toContain("validation failed");
+    }
+  });
+});

--- a/packages/verifier/src/__tests__/service.test.ts
+++ b/packages/verifier/src/__tests__/service.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, test } from "bun:test";
+import { createVerifierService } from "../service.js";
+import { canonicalize } from "../canonicalize.js";
+import {
+  createTestVerificationRequest,
+  createTestConfig,
+  createTestFetcher,
+  mockSign,
+} from "./fixtures.js";
+import { createSourceAvailableCheck } from "../checks/source-available.js";
+import { createBuildProvenanceCheck } from "../checks/build-provenance.js";
+import { createReleaseSigningCheck } from "../checks/release-signing.js";
+import { createAttestationSignatureCheck } from "../checks/attestation-signature.js";
+import { createAttestationChainCheck } from "../checks/attestation-chain.js";
+import { createSchemaComplianceCheck } from "../checks/schema-compliance.js";
+
+function createTestService(overrides?: {
+  config?: Partial<ReturnType<typeof createTestConfig>>;
+  now?: () => number;
+}) {
+  const config = createTestConfig(overrides?.config);
+  const now =
+    overrides?.now ?? (() => new Date("2025-01-15T00:00:00.000Z").getTime());
+
+  return createVerifierService({
+    config,
+    sign: mockSign,
+    generateId: (() => {
+      let counter = 0;
+      return () => {
+        counter++;
+        return `stmt-${String(counter).padStart(3, "0")}`;
+      };
+    })(),
+    now,
+    checks: [
+      createSourceAvailableCheck({
+        fetcher: createTestFetcher({
+          "https://github.com/xmtp/xmtp-broker": { status: 200 },
+        }),
+      }),
+      createBuildProvenanceCheck(),
+      createReleaseSigningCheck(),
+      createAttestationSignatureCheck(),
+      createAttestationChainCheck(),
+      createSchemaComplianceCheck(),
+    ],
+  });
+}
+
+describe("VerifierService", () => {
+  describe("handleRequest", () => {
+    test("returns a verified statement when all checks pass", async () => {
+      const service = createTestService();
+      const request = createTestVerificationRequest();
+      const result = await service.handleRequest(request, "sender-inbox-001");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        // source_available passes, build_provenance skips (null),
+        // release_signing skips (null), attestation_* pass, schema passes
+        // Some skip -> partial
+        expect(result.value.verdict).toBe("partial");
+        expect(result.value.verifiedTier).toBe("unverified");
+        expect(result.value.requestId).toBe("req-001");
+        expect(result.value.signatureAlgorithm).toBe("Ed25519");
+      }
+    });
+
+    test("echoes challengeNonce from the request", async () => {
+      const service = createTestService();
+      const nonce = "cafebabe".repeat(8);
+      const request = createTestVerificationRequest({
+        challengeNonce: nonce,
+      });
+      const result = await service.handleRequest(request, "sender-inbox-001");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.challengeNonce).toBe(nonce);
+      }
+    });
+
+    test("returns rejected when source is unavailable", async () => {
+      const config = createTestConfig();
+      const service = createVerifierService({
+        config,
+        sign: mockSign,
+        generateId: () => "stmt-001",
+        now: () => new Date("2025-01-15T00:00:00.000Z").getTime(),
+        checks: [
+          createSourceAvailableCheck({
+            fetcher: createTestFetcher({
+              "https://github.com/xmtp/xmtp-broker": { status: 404 },
+            }),
+          }),
+          createBuildProvenanceCheck(),
+          createReleaseSigningCheck(),
+          createAttestationSignatureCheck(),
+          createAttestationChainCheck(),
+          createSchemaComplianceCheck(),
+        ],
+      });
+
+      const result = await service.handleRequest(
+        createTestVerificationRequest(),
+        "sender-inbox-001",
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.verdict).toBe("rejected");
+        expect(result.value.verifiedTier).toBe("unverified");
+        const sourceCheck = result.value.checks.find(
+          (c) => c.checkId === "source_available",
+        );
+        expect(sourceCheck?.verdict).toBe("fail");
+      }
+    });
+
+    test("returns partial when only source passes and others skip", async () => {
+      const service = createTestService();
+      const request = createTestVerificationRequest({
+        attestation: null,
+        buildProvenanceBundle: null,
+        releaseTag: null,
+      });
+
+      const result = await service.handleRequest(request, "sender-inbox-001");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.verdict).toBe("partial");
+      }
+    });
+
+    test("includes all check results in statement", async () => {
+      const service = createTestService();
+      const result = await service.handleRequest(
+        createTestVerificationRequest(),
+        "sender-inbox-001",
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.checks.length).toBe(6);
+        const checkIds = result.value.checks.map((c) => c.checkId);
+        expect(checkIds).toContain("source_available");
+        expect(checkIds).toContain("build_provenance");
+        expect(checkIds).toContain("release_signing");
+        expect(checkIds).toContain("attestation_signature");
+        expect(checkIds).toContain("attestation_chain");
+        expect(checkIds).toContain("schema_compliance");
+      }
+    });
+
+    test("signs the statement", async () => {
+      const service = createTestService();
+      const result = await service.handleRequest(
+        createTestVerificationRequest(),
+        "sender-inbox-001",
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.signature).toBe("bW9jay1zaWduYXR1cmU=");
+        expect(result.value.signatureAlgorithm).toBe("Ed25519");
+      }
+    });
+
+    test("sets issuedAt and expiresAt from config", async () => {
+      const baseTime = new Date("2025-01-15T00:00:00.000Z").getTime();
+      const service = createTestService({ now: () => baseTime });
+      const result = await service.handleRequest(
+        createTestVerificationRequest(),
+        "sender-inbox-001",
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.issuedAt).toBe("2025-01-15T00:00:00.000Z");
+        // Default TTL is 86400 seconds = 24 hours
+        expect(result.value.expiresAt).toBe("2025-01-16T00:00:00.000Z");
+      }
+    });
+  });
+
+  describe("rate limiting", () => {
+    test("rejects requests over the rate limit", async () => {
+      const config = createTestConfig({
+        maxRequestsPerRequesterPerHour: 2,
+      });
+      const service = createVerifierService({
+        config,
+        sign: mockSign,
+        generateId: (() => {
+          let c = 0;
+          return () => {
+            c++;
+            return `stmt-${String(c)}`;
+          };
+        })(),
+        now: () => new Date("2025-01-15T00:00:00.000Z").getTime(),
+        checks: [
+          createSourceAvailableCheck({
+            fetcher: createTestFetcher({
+              "https://github.com/xmtp/xmtp-broker": { status: 200 },
+            }),
+          }),
+        ],
+      });
+
+      const request = createTestVerificationRequest();
+      const sender = "sender-inbox-001";
+
+      // First two should succeed
+      const r1 = await service.handleRequest(request, sender);
+      expect(r1.isOk()).toBe(true);
+      const r2 = await service.handleRequest(request, sender);
+      expect(r2.isOk()).toBe(true);
+
+      // Third should be rate-limited
+      const r3 = await service.handleRequest(request, sender);
+      expect(r3.isOk()).toBe(true);
+      if (r3.isOk()) {
+        expect(r3.value.verdict).toBe("rejected");
+        const rateLimitCheck = r3.value.checks.find(
+          (c) => c.checkId === "rate_limit_exceeded",
+        );
+        expect(rateLimitCheck).toBeDefined();
+        expect(rateLimitCheck?.verdict).toBe("fail");
+      }
+    });
+
+    test("rate limits per sender independently", async () => {
+      const config = createTestConfig({
+        maxRequestsPerRequesterPerHour: 1,
+      });
+      const service = createVerifierService({
+        config,
+        sign: mockSign,
+        generateId: (() => {
+          let c = 0;
+          return () => {
+            c++;
+            return `stmt-${String(c)}`;
+          };
+        })(),
+        now: () => new Date("2025-01-15T00:00:00.000Z").getTime(),
+        checks: [
+          createSourceAvailableCheck({
+            fetcher: createTestFetcher({
+              "https://github.com/xmtp/xmtp-broker": { status: 200 },
+            }),
+          }),
+        ],
+      });
+
+      const request = createTestVerificationRequest();
+
+      const r1 = await service.handleRequest(request, "sender-1");
+      expect(r1.isOk()).toBe(true);
+
+      const r2 = await service.handleRequest(request, "sender-2");
+      expect(r2.isOk()).toBe(true);
+      if (r2.isOk()) {
+        // sender-2's first request should not be rate-limited
+        expect(r2.value.verdict).not.toBe("rejected");
+      }
+    });
+  });
+
+  describe("selfAttestation", () => {
+    test("returns verifier capabilities", () => {
+      const service = createTestService();
+      const attestation = service.selfAttestation();
+
+      expect(attestation.verifierInboxId).toBe("verifier-inbox-001");
+      expect(attestation.capabilities.supportedTiers).toEqual(["unverified"]);
+      expect(attestation.capabilities.supportedChecks).toContain(
+        "source_available",
+      );
+      expect(attestation.capabilities.maxRequestsPerHour).toBe(10);
+      expect(attestation.sourceRepoUrl).toBe(
+        "https://github.com/xmtp/xmtp-verifier",
+      );
+    });
+
+    test("returns cached instance on subsequent calls", () => {
+      const service = createTestService();
+      const a1 = service.selfAttestation();
+      const a2 = service.selfAttestation();
+      expect(a1).toBe(a2); // same reference
+    });
+  });
+});
+
+describe("canonicalize", () => {
+  test("produces deterministic output regardless of key order", () => {
+    const a = { z: 1, a: 2 };
+    const b = { a: 2, z: 1 };
+    const bytesA = canonicalize(a);
+    const bytesB = canonicalize(b);
+    expect(bytesA).toEqual(bytesB);
+  });
+
+  test("excludes nothing — serializes all fields", () => {
+    const obj = {
+      statementId: "stmt-001",
+      verdict: "verified",
+      extra: "included",
+    };
+
+    const bytes = canonicalize(obj);
+    const decoded = new TextDecoder().decode(bytes);
+    expect(decoded).toContain("statementId");
+    expect(decoded).toContain("verdict");
+    expect(decoded).toContain("extra");
+  });
+});

--- a/packages/verifier/src/__tests__/smoke.test.ts
+++ b/packages/verifier/src/__tests__/smoke.test.ts
@@ -1,7 +1,0 @@
-import { describe, expect, it } from "bun:test";
-
-describe("workspace", () => {
-  it("test runner works", () => {
-    expect(true).toBe(true);
-  });
-});

--- a/packages/verifier/src/__tests__/source-available.test.ts
+++ b/packages/verifier/src/__tests__/source-available.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import { createSourceAvailableCheck } from "../checks/source-available.js";
+import {
+  createTestVerificationRequest,
+  createTestFetcher,
+} from "./fixtures.js";
+
+describe("source_available check", () => {
+  test("passes when source repo returns 200", async () => {
+    const check = createSourceAvailableCheck({
+      fetcher: createTestFetcher({
+        "https://github.com/xmtp/xmtp-broker": { status: 200 },
+      }),
+    });
+
+    const result = await check.execute(createTestVerificationRequest());
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.verdict).toBe("pass");
+      expect(result.value.checkId).toBe("source_available");
+    }
+  });
+
+  test("fails when source repo returns 404", async () => {
+    const check = createSourceAvailableCheck({
+      fetcher: createTestFetcher({
+        "https://github.com/xmtp/xmtp-broker": { status: 404 },
+      }),
+    });
+
+    const result = await check.execute(createTestVerificationRequest());
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.verdict).toBe("fail");
+      expect(result.value.reason).toContain("404");
+    }
+  });
+
+  test("fails when fetch throws (network error)", async () => {
+    const check = createSourceAvailableCheck({
+      fetcher: (async () => {
+        throw new Error("Network error");
+      }) as unknown as typeof fetch,
+    });
+
+    const result = await check.execute(createTestVerificationRequest());
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.verdict).toBe("fail");
+      expect(result.value.reason).toContain("Network error");
+    }
+  });
+
+  test("clears the timeout when fetch fails early", async () => {
+    const originalClearTimeout = globalThis.clearTimeout;
+    let cleared = false;
+
+    globalThis.clearTimeout = ((timer: ReturnType<typeof setTimeout>) => {
+      cleared = true;
+      return originalClearTimeout(timer);
+    }) as typeof clearTimeout;
+
+    try {
+      const check = createSourceAvailableCheck({
+        timeoutMs: 10_000,
+        fetcher: (async () => {
+          throw new Error("Immediate failure");
+        }) as unknown as typeof fetch,
+      });
+
+      const result = await check.execute(createTestVerificationRequest());
+      expect(result.isOk()).toBe(true);
+      expect(cleared).toBe(true);
+    } finally {
+      globalThis.clearTimeout = originalClearTimeout;
+    }
+  });
+
+  test("includes evidence with url and timing", async () => {
+    const check = createSourceAvailableCheck({
+      fetcher: createTestFetcher({
+        "https://github.com/xmtp/xmtp-broker": { status: 200 },
+      }),
+    });
+
+    const result = await check.execute(createTestVerificationRequest());
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.evidence).not.toBeNull();
+      const evidence = result.value.evidence as Record<string, unknown>;
+      expect(evidence["url"]).toBe("https://github.com/xmtp/xmtp-broker");
+      expect(typeof evidence["responseTimeMs"]).toBe("number");
+    }
+  });
+});

--- a/packages/verifier/src/__tests__/statement.test.ts
+++ b/packages/verifier/src/__tests__/statement.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { VerificationStatementSchema } from "../schemas/statement.js";
+
+describe("VerificationStatementSchema", () => {
+  const validStatement = {
+    statementId: "stmt-001",
+    requestId: "req-001",
+    verifierInboxId: "verifier-inbox-001",
+    brokerInboxId: "broker-inbox-001",
+    agentInboxId: "agent-inbox-001",
+    verdict: "verified",
+    verifiedTier: "source-verified",
+    checks: [
+      {
+        checkId: "schema_compliance",
+        verdict: "pass",
+        reason: "Valid",
+        evidence: null,
+      },
+    ],
+    challengeNonce: "deadbeef".repeat(8),
+    issuedAt: "2025-01-15T00:00:00.000Z",
+    expiresAt: "2025-01-16T00:00:00.000Z",
+    signature: "bW9jay1zaWduYXR1cmU=",
+    signatureAlgorithm: "Ed25519" as const,
+  };
+
+  test("accepts a valid statement", () => {
+    const result = VerificationStatementSchema.safeParse(validStatement);
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects statement with invalid verdict", () => {
+    const result = VerificationStatementSchema.safeParse({
+      ...validStatement,
+      verdict: "unknown",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects statement with wrong signatureAlgorithm", () => {
+    const result = VerificationStatementSchema.safeParse({
+      ...validStatement,
+      signatureAlgorithm: "RSA",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects statement missing checks array", () => {
+    const { checks: _, ...rest } = validStatement;
+    const result = VerificationStatementSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects statement with invalid datetime", () => {
+    const result = VerificationStatementSchema.safeParse({
+      ...validStatement,
+      issuedAt: "not-a-date",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/verifier/src/__tests__/verdict.test.ts
+++ b/packages/verifier/src/__tests__/verdict.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { determineVerdict, determineVerifiedTier } from "../verdict.js";
+
+describe("determineVerdict", () => {
+  test("returns verified when all checks pass", () => {
+    expect(determineVerdict(["pass", "pass", "pass"])).toBe("verified");
+  });
+
+  test("returns partial when some checks pass and some skip", () => {
+    expect(determineVerdict(["pass", "skip", "pass"])).toBe("partial");
+  });
+
+  test("returns rejected when any check fails", () => {
+    expect(determineVerdict(["pass", "fail", "pass"])).toBe("rejected");
+  });
+
+  test("returns rejected when fail and skip both present", () => {
+    expect(determineVerdict(["pass", "fail", "skip"])).toBe("rejected");
+  });
+
+  test("returns partial when all checks skip", () => {
+    expect(determineVerdict(["skip", "skip"])).toBe("partial");
+  });
+
+  test("returns verified for single passing check", () => {
+    expect(determineVerdict(["pass"])).toBe("verified");
+  });
+});
+
+describe("determineVerifiedTier", () => {
+  test("returns source-verified for verified verdict", () => {
+    expect(determineVerifiedTier("verified", "source-verified")).toBe(
+      "source-verified",
+    );
+  });
+
+  test("returns unverified for partial verdict", () => {
+    expect(determineVerifiedTier("partial", "source-verified")).toBe(
+      "unverified",
+    );
+  });
+
+  test("returns unverified for rejected verdict", () => {
+    expect(determineVerifiedTier("rejected", "source-verified")).toBe(
+      "unverified",
+    );
+  });
+
+  test("caps at source-verified even if higher tier requested", () => {
+    expect(determineVerifiedTier("verified", "runtime-attested")).toBe(
+      "source-verified",
+    );
+  });
+
+  test("returns unverified when unverified tier requested and partial", () => {
+    expect(determineVerifiedTier("partial", "unverified")).toBe("unverified");
+  });
+});

--- a/packages/verifier/src/canonicalize.ts
+++ b/packages/verifier/src/canonicalize.ts
@@ -1,0 +1,36 @@
+/**
+ * Produces the canonical byte representation of a verification statement
+ * for signing. Serializes with sorted keys and no whitespace as UTF-8.
+ *
+ * Accepts the statement fields without signature/signatureAlgorithm
+ * (which are added after signing).
+ */
+export function canonicalizeStatement(
+  statement: Omit<
+    import("./schemas/statement.js").VerificationStatement,
+    "signature" | "signatureAlgorithm"
+  >,
+): Uint8Array {
+  return canonicalize(statement);
+}
+
+/** Deterministic JSON serialization as UTF-8 bytes. */
+export function canonicalize(value: unknown): Uint8Array {
+  const json = JSON.stringify(sortKeys(value));
+  return new TextEncoder().encode(json);
+}
+
+function sortKeys(value: unknown): unknown {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(sortKeys);
+  }
+  const sorted: Record<string, unknown> = {};
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  for (const key of keys) {
+    sorted[key] = sortKeys((value as Record<string, unknown>)[key]);
+  }
+  return sorted;
+}

--- a/packages/verifier/src/checks/attestation-chain.ts
+++ b/packages/verifier/src/checks/attestation-chain.ts
@@ -1,0 +1,93 @@
+import { Result } from "better-result";
+import type { InternalError } from "@xmtp-broker/schemas";
+import type { VerificationCheck } from "../schemas/check.js";
+import type { VerificationRequest } from "../schemas/request.js";
+import type { CheckHandler } from "./handler.js";
+
+export const ATTESTATION_CHAIN_CHECK_ID = "attestation_chain" as const;
+
+/**
+ * Verifies the attestation links to the correct previous attestation.
+ * v0: structural check only -- verifies previousAttestationId is either
+ * null (initial) or a well-formed string. Full chain walk is deferred.
+ */
+export function createAttestationChainCheck(): CheckHandler {
+  return {
+    checkId: ATTESTATION_CHAIN_CHECK_ID,
+
+    async execute(
+      request: VerificationRequest,
+    ): Promise<Result<VerificationCheck, InternalError>> {
+      if (request.attestation === null) {
+        return Result.ok({
+          checkId: ATTESTATION_CHAIN_CHECK_ID,
+          verdict: "skip",
+          reason: "No attestation provided",
+          evidence: null,
+        });
+      }
+
+      const { previousAttestationId, attestationId } = request.attestation;
+
+      // Check attestationId is present and non-empty
+      if (!attestationId || attestationId.length === 0) {
+        return Result.ok({
+          checkId: ATTESTATION_CHAIN_CHECK_ID,
+          verdict: "fail",
+          reason: "Attestation missing attestationId",
+          evidence: {
+            chainLength: 0,
+            previousId: previousAttestationId,
+            chainValid: false,
+          },
+        });
+      }
+
+      // previousAttestationId should be null for initial or a non-empty string
+      if (
+        previousAttestationId !== null &&
+        (typeof previousAttestationId !== "string" ||
+          previousAttestationId.length === 0)
+      ) {
+        return Result.ok({
+          checkId: ATTESTATION_CHAIN_CHECK_ID,
+          verdict: "fail",
+          reason: "previousAttestationId must be null or a non-empty string",
+          evidence: {
+            chainLength: 0,
+            previousId: previousAttestationId,
+            chainValid: false,
+          },
+        });
+      }
+
+      // Self-referencing chain is invalid
+      if (previousAttestationId === attestationId) {
+        return Result.ok({
+          checkId: ATTESTATION_CHAIN_CHECK_ID,
+          verdict: "fail",
+          reason: "Attestation references itself as previous",
+          evidence: {
+            chainLength: 0,
+            previousId: previousAttestationId,
+            chainValid: false,
+          },
+        });
+      }
+
+      return Result.ok({
+        checkId: ATTESTATION_CHAIN_CHECK_ID,
+        verdict: "pass",
+        reason:
+          previousAttestationId === null
+            ? "Initial attestation (no previous)"
+            : "Chain link structurally valid (v0: full chain walk deferred)",
+        evidence: {
+          chainLength: previousAttestationId === null ? 1 : 2,
+          previousId: previousAttestationId,
+          chainValid: true,
+        },
+      });
+    },
+  };
+}

--- a/packages/verifier/src/checks/attestation-signature.ts
+++ b/packages/verifier/src/checks/attestation-signature.ts
@@ -1,0 +1,75 @@
+import { Result } from "better-result";
+import type { InternalError } from "@xmtp-broker/schemas";
+import type { VerificationCheck } from "../schemas/check.js";
+import type { VerificationRequest } from "../schemas/request.js";
+import type { CheckHandler } from "./handler.js";
+
+export const ATTESTATION_SIGNATURE_CHECK_ID = "attestation_signature" as const;
+
+/**
+ * Verifies the attestation's cryptographic signature.
+ * v0: structural check -- verifies the attestation has all required
+ * fields and that the issuer field is present. Full Ed25519 verification
+ * against the agent's inbox key requires XMTP identity lookup, which
+ * is deferred.
+ */
+export function createAttestationSignatureCheck(): CheckHandler {
+  return {
+    checkId: ATTESTATION_SIGNATURE_CHECK_ID,
+
+    async execute(
+      request: VerificationRequest,
+    ): Promise<Result<VerificationCheck, InternalError>> {
+      if (request.attestation === null) {
+        return Result.ok({
+          checkId: ATTESTATION_SIGNATURE_CHECK_ID,
+          verdict: "skip",
+          reason: "No attestation provided",
+          evidence: null,
+        });
+      }
+
+      const attestation = request.attestation;
+
+      // Structural check: verify required signing-related fields exist
+      if (!attestation.issuer || attestation.issuer.length === 0) {
+        return Result.ok({
+          checkId: ATTESTATION_SIGNATURE_CHECK_ID,
+          verdict: "fail",
+          reason: "Attestation missing issuer field",
+          evidence: {
+            signerKeyRef: null,
+            signatureValid: false,
+          },
+        });
+      }
+
+      // Check that the attestation's agentInboxId matches the request
+      if (attestation.agentInboxId !== request.agentInboxId) {
+        return Result.ok({
+          checkId: ATTESTATION_SIGNATURE_CHECK_ID,
+          verdict: "fail",
+          reason:
+            "Attestation agentInboxId does not match request agentInboxId",
+          evidence: {
+            attestationAgentInboxId: attestation.agentInboxId,
+            requestAgentInboxId: request.agentInboxId,
+            signatureValid: false,
+          },
+        });
+      }
+
+      // v0: structural validation passes -- full signature verification
+      // requires XMTP identity lookup
+      return Result.ok({
+        checkId: ATTESTATION_SIGNATURE_CHECK_ID,
+        verdict: "skip",
+        reason: "v0: no cryptographic verification performed",
+        evidence: {
+          signerKeyRef: attestation.issuer,
+          signatureValid: null,
+        },
+      });
+    },
+  };
+}

--- a/packages/verifier/src/checks/build-provenance.ts
+++ b/packages/verifier/src/checks/build-provenance.ts
@@ -1,0 +1,57 @@
+import { Result } from "better-result";
+import type { InternalError } from "@xmtp-broker/schemas";
+import type { VerificationCheck } from "../schemas/check.js";
+import type { VerificationRequest } from "../schemas/request.js";
+import type { CheckHandler } from "./handler.js";
+
+export const BUILD_PROVENANCE_CHECK_ID = "build_provenance" as const;
+
+/**
+ * Verifies the agent was built from the claimed source.
+ * v0: stub that returns "skip" when no bundle is provided,
+ * or a basic structural validation when one is.
+ */
+export function createBuildProvenanceCheck(): CheckHandler {
+  return {
+    checkId: BUILD_PROVENANCE_CHECK_ID,
+
+    async execute(
+      request: VerificationRequest,
+    ): Promise<Result<VerificationCheck, InternalError>> {
+      if (request.buildProvenanceBundle === null) {
+        return Result.ok({
+          checkId: BUILD_PROVENANCE_CHECK_ID,
+          verdict: "skip",
+          reason: "No build provenance bundle provided",
+          evidence: null,
+        });
+      }
+
+      // v0 stub: attempt basic JSON parse but don't do full verification
+      try {
+        const decoded = atob(request.buildProvenanceBundle);
+        JSON.parse(decoded);
+
+        return Result.ok({
+          checkId: BUILD_PROVENANCE_CHECK_ID,
+          verdict: "fail",
+          reason: "Build provenance verification not yet implemented (v0 stub)",
+          evidence: {
+            bundlePresent: true,
+            artifactDigest: request.artifactDigest,
+          },
+        });
+      } catch {
+        return Result.ok({
+          checkId: BUILD_PROVENANCE_CHECK_ID,
+          verdict: "fail",
+          reason: "Build provenance bundle is not valid base64-encoded JSON",
+          evidence: {
+            bundlePresent: true,
+            artifactDigest: request.artifactDigest,
+          },
+        });
+      }
+    },
+  };
+}

--- a/packages/verifier/src/checks/handler.ts
+++ b/packages/verifier/src/checks/handler.ts
@@ -1,0 +1,15 @@
+import type { Result } from "better-result";
+import type { InternalError } from "@xmtp-broker/schemas";
+import type { VerificationCheck } from "../schemas/check.js";
+import type { VerificationRequest } from "../schemas/request.js";
+
+/**
+ * Each verification check is an independent handler.
+ * Checks are stateless and composable.
+ */
+export interface CheckHandler {
+  readonly checkId: string;
+  execute(
+    request: VerificationRequest,
+  ): Promise<Result<VerificationCheck, InternalError>>;
+}

--- a/packages/verifier/src/checks/release-signing.ts
+++ b/packages/verifier/src/checks/release-signing.ts
@@ -1,0 +1,42 @@
+import { Result } from "better-result";
+import type { InternalError } from "@xmtp-broker/schemas";
+import type { VerificationCheck } from "../schemas/check.js";
+import type { VerificationRequest } from "../schemas/request.js";
+import type { CheckHandler } from "./handler.js";
+
+export const RELEASE_SIGNING_CHECK_ID = "release_signing" as const;
+
+/**
+ * Verifies the release artifact is signed.
+ * v0: stub that returns "skip" since full GitHub API
+ * attestation verification is deferred.
+ */
+export function createReleaseSigningCheck(): CheckHandler {
+  return {
+    checkId: RELEASE_SIGNING_CHECK_ID,
+
+    async execute(
+      request: VerificationRequest,
+    ): Promise<Result<VerificationCheck, InternalError>> {
+      if (request.releaseTag === null) {
+        return Result.ok({
+          checkId: RELEASE_SIGNING_CHECK_ID,
+          verdict: "skip",
+          reason: "No release tag provided",
+          evidence: null,
+        });
+      }
+
+      // v0 stub: acknowledge the tag but skip verification
+      return Result.ok({
+        checkId: RELEASE_SIGNING_CHECK_ID,
+        verdict: "skip",
+        reason: "Release signing verification not yet implemented (v0 stub)",
+        evidence: {
+          releaseTag: request.releaseTag,
+          sourceRepoUrl: request.sourceRepoUrl,
+        },
+      });
+    },
+  };
+}

--- a/packages/verifier/src/checks/schema-compliance.ts
+++ b/packages/verifier/src/checks/schema-compliance.ts
@@ -1,0 +1,53 @@
+import { Result } from "better-result";
+import { AttestationSchema, type InternalError } from "@xmtp-broker/schemas";
+import type { VerificationCheck } from "../schemas/check.js";
+import type { VerificationRequest } from "../schemas/request.js";
+import type { CheckHandler } from "./handler.js";
+
+export const SCHEMA_COMPLIANCE_CHECK_ID = "schema_compliance" as const;
+
+/**
+ * Verifies the attestation conforms to the expected schema.
+ * Runs the attestation through AttestationSchema.safeParse.
+ */
+export function createSchemaComplianceCheck(): CheckHandler {
+  return {
+    checkId: SCHEMA_COMPLIANCE_CHECK_ID,
+
+    async execute(
+      request: VerificationRequest,
+    ): Promise<Result<VerificationCheck, InternalError>> {
+      if (request.attestation === null) {
+        return Result.ok({
+          checkId: SCHEMA_COMPLIANCE_CHECK_ID,
+          verdict: "skip",
+          reason: "No attestation provided",
+          evidence: null,
+        });
+      }
+
+      const parseResult = AttestationSchema.safeParse(request.attestation);
+
+      if (parseResult.success) {
+        return Result.ok({
+          checkId: SCHEMA_COMPLIANCE_CHECK_ID,
+          verdict: "pass",
+          reason: "Attestation conforms to AttestationSchema",
+          evidence: null,
+        });
+      }
+
+      const errors = parseResult.error.issues.map((issue) => ({
+        path: issue.path.join("."),
+        message: issue.message,
+      }));
+
+      return Result.ok({
+        checkId: SCHEMA_COMPLIANCE_CHECK_ID,
+        verdict: "fail",
+        reason: `Attestation schema validation failed: ${String(parseResult.error.issues.length)} issue(s)`,
+        evidence: { errors },
+      });
+    },
+  };
+}

--- a/packages/verifier/src/checks/source-available.ts
+++ b/packages/verifier/src/checks/source-available.ts
@@ -1,0 +1,78 @@
+import { Result } from "better-result";
+import type { InternalError } from "@xmtp-broker/schemas";
+import type { VerificationCheck } from "../schemas/check.js";
+import type { VerificationRequest } from "../schemas/request.js";
+import type { CheckHandler } from "./handler.js";
+
+export const SOURCE_AVAILABLE_CHECK_ID = "source_available" as const;
+
+export interface SourceAvailableConfig {
+  /** Injectable fetch for testing. Defaults to global fetch. */
+  readonly fetcher?: typeof fetch;
+  /** Timeout in milliseconds. Defaults to 10000. */
+  readonly timeoutMs?: number;
+}
+
+/**
+ * Checks that the agent's source code repository is accessible.
+ * v0: performs an HTTP GET against sourceRepoUrl, expects 200.
+ */
+export function createSourceAvailableCheck(
+  config?: SourceAvailableConfig,
+): CheckHandler {
+  const fetcher = config?.fetcher ?? fetch;
+  const timeoutMs = config?.timeoutMs ?? 10_000;
+
+  return {
+    checkId: SOURCE_AVAILABLE_CHECK_ID,
+
+    async execute(
+      request: VerificationRequest,
+    ): Promise<Result<VerificationCheck, InternalError>> {
+      const startTime = Date.now();
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+      try {
+        const response = await fetcher(request.sourceRepoUrl, {
+          method: "GET",
+          signal: controller.signal,
+          redirect: "follow",
+        });
+
+        const elapsed = Date.now() - startTime;
+        const check: VerificationCheck = {
+          checkId: SOURCE_AVAILABLE_CHECK_ID,
+          verdict: response.ok ? "pass" : "fail",
+          reason: response.ok
+            ? `Source repository accessible (HTTP ${String(response.status)})`
+            : `Source repository returned HTTP ${String(response.status)}`,
+          evidence: {
+            url: request.sourceRepoUrl,
+            statusCode: response.status,
+            responseTimeMs: elapsed,
+          },
+        };
+
+        return Result.ok(check);
+      } catch (error) {
+        const elapsed = Date.now() - startTime;
+        const message = error instanceof Error ? error.message : String(error);
+        const check: VerificationCheck = {
+          checkId: SOURCE_AVAILABLE_CHECK_ID,
+          verdict: "fail",
+          reason: `Source repository unreachable: ${message}`,
+          evidence: {
+            url: request.sourceRepoUrl,
+            responseTimeMs: elapsed,
+            error: message,
+          },
+        };
+
+        return Result.ok(check);
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  };
+}

--- a/packages/verifier/src/config.ts
+++ b/packages/verifier/src/config.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+/** Parsed verifier configuration (all defaults applied). */
+export type VerifierConfig = {
+  verifierInboxId: string;
+  sourceRepoUrl: string;
+  statementTtlSeconds: number;
+  maxRequestsPerRequesterPerHour: number;
+};
+
+/** Input to VerifierConfigSchema (fields with defaults are optional). */
+type VerifierConfigInput = {
+  verifierInboxId: string;
+  sourceRepoUrl: string;
+  statementTtlSeconds?: number | undefined;
+  maxRequestsPerRequesterPerHour?: number | undefined;
+};
+
+export const VerifierConfigSchema: z.ZodType<
+  VerifierConfig,
+  z.ZodTypeDef,
+  VerifierConfigInput
+> = z.object({
+  verifierInboxId: z
+    .string()
+    .describe("XMTP inbox ID of this verifier instance"),
+  sourceRepoUrl: z.string().url().describe("URL of the verifier's source code"),
+  statementTtlSeconds: z
+    .number()
+    .int()
+    .positive()
+    .default(86400)
+    .describe("Statement lifetime in seconds (default: 24h)"),
+  maxRequestsPerRequesterPerHour: z
+    .number()
+    .int()
+    .positive()
+    .default(10)
+    .describe("Rate limit per requester per hour"),
+});
+
+export const DEFAULT_STATEMENT_TTL_SECONDS = 86400;
+export const DEFAULT_MAX_REQUESTS_PER_HOUR = 10;

--- a/packages/verifier/src/content-types.ts
+++ b/packages/verifier/src/content-types.ts
@@ -1,0 +1,5 @@
+export const VERIFICATION_REQUEST_CONTENT_TYPE_ID =
+  "xmtp.org/verificationRequest:1.0" as const;
+
+export const VERIFICATION_STATEMENT_CONTENT_TYPE_ID =
+  "xmtp.org/verificationStatement:1.0" as const;

--- a/packages/verifier/src/index.ts
+++ b/packages/verifier/src/index.ts
@@ -1,2 +1,59 @@
-// Placeholder — real exports added by subsequent specs.
-export {};
+// Schemas
+export { CheckVerdict, VerificationCheck } from "./schemas/check.js";
+export {
+  VerificationRequestSchema,
+  type VerificationRequest,
+} from "./schemas/request.js";
+export {
+  VerificationVerdict,
+  VerificationStatementSchema,
+  type VerificationStatement,
+} from "./schemas/statement.js";
+export {
+  VerifierCapabilities,
+  VerifierSelfAttestationSchema,
+  type VerifierSelfAttestation,
+} from "./schemas/self-attestation.js";
+
+// Config
+export {
+  VerifierConfigSchema,
+  type VerifierConfig,
+  DEFAULT_STATEMENT_TTL_SECONDS,
+  DEFAULT_MAX_REQUESTS_PER_HOUR,
+} from "./config.js";
+
+// Content types
+export {
+  VERIFICATION_REQUEST_CONTENT_TYPE_ID,
+  VERIFICATION_STATEMENT_CONTENT_TYPE_ID,
+} from "./content-types.js";
+
+// Canonicalize
+export { canonicalizeStatement, canonicalize } from "./canonicalize.js";
+
+// Rate limiter
+export {
+  createRateLimiter,
+  type RateLimiter,
+  type RateLimiterConfig,
+} from "./rate-limiter.js";
+
+// Verdict
+export { determineVerdict, determineVerifiedTier } from "./verdict.js";
+
+// Checks
+export type { CheckHandler } from "./checks/handler.js";
+export { createSourceAvailableCheck } from "./checks/source-available.js";
+export { createBuildProvenanceCheck } from "./checks/build-provenance.js";
+export { createReleaseSigningCheck } from "./checks/release-signing.js";
+export { createAttestationSignatureCheck } from "./checks/attestation-signature.js";
+export { createAttestationChainCheck } from "./checks/attestation-chain.js";
+export { createSchemaComplianceCheck } from "./checks/schema-compliance.js";
+
+// Service
+export {
+  createVerifierService,
+  type VerifierService,
+  type VerifierServiceOptions,
+} from "./service.js";

--- a/packages/verifier/src/rate-limiter.ts
+++ b/packages/verifier/src/rate-limiter.ts
@@ -1,0 +1,62 @@
+/**
+ * In-memory sliding window rate limiter.
+ * Tracks request timestamps per requester and rejects when the
+ * count within the window exceeds the configured maximum.
+ */
+export interface RateLimiter {
+  /** Returns true if the request is allowed, false if rate-limited. */
+  check(requesterId: string): boolean;
+  /** Reset all state (for testing). */
+  reset(): void;
+}
+
+export interface RateLimiterConfig {
+  readonly maxRequests: number;
+  readonly windowMs: number;
+  /** Injectable clock for testing. Defaults to Date.now. */
+  readonly now?: () => number;
+}
+
+export function createRateLimiter(config: RateLimiterConfig): RateLimiter {
+  const timestamps = new Map<string, number[]>();
+  const getNow = config.now ?? Date.now;
+
+  return {
+    check(requesterId: string): boolean {
+      const now = getNow();
+      const windowStart = now - config.windowMs;
+
+      const entries = timestamps.get(requesterId);
+      if (entries === undefined) {
+        timestamps.set(requesterId, [now]);
+        return true;
+      }
+
+      // Evict entries outside the window
+      const firstValid = entries.findIndex((t) => t >= windowStart);
+      if (firstValid > 0) {
+        entries.splice(0, firstValid);
+      } else if (firstValid === -1 && entries.length > 0) {
+        entries.length = 0;
+      }
+
+      // Reclaim memory for inactive requesters
+      if (entries.length === 0) {
+        timestamps.delete(requesterId);
+        timestamps.set(requesterId, [now]);
+        return true;
+      }
+
+      if (entries.length >= config.maxRequests) {
+        return false;
+      }
+
+      entries.push(now);
+      return true;
+    },
+
+    reset(): void {
+      timestamps.clear();
+    },
+  };
+}

--- a/packages/verifier/src/schemas/check.ts
+++ b/packages/verifier/src/schemas/check.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+export const CheckVerdict: z.ZodEnum<["pass", "fail", "skip"]> = z
+  .enum(["pass", "fail", "skip"])
+  .describe("Outcome of a single verification check");
+
+export type CheckVerdict = z.infer<typeof CheckVerdict>;
+
+export type VerificationCheck = {
+  checkId: string;
+  verdict: CheckVerdict;
+  reason: string;
+  evidence: Record<string, unknown> | null;
+};
+
+const _VerificationCheck = z
+  .object({
+    checkId: z.string().describe("Identifier for the check type"),
+    verdict: CheckVerdict.describe("Pass, fail, or skip"),
+    reason: z.string().describe("Human-readable explanation of the result"),
+    evidence: z
+      .record(z.string(), z.unknown())
+      .nullable()
+      .describe("Structured evidence supporting the verdict"),
+  })
+  .describe("Result of a single verification check");
+
+export const VerificationCheck: z.ZodType<VerificationCheck> =
+  _VerificationCheck;

--- a/packages/verifier/src/schemas/request.ts
+++ b/packages/verifier/src/schemas/request.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import {
+  AttestationSchema,
+  TrustTier,
+} from "@xmtp-broker/schemas";
+import type { Attestation, TrustTier as TrustTierType } from "@xmtp-broker/schemas";
+
+export type VerificationRequest = {
+  requestId: string;
+  agentInboxId: string;
+  brokerInboxId: string;
+  groupId: string | null;
+  attestation: Attestation | null;
+  artifactDigest: string;
+  buildProvenanceBundle: string | null;
+  sourceRepoUrl: string;
+  releaseTag: string | null;
+  requestedTier: TrustTierType;
+  challengeNonce: string;
+};
+
+export const VerificationRequestSchema: z.ZodType<VerificationRequest> = z
+  .object({
+    requestId: z.string().describe("Unique request identifier for correlation"),
+    agentInboxId: z
+      .string()
+      .describe("XMTP inbox ID of the agent being verified"),
+    brokerInboxId: z
+      .string()
+      .describe("XMTP inbox ID of the broker operating the agent"),
+    groupId: z
+      .string()
+      .nullable()
+      .describe("Group context for verification, null for broker-wide"),
+    attestation: AttestationSchema.nullable().describe(
+      "Attestation to verify, null if only checking provenance",
+    ),
+    artifactDigest: z
+      .string()
+      .describe("SHA-256 digest of the broker artifact (hex-encoded)"),
+    buildProvenanceBundle: z
+      .string()
+      .nullable()
+      .describe("Base64-encoded SLSA provenance or Sigstore bundle"),
+    sourceRepoUrl: z
+      .string()
+      .url()
+      .describe("URL of the broker source repository"),
+    releaseTag: z
+      .string()
+      .nullable()
+      .describe("Git tag or release version, null for dev builds"),
+    requestedTier: TrustTier.describe("Trust tier the requester is claiming"),
+    challengeNonce: z
+      .string()
+      .describe("Random nonce to prevent replay (hex-encoded, 32 bytes)"),
+  })
+  .describe("Verification request sent to the verifier via XMTP DM");

--- a/packages/verifier/src/schemas/self-attestation.ts
+++ b/packages/verifier/src/schemas/self-attestation.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+import { TrustTier } from "@xmtp-broker/schemas";
+import type { TrustTier as TrustTierType } from "@xmtp-broker/schemas";
+
+export type VerifierCapabilities = {
+  supportedTiers: TrustTierType[];
+  supportedChecks: string[];
+  maxRequestsPerHour: number;
+};
+
+const _VerifierCapabilities = z
+  .object({
+    supportedTiers: z
+      .array(TrustTier)
+      .describe("Trust tiers this verifier can check"),
+    supportedChecks: z
+      .array(z.string())
+      .describe("Check IDs this verifier performs"),
+    maxRequestsPerHour: z
+      .number()
+      .int()
+      .positive()
+      .describe("Rate limit per requester per hour"),
+  })
+  .describe("Capabilities advertised by this verifier");
+
+export const VerifierCapabilities: z.ZodType<VerifierCapabilities> =
+  _VerifierCapabilities;
+
+export type VerifierSelfAttestation = {
+  verifierInboxId: string;
+  capabilities: VerifierCapabilities;
+  sourceRepoUrl: string;
+  issuedAt: string;
+  signature: string;
+};
+
+export const VerifierSelfAttestationSchema: z.ZodType<VerifierSelfAttestation> =
+  z
+    .object({
+      verifierInboxId: z.string().describe("XMTP inbox ID of this verifier"),
+      capabilities: _VerifierCapabilities.describe(
+        "What this verifier can do",
+      ),
+      sourceRepoUrl: z
+        .string()
+        .url()
+        .describe("URL of the verifier's source code"),
+      issuedAt: z
+        .string()
+        .datetime()
+        .describe("When this self-attestation was created"),
+      signature: z.string().describe("Base64-encoded self-signature"),
+    })
+    .describe("Self-attestation published by the verifier");

--- a/packages/verifier/src/schemas/statement.ts
+++ b/packages/verifier/src/schemas/statement.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import { TrustTier } from "@xmtp-broker/schemas";
+import type { TrustTier as TrustTierType } from "@xmtp-broker/schemas";
+import { VerificationCheck } from "./check.js";
+
+export const VerificationVerdict: z.ZodEnum<
+  ["verified", "partial", "rejected"]
+> = z
+  .enum(["verified", "partial", "rejected"])
+  .describe("Overall verification outcome");
+
+export type VerificationVerdict = z.infer<typeof VerificationVerdict>;
+
+export type VerificationStatement = {
+  statementId: string;
+  requestId: string;
+  verifierInboxId: string;
+  brokerInboxId: string;
+  agentInboxId: string;
+  verdict: VerificationVerdict;
+  verifiedTier: TrustTierType;
+  checks: z.infer<typeof VerificationCheck>[];
+  challengeNonce: string;
+  issuedAt: string;
+  expiresAt: string;
+  signature: string;
+  signatureAlgorithm: "Ed25519";
+};
+
+export const VerificationStatementSchema: z.ZodType<VerificationStatement> = z
+  .object({
+    statementId: z.string().describe("Unique statement identifier"),
+    requestId: z.string().describe("Correlates with the original request"),
+    verifierInboxId: z
+      .string()
+      .describe("XMTP inbox ID of the verifier that issued this statement"),
+    brokerInboxId: z
+      .string()
+      .describe("XMTP inbox ID of the broker being verified"),
+    agentInboxId: z
+      .string()
+      .describe("XMTP inbox ID of the agent being verified"),
+    verdict: VerificationVerdict.describe("Overall verification outcome"),
+    verifiedTier: TrustTier.describe(
+      "Highest trust tier confirmed by this verification",
+    ),
+    checks: z.array(VerificationCheck).describe("Individual check results"),
+    challengeNonce: z.string().describe("Echoed nonce from the request"),
+    issuedAt: z.string().datetime().describe("When this statement was issued"),
+    expiresAt: z.string().datetime().describe("When this statement expires"),
+    signature: z
+      .string()
+      .describe(
+        "Base64-encoded Ed25519 signature over canonical statement bytes",
+      ),
+    signatureAlgorithm: z.literal("Ed25519").describe("Signature algorithm"),
+  })
+  .describe("Signed verification statement issued by the verifier");

--- a/packages/verifier/src/service.ts
+++ b/packages/verifier/src/service.ts
@@ -1,0 +1,236 @@
+import { Result } from "better-result";
+import {
+  type InternalError,
+  type ValidationError,
+  type TimeoutError,
+  InternalError as InternalErrorClass,
+} from "@xmtp-broker/schemas";
+import type { VerificationRequest } from "./schemas/request.js";
+import type {
+  VerificationStatement,
+  VerificationVerdict,
+} from "./schemas/statement.js";
+import type { VerificationCheck } from "./schemas/check.js";
+import type { VerifierSelfAttestation } from "./schemas/self-attestation.js";
+import type { VerifierConfig } from "./config.js";
+import type { CheckHandler } from "./checks/handler.js";
+import type { RateLimiter } from "./rate-limiter.js";
+import { createRateLimiter } from "./rate-limiter.js";
+import { canonicalizeStatement } from "./canonicalize.js";
+import { determineVerdict, determineVerifiedTier } from "./verdict.js";
+import { createSourceAvailableCheck } from "./checks/source-available.js";
+import { createBuildProvenanceCheck } from "./checks/build-provenance.js";
+import { createReleaseSigningCheck } from "./checks/release-signing.js";
+import { createAttestationSignatureCheck } from "./checks/attestation-signature.js";
+import { createAttestationChainCheck } from "./checks/attestation-chain.js";
+import { createSchemaComplianceCheck } from "./checks/schema-compliance.js";
+import {
+  DEFAULT_MAX_REQUESTS_PER_HOUR,
+  DEFAULT_STATEMENT_TTL_SECONDS,
+} from "./config.js";
+
+const HOUR_MS = 3_600_000;
+
+const ALL_CHECK_IDS = [
+  "source_available",
+  "build_provenance",
+  "release_signing",
+  "attestation_signature",
+  "attestation_chain",
+  "schema_compliance",
+] as const;
+
+export interface VerifierServiceOptions {
+  readonly config: VerifierConfig;
+  /** Injectable signing function. Signs canonical bytes, returns base64. */
+  readonly sign: (bytes: Uint8Array) => Promise<string>;
+  /** Injectable ID generator. */
+  readonly generateId?: () => string;
+  /** Injectable clock for testing. */
+  readonly now?: () => number;
+  /** Override check handlers for testing. */
+  readonly checks?: readonly CheckHandler[];
+  /** Override rate limiter for testing. */
+  readonly rateLimiter?: RateLimiter;
+}
+
+export interface VerifierService {
+  handleRequest(
+    request: VerificationRequest,
+    senderInboxId: string,
+  ): Promise<
+    Result<
+      VerificationStatement,
+      ValidationError | InternalError | TimeoutError
+    >
+  >;
+  selfAttestation(): VerifierSelfAttestation;
+}
+
+export function createVerifierService(
+  options: VerifierServiceOptions,
+): VerifierService {
+  const { config, sign } = options;
+  const getNow = options.now ?? (() => Date.now());
+  const generateId = options.generateId ?? (() => crypto.randomUUID());
+
+  const rateLimiter =
+    options.rateLimiter ??
+    createRateLimiter({
+      maxRequests:
+        config.maxRequestsPerRequesterPerHour ?? DEFAULT_MAX_REQUESTS_PER_HOUR,
+      windowMs: HOUR_MS,
+      now: getNow,
+    });
+
+  const checks: readonly CheckHandler[] = options.checks ?? [
+    createSourceAvailableCheck(),
+    createBuildProvenanceCheck(),
+    createReleaseSigningCheck(),
+    createAttestationSignatureCheck(),
+    createAttestationChainCheck(),
+    createSchemaComplianceCheck(),
+  ];
+
+  const ttlSeconds =
+    config.statementTtlSeconds ?? DEFAULT_STATEMENT_TTL_SECONDS;
+
+  let cachedSelfAttestation: VerifierSelfAttestation | undefined;
+
+  return {
+    async handleRequest(
+      request: VerificationRequest,
+      senderInboxId: string,
+    ): Promise<
+      Result<
+        VerificationStatement,
+        ValidationError | InternalError | TimeoutError
+      >
+    > {
+      // Rate limit check
+      if (!rateLimiter.check(senderInboxId)) {
+        const now = new Date(getNow());
+        const expiresAt = new Date(now.getTime() + ttlSeconds * 1000);
+
+        const rateLimitCheck: VerificationCheck = {
+          checkId: "rate_limit_exceeded",
+          verdict: "fail",
+          reason: `Rate limit exceeded: max ${String(config.maxRequestsPerRequesterPerHour ?? DEFAULT_MAX_REQUESTS_PER_HOUR)} requests per hour`,
+          evidence: {
+            senderInboxId,
+            limit:
+              config.maxRequestsPerRequesterPerHour ??
+              DEFAULT_MAX_REQUESTS_PER_HOUR,
+          },
+        };
+
+        const statement = await buildAndSignStatement(
+          {
+            statementId: generateId(),
+            requestId: request.requestId,
+            verifierInboxId: config.verifierInboxId,
+            brokerInboxId: request.brokerInboxId,
+            agentInboxId: request.agentInboxId,
+            verdict: "rejected" as VerificationVerdict,
+            verifiedTier: "unverified" as const,
+            checks: [rateLimitCheck],
+            challengeNonce: request.challengeNonce,
+            issuedAt: now.toISOString(),
+            expiresAt: expiresAt.toISOString(),
+          },
+          sign,
+        );
+
+        return statement;
+      }
+
+      // Run all checks in parallel
+      const checkResults = await Promise.all(
+        checks.map((handler) => handler.execute(request)),
+      );
+
+      // Collect results, bail on internal errors
+      const completedChecks: VerificationCheck[] = [];
+      for (const result of checkResults) {
+        if (result.isErr()) {
+          return Result.err(result.error);
+        }
+        completedChecks.push(result.value);
+      }
+
+      // Determine verdict and tier
+      const verdicts = completedChecks.map((c) => c.verdict);
+      const verdict = determineVerdict(verdicts);
+      const verifiedTier = determineVerifiedTier(
+        verdict,
+        request.requestedTier,
+      );
+
+      const now = new Date(getNow());
+      const expiresAt = new Date(now.getTime() + ttlSeconds * 1000);
+
+      return buildAndSignStatement(
+        {
+          statementId: generateId(),
+          requestId: request.requestId,
+          verifierInboxId: config.verifierInboxId,
+          brokerInboxId: request.brokerInboxId,
+          agentInboxId: request.agentInboxId,
+          verdict,
+          verifiedTier,
+          checks: completedChecks,
+          challengeNonce: request.challengeNonce,
+          issuedAt: now.toISOString(),
+          expiresAt: expiresAt.toISOString(),
+        },
+        sign,
+      );
+    },
+
+    selfAttestation(): VerifierSelfAttestation {
+      if (cachedSelfAttestation !== undefined) {
+        return cachedSelfAttestation;
+      }
+
+      // Build a self-attestation (signature is a placeholder in v0)
+      cachedSelfAttestation = {
+        verifierInboxId: config.verifierInboxId,
+        capabilities: {
+          supportedTiers: ["unverified"],
+          supportedChecks: [...ALL_CHECK_IDS],
+          maxRequestsPerHour:
+            config.maxRequestsPerRequesterPerHour ??
+            DEFAULT_MAX_REQUESTS_PER_HOUR,
+        },
+        sourceRepoUrl: config.sourceRepoUrl,
+        issuedAt: new Date(getNow()).toISOString(),
+        signature: "",
+      };
+
+      return cachedSelfAttestation;
+    },
+  };
+}
+
+async function buildAndSignStatement(
+  fields: Omit<VerificationStatement, "signature" | "signatureAlgorithm">,
+  sign: (bytes: Uint8Array) => Promise<string>,
+): Promise<Result<VerificationStatement, InternalError>> {
+  try {
+    const canonical = canonicalizeStatement(fields);
+    const signature = await sign(canonical);
+
+    const statement: VerificationStatement = {
+      ...fields,
+      signature,
+      signatureAlgorithm: "Ed25519",
+    };
+
+    return Result.ok(statement);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return Result.err(
+      InternalErrorClass.create(`Failed to sign statement: ${message}`),
+    );
+  }
+}

--- a/packages/verifier/src/verdict.ts
+++ b/packages/verifier/src/verdict.ts
@@ -1,0 +1,61 @@
+import type { CheckVerdict } from "./schemas/check.js";
+import type { VerificationVerdict } from "./schemas/statement.js";
+import type { TrustTier } from "@xmtp-broker/schemas";
+
+/**
+ * Determines the overall verification verdict from individual check results.
+ *
+ * - verified: all applicable checks pass
+ * - partial: some checks pass, some skip, none fail
+ * - rejected: any check fails
+ */
+export function determineVerdict(
+  verdicts: readonly CheckVerdict[],
+): VerificationVerdict {
+  const hasFail = verdicts.some((v) => v === "fail");
+  if (hasFail) {
+    return "rejected";
+  }
+
+  const hasSkip = verdicts.some((v) => v === "skip");
+  if (hasSkip) {
+    return "partial";
+  }
+
+  return "verified";
+}
+
+/**
+ * Determines the highest verified trust tier based on check results.
+ * For v0, the maximum achievable tier is "source-verified".
+ * Returns "unverified" if any required check fails.
+ */
+export function determineVerifiedTier(
+  verdict: VerificationVerdict,
+  requestedTier: TrustTier,
+): TrustTier {
+  if (verdict === "rejected") {
+    return "unverified";
+  }
+
+  // v0 caps at source-verified regardless of what was requested
+  const tierRank: Record<TrustTier, number> = {
+    unverified: 0,
+    "source-verified": 1,
+    "reproducibly-verified": 2,
+    "runtime-attested": 3,
+  };
+
+  const requestedRank = tierRank[requestedTier];
+  const maxV0Rank = tierRank["source-verified"];
+  const effectiveRank = Math.min(requestedRank, maxV0Rank);
+
+  // source-verified requires all applicable checks to pass
+  if (verdict === "verified") {
+    if (effectiveRank >= tierRank["source-verified"]) {
+      return "source-verified";
+    }
+  }
+
+  return "unverified";
+}


### PR DESCRIPTION
## Context
This branch adds the reference verifier that evaluates broker attestations. Review this PR against `v0/websocket`, not `main`.

## What Changed
- implements the verifier service, request/statement schemas, and verdict model
- adds six trust checks covering source availability, schema compliance, attestation signatures, attestation chains, build provenance, and release signing
- includes rate limiting, canonicalization, and content-type helpers needed to evaluate verifier requests safely
- adds comprehensive tests for each check plus request handling and verdict generation

## Why This Branch Exists
The broker's trust model needs an independent way to verify signed statements and published artifacts. This PR provides that reference implementation.

## Key Files
- `packages/verifier/src/service.ts`
- `packages/verifier/src/checks/*`
- `packages/verifier/src/verdict.ts`
- `packages/verifier/src/schemas/*`
- `packages/verifier/src/rate-limiter.ts`

## Verification
- verifier package test suite under `packages/verifier/src/__tests__`
- repo verification via pre-push stack checks (`lint`, `test`, `typecheck`)
