### PR TITLE
feat(cli): admin socket with JSON-RPC 2.0 and AdminDispatcher

### DIFF
--- a/packages/cli/src/__tests__/admin-dispatcher.test.ts
+++ b/packages/cli/src/__tests__/admin-dispatcher.test.ts
@@ -1,0 +1,184 @@
+import { describe, test, expect } from "bun:test";
+import { Result } from "better-result";
+import { z } from "zod";
+import {
+  createActionRegistry,
+  type ActionSpec,
+  type HandlerContext,
+} from "@xmtp-broker/contracts";
+import { ValidationError, type BrokerError } from "@xmtp-broker/schemas";
+import { createAdminDispatcher } from "../admin/dispatcher.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeHandlerContext(
+  overrides?: Partial<HandlerContext>,
+): HandlerContext {
+  return {
+    brokerId: "test-broker",
+    signerProvider: {} as HandlerContext["signerProvider"],
+    requestId: crypto.randomUUID(),
+    signal: AbortSignal.timeout(5_000),
+    ...overrides,
+  };
+}
+
+function makeSpec(
+  id: string,
+  opts?: {
+    rpcMethod?: string;
+    command?: string;
+    handler?: ActionSpec<unknown, unknown, BrokerError>["handler"];
+    input?: z.ZodType<unknown>;
+  },
+): ActionSpec<unknown, unknown, BrokerError> {
+  return {
+    id,
+    handler: opts?.handler ?? (async (input: unknown) => Result.ok(input)),
+    input: opts?.input ?? z.object({}).passthrough(),
+    cli: {
+      command: opts?.command ?? id.replace(/\./g, ":"),
+      rpcMethod: opts?.rpcMethod,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AdminDispatcher", () => {
+  test("dispatches to correct handler via explicit rpcMethod", async () => {
+    const registry = createActionRegistry();
+    const spec = makeSpec("session.list", {
+      rpcMethod: "session.list",
+      command: "session:list",
+      handler: async () => Result.ok({ sessions: [] }),
+    });
+    registry.register(spec);
+
+    const dispatcher = createAdminDispatcher(registry);
+    const ctx = makeHandlerContext();
+    const result = await dispatcher.dispatch("session.list", {}, ctx);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual({ sessions: [] });
+    }
+  });
+
+  test("derives rpcMethod from command by replacing : with .", async () => {
+    const registry = createActionRegistry();
+    // No explicit rpcMethod -- should derive "session.revoke" from "session:revoke"
+    const spec = makeSpec("session.revoke", {
+      command: "session:revoke",
+      handler: async () => Result.ok({ revoked: true }),
+    });
+    registry.register(spec);
+
+    const dispatcher = createAdminDispatcher(registry);
+    const ctx = makeHandlerContext();
+    const result = await dispatcher.dispatch("session.revoke", {}, ctx);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual({ revoked: true });
+    }
+  });
+
+  test("returns error for unknown method", async () => {
+    const registry = createActionRegistry();
+    const dispatcher = createAdminDispatcher(registry);
+    const ctx = makeHandlerContext();
+    const result = await dispatcher.dispatch("nonexistent.method", {}, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.category).toBe("not_found");
+    }
+  });
+
+  test("returns validation error when input fails schema", async () => {
+    const registry = createActionRegistry();
+    const spec = makeSpec("session.issue", {
+      rpcMethod: "session.issue",
+      command: "session:issue",
+      input: z.object({
+        agentId: z.string().min(1),
+      }),
+    });
+    registry.register(spec);
+
+    const dispatcher = createAdminDispatcher(registry);
+    const ctx = makeHandlerContext();
+    // Missing required agentId
+    const result = await dispatcher.dispatch("session.issue", {}, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.category).toBe("validation");
+    }
+  });
+
+  test("wraps handler error in ActionResult", async () => {
+    const registry = createActionRegistry();
+    const spec = makeSpec("key.rotate", {
+      rpcMethod: "key.rotate",
+      command: "key:rotate",
+      handler: async () =>
+        Result.err(ValidationError.create("keyId", "Key not found")),
+    });
+    registry.register(spec);
+
+    const dispatcher = createAdminDispatcher(registry);
+    const ctx = makeHandlerContext();
+    const result = await dispatcher.dispatch("key.rotate", {}, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error._tag).toBe("ValidationError");
+    }
+  });
+
+  test("hasMethod returns true for registered method", () => {
+    const registry = createActionRegistry();
+    const spec = makeSpec("session.list", {
+      rpcMethod: "session.list",
+      command: "session:list",
+    });
+    registry.register(spec);
+
+    const dispatcher = createAdminDispatcher(registry);
+    expect(dispatcher.hasMethod("session.list")).toBe(true);
+  });
+
+  test("hasMethod returns false for unregistered method", () => {
+    const registry = createActionRegistry();
+    const dispatcher = createAdminDispatcher(registry);
+    expect(dispatcher.hasMethod("unknown.method")).toBe(false);
+  });
+
+  test("handler that throws returns InternalError", async () => {
+    const registry = createActionRegistry();
+    const spec = makeSpec("boom.action", {
+      rpcMethod: "boom.action",
+      command: "boom:action",
+      handler: async () => {
+        throw new Error("unexpected kaboom");
+      },
+    });
+    registry.register(spec);
+
+    const dispatcher = createAdminDispatcher(registry);
+    const ctx = makeHandlerContext();
+    const result = await dispatcher.dispatch("boom.action", {}, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error._tag).toBe("InternalError");
+      expect(result.error.message).toContain("unexpected kaboom");
+    }
+  });
+});

