### PR TITLE
feat(contracts): ActionSpec, ActionRegistry, extended HandlerContext

### DIFF
--- a/packages/contracts/src/__tests__/action-registry.test.ts
+++ b/packages/contracts/src/__tests__/action-registry.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "bun:test";
+import { Ok } from "better-result";
+import { z } from "zod";
+import type { BrokerError } from "@xmtp-broker/schemas";
+import { createActionRegistry } from "../action-registry.js";
+import type { ActionSpec, CliSurface, McpSurface } from "../action-spec.js";
+import type { HandlerContext } from "../handler-types.js";
+
+/** Minimal CLI surface for testing. */
+const testCliSurface: CliSurface = {
+  command: "test:run",
+  description: "A test command",
+};
+
+/** Minimal MCP surface for testing. */
+const testMcpSurface: McpSurface = {
+  toolName: "broker/test/run",
+  description: "A test tool",
+  readOnly: true,
+};
+
+/** Create a minimal ActionSpec for testing. */
+function createTestSpec(
+  id: string,
+  surfaces?: { cli?: CliSurface; mcp?: McpSurface },
+): ActionSpec<unknown, unknown, BrokerError> {
+  return {
+    id,
+    handler: (_input: unknown, _ctx: HandlerContext) =>
+      Promise.resolve(new Ok(null)),
+    input: z.object({}),
+    ...surfaces,
+  };
+}
+
+describe("ActionRegistry", () => {
+  it("registers and looks up a spec by id", () => {
+    const registry = createActionRegistry();
+    const spec = createTestSpec("session.list");
+    registry.register(spec);
+
+    expect(registry.lookup("session.list")).toBe(spec);
+  });
+
+  it("throws on duplicate registration", () => {
+    const registry = createActionRegistry();
+    const spec = createTestSpec("session.list");
+    registry.register(spec);
+
+    expect(() => registry.register(spec)).toThrow(
+      "Action 'session.list' is already registered",
+    );
+  });
+
+  it("returns undefined for unknown id", () => {
+    const registry = createActionRegistry();
+    expect(registry.lookup("nonexistent")).toBeUndefined();
+  });
+
+  it("lists all registered specs", () => {
+    const registry = createActionRegistry();
+    const spec1 = createTestSpec("session.list");
+    const spec2 = createTestSpec("session.revoke");
+    registry.register(spec1);
+    registry.register(spec2);
+
+    const all = registry.list();
+    expect(all).toHaveLength(2);
+    expect(all).toContain(spec1);
+    expect(all).toContain(spec2);
+  });
+
+  it("filters by mcp surface", () => {
+    const registry = createActionRegistry();
+    const cliOnly = createTestSpec("broker.stop", {
+      cli: testCliSurface,
+    });
+    const mcpOnly = createTestSpec("message.list", {
+      mcp: testMcpSurface,
+    });
+    const both = createTestSpec("session.list", {
+      cli: testCliSurface,
+      mcp: testMcpSurface,
+    });
+    registry.register(cliOnly);
+    registry.register(mcpOnly);
+    registry.register(both);
+
+    const mcpSpecs = registry.listForSurface("mcp");
+    expect(mcpSpecs).toHaveLength(2);
+    expect(mcpSpecs).toContain(mcpOnly);
+    expect(mcpSpecs).toContain(both);
+  });
+
+  it("filters by cli surface", () => {
+    const registry = createActionRegistry();
+    const cliOnly = createTestSpec("broker.stop", {
+      cli: testCliSurface,
+    });
+    const mcpOnly = createTestSpec("message.list", {
+      mcp: testMcpSurface,
+    });
+    const both = createTestSpec("session.list", {
+      cli: testCliSurface,
+      mcp: testMcpSurface,
+    });
+    registry.register(cliOnly);
+    registry.register(mcpOnly);
+    registry.register(both);
+
+    const cliSpecs = registry.listForSurface("cli");
+    expect(cliSpecs).toHaveLength(2);
+    expect(cliSpecs).toContain(cliOnly);
+    expect(cliSpecs).toContain(both);
+  });
+
+  it("spec with both surfaces appears in both filtered lists", () => {
+    const registry = createActionRegistry();
+    const both = createTestSpec("session.list", {
+      cli: testCliSurface,
+      mcp: testMcpSurface,
+    });
+    registry.register(both);
+
+    expect(registry.listForSurface("cli")).toContain(both);
+    expect(registry.listForSurface("mcp")).toContain(both);
+  });
+
+  it("reflects count via size", () => {
+    const registry = createActionRegistry();
+    expect(registry.size).toBe(0);
+
+    registry.register(createTestSpec("a.one"));
+    expect(registry.size).toBe(1);
+
+    registry.register(createTestSpec("a.two"));
+    expect(registry.size).toBe(2);
+  });
+});

