### PR TITLE
feat(keys): admin key pair and JWT auth

### DIFF
--- a/packages/keys/src/__tests__/admin-integration.test.ts
+++ b/packages/keys/src/__tests__/admin-integration.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Result } from "better-result";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createKeyManager, type KeyManager } from "../key-manager.js";
+
+describe("KeyManager.admin integration", () => {
+  let dataDir: string;
+  let manager: KeyManager;
+
+  beforeEach(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "admin-integ-test-"));
+    const result = await createKeyManager({ dataDir });
+    if (Result.isError(result)) throw new Error("key manager setup failed");
+    manager = result.value;
+  });
+
+  afterEach(() => {
+    manager.close();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  test("admin property is accessible on KeyManager", () => {
+    expect(manager.admin).toBeDefined();
+  });
+
+  test("creates admin key through facade", async () => {
+    const result = await manager.admin.create();
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result)) throw new Error("create failed");
+    expect(result.value.publicKey).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.value.fingerprint).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("signs and verifies JWT through facade", async () => {
+    await manager.admin.create();
+
+    const jwt = await manager.admin.signJwt();
+    expect(Result.isOk(jwt)).toBe(true);
+    if (Result.isError(jwt)) throw new Error("sign failed");
+
+    const verified = await manager.admin.verifyJwt(jwt.value);
+    expect(Result.isOk(verified)).toBe(true);
+    if (Result.isError(verified)) throw new Error("verify failed");
+    expect(verified.value.sub).toBe("admin");
+  });
+
+  test("admin key exists check through facade", async () => {
+    expect(manager.admin.exists()).toBe(false);
+    await manager.admin.create();
+    expect(manager.admin.exists()).toBe(true);
+  });
+
+  test("admin and operational keys coexist in vault", async () => {
+    await manager.admin.create();
+    await manager.createOperationalKey("agent-1", null);
+
+    const vaultKeys = manager.vaultList();
+    const adminKeys = vaultKeys.filter((k) => k.startsWith("admin-key:"));
+    const opKeys = vaultKeys.filter((k) => k.startsWith("op-key:"));
+
+    expect(adminKeys.length).toBeGreaterThan(0);
+    expect(opKeys.length).toBeGreaterThan(0);
+  });
+
+  test("rotates admin key through facade", async () => {
+    const original = await manager.admin.create();
+    if (Result.isError(original)) throw new Error("create failed");
+
+    const rotated = await manager.admin.rotate();
+    expect(Result.isOk(rotated)).toBe(true);
+    if (Result.isError(rotated)) throw new Error("rotate failed");
+
+    expect(rotated.value.fingerprint).not.toBe(original.value.fingerprint);
+  });
+
+  test("exports public key through facade", async () => {
+    await manager.admin.create();
+    const result = await manager.admin.exportPublicKey();
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result)) throw new Error("export failed");
+    expect(result.value).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/packages/keys/src/__tests__/admin-key.test.ts
+++ b/packages/keys/src/__tests__/admin-key.test.ts
@@ -1,0 +1,337 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Result } from "better-result";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createVault, type Vault } from "../vault.js";
+import { createAdminKeyManager, type AdminKeyManager } from "../admin-key.js";
+import { base64urlDecode } from "../jwt.js";
+
+/** Decode a JWT payload without verification (for test assertions). */
+function decodeJwtPayload(token: string): Record<string, unknown> {
+  const parts = token.split(".");
+  if (parts.length !== 3) throw new Error("Invalid JWT");
+  const payloadPart = parts[1];
+  if (payloadPart === undefined) throw new Error("Missing payload");
+  const decoded = base64urlDecode(payloadPart);
+  const text = new TextDecoder().decode(decoded);
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+describe("AdminKeyManager", () => {
+  let dataDir: string;
+  let vault: Vault;
+  let admin: AdminKeyManager;
+
+  beforeEach(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "admin-key-test-"));
+    const vaultResult = await createVault(dataDir);
+    if (Result.isError(vaultResult)) throw new Error("vault setup failed");
+    vault = vaultResult.value;
+    admin = createAdminKeyManager(vault);
+  });
+
+  afterEach(() => {
+    vault.close();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  describe("create", () => {
+    test("creates admin key and returns record", async () => {
+      const result = await admin.create();
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("create failed");
+
+      const record = result.value;
+      expect(record.keyId).toBeDefined();
+      expect(record.publicKey).toMatch(/^[0-9a-f]{64}$/);
+      expect(record.fingerprint).toMatch(/^[0-9a-f]{64}$/);
+      expect(record.createdAt).toBeDefined();
+      expect(record.rotatedAt).toBeNull();
+    });
+
+    test("fails with InternalError when admin key already exists", async () => {
+      const first = await admin.create();
+      if (Result.isError(first)) throw new Error("first create failed");
+
+      const second = await admin.create();
+      expect(Result.isError(second)).toBe(true);
+      if (Result.isOk(second)) throw new Error("expected error");
+      expect(second.error._tag).toBe("InternalError");
+    });
+  });
+
+  describe("get", () => {
+    test("returns the created admin key record", async () => {
+      const created = await admin.create();
+      if (Result.isError(created)) throw new Error("create failed");
+
+      const result = await admin.get();
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("get failed");
+
+      expect(result.value.keyId).toBe(created.value.keyId);
+      expect(result.value.publicKey).toBe(created.value.publicKey);
+      expect(result.value.fingerprint).toBe(created.value.fingerprint);
+    });
+
+    test("returns NotFoundError when no admin key exists", async () => {
+      const result = await admin.get();
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isOk(result)) throw new Error("expected error");
+      expect(result.error._tag).toBe("NotFoundError");
+    });
+  });
+
+  describe("exists", () => {
+    test("returns false when no admin key exists", () => {
+      expect(admin.exists()).toBe(false);
+    });
+
+    test("returns true after admin key is created", async () => {
+      await admin.create();
+      expect(admin.exists()).toBe(true);
+    });
+  });
+
+  describe("rotate", () => {
+    test("replaces admin key with new key pair", async () => {
+      const original = await admin.create();
+      if (Result.isError(original)) throw new Error("create failed");
+
+      const rotated = await admin.rotate();
+      expect(Result.isOk(rotated)).toBe(true);
+      if (Result.isError(rotated)) throw new Error("rotate failed");
+
+      expect(rotated.value.fingerprint).not.toBe(original.value.fingerprint);
+      expect(rotated.value.publicKey).not.toBe(original.value.publicKey);
+      expect(rotated.value.rotatedAt).not.toBeNull();
+    });
+
+    test("returns NotFoundError when no admin key exists", async () => {
+      const result = await admin.rotate();
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isOk(result)) throw new Error("expected error");
+      expect(result.error._tag).toBe("NotFoundError");
+    });
+
+    test("old JWTs fail verification after rotation", async () => {
+      await admin.create();
+      const oldJwt = await admin.signJwt();
+      if (Result.isError(oldJwt)) throw new Error("sign failed");
+
+      await admin.rotate();
+
+      const result = await admin.verifyJwt(oldJwt.value);
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isOk(result)) throw new Error("expected error");
+      expect(result.error._tag).toBe("AuthError");
+    });
+
+    test("new JWTs succeed after rotation", async () => {
+      await admin.create();
+      await admin.rotate();
+
+      const newJwt = await admin.signJwt();
+      if (Result.isError(newJwt)) throw new Error("sign failed");
+
+      const result = await admin.verifyJwt(newJwt.value);
+      expect(Result.isOk(result)).toBe(true);
+    });
+  });
+
+  describe("signJwt", () => {
+    test("produces a valid 3-part compact JWT", async () => {
+      await admin.create();
+      const result = await admin.signJwt();
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("sign failed");
+
+      const parts = result.value.split(".");
+      expect(parts).toHaveLength(3);
+    });
+
+    test("JWT payload has correct claims", async () => {
+      const created = await admin.create();
+      if (Result.isError(created)) throw new Error("create failed");
+
+      const jwt = await admin.signJwt();
+      if (Result.isError(jwt)) throw new Error("sign failed");
+
+      const payload = decodeJwtPayload(jwt.value);
+      expect(payload.sub).toBe("admin");
+      expect(payload.iss).toBe(created.value.fingerprint);
+      expect(typeof payload.iat).toBe("number");
+      expect(typeof payload.exp).toBe("number");
+      expect(typeof payload.jti).toBe("string");
+    });
+
+    test("returns NotFoundError when no admin key exists", async () => {
+      const result = await admin.signJwt();
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isOk(result)) throw new Error("expected error");
+      expect(result.error._tag).toBe("NotFoundError");
+    });
+
+    test("rejects TTL exceeding max with ValidationError", async () => {
+      await admin.create();
+      const result = await admin.signJwt({ ttlSeconds: 7200 });
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isOk(result)) throw new Error("expected error");
+      expect(result.error._tag).toBe("ValidationError");
+    });
+
+    test("rejects TTL of zero with ValidationError", async () => {
+      await admin.create();
+      const result = await admin.signJwt({ ttlSeconds: 0 });
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isOk(result)) throw new Error("expected error");
+      expect(result.error._tag).toBe("ValidationError");
+    });
+
+    test("rejects negative TTL with ValidationError", async () => {
+      await admin.create();
+      const result = await admin.signJwt({ ttlSeconds: -1 });
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isOk(result)) throw new Error("expected error");
+      expect(result.error._tag).toBe("ValidationError");
+    });
+
+    test("rejects fractional TTL with ValidationError", async () => {
+      await admin.create();
+      const result = await admin.signJwt({ ttlSeconds: 1.5 });
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isOk(result)) throw new Error("expected error");
+      expect(result.error._tag).toBe("ValidationError");
+    });
+
+    test("rejects NaN TTL with ValidationError", async () => {
+      await admin.create();
+      const result = await admin.signJwt({ ttlSeconds: NaN });
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isOk(result)) throw new Error("expected error");
+      expect(result.error._tag).toBe("ValidationError");
+    });
+
+    test("each call produces a unique jti", async () => {
+      await admin.create();
+      const jwt1 = await admin.signJwt();
+      const jwt2 = await admin.signJwt();
+      if (Result.isError(jwt1) || Result.isError(jwt2))
+        throw new Error("sign failed");
+
+      const p1 = decodeJwtPayload(jwt1.value);
+      const p2 = decodeJwtPayload(jwt2.value);
+      expect(p1.jti).not.toBe(p2.jti);
+    });
+
+    test("respects custom TTL", async () => {
+      await admin.create();
+      const jwt = await admin.signJwt({ ttlSeconds: 300 });
+      if (Result.isError(jwt)) throw new Error("sign failed");
+
+      const payload = decodeJwtPayload(jwt.value);
+      const iat = payload.iat as number;
+      const exp = payload.exp as number;
+      expect(exp - iat).toBe(300);
+    });
+  });
+
+  describe("verifyJwt", () => {
+    test("verifies a valid JWT", async () => {
+      const created = await admin.create();
+      if (Result.isError(created)) throw new Error("create failed");
+
+      const jwt = await admin.signJwt();
+      if (Result.isError(jwt)) throw new Error("sign failed");
+
+      const result = await admin.verifyJwt(jwt.value);
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("verify failed");
+      expect(result.value.sub).toBe("admin");
+      expect(result.value.iss).toBe(created.value.fingerprint);
+    });
+
+    test("rejects tampered signature with AuthError", async () => {
+      await admin.create();
+      const jwt = await admin.signJwt();
+      if (Result.isError(jwt)) throw new Error("sign failed");
+
+      const tampered = jwt.value.slice(0, -4) + "AAAA";
+      const result = await admin.verifyJwt(tampered);
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isOk(result)) throw new Error("expected error");
+      expect(result.error._tag).toBe("AuthError");
+    });
+
+    test("rejects malformed JWT with ValidationError", async () => {
+      await admin.create();
+      const result = await admin.verifyJwt("not.a.valid.jwt.token");
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isOk(result)) throw new Error("expected error");
+      expect(result.error._tag).toBe("ValidationError");
+    });
+
+    test("rejects invalid payload schema with ValidationError", async () => {
+      await admin.create();
+      // Manually craft a JWT with invalid payload (missing required fields)
+      const header = btoa(JSON.stringify({ alg: "EdDSA", typ: "JWT" }))
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+      const payload = btoa(JSON.stringify({ foo: "bar" }))
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+      const fakeSig = btoa("fakesig")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+      const result = await admin.verifyJwt(`${header}.${payload}.${fakeSig}`);
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isOk(result)) throw new Error("expected error");
+      // Could be ValidationError or AuthError depending on check order
+      expect(["ValidationError", "AuthError"]).toContain(result.error._tag);
+    });
+  });
+
+  describe("exportPublicKey", () => {
+    test("returns hex-encoded public key", async () => {
+      await admin.create();
+      const result = await admin.exportPublicKey();
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) throw new Error("export failed");
+      expect(result.value).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    test("returns NotFoundError when no admin key exists", async () => {
+      const result = await admin.exportPublicKey();
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isOk(result)) throw new Error("expected error");
+      expect(result.error._tag).toBe("NotFoundError");
+    });
+  });
+
+  describe("vault isolation", () => {
+    test("admin keys use admin-key: prefix", async () => {
+      await admin.create();
+      const keys = vault.list();
+      const adminKeys = keys.filter((k) => k.startsWith("admin-key:"));
+      expect(adminKeys.length).toBeGreaterThanOrEqual(3);
+      expect(adminKeys).toContain("admin-key:private");
+      expect(adminKeys).toContain("admin-key:public");
+      expect(adminKeys).toContain("admin-key:meta");
+    });
+
+    test("admin keys do not collide with op-key: prefix", async () => {
+      await admin.create();
+      const keys = vault.list();
+      const opKeys = keys.filter((k) => k.startsWith("op-key:"));
+      const adminKeys = keys.filter((k) => k.startsWith("admin-key:"));
+      // No overlap between prefixes
+      for (const ak of adminKeys) {
+        expect(opKeys).not.toContain(ak);
+      }
+    });
+  });
+});