--- a/packages/cli/src/__tests__/admin-protocol.test.ts
+++ b/packages/cli/src/__tests__/admin-protocol.test.ts
@@ -1,0 +1,158 @@
+import { describe, test, expect } from "bun:test";
+import {
+  JsonRpcRequestSchema,
+  JsonRpcSuccessSchema,
+  JsonRpcErrorSchema,
+  AdminAuthFrameSchema,
+  JsonRpcNotificationSchema,
+} from "../admin/protocol.js";
+
+describe("AdminAuthFrameSchema", () => {
+  test("validates a well-formed auth frame", () => {
+    const result = AdminAuthFrameSchema.safeParse({
+      type: "admin_auth",
+      token: "eyJhbGciOiJFZERTQSJ9.payload.signature",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.type).toBe("admin_auth");
+      expect(result.data.token).toBe("eyJhbGciOiJFZERTQSJ9.payload.signature");
+    }
+  });
+
+  test("rejects frame with missing token", () => {
+    const result = AdminAuthFrameSchema.safeParse({
+      type: "admin_auth",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects frame with wrong type", () => {
+    const result = AdminAuthFrameSchema.safeParse({
+      type: "other",
+      token: "jwt-token",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("JsonRpcRequestSchema", () => {
+  test("validates a well-formed request", () => {
+    const result = JsonRpcRequestSchema.safeParse({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "session.list",
+      params: { limit: 10 },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.jsonrpc).toBe("2.0");
+      expect(result.data.id).toBe(1);
+      expect(result.data.method).toBe("session.list");
+      expect(result.data.params).toEqual({ limit: 10 });
+    }
+  });
+
+  test("accepts string id", () => {
+    const result = JsonRpcRequestSchema.safeParse({
+      jsonrpc: "2.0",
+      id: "abc-123",
+      method: "session.list",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.id).toBe("abc-123");
+    }
+  });
+
+  test("defaults params to empty object when omitted", () => {
+    const result = JsonRpcRequestSchema.safeParse({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "session.list",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.params).toEqual({});
+    }
+  });
+
+  test("rejects missing jsonrpc version", () => {
+    const result = JsonRpcRequestSchema.safeParse({
+      id: 1,
+      method: "session.list",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects wrong jsonrpc version", () => {
+    const result = JsonRpcRequestSchema.safeParse({
+      jsonrpc: "1.0",
+      id: 1,
+      method: "session.list",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("JsonRpcSuccessSchema", () => {
+  test("validates a success response", () => {
+    const result = JsonRpcSuccessSchema.safeParse({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { ok: true, data: [], meta: {} },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.id).toBe(1);
+    }
+  });
+});
+
+describe("JsonRpcErrorSchema", () => {
+  test("validates an error response", () => {
+    const result = JsonRpcErrorSchema.safeParse({
+      jsonrpc: "2.0",
+      id: 1,
+      error: {
+        code: -32600,
+        message: "Invalid Request",
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.error.code).toBe(-32600);
+      expect(result.data.error.message).toBe("Invalid Request");
+    }
+  });
+
+  test("validates error with data field", () => {
+    const result = JsonRpcErrorSchema.safeParse({
+      jsonrpc: "2.0",
+      id: 1,
+      error: {
+        code: -32000,
+        message: "Server error",
+        data: { detail: "something broke" },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.error.data).toEqual({ detail: "something broke" });
+    }
+  });
+});
+
+describe("JsonRpcNotificationSchema", () => {
+  test("validates a notification (no id)", () => {
+    const result = JsonRpcNotificationSchema.safeParse({
+      jsonrpc: "2.0",
+      method: "stream.data",
+      params: { content: "hello" },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.method).toBe("stream.data");
+    }
+  });
+});

--- a/packages/cli/src/__tests__/admin-socket.test.ts
+++ b/packages/cli/src/__tests__/admin-socket.test.ts
@@ -1,0 +1,312 @@
+import { describe, test, expect, afterEach, beforeAll } from "bun:test";
+import { Result } from "better-result";
+import { z } from "zod";
+import {
+  createActionRegistry,
+  type ActionSpec,
+  type SignerProvider,
+} from "@xmtp-broker/contracts";
+import {
+  AuthError,
+  InternalError,
+  PermissionError,
+  type BrokerError,
+} from "@xmtp-broker/schemas";
+import { createAdminServer, type AdminServer } from "../admin/server.js";
+import { createAdminClient, type AdminClient } from "../admin/client.js";
+import { createAdminDispatcher } from "../admin/dispatcher.js";
+import type { AdminJwtPayload } from "../admin/protocol.js";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Unix socket paths are limited to ~104 chars on macOS.
+// Keep test paths short to avoid ENAMETOOLONG.
+let testCounter = 0;
+const TEST_SOCKET_DIR = join(tmpdir(), "xb-test");
+
+beforeAll(() => {
+  mkdirSync(TEST_SOCKET_DIR, { recursive: true });
+});
+
+function testSocketPath(): string {
+  testCounter++;
+  return join(TEST_SOCKET_DIR, `s${Date.now()}-${testCounter}.sock`);
+}
+
+/** Minimal mock key manager for testing. */
+function makeKeyManager(opts?: { rejectAuth?: boolean }) {
+  return {
+    admin: {
+      async verifyJwt(
+        token: string,
+      ): Promise<Result<AdminJwtPayload, InstanceType<typeof AuthError>>> {
+        if (opts?.rejectAuth || token === "invalid-jwt") {
+          return Result.err(AuthError.create("Invalid token"));
+        }
+        return Result.ok({
+          iss: "test-fingerprint",
+          sub: "admin" as const,
+          iat: Math.floor(Date.now() / 1000),
+          exp: Math.floor(Date.now() / 1000) + 120,
+          jti: "test-jti",
+        });
+      },
+    },
+  };
+}
+
+/** Stub SignerProvider that errors if called (admin handlers don't use it). */
+function makeStubSignerProvider(): SignerProvider {
+  const err = () =>
+    Result.err(InternalError.create("Not available in admin context"));
+  return {
+    sign: async () => err(),
+    getPublicKey: async () => err(),
+    getFingerprint: async () => err(),
+    getDbEncryptionKey: async () => err(),
+    getXmtpIdentityKey: async () => err(),
+  };
+}
+
+function makeTestSpec(
+  id: string,
+  handler: ActionSpec<unknown, unknown, BrokerError>["handler"],
+  rpcMethod?: string,
+): ActionSpec<unknown, unknown, BrokerError> {
+  return {
+    id,
+    handler,
+    input: z.object({}).passthrough(),
+    cli: {
+      command: id.replace(/\./g, ":"),
+      rpcMethod,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test state
+// ---------------------------------------------------------------------------
+
+let server: AdminServer | undefined;
+let client: AdminClient | undefined;
+
+afterEach(async () => {
+  if (client) {
+    await client.close();
+    client = undefined;
+  }
+  if (server) {
+    await server.stop();
+    server = undefined;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AdminSocket round-trip", () => {
+  test("server starts and listens on Unix socket", async () => {
+    const socketPath = testSocketPath();
+    const registry = createActionRegistry();
+    const dispatcher = createAdminDispatcher(registry);
+
+    server = createAdminServer(
+      { socketPath, authMode: "admin-key" },
+      {
+        keyManager: makeKeyManager(),
+        dispatcher,
+        brokerId: "test-broker",
+        signerProvider: makeStubSignerProvider(),
+      },
+    );
+
+    const result = await server.start();
+    expect(result.isOk()).toBe(true);
+    expect(server.state).toBe("listening");
+
+    // Server being in "listening" state confirms the socket is bound
+    expect(server.state).toBe("listening");
+  });
+
+  test("client connects, authenticates, sends request, gets response", async () => {
+    const socketPath = testSocketPath();
+    const registry = createActionRegistry();
+    const spec = makeTestSpec(
+      "broker.status",
+      async () =>
+        Result.ok({
+          state: "running",
+          uptime: 123,
+        }),
+      "broker.status",
+    );
+    registry.register(spec);
+    const dispatcher = createAdminDispatcher(registry);
+
+    server = createAdminServer(
+      { socketPath, authMode: "admin-key" },
+      {
+        keyManager: makeKeyManager(),
+        dispatcher,
+        brokerId: "test-broker",
+        signerProvider: makeStubSignerProvider(),
+      },
+    );
+    await server.start();
+
+    client = createAdminClient(socketPath);
+    const connectResult = await client.connect("valid-jwt-token");
+    expect(connectResult.isOk()).toBe(true);
+
+    const response = await client.request<{
+      state: string;
+      uptime: number;
+    }>("broker.status");
+    expect(response.isOk()).toBe(true);
+    if (response.isOk()) {
+      expect(response.value.state).toBe("running");
+      expect(response.value.uptime).toBe(123);
+    }
+  });
+
+  test("invalid JWT is rejected", async () => {
+    const socketPath = testSocketPath();
+    const registry = createActionRegistry();
+    const dispatcher = createAdminDispatcher(registry);
+
+    server = createAdminServer(
+      { socketPath, authMode: "admin-key" },
+      {
+        keyManager: makeKeyManager(),
+        dispatcher,
+        brokerId: "test-broker",
+        signerProvider: makeStubSignerProvider(),
+      },
+    );
+    await server.start();
+
+    client = createAdminClient(socketPath);
+    const connectResult = await client.connect("invalid-jwt");
+    expect(connectResult.isOk()).toBe(false);
+  });
+
+  test("multiple sequential requests work", async () => {
+    const socketPath = testSocketPath();
+    const registry = createActionRegistry();
+
+    let callCount = 0;
+    const spec = makeTestSpec(
+      "session.list",
+      async () => {
+        callCount++;
+        return Result.ok({ count: callCount });
+      },
+      "session.list",
+    );
+    registry.register(spec);
+    const dispatcher = createAdminDispatcher(registry);
+
+    server = createAdminServer(
+      { socketPath, authMode: "admin-key" },
+      {
+        keyManager: makeKeyManager(),
+        dispatcher,
+        brokerId: "test-broker",
+        signerProvider: makeStubSignerProvider(),
+      },
+    );
+    await server.start();
+
+    client = createAdminClient(socketPath);
+    await client.connect("valid-jwt-token");
+
+    const r1 = await client.request<{ count: number }>("session.list");
+    expect(r1.isOk()).toBe(true);
+    if (r1.isOk()) {
+      expect(r1.value.count).toBe(1);
+    }
+
+    const r2 = await client.request<{ count: number }>("session.list");
+    expect(r2.isOk()).toBe(true);
+    if (r2.isOk()) {
+      expect(r2.value.count).toBe(2);
+    }
+  });
+
+  test("client preserves structured broker errors from JSON-RPC failures", async () => {
+    const socketPath = testSocketPath();
+    const registry = createActionRegistry();
+    const spec = makeTestSpec(
+      "message.send",
+      async () =>
+        Result.err(
+          PermissionError.create("Operation denied", {
+            grant: "messaging.send",
+          }),
+        ),
+      "message.send",
+    );
+    registry.register(spec);
+    const dispatcher = createAdminDispatcher(registry);
+
+    server = createAdminServer(
+      { socketPath, authMode: "admin-key" },
+      {
+        keyManager: makeKeyManager(),
+        dispatcher,
+        brokerId: "test-broker",
+        signerProvider: makeStubSignerProvider(),
+      },
+    );
+    await server.start();
+
+    client = createAdminClient(socketPath);
+    await client.connect("valid-jwt-token");
+
+    const response = await client.request("message.send", {
+      groupId: "g1",
+    });
+
+    expect(response.isErr()).toBe(true);
+    if (response.isOk()) {
+      return;
+    }
+    expect(response.error._tag).toBe("PermissionError");
+    expect(response.error.category).toBe("permission");
+    expect(response.error.message).toBe("Operation denied");
+    expect(response.error.context).toEqual({ grant: "messaging.send" });
+  });
+
+  test("server stop cleans up socket file", async () => {
+    const socketPath = testSocketPath();
+    const registry = createActionRegistry();
+    const dispatcher = createAdminDispatcher(registry);
+
+    server = createAdminServer(
+      { socketPath, authMode: "admin-key" },
+      {
+        keyManager: makeKeyManager(),
+        dispatcher,
+        brokerId: "test-broker",
+        signerProvider: makeStubSignerProvider(),
+      },
+    );
+    await server.start();
+    expect(server.state).toBe("listening");
+
+    const stopResult = await server.stop();
+    expect(stopResult.isOk()).toBe(true);
+    expect(server.state).toBe("stopped");
+
+    // Socket file should be cleaned up
+    const exists = await Bun.file(socketPath).exists();
+    expect(exists).toBe(false);
+  });
+});

--- a/packages/cli/src/admin/client.ts
+++ b/packages/cli/src/admin/client.ts
@@ -1,0 +1,436 @@
+import { Result } from "better-result";
+import {
+  AuthError,
+  CancelledError,
+  GrantDeniedError,
+  InternalError,
+  NetworkError,
+  NotFoundError,
+  PermissionError,
+  SessionExpiredError,
+  TimeoutError,
+  ValidationError,
+  type ActionError,
+  type BrokerError,
+} from "@xmtp-broker/schemas";
+import { JSON_RPC_ERRORS } from "./protocol.js";
+
+/**
+ * Client for communicating with the AdminServer over a Unix domain socket.
+ * Sends an auth frame first, then JSON-RPC 2.0 requests.
+ */
+export interface AdminClient {
+  connect(token: string): Promise<Result<void, AuthError | InternalError>>;
+  request<T>(
+    method: string,
+    params?: Record<string, unknown>,
+  ): Promise<Result<T, BrokerError>>;
+  close(): Promise<void>;
+}
+
+type PendingRequest = {
+  resolve: (value: unknown) => void;
+  reject: (error: BrokerError) => void;
+};
+
+type SocketHandle = {
+  write(data: string | Uint8Array): number;
+  end(): void;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isBrokerError(value: unknown): value is BrokerError {
+  return (
+    isRecord(value) &&
+    typeof value["_tag"] === "string" &&
+    typeof value["code"] === "number" &&
+    typeof value["category"] === "string" &&
+    "context" in value
+  );
+}
+
+function toBrokerErrorFromActionError(error: ActionError): BrokerError {
+  const context = error.context ?? undefined;
+
+  switch (error._tag) {
+    case "ValidationError":
+      return new ValidationError(error.message, {
+        field:
+          typeof context?.["field"] === "string" ? context["field"] : "params",
+        reason:
+          typeof context?.["reason"] === "string"
+            ? context["reason"]
+            : error.message,
+        ...context,
+      });
+    case "NotFoundError":
+      return new NotFoundError(error.message, {
+        resourceType:
+          typeof context?.["resourceType"] === "string"
+            ? context["resourceType"]
+            : "resource",
+        resourceId:
+          typeof context?.["resourceId"] === "string"
+            ? context["resourceId"]
+            : error.message,
+        ...context,
+      });
+    case "PermissionError":
+      return new PermissionError(error.message, context ?? null);
+    case "GrantDeniedError":
+      if (
+        typeof context?.["operation"] === "string" &&
+        typeof context?.["grantType"] === "string"
+      ) {
+        return new GrantDeniedError(error.message, {
+          operation: context["operation"],
+          grantType: context["grantType"],
+          ...context,
+        });
+      }
+      return new PermissionError(error.message, context ?? null);
+    case "AuthError":
+      return new AuthError(error.message, context ?? null);
+    case "SessionExpiredError":
+      return new SessionExpiredError(error.message, {
+        sessionId:
+          typeof context?.["sessionId"] === "string"
+            ? context["sessionId"]
+            : "unknown",
+        ...context,
+      });
+    case "TimeoutError":
+      return new TimeoutError(error.message, {
+        operation:
+          typeof context?.["operation"] === "string"
+            ? context["operation"]
+            : "request",
+        timeoutMs:
+          typeof context?.["timeoutMs"] === "number" ? context["timeoutMs"] : 0,
+        ...context,
+      });
+    case "CancelledError":
+      return CancelledError.create(error.message);
+    case "NetworkError":
+      return new NetworkError(error.message, {
+        endpoint:
+          typeof context?.["endpoint"] === "string"
+            ? context["endpoint"]
+            : "admin-socket",
+        reason:
+          typeof context?.["reason"] === "string"
+            ? context["reason"]
+            : error.message,
+        ...context,
+      });
+    default:
+      return new InternalError(error.message, context ?? null);
+  }
+}
+
+function toBrokerErrorFromJsonRpc(error: {
+  code: number;
+  message: string;
+  data?: unknown;
+}): BrokerError {
+  if (
+    isRecord(error.data) &&
+    typeof error.data["_tag"] === "string" &&
+    typeof error.data["category"] === "string" &&
+    typeof error.data["message"] === "string" &&
+    ("context" in error.data
+      ? error.data["context"] === null || isRecord(error.data["context"])
+      : true)
+  ) {
+    return toBrokerErrorFromActionError({
+      _tag: error.data["_tag"],
+      category: error.data["category"] as ActionError["category"],
+      message: error.data["message"],
+      context:
+        ("context" in error.data
+          ? (error.data["context"] as ActionError["context"])
+          : null) ?? null,
+    });
+  }
+
+  switch (error.code) {
+    case JSON_RPC_ERRORS.AUTH_FAILED:
+      return AuthError.create(error.message);
+    case JSON_RPC_ERRORS.PERMISSION_DENIED:
+      return PermissionError.create(error.message);
+    case JSON_RPC_ERRORS.NOT_FOUND:
+    case JSON_RPC_ERRORS.METHOD_NOT_FOUND:
+      return NotFoundError.create("Method", error.message);
+    case JSON_RPC_ERRORS.INVALID_PARAMS:
+    case JSON_RPC_ERRORS.INVALID_REQUEST:
+    case JSON_RPC_ERRORS.PARSE_ERROR:
+      return ValidationError.create("rpc", error.message);
+    default:
+      return InternalError.create(error.message);
+  }
+}
+
+function normalizeUnknownError(error: unknown): BrokerError {
+  if (isBrokerError(error)) {
+    return error;
+  }
+  if (error instanceof Error) {
+    return InternalError.create(error.message);
+  }
+  return InternalError.create(String(error));
+}
+
+/**
+ * Create an AdminClient that connects to the admin Unix socket,
+ * authenticates with a JWT, and sends JSON-RPC 2.0 requests.
+ */
+export function createAdminClient(socketPath: string): AdminClient {
+  let socket: SocketHandle | undefined;
+  let nextId = 1;
+  let buffer = "";
+  const pending = new Map<string, PendingRequest>();
+
+  function rejectAll(error: BrokerError): void {
+    for (const request of pending.values()) {
+      request.reject(error);
+    }
+    pending.clear();
+  }
+
+  function processLine(line: string): void {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      return;
+    }
+
+    if (!isRecord(parsed)) {
+      return;
+    }
+
+    const resultField = parsed["result"];
+    if (
+      parsed["id"] === undefined &&
+      isRecord(resultField) &&
+      resultField["authenticated"] === true
+    ) {
+      const authRequest = pending.get("auth");
+      if (authRequest !== undefined) {
+        pending.delete("auth");
+        authRequest.resolve(undefined);
+      }
+      return;
+    }
+
+    if (
+      (parsed["id"] === undefined || parsed["id"] === null) &&
+      isRecord(parsed["error"])
+    ) {
+      const authRequest = pending.get("auth");
+      if (authRequest !== undefined) {
+        pending.delete("auth");
+        authRequest.reject(
+          toBrokerErrorFromJsonRpc({
+            code:
+              typeof parsed["error"]["code"] === "number"
+                ? parsed["error"]["code"]
+                : JSON_RPC_ERRORS.AUTH_FAILED,
+            message:
+              typeof parsed["error"]["message"] === "string"
+                ? parsed["error"]["message"]
+                : "Authentication failed",
+            data: parsed["error"]["data"],
+          }),
+        );
+      }
+      return;
+    }
+
+    if (parsed["id"] === undefined) {
+      return;
+    }
+
+    const pendingRequest = pending.get(String(parsed["id"]));
+    if (pendingRequest === undefined) {
+      return;
+    }
+    pending.delete(String(parsed["id"]));
+
+    if (isRecord(parsed["error"])) {
+      pendingRequest.reject(
+        toBrokerErrorFromJsonRpc({
+          code:
+            typeof parsed["error"]["code"] === "number"
+              ? parsed["error"]["code"]
+              : JSON_RPC_ERRORS.INTERNAL_ERROR,
+          message:
+            typeof parsed["error"]["message"] === "string"
+              ? parsed["error"]["message"]
+              : "RPC error",
+          data: parsed["error"]["data"],
+        }),
+      );
+      return;
+    }
+
+    pendingRequest.resolve(parsed["result"]);
+  }
+
+  return {
+    async connect(
+      token: string,
+    ): Promise<Result<void, AuthError | InternalError>> {
+      try {
+        const authPromise = new Promise<void>((resolve, reject) => {
+          pending.set("auth", {
+            resolve: resolve as (value: unknown) => void,
+            reject: reject as (error: BrokerError) => void,
+          });
+        });
+
+        socket = await Bun.connect({
+          unix: socketPath,
+          socket: {
+            data(_socket, data) {
+              buffer += new TextDecoder().decode(data);
+
+              let newlineIndex = buffer.indexOf("\n");
+              while (newlineIndex !== -1) {
+                const line = buffer.slice(0, newlineIndex).trim();
+                buffer = buffer.slice(newlineIndex + 1);
+
+                if (line.length > 0) {
+                  processLine(line);
+                }
+
+                newlineIndex = buffer.indexOf("\n");
+              }
+            },
+            error(_socket, error) {
+              rejectAll(
+                InternalError.create(
+                  error instanceof Error ? error.message : String(error),
+                ),
+              );
+            },
+            close() {
+              rejectAll(InternalError.create("Connection closed"));
+            },
+            open() {},
+          },
+        });
+
+        socket.write(
+          JSON.stringify({
+            type: "admin_auth",
+            token,
+          }) + "\n",
+        );
+
+        await authPromise;
+        return Result.ok(undefined);
+      } catch (error) {
+        // Close and nullify socket on failure to prevent writes
+        // to an unauthenticated connection
+        if (socket !== undefined) {
+          try {
+            socket.end();
+          } catch {
+            // Ignore close errors during error handling
+          }
+          socket = undefined;
+        }
+
+        const brokerError = normalizeUnknownError(error);
+        if (brokerError.category === "auth") {
+          return Result.err(AuthError.create(brokerError.message));
+        }
+        return Result.err(
+          InternalError.create("Failed to connect to admin socket", {
+            cause: brokerError.message,
+          }),
+        );
+      }
+    },
+
+    async request<T>(
+      method: string,
+      params?: Record<string, unknown>,
+    ): Promise<Result<T, BrokerError>> {
+      if (socket === undefined) {
+        return Result.err(
+          InternalError.create("Not connected to admin socket"),
+        );
+      }
+
+      const id = nextId++;
+
+      try {
+        const responsePromise = new Promise<unknown>((resolve, reject) => {
+          pending.set(String(id), {
+            resolve,
+            reject: reject as (error: BrokerError) => void,
+          });
+        });
+
+        socket.write(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id,
+            method,
+            params: params ?? {},
+          }) + "\n",
+        );
+
+        const response = await responsePromise;
+
+        if (
+          isRecord(response) &&
+          response["ok"] === true &&
+          "data" in response
+        ) {
+          return Result.ok(response["data"] as T);
+        }
+
+        if (
+          isRecord(response) &&
+          response["ok"] === false &&
+          isRecord(response["error"]) &&
+          typeof response["error"]["_tag"] === "string" &&
+          typeof response["error"]["category"] === "string" &&
+          typeof response["error"]["message"] === "string"
+        ) {
+          return Result.err(
+            toBrokerErrorFromActionError({
+              _tag: response["error"]["_tag"],
+              category: response["error"][
+                "category"
+              ] as ActionError["category"],
+              message: response["error"]["message"],
+              context: isRecord(response["error"]["context"])
+                ? response["error"]["context"]
+                : response["error"]["context"] === null
+                  ? null
+                  : null,
+            }),
+          );
+        }
+
+        return Result.ok(response as T);
+      } catch (error) {
+        return Result.err(normalizeUnknownError(error));
+      }
+    },
+
+    async close(): Promise<void> {
+      if (socket !== undefined) {
+        socket.end();
+        socket = undefined;
+      }
+    },
+  };
+}

--- a/packages/cli/src/admin/dispatcher.ts
+++ b/packages/cli/src/admin/dispatcher.ts
@@ -1,0 +1,120 @@
+import type {
+  ActionRegistry,
+  ActionResult,
+  ActionSpec,
+  HandlerContext,
+} from "@xmtp-broker/contracts";
+import { toActionResult } from "@xmtp-broker/contracts";
+import type { BrokerError, ActionResultMeta } from "@xmtp-broker/schemas";
+import { InternalError, NotFoundError, ValidationError } from "@xmtp-broker/schemas";
+import { Result } from "better-result";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Dispatches JSON-RPC method calls to ActionSpec handlers via the
+ * shared ActionRegistry. Maps RPC method names to ActionSpecs using
+ * CliSurface.rpcMethod (or derives from CliSurface.command).
+ */
+export interface AdminDispatcher {
+  dispatch(
+    method: string,
+    params: Record<string, unknown>,
+    ctx: HandlerContext,
+  ): Promise<ActionResult<unknown>>;
+  hasMethod(method: string): boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a lookup map from RPC method name to ActionSpec.
+ * If rpcMethod is not set, derive it from command by replacing : with .
+ */
+function buildMethodMap(
+  registry: ActionRegistry,
+): Map<string, ActionSpec<unknown, unknown, BrokerError>> {
+  const map = new Map<string, ActionSpec<unknown, unknown, BrokerError>>();
+
+  for (const spec of registry.listForSurface("cli")) {
+    const cli = spec.cli;
+    if (cli === undefined) continue;
+
+    const rpcMethod = cli.rpcMethod ?? cli.command.replace(/:/g, ".");
+    map.set(rpcMethod, spec);
+  }
+
+  return map;
+}
+
+function makeMeta(ctx: HandlerContext, startMs: number): ActionResultMeta {
+  return {
+    requestId: ctx.requestId,
+    timestamp: new Date().toISOString(),
+    durationMs: Date.now() - startMs,
+  };
+}
+
+/**
+ * Create an AdminDispatcher that routes JSON-RPC methods to ActionSpecs
+ * via the shared ActionRegistry.
+ */
+export function createAdminDispatcher(
+  registry: ActionRegistry,
+): AdminDispatcher {
+  const methodMap = buildMethodMap(registry);
+
+  return {
+    async dispatch(
+      method: string,
+      params: Record<string, unknown>,
+      ctx: HandlerContext,
+    ): Promise<ActionResult<unknown>> {
+      const startMs = Date.now();
+      const spec = methodMap.get(method);
+
+      if (spec === undefined) {
+        return toActionResult(
+          Result.err(NotFoundError.create("Method", method)),
+          makeMeta(ctx, startMs),
+        );
+      }
+
+      // Validate input against spec's Zod schema
+      const parseResult = spec.input.safeParse(params);
+      if (!parseResult.success) {
+        const issues = parseResult.error.issues
+          .map((i) => `${i.path.join(".")}: ${i.message}`)
+          .join("; ");
+        return toActionResult(
+          Result.err(ValidationError.create("params", issues)),
+          makeMeta(ctx, startMs),
+        );
+      }
+
+      // Call the handler -- catch unexpected throws and wrap as InternalError
+      let result: Awaited<ReturnType<typeof spec.handler>>;
+      try {
+        result = await spec.handler(parseResult.data, ctx);
+      } catch (thrown: unknown) {
+        const message =
+          thrown instanceof Error ? thrown.message : String(thrown);
+        return toActionResult(
+          Result.err(
+            InternalError.create(`Handler threw: ${message}`),
+          ),
+          makeMeta(ctx, startMs),
+        );
+      }
+      return toActionResult(result, makeMeta(ctx, startMs));
+    },
+
+    hasMethod(method: string): boolean {
+      return methodMap.has(method);
+    },
+  };
+}

--- a/packages/cli/src/admin/protocol.ts
+++ b/packages/cli/src/admin/protocol.ts
@@ -1,0 +1,142 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Admin auth frame (client -> server, first message)
+// ---------------------------------------------------------------------------
+
+export type AdminAuthFrame = {
+  type: "admin_auth";
+  token: string;
+};
+
+/**
+ * Admin authentication frame sent as the first message on a new connection.
+ * The token is an EdDSA-signed JWT from the admin key (spec 12).
+ */
+export const AdminAuthFrameSchema: z.ZodType<AdminAuthFrame> = z
+  .object({
+    type: z.literal("admin_auth"),
+    token: z.string().describe("Admin JWT (EdDSA-signed, from spec 12)"),
+  })
+  .describe("Admin authentication frame");
+
+// ---------------------------------------------------------------------------
+// JSON-RPC 2.0 request
+// ---------------------------------------------------------------------------
+
+export type JsonRpcRequest = {
+  jsonrpc: "2.0";
+  id: number | string;
+  method: string;
+  params: Record<string, unknown>;
+};
+
+/**
+ * JSON-RPC 2.0 request. Sent by the client after authentication.
+ */
+export const JsonRpcRequestSchema: z.ZodType<
+  JsonRpcRequest,
+  z.ZodTypeDef,
+  {
+    jsonrpc: "2.0";
+    id: number | string;
+    method: string;
+    params?: Record<string, unknown> | undefined;
+  }
+> = z.object({
+  jsonrpc: z.literal("2.0"),
+  id: z.union([z.number(), z.string()]),
+  method: z.string(),
+  params: z.record(z.string(), z.unknown()).default({}),
+});
+
+// ---------------------------------------------------------------------------
+// JSON-RPC 2.0 success response
+// ---------------------------------------------------------------------------
+
+export type JsonRpcSuccess = {
+  jsonrpc: "2.0";
+  id: number | string;
+  result?: unknown;
+};
+
+/**
+ * JSON-RPC 2.0 success response. Server -> client.
+ */
+export const JsonRpcSuccessSchema: z.ZodType<JsonRpcSuccess> = z.object({
+  jsonrpc: z.literal("2.0"),
+  id: z.union([z.number(), z.string()]),
+  result: z.unknown(),
+});
+
+// ---------------------------------------------------------------------------
+// JSON-RPC 2.0 error response
+// ---------------------------------------------------------------------------
+
+export type JsonRpcErrorDetail = {
+  code: number;
+  message: string;
+  data?: unknown;
+};
+
+export type JsonRpcError = {
+  jsonrpc: "2.0";
+  id: number | string | null;
+  error: JsonRpcErrorDetail;
+};
+
+/**
+ * JSON-RPC 2.0 error response. Server -> client.
+ */
+export const JsonRpcErrorSchema: z.ZodType<JsonRpcError> = z.object({
+  jsonrpc: z.literal("2.0"),
+  id: z.union([z.number(), z.string(), z.null()]),
+  error: z.object({
+    code: z.number(),
+    message: z.string(),
+    data: z.unknown().optional(),
+  }),
+});
+
+// ---------------------------------------------------------------------------
+// JSON-RPC 2.0 notification (streaming)
+// ---------------------------------------------------------------------------
+
+export type JsonRpcNotification = {
+  jsonrpc: "2.0";
+  method: string;
+  params?: Record<string, unknown> | undefined;
+};
+
+/**
+ * JSON-RPC 2.0 notification (no id, no response expected).
+ * Used for streaming responses.
+ */
+export const JsonRpcNotificationSchema: z.ZodType<JsonRpcNotification> =
+  z.object({
+    jsonrpc: z.literal("2.0"),
+    method: z.string(),
+    params: z.record(z.string(), z.unknown()).optional(),
+  });
+
+// ---------------------------------------------------------------------------
+// JSON-RPC error codes
+// ---------------------------------------------------------------------------
+
+/** Standard JSON-RPC 2.0 error codes and broker extensions. */
+export const JSON_RPC_ERRORS = {
+  PARSE_ERROR: -32700,
+  INVALID_REQUEST: -32600,
+  METHOD_NOT_FOUND: -32601,
+  INVALID_PARAMS: -32602,
+  INTERNAL_ERROR: -32603,
+  /** Custom: authentication failed. */
+  AUTH_FAILED: -32000,
+  /** Custom: permission denied. */
+  PERMISSION_DENIED: -32001,
+  /** Custom: not found. */
+  NOT_FOUND: -32002,
+} as const;
+
+// Re-export the AdminJwtPayload type for convenience
+export type { AdminJwtPayload } from "@xmtp-broker/keys";

--- a/packages/cli/src/admin/server.ts
+++ b/packages/cli/src/admin/server.ts
@@ -1,0 +1,327 @@
+import { Result } from "better-result";
+import {
+  InternalError,
+  AuthError,
+  type ValidationError,
+} from "@xmtp-broker/schemas";
+import type { HandlerContext } from "@xmtp-broker/contracts";
+import type { AdminDispatcher } from "./dispatcher.js";
+import {
+  AdminAuthFrameSchema,
+  JsonRpcRequestSchema,
+  JSON_RPC_ERRORS,
+  type AdminJwtPayload,
+} from "./protocol.js";
+import type { AdminServerConfig } from "../config/schema.js";
+import { existsSync, unlinkSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AdminServer {
+  start(): Promise<Result<void, InternalError>>;
+  stop(): Promise<Result<void, InternalError>>;
+  readonly state: "idle" | "listening" | "stopped";
+}
+
+export interface AdminServerDeps {
+  readonly keyManager: {
+    admin: {
+      verifyJwt(
+        token: string,
+      ): Promise<Result<AdminJwtPayload, AuthError | ValidationError>>;
+    };
+  };
+  readonly dispatcher: AdminDispatcher;
+  readonly brokerId: string;
+  readonly signerProvider: HandlerContext["signerProvider"];
+}
+
+// ---------------------------------------------------------------------------
+// Per-connection state
+// ---------------------------------------------------------------------------
+
+interface ConnectionState {
+  authenticated: boolean;
+  adminFingerprint: string | null;
+  buffer: string;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an AdminServer that listens on a Unix domain socket,
+ * authenticates via admin JWT, and dispatches JSON-RPC 2.0 requests
+ * through the AdminDispatcher.
+ */
+export function createAdminServer(
+  config: AdminServerConfig,
+  deps: AdminServerDeps,
+): AdminServer {
+  let serverState: "idle" | "listening" | "stopped" = "idle";
+  let listener: ReturnType<typeof Bun.listen> | undefined;
+  const socketPath = config.socketPath ?? "/tmp/xmtp-broker/admin.sock";
+
+  const connectionStates = new WeakMap<object, ConnectionState>();
+
+  function getOrCreateState(socket: object): ConnectionState {
+    let state = connectionStates.get(socket);
+    if (state === undefined) {
+      state = {
+        authenticated: false,
+        adminFingerprint: null,
+        buffer: "",
+      };
+      connectionStates.set(socket, state);
+    }
+    return state;
+  }
+
+  function makeJsonRpcError(
+    id: number | string | null,
+    code: number,
+    message: string,
+    data?: unknown,
+  ): string {
+    const response: Record<string, unknown> = {
+      jsonrpc: "2.0",
+      id,
+      error: { code, message, ...(data !== undefined ? { data } : {}) },
+    };
+    return JSON.stringify(response) + "\n";
+  }
+
+  function makeJsonRpcSuccess(id: number | string, result: unknown): string {
+    return (
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id,
+        result,
+      }) + "\n"
+    );
+  }
+
+  function makeHandlerContext(fingerprint: string): HandlerContext {
+    return {
+      brokerId: deps.brokerId,
+      signerProvider: deps.signerProvider,
+      requestId: crypto.randomUUID(),
+      signal: AbortSignal.timeout(30_000),
+      adminAuth: { adminKeyFingerprint: fingerprint },
+    };
+  }
+
+  async function handleLine(
+    socket: { write(data: string | Uint8Array): number },
+    line: string,
+    connState: ConnectionState,
+  ): Promise<void> {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      socket.write(
+        makeJsonRpcError(null, JSON_RPC_ERRORS.PARSE_ERROR, "Parse error"),
+      );
+      return;
+    }
+
+    // First message must be auth frame
+    if (!connState.authenticated) {
+      const authResult = AdminAuthFrameSchema.safeParse(parsed);
+      if (!authResult.success) {
+        socket.write(
+          makeJsonRpcError(
+            null,
+            JSON_RPC_ERRORS.AUTH_FAILED,
+            "Expected admin_auth frame as first message",
+          ),
+        );
+        return;
+      }
+
+      const verifyResult = await deps.keyManager.admin.verifyJwt(
+        authResult.data.token,
+      );
+      if (Result.isError(verifyResult)) {
+        socket.write(
+          makeJsonRpcError(
+            null,
+            JSON_RPC_ERRORS.AUTH_FAILED,
+            verifyResult.error.message,
+          ),
+        );
+        return;
+      }
+
+      connState.authenticated = true;
+      connState.adminFingerprint = verifyResult.value.iss;
+      // Send auth success acknowledgment
+      socket.write(
+        JSON.stringify({ jsonrpc: "2.0", result: { authenticated: true } }) +
+          "\n",
+      );
+      return;
+    }
+
+    // Authenticated: expect JSON-RPC request
+    const rpcResult = JsonRpcRequestSchema.safeParse(parsed);
+    if (!rpcResult.success) {
+      socket.write(
+        makeJsonRpcError(
+          null,
+          JSON_RPC_ERRORS.INVALID_REQUEST,
+          "Invalid JSON-RPC request",
+        ),
+      );
+      return;
+    }
+
+    const request = rpcResult.data;
+    if (!deps.dispatcher.hasMethod(request.method)) {
+      socket.write(
+        makeJsonRpcError(
+          request.id,
+          JSON_RPC_ERRORS.METHOD_NOT_FOUND,
+          `Method '${request.method}' not found`,
+        ),
+      );
+      return;
+    }
+
+    const ctx = makeHandlerContext(connState.adminFingerprint ?? "");
+
+    const actionResult = await deps.dispatcher.dispatch(
+      request.method,
+      request.params,
+      ctx,
+    );
+
+    if (actionResult.ok) {
+      socket.write(makeJsonRpcSuccess(request.id, actionResult));
+    } else {
+      const errorCode =
+        actionResult.error.category === "validation"
+          ? JSON_RPC_ERRORS.INVALID_PARAMS
+          : actionResult.error.category === "auth"
+            ? JSON_RPC_ERRORS.AUTH_FAILED
+            : actionResult.error.category === "permission"
+              ? JSON_RPC_ERRORS.PERMISSION_DENIED
+              : actionResult.error.category === "not_found"
+                ? JSON_RPC_ERRORS.NOT_FOUND
+                : JSON_RPC_ERRORS.INTERNAL_ERROR;
+
+      socket.write(
+        makeJsonRpcError(
+          request.id,
+          errorCode,
+          actionResult.error.message,
+          actionResult.error,
+        ),
+      );
+    }
+  }
+
+  return {
+    async start(): Promise<Result<void, InternalError>> {
+      if (serverState !== "idle") {
+        return Result.err(
+          InternalError.create(`Cannot start server in state '${serverState}'`),
+        );
+      }
+
+      try {
+        // Ensure directory exists
+        const dir = dirname(socketPath);
+        mkdirSync(dir, { recursive: true });
+
+        // Remove stale socket file
+        if (existsSync(socketPath)) {
+          unlinkSync(socketPath);
+        }
+
+        listener = Bun.listen({
+          unix: socketPath,
+          socket: {
+            open(socket) {
+              getOrCreateState(socket);
+            },
+            data(socket, data) {
+              const connState = getOrCreateState(socket);
+              const decoder = new TextDecoder();
+              connState.buffer += decoder.decode(data);
+
+              // Process complete lines
+              let newlineIdx = connState.buffer.indexOf("\n");
+              while (newlineIdx !== -1) {
+                const line = connState.buffer.slice(0, newlineIdx).trim();
+                connState.buffer = connState.buffer.slice(newlineIdx + 1);
+
+                if (line.length > 0) {
+                  // Fire and forget -- errors are sent as JSON-RPC errors
+                  void handleLine(socket, line, connState);
+                }
+
+                newlineIdx = connState.buffer.indexOf("\n");
+              }
+            },
+            close(_socket) {
+              // Connection state will be GC'd via WeakMap
+            },
+            error(_socket, error) {
+              // Log but don't crash -- connection will be cleaned up
+              console.error("Admin socket connection error:", error);
+            },
+          },
+        });
+
+        serverState = "listening";
+        return Result.ok(undefined);
+      } catch (e) {
+        serverState = "idle";
+        return Result.err(
+          InternalError.create("Failed to start admin server", {
+            cause: String(e),
+          }),
+        );
+      }
+    },
+
+    async stop(): Promise<Result<void, InternalError>> {
+      if (serverState !== "listening") {
+        return Result.err(
+          InternalError.create(`Cannot stop server in state '${serverState}'`),
+        );
+      }
+
+      try {
+        if (listener !== undefined) {
+          listener.stop();
+          listener = undefined;
+        }
+
+        // Clean up socket file
+        if (existsSync(socketPath)) {
+          unlinkSync(socketPath);
+        }
+
+        serverState = "stopped";
+        return Result.ok(undefined);
+      } catch (e) {
+        return Result.err(
+          InternalError.create("Failed to stop admin server", {
+            cause: String(e),
+          }),
+        );
+      }
+    },
+
+    get state() {
+      return serverState;
+    },
+  };
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,3 +24,25 @@ export { createPidFile } from "./daemon/pid.js";
 export { setupSignalHandlers } from "./daemon/signals.js";
 export type { DaemonStatus } from "./daemon/status.js";
 export { DaemonStatusSchema } from "./daemon/status.js";
+
+export type { AdminServer, AdminServerDeps } from "./admin/server.js";
+export { createAdminServer } from "./admin/server.js";
+export type { AdminClient } from "./admin/client.js";
+export { createAdminClient } from "./admin/client.js";
+export type { AdminDispatcher } from "./admin/dispatcher.js";
+export { createAdminDispatcher } from "./admin/dispatcher.js";
+export {
+  JsonRpcRequestSchema,
+  JsonRpcSuccessSchema,
+  JsonRpcErrorSchema,
+  JsonRpcNotificationSchema,
+  AdminAuthFrameSchema,
+  JSON_RPC_ERRORS,
+} from "./admin/protocol.js";
+export type {
+  JsonRpcRequest,
+  JsonRpcSuccess,
+  JsonRpcError,
+  JsonRpcNotification,
+  AdminAuthFrame,
+} from "./admin/protocol.js";


### PR DESCRIPTION
## Summary

- Adds Unix socket admin interface to `packages/cli/`: JSON-RPC 2.0 server, client, dispatcher, and protocol schemas
- This is the admin-facing counterpart to the WebSocket's harness-facing interface

## Components

- **`protocol.ts`** — Zod schemas for JSON-RPC 2.0 messages (`JsonRpcRequestSchema`, `JsonRpcSuccessSchema`, `JsonRpcErrorSchema`) and `AdminAuthFrameSchema`
- **`server.ts`** — `AdminServer` using `Bun.listen({ unix })`. Auth frame with JWT verification on connect, newline-delimited JSON-RPC dispatch.
- **`client.ts`** — `AdminClient` using `Bun.connect({ unix })`. Auto-incrementing request IDs, auth frame on connect.
- **`dispatcher.ts`** — `AdminDispatcher` wrapping `ActionRegistry`. Maps JSON-RPC method names to `ActionSpec`s via `CliSurface.rpcMethod` (or derived from `command` with `:` → `.`).

## Protocol flow

1. Client connects to Unix socket
2. Client sends auth frame: `{ type: "admin_auth", token: "<jwt>" }`
3. Server verifies JWT via `AdminKeyManager.verifyJwt()`
4. Client sends JSON-RPC requests, server dispatches to handlers via ActionRegistry

**24 tests** covering protocol schema validation, dispatcher routing, and full socket round-trip

## Spec

[`13-daemon-cli.md`](.agents/plans/v0/13-daemon-cli.md) (part 3 of 6)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)