--- a/packages/contracts/src/__tests__/result-envelope.test.ts
+++ b/packages/contracts/src/__tests__/result-envelope.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "bun:test";
+import { Ok, Err } from "better-result";
+import { z } from "zod";
+import {
+  ValidationError,
+  NotFoundError,
+  ActionResultSchema,
+  ActionErrorResultSchema,
+} from "@xmtp-broker/schemas";
+import type { ActionResultMeta } from "@xmtp-broker/schemas";
+import { toActionResult } from "../result-envelope.js";
+
+function validMeta(): ActionResultMeta {
+  return {
+    requestId: "req-001",
+    timestamp: "2026-01-15T12:00:00Z",
+    durationMs: 5,
+  };
+}
+
+describe("toActionResult", () => {
+  it("wraps a success Result correctly", () => {
+    const result = new Ok({ sessions: [] });
+    const envelope = toActionResult(result, validMeta());
+
+    expect(envelope.ok).toBe(true);
+    if (envelope.ok) {
+      expect(envelope.data).toEqual({ sessions: [] });
+      expect(envelope.meta.requestId).toBe("req-001");
+      expect(envelope.pagination).toBeUndefined();
+    }
+  });
+
+  it("wraps an error Result correctly", () => {
+    const error = ValidationError.create("groupId", "required");
+    const result = new Err(error);
+    const envelope = toActionResult(result, validMeta());
+
+    expect(envelope.ok).toBe(false);
+    if (!envelope.ok) {
+      expect(envelope.error._tag).toBe("ValidationError");
+      expect(envelope.error.category).toBe("validation");
+      expect(envelope.error.message).toContain("groupId");
+      expect(envelope.error.context).toEqual(
+        expect.objectContaining({ field: "groupId" }),
+      );
+    }
+  });
+
+  it("includes pagination when provided", () => {
+    const result = new Ok(["item1", "item2"]);
+    const pagination = {
+      count: 2,
+      hasMore: true,
+      nextCursor: "cursor-abc",
+    };
+    const envelope = toActionResult(result, validMeta(), pagination);
+
+    expect(envelope.ok).toBe(true);
+    if (envelope.ok) {
+      expect(envelope.pagination).toEqual(pagination);
+    }
+  });
+
+  it("omits pagination when not provided", () => {
+    const result = new Ok([]);
+    const envelope = toActionResult(result, validMeta());
+
+    expect(envelope.ok).toBe(true);
+    if (envelope.ok) {
+      expect(envelope.pagination).toBeUndefined();
+    }
+  });
+
+  it("meta fields present on success envelope", () => {
+    const result = new Ok("data");
+    const envelope = toActionResult(result, validMeta());
+
+    expect(envelope.meta.requestId).toBe("req-001");
+    expect(envelope.meta.timestamp).toBe("2026-01-15T12:00:00Z");
+    expect(envelope.meta.durationMs).toBe(5);
+  });
+
+  it("meta fields present on error envelope", () => {
+    const error = NotFoundError.create("session", "s-123");
+    const result = new Err(error);
+    const envelope = toActionResult(result, validMeta());
+
+    expect(envelope.meta.requestId).toBe("req-001");
+    expect(envelope.meta.timestamp).toBe("2026-01-15T12:00:00Z");
+    expect(envelope.meta.durationMs).toBe(5);
+  });
+});
+
+describe("ActionResult schema validation", () => {
+  const TestSchema = ActionResultSchema(z.array(z.string()));
+
+  it("success envelope validates against schema", () => {
+    const result = new Ok(["s1", "s2"]);
+    const envelope = toActionResult(result, validMeta());
+    const parsed = TestSchema.safeParse(envelope);
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("success envelope with pagination validates", () => {
+    const result = new Ok(["s1"]);
+    const pagination = { count: 1, hasMore: false };
+    const envelope = toActionResult(result, validMeta(), pagination);
+    const parsed = TestSchema.safeParse(envelope);
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("error envelope validates against ActionErrorResultSchema", () => {
+    const error = ValidationError.create("field", "bad");
+    const result = new Err(error);
+    const envelope = toActionResult(result, validMeta());
+    const parsed = ActionErrorResultSchema.safeParse(envelope);
+
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/packages/contracts/src/action-registry.ts
+++ b/packages/contracts/src/action-registry.ts
@@ -1,0 +1,75 @@
+import type { BrokerError } from "@xmtp-broker/schemas";
+import type { ActionSpec } from "./action-spec.js";
+
+/**
+ * Base type that any ActionSpec satisfies, regardless of its
+ * input/output type parameters. Used for heterogeneous storage
+ * in the registry where we only need access to id, input schema,
+ * and surface metadata — not the strongly-typed handler signature.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyActionSpec = ActionSpec<any, any, BrokerError>;
+
+/**
+ * Registry for ActionSpec instances. Transport adapters query the
+ * registry at startup to discover actions they should expose.
+ */
+export interface ActionRegistry {
+  /**
+   * Register an ActionSpec. Throws if an action with the same id
+   * is already registered (fail-fast for duplicate registrations).
+   *
+   * Accepts any ActionSpec regardless of its input/output type
+   * parameters, avoiding variance issues with contravariant handler
+   * inputs.
+   */
+  register(spec: AnyActionSpec): void;
+
+  /** Look up an ActionSpec by id. Returns undefined if not found. */
+  lookup(id: string): AnyActionSpec | undefined;
+
+  /** List all registered ActionSpecs. */
+  list(): readonly AnyActionSpec[];
+
+  /**
+   * List ActionSpecs that have a specific surface.
+   * Convenience for transport adapters.
+   */
+  listForSurface(surface: "cli" | "mcp"): readonly AnyActionSpec[];
+
+  /** Number of registered actions. */
+  readonly size: number;
+}
+
+/**
+ * Create an ActionRegistry instance.
+ * The registry is an in-memory Map. No persistence, no async.
+ */
+export function createActionRegistry(): ActionRegistry {
+  const specs = new Map<string, AnyActionSpec>();
+
+  return {
+    register(spec) {
+      if (specs.has(spec.id)) {
+        throw new Error(`Action '${spec.id}' is already registered`);
+      }
+      specs.set(spec.id, spec);
+    },
+
+    lookup(id) {
+      return specs.get(id);
+    },
+
+    list() {
+      return [...specs.values()];
+    },
+
+    listForSurface(surface) {
+      return [...specs.values()].filter((spec) => spec[surface] != null);
+    },
+
+    get size() {
+      return specs.size;
+    },
+  };
+}

--- a/packages/contracts/src/action-spec.ts
+++ b/packages/contracts/src/action-spec.ts
@@ -1,0 +1,111 @@
+import type { z } from "zod";
+import type { BrokerError } from "@xmtp-broker/schemas";
+import type { Handler } from "./handler-types.js";
+
+/**
+ * CLI option definition. Maps a CLI flag to an input schema field.
+ */
+export interface CliOption {
+  /** Flag definition (e.g., `"--group-id <id>"`). */
+  readonly flag: string;
+
+  /** Human-readable description. */
+  readonly description: string;
+
+  /** Input schema field this maps to. Dot-path for nested fields. */
+  readonly field: string;
+
+  /** Whether this option is required. Defaults to false. */
+  readonly required?: boolean;
+}
+
+/**
+ * CLI-specific metadata for an ActionSpec.
+ * The CLI adapter uses this to build commands, parse arguments,
+ * and format output.
+ */
+export interface CliSurface {
+  /** Command name. Colon-delimited for namespacing (e.g., `session:list`). */
+  readonly command: string;
+
+  /**
+   * JSON-RPC method name for admin socket dispatch.
+   * Dot-delimited (e.g., `session.list`). Derived from `command` by
+   * replacing `:` with `.` if not explicitly set.
+   */
+  readonly rpcMethod?: string;
+
+  /** Short aliases (e.g., `["sl"]`). */
+  readonly aliases?: readonly string[];
+
+  /** CLI option definitions. Maps CLI flags to input schema fields. */
+  readonly options?: readonly CliOption[];
+
+  /** Default output format for this command. */
+  readonly outputFormat?: "table" | "json" | "text";
+
+  /** Command group for help text organization. */
+  readonly group?: string;
+
+  /** One-line description for help text. */
+  readonly description?: string;
+}
+
+/**
+ * MCP-specific metadata for an ActionSpec.
+ * The MCP adapter uses this to register tools with the MCP server.
+ */
+export interface McpSurface {
+  /**
+   * MCP tool name. Convention: `broker/{group}/{action}`
+   * (e.g., `broker/session/list`).
+   */
+  readonly toolName: string;
+
+  /** Human-readable tool description for the MCP tool listing. */
+  readonly description: string;
+
+  /** Whether this tool only reads data (no side effects). */
+  readonly readOnly: boolean;
+
+  /**
+   * Whether this tool performs destructive/irreversible operations.
+   * MCP clients may require confirmation for destructive tools.
+   */
+  readonly destructive?: boolean;
+
+  /**
+   * Additional MCP tool annotations. Passed through to the MCP
+   * server as-is. See MCP spec for supported annotation keys.
+   */
+  readonly annotations?: Record<string, unknown>;
+}
+
+/**
+ * Bundles a handler with its input schema and per-surface metadata.
+ * Transport adapters consume ActionSpecs to wire domain logic into
+ * their protocol. Co-located with handlers in runtime packages.
+ */
+export interface ActionSpec<
+  TInput,
+  TOutput,
+  TError extends BrokerError = BrokerError,
+> {
+  /** Unique action identifier. Convention: `{domain}.{verb}` (e.g., `session.list`). */
+  readonly id: string;
+
+  /** The transport-agnostic handler function. */
+  readonly handler: Handler<TInput, TOutput, TError>;
+
+  /** Zod schema for input validation. Transports parse raw input against this. */
+  readonly input: z.ZodType<TInput>;
+
+  /** Zod schema for output validation. Optional; used for documentation and testing. */
+  readonly output?: z.ZodType<TOutput>;
+
+  /** CLI surface metadata. Omit to exclude from CLI. */
+  readonly cli?: CliSurface;
+
+  /** MCP surface metadata. Omit to exclude from MCP. */
+  readonly mcp?: McpSurface;
+}

--- a/packages/contracts/src/handler-types.ts
+++ b/packages/contracts/src/handler-types.ts
@@ -3,12 +3,37 @@ import type { BrokerError } from "@xmtp-broker/schemas";
 import type { CoreContext } from "./core-types.js";
 
 /**
- * Canonical handler context. Extends CoreContext with any additional
- * context fields handlers may need. Currently identical to CoreContext;
- * adding fields here (e.g., sessionId, requestId, AbortSignal) allows
- * all handlers to pick them up without changing their signatures.
+ * Authentication context for admin callers. The admin key proves
+ * the caller has root access to the broker.
  */
-export interface HandlerContext extends CoreContext {}
+export interface AdminAuthContext {
+  /** Fingerprint of the admin key used for authentication. */
+  readonly adminKeyFingerprint: string;
+}
+
+/**
+ * Canonical handler context. Extends CoreContext with cross-cutting
+ * concerns needed by all handlers.
+ */
+export interface HandlerContext extends CoreContext {
+  /** Unique identifier for this request. Used in ActionResult.meta and tracing. */
+  readonly requestId: string;
+
+  /** Cancellation signal. Handlers should check this for long operations. */
+  readonly signal: AbortSignal;
+
+  /**
+   * Admin authentication context. Present when the caller is the broker
+   * admin (CLI, local MCP). Absent for harness sessions.
+   */
+  readonly adminAuth?: AdminAuthContext;
+
+  /**
+   * Session identifier. Present when the caller is an authenticated
+   * harness session. Absent for admin callers.
+   */
+  readonly sessionId?: string;
+}
 
 /**
  * Canonical handler type for all domain logic. Handlers receive

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -24,7 +24,27 @@ export type {
 } from "./attestation-types.js";
 
 // Handler types
-export type { HandlerContext, Handler } from "./handler-types.js";
+export type {
+  AdminAuthContext,
+  HandlerContext,
+  Handler,
+} from "./handler-types.js";
+
+// Action types
+export type {
+  ActionSpec,
+  CliSurface,
+  McpSurface,
+  CliOption,
+} from "./action-spec.js";
+
+// Action registry
+export { createActionRegistry } from "./action-registry.js";
+export type { ActionRegistry } from "./action-registry.js";
+
+// Result envelope
+export { toActionResult } from "./result-envelope.js";
+export type { ActionResult } from "./result-envelope.js";
 
 // Service interfaces
 export type {

--- a/packages/contracts/src/result-envelope.ts
+++ b/packages/contracts/src/result-envelope.ts
@@ -1,0 +1,57 @@
+import type { Result } from "better-result";
+import type {
+  BrokerError,
+  ActionResultMeta,
+  ActionError,
+  Pagination,
+} from "@xmtp-broker/schemas";
+
+/**
+ * Universal output envelope. All transports render from this shape.
+ */
+export type ActionResult<T> =
+  | {
+      readonly ok: true;
+      readonly data: T;
+      readonly meta: ActionResultMeta;
+      readonly pagination?: Pagination;
+    }
+  | {
+      readonly ok: false;
+      readonly error: ActionError;
+      readonly meta: ActionResultMeta;
+    };
+
+/**
+ * Convert a handler Result into an ActionResult envelope.
+ * Called by transport adapters after handler execution.
+ */
+export function toActionResult<T>(
+  result: Result<T, BrokerError>,
+  meta: ActionResultMeta,
+  pagination?: Pagination,
+): ActionResult<T> {
+  if (result.isOk()) {
+    const envelope: ActionResult<T> = {
+      ok: true,
+      data: result.value,
+      meta,
+    };
+    if (pagination !== undefined) {
+      return { ...envelope, pagination } as ActionResult<T>;
+    }
+    return envelope;
+  }
+
+  const error = result.error;
+  return {
+    ok: false,
+    error: {
+      _tag: error._tag,
+      category: error.category,
+      message: error.message,
+      context: error.context,
+    },
+    meta,
+  };
+}

--- a/packages/schemas/src/__tests__/action-result.test.ts
+++ b/packages/schemas/src/__tests__/action-result.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "bun:test";
+import { z } from "zod";
+import {
+  ActionResultMetaSchema,
+  ActionErrorSchema,
+  PaginationSchema,
+  ActionResultSchema,
+  ActionErrorResultSchema,
+} from "../result/action-result.js";
+
+function validMeta() {
+  return {
+    requestId: "req-001",
+    timestamp: "2026-01-15T12:00:00Z",
+    durationMs: 42,
+  };
+}
+
+describe("ActionResultMetaSchema", () => {
+  it("accepts valid meta", () => {
+    const result = ActionResultMetaSchema.safeParse(validMeta());
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing requestId", () => {
+    const { requestId: _, ...rest } = validMeta();
+    expect(ActionResultMetaSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it("rejects invalid timestamp", () => {
+    expect(
+      ActionResultMetaSchema.safeParse({
+        ...validMeta(),
+        timestamp: "not-a-date",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects negative durationMs", () => {
+    expect(
+      ActionResultMetaSchema.safeParse({
+        ...validMeta(),
+        durationMs: -1,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("ActionErrorSchema", () => {
+  it("accepts valid error", () => {
+    const result = ActionErrorSchema.safeParse({
+      _tag: "ValidationError",
+      category: "validation",
+      message: "Bad input",
+      context: { field: "groupId" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts null context", () => {
+    const result = ActionErrorSchema.safeParse({
+      _tag: "InternalError",
+      category: "internal",
+      message: "Something broke",
+      context: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid category", () => {
+    const result = ActionErrorSchema.safeParse({
+      _tag: "ValidationError",
+      category: "bogus",
+      message: "Bad",
+      context: null,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing _tag", () => {
+    const result = ActionErrorSchema.safeParse({
+      category: "validation",
+      message: "Bad",
+      context: null,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("PaginationSchema", () => {
+  it("accepts valid pagination", () => {
+    const result = PaginationSchema.safeParse({
+      count: 10,
+      hasMore: true,
+      nextCursor: "cursor-abc",
+      total: 42,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts minimal pagination without optional fields", () => {
+    const result = PaginationSchema.safeParse({
+      count: 0,
+      hasMore: false,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects negative count", () => {
+    const result = PaginationSchema.safeParse({
+      count: -1,
+      hasMore: false,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-integer count", () => {
+    const result = PaginationSchema.safeParse({
+      count: 1.5,
+      hasMore: false,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("ActionResultSchema (success factory)", () => {
+  const TestDataSchema = z.object({ sessions: z.array(z.string()) });
+  const TestResultSchema = ActionResultSchema(TestDataSchema);
+
+  it("accepts valid success envelope", () => {
+    const result = TestResultSchema.safeParse({
+      ok: true,
+      data: { sessions: ["s1", "s2"] },
+      meta: validMeta(),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts success envelope with pagination", () => {
+    const result = TestResultSchema.safeParse({
+      ok: true,
+      data: { sessions: ["s1"] },
+      meta: validMeta(),
+      pagination: { count: 1, hasMore: true, nextCursor: "c1" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects ok: false", () => {
+    const result = TestResultSchema.safeParse({
+      ok: false,
+      data: { sessions: [] },
+      meta: validMeta(),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects data that does not match the schema", () => {
+    const result = TestResultSchema.safeParse({
+      ok: true,
+      data: { wrong: "shape" },
+      meta: validMeta(),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing meta", () => {
+    const result = TestResultSchema.safeParse({
+      ok: true,
+      data: { sessions: [] },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("ActionErrorResultSchema", () => {
+  it("accepts valid error envelope", () => {
+    const result = ActionErrorResultSchema.safeParse({
+      ok: false,
+      error: {
+        _tag: "NotFoundError",
+        category: "not_found",
+        message: "Session not found",
+        context: { sessionId: "s-123" },
+      },
+      meta: validMeta(),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects ok: true", () => {
+    const result = ActionErrorResultSchema.safeParse({
+      ok: true,
+      error: {
+        _tag: "NotFoundError",
+        category: "not_found",
+        message: "Not found",
+        context: null,
+      },
+      meta: validMeta(),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing error field", () => {
+    const result = ActionErrorResultSchema.safeParse({
+      ok: false,
+      meta: validMeta(),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing meta field", () => {
+    const result = ActionErrorResultSchema.safeParse({
+      ok: false,
+      error: {
+        _tag: "InternalError",
+        category: "internal",
+        message: "Oops",
+        context: null,
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -97,6 +97,19 @@ export {
 // Response
 export { RequestSuccess, RequestFailure, RequestResponse } from "./response.js";
 
+// Action Result
+export {
+  ActionResultMetaSchema,
+  type ActionResultMeta,
+  ActionErrorSchema,
+  type ActionError,
+  PaginationSchema,
+  type Pagination,
+  ActionResultSchema,
+  ActionErrorResultSchema,
+  type ActionErrorResult,
+} from "./result/index.js";
+
 // Errors
 export {
   ErrorCategory,

--- a/packages/schemas/src/result/action-result.ts
+++ b/packages/schemas/src/result/action-result.ts
@@ -1,0 +1,136 @@
+import { z } from "zod";
+import type { ErrorCategory } from "../errors/category.js";
+import { ErrorCategory as ErrorCategorySchema } from "../errors/category.js";
+
+// -- ActionResultMeta --
+
+export type ActionResultMeta = {
+  requestId: string;
+  timestamp: string;
+  durationMs: number;
+};
+
+const _ActionResultMetaSchema = z
+  .object({
+    requestId: z.string().describe("Correlates with HandlerContext.requestId"),
+    timestamp: z
+      .string()
+      .datetime()
+      .describe("ISO 8601 timestamp of response creation"),
+    durationMs: z
+      .number()
+      .nonnegative()
+      .describe("Handler execution time in milliseconds"),
+  })
+  .describe("Response metadata present on every ActionResult");
+
+/**
+ * Response metadata present on every ActionResult envelope.
+ * Correlates responses to requests and provides timing information.
+ */
+export const ActionResultMetaSchema: z.ZodType<ActionResultMeta> =
+  _ActionResultMetaSchema;
+
+// -- ActionError --
+
+export type ActionError = {
+  _tag: string;
+  category: ErrorCategory;
+  message: string;
+  context: Record<string, unknown> | null;
+};
+
+const _ActionErrorSchema = z
+  .object({
+    _tag: z.string().describe("Error discriminant (e.g., 'ValidationError')"),
+    category: ErrorCategorySchema.describe(
+      "Error category for cross-transport mapping",
+    ),
+    message: z.string().describe("Human-readable error description"),
+    context: z
+      .record(z.string(), z.unknown())
+      .nullable()
+      .describe("Structured error context, null if none"),
+  })
+  .describe("Error detail in a failed ActionResult");
+
+/**
+ * Error detail in a failed ActionResult. Maps BrokerError fields
+ * to a serializable shape for transport rendering.
+ */
+export const ActionErrorSchema: z.ZodType<ActionError> = _ActionErrorSchema;
+
+// -- Pagination --
+
+export type Pagination = {
+  count: number;
+  hasMore: boolean;
+  nextCursor?: string | undefined;
+  total?: number | undefined;
+};
+
+const _PaginationSchema = z
+  .object({
+    count: z
+      .number()
+      .int()
+      .nonnegative()
+      .describe("Number of items in this page"),
+    hasMore: z.boolean().describe("Whether more items exist beyond this page"),
+    nextCursor: z
+      .string()
+      .optional()
+      .describe("Opaque cursor for the next page"),
+    total: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe("Total item count, if known"),
+  })
+  .describe("Pagination metadata for list operations");
+
+/**
+ * Pagination metadata for list operations.
+ */
+export const PaginationSchema: z.ZodType<Pagination> = _PaginationSchema;
+
+// -- ActionResultSchema (factory) --
+
+/**
+ * Factory function that creates a success ActionResult schema
+ * for a given data type. Used by transport adapters to validate
+ * outgoing envelopes.
+ */
+export function ActionResultSchema<T extends z.ZodType>(
+  dataSchema: T,
+): z.ZodObject<{
+  ok: z.ZodLiteral<true>;
+  data: T;
+  meta: z.ZodType<ActionResultMeta>;
+  pagination: z.ZodOptional<z.ZodType<Pagination>>;
+}> {
+  return z.object({
+    ok: z.literal(true),
+    data: dataSchema,
+    meta: _ActionResultMetaSchema,
+    pagination: _PaginationSchema.optional(),
+  });
+}
+
+// -- ActionErrorResultSchema --
+
+export type ActionErrorResult = {
+  ok: false;
+  error: ActionError;
+  meta: ActionResultMeta;
+};
+
+/**
+ * Schema for a failed ActionResult envelope.
+ */
+export const ActionErrorResultSchema: z.ZodType<ActionErrorResult> = z.object({
+  ok: z.literal(false),
+  error: _ActionErrorSchema,
+  meta: _ActionResultMetaSchema,
+});

--- a/packages/schemas/src/result/index.ts
+++ b/packages/schemas/src/result/index.ts
@@ -1,0 +1,11 @@
+export {
+  ActionResultMetaSchema,
+  type ActionResultMeta,
+  ActionErrorSchema,
+  type ActionError,
+  PaginationSchema,
+  type Pagination,
+  ActionResultSchema,
+  ActionErrorResultSchema,
+  type ActionErrorResult,
+} from "./action-result.js";


### PR DESCRIPTION
## Summary

- Introduces the "define once, expose everywhere" pattern: `ActionSpec` bundles a handler with its Zod input schema and per-surface metadata (CLI, MCP)
- `ActionRegistry` — synchronous in-memory registry for transport adapters to discover available actions at startup
- `ActionResult` — universal output envelope (Zod schemas in `@xmtp-broker/schemas`) that all transports render from
- Extends `HandlerContext` with `requestId`, `signal` (AbortSignal), optional `adminAuth` and `sessionId`
- `toActionResult()` bridges handler `Result<T, BrokerError>` to the transport world

## Key types

- `ActionSpec<TInput, TOutput, TError>` — handler + input schema + CLI/MCP surface metadata
- `CliSurface` / `McpSurface` — per-transport metadata (command names, tool names, annotations)
- `ActionRegistry` — register, lookup, list, listForSurface("cli" | "mcp")
- `AdminAuthContext` — authentication context for admin callers

## Changes

- **`@xmtp-broker/contracts`**: new `action-spec.ts`, `action-registry.ts`, `result-envelope.ts`; extended `handler-types.ts`
- **`@xmtp-broker/schemas`**: new `result/action-result.ts` with `ActionResultMetaSchema`, `ActionErrorSchema`, `PaginationSchema`

**38 tests**

## Spec

[`10-action-registry.md`](.agents/plans/v0/10-action-registry.md)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)