--- a/packages/keys/src/__tests__/jwt.test.ts
+++ b/packages/keys/src/__tests__/jwt.test.ts
@@ -1,0 +1,277 @@
+import { describe, test, expect } from "bun:test";
+import {
+  base64urlEncode,
+  base64urlDecode,
+  encodeJwt,
+  decodeJwt,
+  signJwt,
+  verifyJwt,
+  AdminJwtConfigSchema,
+} from "../jwt.js";
+import { generateEd25519KeyPair, exportPublicKey } from "../crypto-keys.js";
+import { Result } from "better-result";
+
+describe("base64url", () => {
+  test("round-trips arbitrary bytes", () => {
+    const data = new Uint8Array([0, 1, 2, 253, 254, 255]);
+    const encoded = base64urlEncode(data);
+    const decoded = base64urlDecode(encoded);
+    expect(decoded).toEqual(data);
+  });
+
+  test("round-trips empty data", () => {
+    const data = new Uint8Array([]);
+    const encoded = base64urlEncode(data);
+    const decoded = base64urlDecode(encoded);
+    expect(decoded).toEqual(data);
+  });
+
+  test("round-trips all byte values", () => {
+    const data = new Uint8Array(256);
+    for (let i = 0; i < 256; i++) {
+      data[i] = i;
+    }
+    const encoded = base64urlEncode(data);
+    const decoded = base64urlDecode(encoded);
+    expect(decoded).toEqual(data);
+  });
+
+  test("produces URL-safe output without padding", () => {
+    const data = new Uint8Array([255, 254, 253]);
+    const encoded = base64urlEncode(data);
+    expect(encoded).not.toContain("+");
+    expect(encoded).not.toContain("/");
+    expect(encoded).not.toContain("=");
+  });
+});
+
+describe("encodeJwt / decodeJwt", () => {
+  test("encodes header and payload into two base64url parts", () => {
+    const header = { alg: "EdDSA", typ: "JWT" };
+    const payload = { sub: "admin", iss: "test" };
+    const encoded = encodeJwt(header, payload);
+    expect(encoded.split(".")).toHaveLength(2);
+  });
+
+  test("decodeJwt round-trips the payload", () => {
+    const header = { alg: "EdDSA", typ: "JWT" };
+    const payload = {
+      iss: "abc123",
+      sub: "admin",
+      iat: 1000,
+      exp: 2000,
+      jti: "nonce123",
+    };
+    const encoded = encodeJwt(header, payload);
+    const decoded = decodeJwt(encoded);
+    expect(Result.isOk(decoded)).toBe(true);
+    if (Result.isError(decoded)) throw new Error("decode failed");
+    expect(decoded.value.header).toEqual(header);
+    expect(decoded.value.payload).toEqual(payload);
+  });
+
+  test("decodeJwt rejects string with wrong part count", () => {
+    const result = decodeJwt("one.two.three.four");
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isOk(result)) throw new Error("expected error");
+    expect(result.error._tag).toBe("ValidationError");
+  });
+
+  test("decodeJwt rejects invalid base64url", () => {
+    const result = decodeJwt("!!!.@@@");
+    expect(Result.isError(result)).toBe(true);
+  });
+});
+
+describe("signJwt / verifyJwt", () => {
+  test("sign and verify round-trip succeeds", async () => {
+    const keyPair = await generateEd25519KeyPair();
+    if (Result.isError(keyPair)) throw new Error("keygen failed");
+
+    const payload = {
+      iss: "fingerprint-hex",
+      sub: "admin" as const,
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 120,
+      jti: "abc123",
+    };
+
+    const token = await signJwt(keyPair.value.privateKey, payload);
+    expect(Result.isOk(token)).toBe(true);
+    if (Result.isError(token)) throw new Error("sign failed");
+
+    const parts = token.value.split(".");
+    expect(parts).toHaveLength(3);
+
+    const pubBytes = await exportPublicKey(keyPair.value.publicKey);
+    if (Result.isError(pubBytes)) throw new Error("export failed");
+
+    const verified = await verifyJwt(token.value, pubBytes.value);
+    expect(Result.isOk(verified)).toBe(true);
+    if (Result.isError(verified)) throw new Error("verify failed");
+    expect(verified.value.sub).toBe("admin");
+    expect(verified.value.iss).toBe("fingerprint-hex");
+  });
+
+  test("verifyJwt rejects tampered signature", async () => {
+    const keyPair = await generateEd25519KeyPair();
+    if (Result.isError(keyPair)) throw new Error("keygen failed");
+
+    const payload = {
+      iss: "fp",
+      sub: "admin" as const,
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 120,
+      jti: "nonce",
+    };
+
+    const token = await signJwt(keyPair.value.privateKey, payload);
+    if (Result.isError(token)) throw new Error("sign failed");
+
+    const tampered = token.value.slice(0, -4) + "AAAA";
+    const pubBytes = await exportPublicKey(keyPair.value.publicKey);
+    if (Result.isError(pubBytes)) throw new Error("export failed");
+
+    const result = await verifyJwt(tampered, pubBytes.value);
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isOk(result)) throw new Error("expected error");
+    expect(result.error._tag).toBe("AuthError");
+  });
+
+  test("verifyJwt rejects expired token", async () => {
+    const keyPair = await generateEd25519KeyPair();
+    if (Result.isError(keyPair)) throw new Error("keygen failed");
+
+    const now = Math.floor(Date.now() / 1000);
+    const payload = {
+      iss: "fp",
+      sub: "admin" as const,
+      iat: now - 600,
+      exp: now - 300,
+      jti: "nonce",
+    };
+
+    const token = await signJwt(keyPair.value.privateKey, payload);
+    if (Result.isError(token)) throw new Error("sign failed");
+
+    const pubBytes = await exportPublicKey(keyPair.value.publicKey);
+    if (Result.isError(pubBytes)) throw new Error("export failed");
+
+    const result = await verifyJwt(token.value, pubBytes.value);
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isOk(result)) throw new Error("expected error");
+    expect(result.error._tag).toBe("AuthError");
+  });
+
+  test("verifyJwt accepts token within clock skew tolerance", async () => {
+    const keyPair = await generateEd25519KeyPair();
+    if (Result.isError(keyPair)) throw new Error("keygen failed");
+
+    const now = Math.floor(Date.now() / 1000);
+    // Token expired 10 seconds ago but within 30s skew
+    const payload = {
+      iss: "fp",
+      sub: "admin" as const,
+      iat: now - 120,
+      exp: now - 10,
+      jti: "nonce",
+    };
+
+    const token = await signJwt(keyPair.value.privateKey, payload);
+    if (Result.isError(token)) throw new Error("sign failed");
+
+    const pubBytes = await exportPublicKey(keyPair.value.publicKey);
+    if (Result.isError(pubBytes)) throw new Error("export failed");
+
+    const result = await verifyJwt(token.value, pubBytes.value, {
+      clockSkewSeconds: 30,
+    });
+    expect(Result.isOk(result)).toBe(true);
+  });
+
+  test("verifyJwt rejects token issued in the future beyond skew", async () => {
+    const keyPair = await generateEd25519KeyPair();
+    if (Result.isError(keyPair)) throw new Error("keygen failed");
+
+    const now = Math.floor(Date.now() / 1000);
+    const payload = {
+      iss: "fp",
+      sub: "admin" as const,
+      iat: now + 300,
+      exp: now + 600,
+      jti: "nonce",
+    };
+
+    const token = await signJwt(keyPair.value.privateKey, payload);
+    if (Result.isError(token)) throw new Error("sign failed");
+
+    const pubBytes = await exportPublicKey(keyPair.value.publicKey);
+    if (Result.isError(pubBytes)) throw new Error("export failed");
+
+    const result = await verifyJwt(token.value, pubBytes.value, {
+      clockSkewSeconds: 30,
+    });
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isOk(result)) throw new Error("expected error");
+    expect(result.error._tag).toBe("ValidationError");
+  });
+
+  test("verifyJwt rejects malformed token (not 3 parts)", async () => {
+    const keyPair = await generateEd25519KeyPair();
+    if (Result.isError(keyPair)) throw new Error("keygen failed");
+
+    const pubBytes = await exportPublicKey(keyPair.value.publicKey);
+    if (Result.isError(pubBytes)) throw new Error("export failed");
+
+    const result = await verifyJwt("not-a-jwt", pubBytes.value);
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isOk(result)) throw new Error("expected error");
+    expect(result.error._tag).toBe("ValidationError");
+  });
+
+  test("verifyJwt rejects wrong key", async () => {
+    const keyPair1 = await generateEd25519KeyPair();
+    const keyPair2 = await generateEd25519KeyPair();
+    if (Result.isError(keyPair1) || Result.isError(keyPair2))
+      throw new Error("keygen failed");
+
+    const payload = {
+      iss: "fp",
+      sub: "admin" as const,
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 120,
+      jti: "nonce",
+    };
+
+    const token = await signJwt(keyPair1.value.privateKey, payload);
+    if (Result.isError(token)) throw new Error("sign failed");
+
+    const wrongPubBytes = await exportPublicKey(keyPair2.value.publicKey);
+    if (Result.isError(wrongPubBytes)) throw new Error("export failed");
+
+    const result = await verifyJwt(token.value, wrongPubBytes.value);
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isOk(result)) throw new Error("expected error");
+    expect(result.error._tag).toBe("AuthError");
+  });
+});
+
+describe("AdminJwtConfigSchema", () => {
+  test("applies defaults", () => {
+    const parsed = AdminJwtConfigSchema.parse({});
+    expect(parsed.defaultTtlSeconds).toBe(120);
+    expect(parsed.maxTtlSeconds).toBe(3600);
+    expect(parsed.clockSkewSeconds).toBe(30);
+  });
+
+  test("accepts custom values", () => {
+    const parsed = AdminJwtConfigSchema.parse({
+      defaultTtlSeconds: 60,
+      maxTtlSeconds: 1800,
+      clockSkewSeconds: 10,
+    });
+    expect(parsed.defaultTtlSeconds).toBe(60);
+    expect(parsed.maxTtlSeconds).toBe(1800);
+    expect(parsed.clockSkewSeconds).toBe(10);
+  });
+});

--- a/packages/keys/src/admin-key.ts
+++ b/packages/keys/src/admin-key.ts
@@ -1,0 +1,286 @@
+import { Result } from "better-result";
+import {
+  InternalError,
+  NotFoundError,
+  AuthError,
+  ValidationError,
+} from "@xmtp-broker/schemas";
+import type { Vault } from "./vault.js";
+import {
+  generateEd25519KeyPair,
+  exportPublicKey,
+  exportPrivateKey,
+  importEd25519PrivateKey,
+  fingerprint as computeFingerprint,
+  toHex,
+} from "./crypto-keys.js";
+import {
+  signJwt as signJwtRaw,
+  verifyJwt as verifyJwtRaw,
+  AdminJwtConfigSchema,
+  type AdminJwtPayload,
+} from "./jwt.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** An Ed25519 admin key pair managed by the vault. */
+export interface AdminKeyRecord {
+  readonly keyId: string;
+  readonly publicKey: string;
+  readonly fingerprint: string;
+  readonly createdAt: string;
+  readonly rotatedAt: string | null;
+}
+
+/** Authentication context for admin-authenticated requests. */
+export interface AdminAuthContext {
+  readonly authMethod: AdminAuthMethod;
+  readonly adminFingerprint: string;
+  readonly expiresAt: string;
+}
+
+export type AdminAuthMethod = "jwt";
+
+/** Options for signing an admin JWT. */
+export interface AdminJwtOptions {
+  readonly ttlSeconds?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Vault key constants
+// ---------------------------------------------------------------------------
+
+const ADMIN_PRIVATE_KEY = "admin-key:private";
+const ADMIN_PUBLIC_KEY = "admin-key:public";
+const ADMIN_META_KEY = "admin-key:meta";
+
+// ---------------------------------------------------------------------------
+// AdminKeyManager
+// ---------------------------------------------------------------------------
+
+export interface AdminKeyManager {
+  create(): Promise<Result<AdminKeyRecord, InternalError>>;
+  get(): Promise<Result<AdminKeyRecord, NotFoundError | InternalError>>;
+  exists(): boolean;
+  rotate(): Promise<Result<AdminKeyRecord, InternalError | NotFoundError>>;
+  signJwt(
+    options?: AdminJwtOptions,
+  ): Promise<Result<string, InternalError | NotFoundError | ValidationError>>;
+  verifyJwt(
+    token: string,
+  ): Promise<Result<AdminJwtPayload, AuthError | ValidationError>>;
+  exportPublicKey(): Promise<Result<string, NotFoundError | InternalError>>;
+}
+
+/** Create an AdminKeyManager backed by the given vault. */
+export function createAdminKeyManager(vault: Vault): AdminKeyManager {
+  const config = AdminJwtConfigSchema.parse({});
+
+  // Track existence in memory to avoid vault reads for exists()
+  let adminKeyExists = vault.list().some((k) => k === ADMIN_META_KEY);
+
+  async function loadMeta(): Promise<
+    Result<AdminKeyRecord, NotFoundError | InternalError>
+  > {
+    const metaResult = await vault.get(ADMIN_META_KEY);
+    if (Result.isError(metaResult)) {
+      if (metaResult.error._tag === "NotFoundError") {
+        return Result.err(NotFoundError.create("AdminKey", "admin"));
+      }
+      return metaResult as Result<never, InternalError>;
+    }
+    try {
+      const json = new TextDecoder().decode(metaResult.value);
+      return Result.ok(JSON.parse(json) as AdminKeyRecord);
+    } catch (e) {
+      return Result.err(
+        InternalError.create("Failed to parse admin key metadata", {
+          cause: String(e),
+        }),
+      );
+    }
+  }
+
+  async function storeMeta(
+    record: AdminKeyRecord,
+  ): Promise<Result<void, InternalError>> {
+    const bytes = new TextEncoder().encode(JSON.stringify(record));
+    return vault.set(ADMIN_META_KEY, bytes);
+  }
+
+  async function generateAndStore(): Promise<
+    Result<AdminKeyRecord, InternalError>
+  > {
+    const keyPair = await generateEd25519KeyPair();
+    if (Result.isError(keyPair)) return keyPair;
+
+    const pubBytes = await exportPublicKey(keyPair.value.publicKey);
+    if (Result.isError(pubBytes)) return pubBytes;
+
+    const fp = await computeFingerprint(keyPair.value.publicKey);
+    if (Result.isError(fp)) return fp;
+
+    const privBytes = await exportPrivateKey(keyPair.value.privateKey);
+    if (Result.isError(privBytes)) return privBytes;
+
+    // Store private key (PKCS8)
+    const privResult = await vault.set(ADMIN_PRIVATE_KEY, privBytes.value);
+    privBytes.value.fill(0); // zeroize
+    if (Result.isError(privResult)) return privResult;
+
+    // Store public key (raw 32 bytes)
+    const pubResult = await vault.set(ADMIN_PUBLIC_KEY, pubBytes.value);
+    if (Result.isError(pubResult)) return pubResult;
+
+    return Result.ok({
+      keyId: crypto.randomUUID(),
+      publicKey: toHex(pubBytes.value),
+      fingerprint: fp.value,
+      createdAt: new Date().toISOString(),
+      rotatedAt: null,
+    });
+  }
+
+  return {
+    async create(): Promise<Result<AdminKeyRecord, InternalError>> {
+      if (adminKeyExists) {
+        return Result.err(
+          InternalError.create("Admin key already exists; use rotate instead"),
+        );
+      }
+
+      const recordResult = await generateAndStore();
+      if (Result.isError(recordResult)) return recordResult;
+
+      const metaResult = await storeMeta(recordResult.value);
+      if (Result.isError(metaResult)) return metaResult;
+
+      adminKeyExists = true;
+      return recordResult;
+    },
+
+    async get(): Promise<
+      Result<AdminKeyRecord, NotFoundError | InternalError>
+    > {
+      return loadMeta();
+    },
+
+    exists(): boolean {
+      return adminKeyExists;
+    },
+
+    async rotate(): Promise<
+      Result<AdminKeyRecord, InternalError | NotFoundError>
+    > {
+      if (!adminKeyExists) {
+        return Result.err(NotFoundError.create("AdminKey", "admin"));
+      }
+
+      const recordResult = await generateAndStore();
+      if (Result.isError(recordResult)) return recordResult;
+
+      const record: AdminKeyRecord = {
+        ...recordResult.value,
+        rotatedAt: new Date().toISOString(),
+      };
+
+      const metaResult = await storeMeta(record);
+      if (Result.isError(metaResult)) return metaResult;
+
+      return Result.ok(record);
+    },
+
+    async signJwt(
+      options?: AdminJwtOptions,
+    ): Promise<
+      Result<string, InternalError | NotFoundError | ValidationError>
+    > {
+      const ttl = options?.ttlSeconds ?? config.defaultTtlSeconds;
+      if (!Number.isFinite(ttl) || !Number.isInteger(ttl) || ttl <= 0) {
+        return Result.err(
+          ValidationError.create(
+            "ttlSeconds",
+            `TTL must be a positive integer, got ${String(ttl)}`,
+          ),
+        );
+      }
+      if (ttl > config.maxTtlSeconds) {
+        return Result.err(
+          ValidationError.create(
+            "ttlSeconds",
+            `TTL ${ttl}s exceeds maximum ${config.maxTtlSeconds}s`,
+          ),
+        );
+      }
+
+      // Load private key
+      const privResult = await vault.get(ADMIN_PRIVATE_KEY);
+      if (Result.isError(privResult)) {
+        if (privResult.error._tag === "NotFoundError") {
+          return Result.err(NotFoundError.create("AdminKey", "admin"));
+        }
+        return privResult as Result<never, InternalError>;
+      }
+
+      const imported = await importEd25519PrivateKey(privResult.value);
+      if (Result.isError(imported)) return imported;
+
+      // Load fingerprint
+      const meta = await loadMeta();
+      if (Result.isError(meta)) return meta;
+
+      const now = Math.floor(Date.now() / 1000);
+      const nonce = crypto.getRandomValues(new Uint8Array(16));
+      const jti = toHex(nonce);
+
+      const payload: AdminJwtPayload = {
+        iss: meta.value.fingerprint,
+        sub: "admin",
+        iat: now,
+        exp: now + ttl,
+        jti,
+      };
+
+      return signJwtRaw(imported.value, payload);
+    },
+
+    async verifyJwt(
+      token: string,
+    ): Promise<Result<AdminJwtPayload, AuthError | ValidationError>> {
+      // Load public key
+      const pubResult = await vault.get(ADMIN_PUBLIC_KEY);
+      if (Result.isError(pubResult)) {
+        return Result.err(
+          AuthError.create("Admin key not found for verification"),
+        );
+      }
+
+      const result = await verifyJwtRaw(token, pubResult.value, {
+        clockSkewSeconds: config.clockSkewSeconds,
+      });
+      if (Result.isError(result)) return result;
+
+      // Check fingerprint matches stored key
+      const meta = await loadMeta();
+      if (Result.isError(meta)) {
+        return Result.err(AuthError.create("Admin key metadata not found"));
+      }
+
+      if (result.value.iss !== meta.value.fingerprint) {
+        return Result.err(AuthError.create("Admin key fingerprint mismatch"));
+      }
+
+      return result;
+    },
+
+    async exportPublicKey(): Promise<
+      Result<string, NotFoundError | InternalError>
+    > {
+      const meta = await loadMeta();
+      if (Result.isError(meta)) return meta;
+      return Result.ok(meta.value.publicKey);
+    },
+  };
+}

--- a/packages/keys/src/index.ts
+++ b/packages/keys/src/index.ts
@@ -38,7 +38,25 @@ export type { OperationalKeyManager } from "./operational-key.js";
 export { createSessionKeyManager } from "./session-key.js";
 export type { SessionKeyManager } from "./session-key.js";
 
-// Crypto utilities
+// Admin key manager
+export { createAdminKeyManager } from "./admin-key.js";
+export type {
+  AdminKeyManager,
+  AdminKeyRecord,
+  AdminAuthContext,
+  AdminAuthMethod,
+  AdminJwtOptions,
+} from "./admin-key.js";
+
+// JWT utilities
+export {
+  AdminJwtConfigSchema,
+  AdminJwtPayloadSchema,
+  base64urlEncode,
+  base64urlDecode,
+} from "./jwt.js";
+export type { AdminJwtConfig, AdminJwtPayload } from "./jwt.js";
+
 // Root key
 export { initializeRootKey, signWithRootKey } from "./root-key.js";
 export type { RootKeyResult } from "./root-key.js";

--- a/packages/keys/src/jwt.ts
+++ b/packages/keys/src/jwt.ts
@@ -1,0 +1,324 @@
+import { z } from "zod";
+import { Result } from "better-result";
+import {
+  AuthError,
+  ValidationError,
+  InternalError,
+} from "@xmtp-broker/schemas";
+
+/**
+ * Helper to convert Uint8Array to a BufferSource compatible with
+ * Bun's strict WebCrypto types.
+ */
+function asBuffer(data: Uint8Array): ArrayBuffer {
+  return data.buffer.slice(
+    data.byteOffset,
+    data.byteOffset + data.byteLength,
+  ) as ArrayBuffer;
+}
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+/** Admin JWT configuration (parsed output). */
+export type AdminJwtConfig = {
+  defaultTtlSeconds: number;
+  maxTtlSeconds: number;
+  clockSkewSeconds: number;
+};
+
+/** Admin JWT configuration (input, fields with defaults are optional). */
+type AdminJwtConfigInput = {
+  defaultTtlSeconds?: number | undefined;
+  maxTtlSeconds?: number | undefined;
+  clockSkewSeconds?: number | undefined;
+};
+
+/** Admin JWT configuration schema with defaults. */
+export const AdminJwtConfigSchema: z.ZodType<
+  AdminJwtConfig,
+  z.ZodTypeDef,
+  AdminJwtConfigInput
+> = z
+  .object({
+    defaultTtlSeconds: z
+      .number()
+      .int()
+      .positive()
+      .default(120)
+      .describe("Default JWT TTL in seconds (2 minutes)"),
+    maxTtlSeconds: z
+      .number()
+      .int()
+      .positive()
+      .default(3600)
+      .describe("Maximum JWT TTL in seconds (1 hour)"),
+    clockSkewSeconds: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(30)
+      .describe("Allowed clock skew for JWT verification"),
+  })
+  .describe("Admin JWT configuration");
+
+/** Admin JWT payload. */
+export interface AdminJwtPayload {
+  readonly iss: string;
+  readonly sub: "admin";
+  readonly iat: number;
+  readonly exp: number;
+  readonly jti: string;
+}
+
+/** Admin JWT payload schema. */
+export const AdminJwtPayloadSchema: z.ZodType<
+  AdminJwtPayload,
+  z.ZodTypeDef,
+  AdminJwtPayload
+> = z
+  .object({
+    iss: z.string().describe("Admin key fingerprint"),
+    sub: z.literal("admin").describe("Subject claim"),
+    iat: z.number().int().positive().describe("Issued-at timestamp"),
+    exp: z.number().int().positive().describe("Expiration timestamp"),
+    jti: z.string().describe("JWT ID (random nonce, hex-encoded, 16 bytes)"),
+  })
+  .describe("Admin JWT payload claims");
+
+/** JWT header for EdDSA. */
+interface JwtHeader {
+  readonly alg: string;
+  readonly typ: string;
+}
+
+/** Decoded JWT parts (header + payload, no signature). */
+export interface DecodedJwt {
+  readonly header: JwtHeader;
+  readonly payload: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Base64url
+// ---------------------------------------------------------------------------
+
+/** Encode bytes to base64url (no padding). */
+export function base64urlEncode(data: Uint8Array): string {
+  if (data.length === 0) return "";
+  return btoa(String.fromCharCode(...data))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/** Decode base64url string to bytes. */
+export function base64urlDecode(str: string): Uint8Array {
+  if (str === "") return new Uint8Array(0);
+  const padded = str + "=".repeat((4 - (str.length % 4)) % 4);
+  const binary = atob(padded.replace(/-/g, "+").replace(/_/g, "/"));
+  return Uint8Array.from(binary, (c) => c.charCodeAt(0));
+}
+
+// ---------------------------------------------------------------------------
+// JWT encode / decode
+// ---------------------------------------------------------------------------
+
+/** Encode JWT header and payload into `base64url(header).base64url(payload)`. */
+export function encodeJwt(header: object, payload: object): string {
+  const headerB64 = base64urlEncode(
+    new TextEncoder().encode(JSON.stringify(header)),
+  );
+  const payloadB64 = base64urlEncode(
+    new TextEncoder().encode(JSON.stringify(payload)),
+  );
+  return `${headerB64}.${payloadB64}`;
+}
+
+/**
+ * Decode a two-part JWT string (header.payload) without verification.
+ * Used internally before signature check.
+ */
+export function decodeJwt(
+  headerPayload: string,
+): Result<DecodedJwt, ValidationError> {
+  const parts = headerPayload.split(".");
+  if (parts.length !== 2) {
+    return Result.err(
+      ValidationError.create("jwt", "Expected 2 parts (header.payload)"),
+    );
+  }
+
+  try {
+    const headerPart = parts[0];
+    const payloadPart = parts[1];
+    if (headerPart === undefined || payloadPart === undefined) {
+      return Result.err(
+        ValidationError.create("jwt", "Missing header or payload"),
+      );
+    }
+    const header = JSON.parse(
+      new TextDecoder().decode(base64urlDecode(headerPart)),
+    ) as JwtHeader;
+    const payload = JSON.parse(
+      new TextDecoder().decode(base64urlDecode(payloadPart)),
+    ) as Record<string, unknown>;
+    return Result.ok({ header, payload });
+  } catch {
+    return Result.err(
+      ValidationError.create("jwt", "Invalid base64url encoding"),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// JWT sign / verify
+// ---------------------------------------------------------------------------
+
+/**
+ * Sign a JWT payload with an Ed25519 private CryptoKey.
+ * Returns the compact three-part JWT string.
+ */
+export async function signJwt(
+  privateKey: CryptoKey,
+  payload: AdminJwtPayload,
+): Promise<Result<string, InternalError>> {
+  try {
+    const header = { alg: "EdDSA", typ: "JWT" };
+    const headerPayload = encodeJwt(header, payload);
+    const data = new TextEncoder().encode(headerPayload);
+
+    const signature = await crypto.subtle.sign(
+      "Ed25519",
+      privateKey,
+      asBuffer(data),
+    );
+
+    const sigB64 = base64urlEncode(new Uint8Array(signature));
+    return Result.ok(`${headerPayload}.${sigB64}`);
+  } catch (e) {
+    return Result.err(
+      InternalError.create("Failed to sign JWT", {
+        cause: String(e),
+      }),
+    );
+  }
+}
+
+/** Options for JWT verification. */
+export interface VerifyJwtOptions {
+  /** Clock skew tolerance in seconds. Default: 30. */
+  readonly clockSkewSeconds?: number;
+}
+
+/**
+ * Verify a compact JWT string against an Ed25519 public key (raw bytes).
+ * Checks signature, expiration, and payload schema.
+ */
+export async function verifyJwt(
+  token: string,
+  publicKeyBytes: Uint8Array,
+  options?: VerifyJwtOptions,
+): Promise<Result<AdminJwtPayload, AuthError | ValidationError>> {
+  const clockSkew = options?.clockSkewSeconds ?? 30;
+
+  // Split into 3 parts
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    return Result.err(
+      ValidationError.create("jwt", "Malformed JWT: expected 3 parts"),
+    );
+  }
+
+  const headerPart = parts[0];
+  const payloadPart = parts[1];
+  const sigPart = parts[2];
+  if (
+    headerPart === undefined ||
+    payloadPart === undefined ||
+    sigPart === undefined
+  ) {
+    return Result.err(
+      ValidationError.create("jwt", "Malformed JWT: missing parts"),
+    );
+  }
+
+  // Decode header
+  const headerPayload = `${headerPart}.${payloadPart}`;
+  const decoded = decodeJwt(headerPayload);
+  if (Result.isError(decoded)) return decoded;
+
+  // Verify header alg
+  if (decoded.value.header.alg !== "EdDSA") {
+    return Result.err(
+      ValidationError.create(
+        "jwt.header.alg",
+        `Expected EdDSA, got ${decoded.value.header.alg}`,
+      ),
+    );
+  }
+
+  // Parse payload with schema
+  const payloadResult = AdminJwtPayloadSchema.safeParse(decoded.value.payload);
+  if (!payloadResult.success) {
+    return Result.err(
+      ValidationError.create("jwt.payload", "Invalid JWT payload schema"),
+    );
+  }
+  const payload = payloadResult.data;
+
+  // Import public key for verification
+  let publicKey: CryptoKey;
+  try {
+    publicKey = await crypto.subtle.importKey(
+      "raw",
+      asBuffer(publicKeyBytes),
+      "Ed25519",
+      false,
+      ["verify"],
+    );
+  } catch {
+    return Result.err(AuthError.create("Failed to import admin public key"));
+  }
+
+  // Verify signature
+  let sigBytes: Uint8Array;
+  try {
+    sigBytes = base64urlDecode(sigPart);
+  } catch {
+    return Result.err(
+      ValidationError.create("jwt.signature", "Invalid base64url signature"),
+    );
+  }
+  const data = new TextEncoder().encode(headerPayload);
+  let valid: boolean;
+  try {
+    valid = await crypto.subtle.verify(
+      "Ed25519",
+      publicKey,
+      asBuffer(sigBytes),
+      asBuffer(data),
+    );
+  } catch {
+    return Result.err(AuthError.create("Invalid admin token signature"));
+  }
+
+  if (!valid) {
+    return Result.err(AuthError.create("Invalid admin token signature"));
+  }
+
+  // Check expiration with clock skew tolerance
+  const now = Math.floor(Date.now() / 1000);
+  if (payload.exp <= now - clockSkew) {
+    return Result.err(AuthError.create("Admin token expired"));
+  }
+
+  // Check iat is not in the future (beyond clock skew)
+  if (payload.iat > now + clockSkew) {
+    return Result.err(
+      ValidationError.create("jwt.iat", "Token issued in future"),
+    );
+  }
+
+  return Result.ok(payload);
+}

--- a/packages/keys/src/key-manager.ts
+++ b/packages/keys/src/key-manager.ts
@@ -20,6 +20,7 @@ import {
   createSessionKeyManager,
   type SessionKeyManager,
 } from "./session-key.js";
+import { createAdminKeyManager, type AdminKeyManager } from "./admin-key.js";
 import { initializeRootKey } from "./root-key.js";
 import type { RootKeyHandle, OperationalKey, SessionKey } from "./types.js";
 
@@ -28,6 +29,9 @@ export interface KeyManager {
 
   readonly platform: PlatformCapability;
   readonly trustTier: TrustTier;
+
+  /** Access admin key operations. */
+  readonly admin: AdminKeyManager;
 
   createOperationalKey(
     identityId: string,
@@ -114,6 +118,7 @@ export async function createKeyManager(
 
   const opKeys: OperationalKeyManager = createOperationalKeyManager(vault);
   const sessionKeys: SessionKeyManager = createSessionKeyManager();
+  const adminKeys: AdminKeyManager = createAdminKeyManager(vault);
 
   let rootKeyHandle: RootKeyHandle | null = null;
 
@@ -124,6 +129,10 @@ export async function createKeyManager(
 
     get trustTier(): TrustTier {
       return trustTier;
+    },
+
+    get admin(): AdminKeyManager {
+      return adminKeys;
     },
 
     async initialize(): Promise<


### PR DESCRIPTION
## Summary

- Adds admin key pair (Ed25519) and JWT auth to `packages/keys/` — separate from the inbox key hierarchy
- Admin key stored in vault with `admin-key:` prefix namespace (no collision with operational keys)
- Compact JWT format with EdDSA signatures via `crypto.subtle` — no external JWT library
- Default TTL: 2 minutes, max: 1 hour. Rotation immediately invalidates all outstanding JWTs

## Public API

- `AdminKeyManager` — create, get, exists, rotate, signJwt, verifyJwt, exportPublicKey
- `KeyManager.admin` — namespace property exposing admin key operations
- `AdminJwtPayloadSchema` — Zod schema for JWT claims (iss, sub, iat, exp, jti)

## Security model

The admin key is independent from inbox keys — compromising one doesn't compromise the other. Both are encrypted at rest by the vault. Short-lived JWTs (2 min default) limit leaked token exposure. The CLI generates a fresh JWT per command.

**48 tests** covering key lifecycle, JWT round-trip, expiry, tampering, rotation invalidation, TTL enforcement, nonce uniqueness, and vault isolation.

## Spec

[`12-admin-keys.md`](.agents/plans/v0/12-admin-keys.md)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)