### PR TITLE
feat(cli): 8 command groups with output formatting

### DIFF
--- a/packages/cli/src/__tests__/command-parsing.test.ts
+++ b/packages/cli/src/__tests__/command-parsing.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, test } from "bun:test";
+import { Command } from "commander";
+import { createBrokerCommands } from "../commands/broker.js";
+import { createIdentityCommands } from "../commands/identity.js";
+import { createSessionCommands } from "../commands/session.js";
+import { createGrantCommands } from "../commands/grant.js";
+import { createAttestationCommands } from "../commands/attestation.js";
+import { createMessageCommands } from "../commands/message.js";
+import { createConversationCommands } from "../commands/conversation.js";
+import { createAdminCommands } from "../commands/admin.js";
+
+function getSubcommandNames(cmd: Command): string[] {
+  return cmd.commands.map((c) => c.name());
+}
+
+function hasOption(cmd: Command, flag: string): boolean {
+  return cmd.options.some((o) => o.long === flag || o.short === flag);
+}
+
+function findSubcommand(parent: Command, name: string): Command | undefined {
+  return parent.commands.find((c) => c.name() === name);
+}
+
+describe("broker commands", () => {
+  const cmd = createBrokerCommands();
+
+  test("registers all subcommands", () => {
+    const names = getSubcommandNames(cmd);
+    expect(names).toContain("start");
+    expect(names).toContain("stop");
+    expect(names).toContain("status");
+    expect(names).toContain("config");
+  });
+
+  test("start has --daemon and --config options", () => {
+    const start = findSubcommand(cmd, "start");
+    expect(start).toBeDefined();
+    expect(hasOption(start!, "--daemon")).toBe(true);
+    expect(hasOption(start!, "--config")).toBe(true);
+  });
+
+  test("stop has --config and --timeout options", () => {
+    const stop = findSubcommand(cmd, "stop");
+    expect(stop).toBeDefined();
+    expect(hasOption(stop!, "--config")).toBe(true);
+    expect(hasOption(stop!, "--timeout")).toBe(true);
+  });
+
+  test("status has --config and --json options", () => {
+    const status = findSubcommand(cmd, "status");
+    expect(status).toBeDefined();
+    expect(hasOption(status!, "--config")).toBe(true);
+    expect(hasOption(status!, "--json")).toBe(true);
+  });
+
+  test("config has show and validate subcommands", () => {
+    const config = findSubcommand(cmd, "config");
+    expect(config).toBeDefined();
+    const configSubs = getSubcommandNames(config!);
+    expect(configSubs).toContain("show");
+    expect(configSubs).toContain("validate");
+  });
+});
+
+describe("identity commands", () => {
+  const cmd = createIdentityCommands();
+
+  test("registers all subcommands", () => {
+    const names = getSubcommandNames(cmd);
+    expect(names).toContain("init");
+    expect(names).toContain("info");
+    expect(names).toContain("rotate-keys");
+    expect(names).toContain("export-public");
+  });
+
+  test("info has --json option", () => {
+    const info = findSubcommand(cmd, "info");
+    expect(info).toBeDefined();
+    expect(hasOption(info!, "--json")).toBe(true);
+  });
+});
+
+describe("session commands", () => {
+  const cmd = createSessionCommands();
+
+  test("registers all subcommands", () => {
+    const names = getSubcommandNames(cmd);
+    expect(names).toContain("list");
+    expect(names).toContain("inspect");
+    expect(names).toContain("revoke");
+    expect(names).toContain("issue");
+  });
+
+  test("list has --config, --agent, and --json options", () => {
+    const list = findSubcommand(cmd, "list");
+    expect(list).toBeDefined();
+    expect(hasOption(list!, "--config")).toBe(true);
+    expect(hasOption(list!, "--agent")).toBe(true);
+    expect(hasOption(list!, "--json")).toBe(true);
+  });
+
+  test("revoke has --config and --reason options", () => {
+    const revoke = findSubcommand(cmd, "revoke");
+    expect(revoke).toBeDefined();
+    expect(hasOption(revoke!, "--config")).toBe(true);
+    expect(hasOption(revoke!, "--reason")).toBe(true);
+  });
+
+  test("issue has --config, --agent, --ttl, --view, --grant options", () => {
+    const issue = findSubcommand(cmd, "issue");
+    expect(issue).toBeDefined();
+    expect(hasOption(issue!, "--config")).toBe(true);
+    expect(hasOption(issue!, "--agent")).toBe(true);
+    expect(hasOption(issue!, "--ttl")).toBe(true);
+    expect(hasOption(issue!, "--view")).toBe(true);
+    expect(hasOption(issue!, "--grant")).toBe(true);
+  });
+});
+
+describe("grant commands", () => {
+  const cmd = createGrantCommands();
+
+  test("registers all subcommands", () => {
+    const names = getSubcommandNames(cmd);
+    expect(names).toContain("list");
+    expect(names).toContain("inspect");
+    expect(names).toContain("revoke");
+  });
+
+  test("list has --session filter option", () => {
+    const list = findSubcommand(cmd, "list");
+    expect(list).toBeDefined();
+    expect(hasOption(list!, "--session")).toBe(true);
+  });
+});
+
+describe("attestation commands", () => {
+  const cmd = createAttestationCommands();
+
+  test("registers all subcommands", () => {
+    const names = getSubcommandNames(cmd);
+    expect(names).toContain("list");
+    expect(names).toContain("inspect");
+    expect(names).toContain("verify");
+    expect(names).toContain("revoke");
+  });
+
+  test("list has --group and --agent filter options", () => {
+    const list = findSubcommand(cmd, "list");
+    expect(list).toBeDefined();
+    expect(hasOption(list!, "--group")).toBe(true);
+    expect(hasOption(list!, "--agent")).toBe(true);
+  });
+});
+
+describe("message commands", () => {
+  const cmd = createMessageCommands();
+
+  test("registers all subcommands", () => {
+    const names = getSubcommandNames(cmd);
+    expect(names).toContain("send");
+    expect(names).toContain("list");
+    expect(names).toContain("stream");
+  });
+
+  test("list has --limit and --before options", () => {
+    const list = findSubcommand(cmd, "list");
+    expect(list).toBeDefined();
+    expect(hasOption(list!, "--limit")).toBe(true);
+    expect(hasOption(list!, "--before")).toBe(true);
+  });
+
+  test("stream has --json option", () => {
+    const stream = findSubcommand(cmd, "stream");
+    expect(stream).toBeDefined();
+    expect(hasOption(stream!, "--json")).toBe(true);
+  });
+});
+
+describe("conversation commands", () => {
+  const cmd = createConversationCommands();
+
+  test("registers all subcommands", () => {
+    const names = getSubcommandNames(cmd);
+    expect(names).toContain("list");
+    expect(names).toContain("info");
+    expect(names).toContain("create");
+    expect(names).toContain("add-member");
+  });
+
+  test("list has --limit option", () => {
+    const list = findSubcommand(cmd, "list");
+    expect(list).toBeDefined();
+    expect(hasOption(list!, "--limit")).toBe(true);
+  });
+
+  test("create has --members option", () => {
+    const create = findSubcommand(cmd, "create");
+    expect(create).toBeDefined();
+    expect(hasOption(create!, "--members")).toBe(true);
+  });
+});
+
+describe("admin commands", () => {
+  const cmd = createAdminCommands();
+
+  test("registers all subcommands", () => {
+    const names = getSubcommandNames(cmd);
+    expect(names).toContain("verify-keys");
+    expect(names).toContain("export-state");
+    expect(names).toContain("audit-log");
+  });
+
+  test("audit-log has --limit and --since options", () => {
+    const auditLog = findSubcommand(cmd, "audit-log");
+    expect(auditLog).toBeDefined();
+    expect(hasOption(auditLog!, "--limit")).toBe(true);
+    expect(hasOption(auditLog!, "--since")).toBe(true);
+  });
+
+  test("export-state has --json option", () => {
+    const exportState = findSubcommand(cmd, "export-state");
+    expect(exportState).toBeDefined();
+    expect(hasOption(exportState!, "--json")).toBe(true);
+  });
+});
+
+describe("all commands on program", () => {
+  test("all 8 command groups are wired into the program", async () => {
+    const { program } = await import("../index.js");
+    const names = program.commands.map((c) => c.name());
+    expect(names).toContain("broker");
+    expect(names).toContain("identity");
+    expect(names).toContain("session");
+    expect(names).toContain("grant");
+    expect(names).toContain("attestation");
+    expect(names).toContain("message");
+    expect(names).toContain("conversation");
+    expect(names).toContain("admin");
+  });
+
+  test("every leaf command supports --json", () => {
+    // Collect all leaf commands (commands without subcommands)
+    function collectLeafCommands(cmd: Command): Command[] {
+      const leaves: Command[] = [];
+      for (const sub of cmd.commands) {
+        if (sub.commands.length === 0) {
+          leaves.push(sub);
+        } else {
+          leaves.push(...collectLeafCommands(sub));
+        }
+      }
+      return leaves;
+    }
+
+    const allCommands = [
+      createBrokerCommands(),
+      createIdentityCommands(),
+      createSessionCommands(),
+      createGrantCommands(),
+      createAttestationCommands(),
+      createMessageCommands(),
+      createConversationCommands(),
+      createAdminCommands(),
+    ];
+
+    for (const group of allCommands) {
+      const leaves = collectLeafCommands(group);
+      for (const leaf of leaves) {
+        // start and stop don't need --json output; config validate is special too
+        // but the spec says "all commands" so we check for it
+        const _name = `${group.name()} ${leaf.name()}`;
+        expect(hasOption(leaf, "--json")).toBe(true);
+      }
+    }
+  });
+});

--- a/packages/cli/src/__tests__/exit-codes.test.ts
+++ b/packages/cli/src/__tests__/exit-codes.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { exitCodeFromCategory } from "../output/exit-codes.js";
+
+describe("exitCodeFromCategory", () => {
+  test("maps validation to exit code from ERROR_CATEGORY_META", () => {
+    expect(exitCodeFromCategory("validation")).toBe(1);
+  });
+
+  test("maps not_found to exit code from ERROR_CATEGORY_META", () => {
+    expect(exitCodeFromCategory("not_found")).toBe(2);
+  });
+
+  test("maps permission to exit code from ERROR_CATEGORY_META", () => {
+    expect(exitCodeFromCategory("permission")).toBe(4);
+  });
+
+  test("maps auth to exit code from ERROR_CATEGORY_META", () => {
+    expect(exitCodeFromCategory("auth")).toBe(9);
+  });
+
+  test("maps internal to exit code from ERROR_CATEGORY_META", () => {
+    expect(exitCodeFromCategory("internal")).toBe(8);
+  });
+
+  test("maps timeout to exit code from ERROR_CATEGORY_META", () => {
+    expect(exitCodeFromCategory("timeout")).toBe(5);
+  });
+
+  test("maps cancelled to exit code from ERROR_CATEGORY_META", () => {
+    expect(exitCodeFromCategory("cancelled")).toBe(130);
+  });
+
+  test("maps network to exit code from ERROR_CATEGORY_META", () => {
+    expect(exitCodeFromCategory("network")).toBe(6);
+  });
+
+  test("returns internal exit code for unknown category", () => {
+    expect(
+      exitCodeFromCategory(
+        "bogus" as Parameters<typeof exitCodeFromCategory>[0],
+      ),
+    ).toBe(8);
+  });
+
+  test("success exit code is 0", () => {
+    // Importing the constant directly
+    const { EXIT_SUCCESS } = require("../output/exit-codes.js") as {
+      EXIT_SUCCESS: number;
+    };
+    expect(EXIT_SUCCESS).toBe(0);
+  });
+});

--- a/packages/cli/src/__tests__/output-formatter.test.ts
+++ b/packages/cli/src/__tests__/output-formatter.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { formatOutput, type OutputFormatter } from "../output/formatter.js";
+
+describe("formatOutput", () => {
+  test("returns JSON string when json option is true", () => {
+    const data = { name: "test", value: 42 };
+    const result = formatOutput(data, { json: true });
+    expect(result).toBe(JSON.stringify(data, null, 2));
+  });
+
+  test("returns JSON string when format is json", () => {
+    const data = [{ id: 1 }, { id: 2 }];
+    const result = formatOutput(data, { format: "json" });
+    expect(result).toBe(JSON.stringify(data, null, 2));
+  });
+
+  test("returns plain string for text format", () => {
+    const result = formatOutput("hello world", { format: "text" });
+    expect(result).toBe("hello world");
+  });
+
+  test("returns table-formatted string for array of records", () => {
+    const data = [
+      { name: "Alice", age: 30 },
+      { name: "Bob", age: 25 },
+    ];
+    const result = formatOutput(data, { format: "table" });
+    // Table should contain column headers and values
+    expect(result).toContain("name");
+    expect(result).toContain("age");
+    expect(result).toContain("Alice");
+    expect(result).toContain("Bob");
+    expect(result).toContain("30");
+    expect(result).toContain("25");
+  });
+
+  test("defaults to text format for non-array data without json flag", () => {
+    const data = { status: "running" };
+    const result = formatOutput(data, {});
+    // Without json flag, non-array data renders as key: value text
+    expect(result).toContain("status");
+    expect(result).toContain("running");
+  });
+});
+
+describe("OutputFormatter", () => {
+  let formatter: OutputFormatter;
+
+  test("json method returns pretty-printed JSON", async () => {
+    const { createOutputFormatter } = await import("../output/formatter.js");
+    formatter = createOutputFormatter();
+    const data = { key: "value" };
+    expect(formatter.json(data)).toBe(JSON.stringify(data, null, 2));
+  });
+
+  test("text method returns the message as-is", async () => {
+    const { createOutputFormatter } = await import("../output/formatter.js");
+    formatter = createOutputFormatter();
+    expect(formatter.text("hello")).toBe("hello");
+  });
+
+  test("table method formats records into aligned columns", async () => {
+    const { createOutputFormatter } = await import("../output/formatter.js");
+    formatter = createOutputFormatter();
+    const data = [
+      { id: "abc", status: "active" },
+      { id: "def", status: "expired" },
+    ];
+    const result = formatter.table(data);
+    expect(result).toContain("id");
+    expect(result).toContain("status");
+    expect(result).toContain("abc");
+    expect(result).toContain("active");
+  });
+
+  test("table with column subset only shows specified columns", async () => {
+    const { createOutputFormatter } = await import("../output/formatter.js");
+    formatter = createOutputFormatter();
+    const data = [{ id: "abc", status: "active", secret: "hidden" }];
+    const result = formatter.table(data, ["id", "status"]);
+    expect(result).toContain("id");
+    expect(result).toContain("status");
+    expect(result).not.toContain("secret");
+    expect(result).not.toContain("hidden");
+  });
+
+  test("formatNdjsonLine returns single-line JSON with newline", async () => {
+    const { formatNdjsonLine } = await import("../output/formatter.js");
+    const data = { type: "message", text: "hi" };
+    const result = formatNdjsonLine(data);
+    expect(result).toBe(JSON.stringify(data) + "\n");
+    expect(result.split("\n").length).toBe(2); // content + trailing empty
+  });
+});

--- a/packages/cli/src/commands/admin.ts
+++ b/packages/cli/src/commands/admin.ts
@@ -1,0 +1,40 @@
+import { Command } from "commander";
+
+/**
+ * Administrative operation commands. All require daemon and admin auth.
+ *
+ * - verify-keys: Verify key hierarchy integrity
+ * - export-state: Export runtime state snapshot for debugging
+ * - audit-log: Read and display the audit trail
+ */
+export function createAdminCommands(): Command {
+  const cmd = new Command("admin").description("Administrative operations");
+
+  cmd
+    .command("verify-keys")
+    .description("Verify key hierarchy integrity")
+    .option("--json", "JSON output")
+    .action(async (_options) => {
+      // Routed via AdminClient
+    });
+
+  cmd
+    .command("export-state")
+    .description("Export runtime state snapshot")
+    .option("--json", "JSON output")
+    .action(async (_options) => {
+      // Routed via AdminClient
+    });
+
+  cmd
+    .command("audit-log")
+    .description("Display audit trail")
+    .option("--limit <n>", "Maximum number of entries", "50")
+    .option("--since <timestamp>", "Filter entries after timestamp")
+    .option("--json", "JSON output")
+    .action(async (_options) => {
+      // Routed via AdminClient
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/attestation.ts
+++ b/packages/cli/src/commands/attestation.ts
@@ -1,0 +1,54 @@
+import { Command } from "commander";
+
+/**
+ * Attestation lifecycle commands. All require daemon.
+ *
+ * - list: List attestations filtered by group or agent
+ * - inspect: Show full attestation content
+ * - verify: Run 6-check verification pipeline
+ * - revoke: Revoke an attestation
+ */
+export function createAttestationCommands(): Command {
+  const cmd = new Command("attestation").description(
+    "Attestation lifecycle management",
+  );
+
+  cmd
+    .command("list")
+    .description("List attestations")
+    .option("--group <groupId>", "Filter by group ID")
+    .option("--agent <inboxId>", "Filter by agent inbox ID")
+    .option("--json", "JSON output")
+    .action(async (_options) => {
+      // Routed via AdminClient
+    });
+
+  cmd
+    .command("inspect")
+    .description("Show full attestation details")
+    .argument("<id>", "Attestation ID")
+    .option("--json", "JSON output")
+    .action(async (_id, _options) => {
+      // Routed via AdminClient
+    });
+
+  cmd
+    .command("verify")
+    .description("Run verification pipeline against an attestation")
+    .argument("<id>", "Attestation ID")
+    .option("--json", "JSON output")
+    .action(async (_id, _options) => {
+      // Routed via AdminClient
+    });
+
+  cmd
+    .command("revoke")
+    .description("Revoke an attestation")
+    .argument("<id>", "Attestation ID")
+    .option("--json", "JSON output")
+    .action(async (_id, _options) => {
+      // Routed via AdminClient
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/broker.ts
+++ b/packages/cli/src/commands/broker.ts
@@ -1,0 +1,331 @@
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { Command } from "commander";
+import { Result } from "better-result";
+import type { BrokerError } from "@xmtp-broker/schemas";
+import type { DaemonStatus } from "../daemon/status.js";
+import { loadConfig } from "../config/loader.js";
+import { resolvePaths } from "../config/paths.js";
+import { formatOutput } from "../output/formatter.js";
+import { exitCodeFromCategory } from "../output/exit-codes.js";
+import { createBrokerRuntime } from "../runtime.js";
+import { createProductionDeps } from "../start.js";
+import { setupSignalHandlers } from "../daemon/signals.js";
+import {
+  createWithDaemonClient,
+  type WithDaemonClient,
+} from "./daemon-client.js";
+
+export interface BrokerCommandDeps {
+  readonly loadConfig: typeof loadConfig;
+  readonly resolvePaths: typeof resolvePaths;
+  readonly createBrokerRuntime: typeof createBrokerRuntime;
+  readonly createProductionDeps: typeof createProductionDeps;
+  readonly setupSignalHandlers: typeof setupSignalHandlers;
+  readonly withDaemonClient: WithDaemonClient;
+  readonly writeStdout: (message: string) => void;
+  readonly writeStderr: (message: string) => void;
+  readonly exit: (code: number) => void;
+}
+
+const defaultDeps: BrokerCommandDeps = {
+  loadConfig,
+  resolvePaths,
+  createBrokerRuntime,
+  createProductionDeps,
+  setupSignalHandlers,
+  withDaemonClient: createWithDaemonClient(),
+  writeStdout(message) {
+    process.stdout.write(message);
+  },
+  writeStderr(message) {
+    process.stderr.write(message);
+  },
+  exit(code) {
+    process.exit(code);
+  },
+};
+
+/**
+ * Broker lifecycle commands.
+ *
+ * - start: Create and start the BrokerRuntime (does not use admin socket)
+ * - stop: Send broker.stop via admin socket
+ * - status: Send broker.status via admin socket
+ * - config show: Show active merged configuration
+ * - config validate: Validate config file (no daemon required)
+ */
+export function createBrokerCommands(
+  deps: Partial<BrokerCommandDeps> = {},
+): Command {
+  const resolvedDeps: BrokerCommandDeps = { ...defaultDeps, ...deps };
+  const cmd = new Command("broker").description(
+    "Broker daemon lifecycle management",
+  );
+
+  cmd
+    .command("start")
+    .description("Start the broker daemon")
+    .option("--daemon", "Fork and run as background daemon")
+    .option("--config <path>", "Path to config file")
+    .option("--json", "JSON output")
+    .action(async (options) => {
+      const json = Boolean(options.json);
+      const write = (msg: string, stream: "stdout" | "stderr" = "stdout") => {
+        const target =
+          stream === "stderr"
+            ? resolvedDeps.writeStderr
+            : resolvedDeps.writeStdout;
+        target(msg + "\n");
+      };
+
+      const configOptions: Parameters<typeof loadConfig>[0] =
+        typeof options.config === "string"
+          ? { configPath: options.config }
+          : undefined;
+      const configResult = await resolvedDeps.loadConfig(configOptions);
+
+      if (configResult.isErr()) {
+        write(
+          formatOutput(
+            {
+              error: "Config load failed",
+              message: configResult.error.message,
+            },
+            { json },
+          ),
+          "stderr",
+        );
+        resolvedDeps.exit(exitCodeFromCategory(configResult.error.category));
+        return;
+      }
+
+      const config = configResult.value;
+      const paths = resolvedDeps.resolvePaths(config);
+
+      for (const dir of [
+        paths.dataDir,
+        dirname(paths.pidFile),
+        dirname(paths.adminSocket),
+        dirname(paths.auditLog),
+      ]) {
+        mkdirSync(dir, { recursive: true });
+      }
+
+      if (!json) {
+        write(`Loading config from ${paths.configFile}`);
+        write(`Data directory: ${paths.dataDir}`);
+        write("Initializing broker runtime...");
+      }
+
+      const runtimeResult = await resolvedDeps.createBrokerRuntime(
+        config,
+        resolvedDeps.createProductionDeps(),
+      );
+
+      if (Result.isError(runtimeResult)) {
+        write(
+          formatOutput(
+            {
+              error: "Runtime creation failed",
+              message: runtimeResult.error.message,
+            },
+            { json },
+          ),
+          "stderr",
+        );
+        resolvedDeps.exit(exitCodeFromCategory(runtimeResult.error.category));
+        return;
+      }
+
+      const runtime = runtimeResult.value;
+
+      if (!json) {
+        write("Starting broker...");
+      }
+
+      const startResult = await runtime.start();
+
+      if (Result.isError(startResult)) {
+        write(
+          formatOutput(
+            {
+              error: "Startup failed",
+              message: startResult.error.message,
+              state: runtime.state,
+            },
+            { json },
+          ),
+          "stderr",
+        );
+        resolvedDeps.exit(exitCodeFromCategory(startResult.error.category));
+        return;
+      }
+
+      resolvedDeps.setupSignalHandlers(async () => {
+        if (!json) {
+          write("Shutting down broker...");
+        }
+        const shutdownResult = await runtime.shutdown();
+        if (Result.isError(shutdownResult)) {
+          write(
+            formatOutput(
+              {
+                error: "Shutdown failed",
+                message: shutdownResult.error.message,
+              },
+              { json },
+            ),
+            "stderr",
+          );
+        }
+        resolvedDeps.exit(0);
+      });
+
+      write(
+        formatOutput(
+          {
+            status: "running",
+            pid: process.pid,
+            ws: `ws://${config.ws.host}:${config.ws.port}`,
+            adminSocket: paths.adminSocket,
+            env: config.broker.env,
+            dataDir: paths.dataDir,
+          },
+          { json },
+        ),
+      );
+    });
+
+  cmd
+    .command("stop")
+    .description("Stop the broker daemon")
+    .option("--config <path>", "Path to config file")
+    .option("--timeout <ms>", "Shutdown timeout in milliseconds", "10000")
+    .option("--json", "JSON output")
+    .action(async (options) => {
+      const result = await resolvedDeps.withDaemonClient(
+        {
+          configPath:
+            typeof options.config === "string" ? options.config : undefined,
+        },
+        (client) => client.request<{ stopped: true }>("broker.stop"),
+      );
+
+      if (result.isErr()) {
+        writeError(resolvedDeps, result.error, Boolean(options.json));
+        return;
+      }
+
+      resolvedDeps.writeStdout(
+        formatOutput(result.value, { json: Boolean(options.json) }) + "\n",
+      );
+    });
+
+  cmd
+    .command("status")
+    .description("Show broker daemon status")
+    .option("--config <path>", "Path to config file")
+    .option("--json", "JSON output")
+    .action(async (options) => {
+      const result = await resolvedDeps.withDaemonClient(
+        {
+          configPath:
+            typeof options.config === "string" ? options.config : undefined,
+        },
+        (client) => client.request<DaemonStatus>("broker.status"),
+      );
+
+      if (result.isErr()) {
+        writeError(resolvedDeps, result.error, Boolean(options.json));
+        return;
+      }
+
+      resolvedDeps.writeStdout(
+        formatOutput(result.value, { json: Boolean(options.json) }) + "\n",
+      );
+    });
+
+  const config = new Command("config").description("Configuration management");
+
+  config
+    .command("show")
+    .description("Show active merged configuration")
+    .option("--config <path>", "Path to config file")
+    .option("--json", "JSON output")
+    .action(async (options) => {
+      const result = await resolvedDeps.loadConfig(
+        typeof options.config === "string"
+          ? { configPath: options.config }
+          : {},
+      );
+      if (result.isErr()) {
+        resolvedDeps.writeStderr(
+          formatOutput(
+            { error: result.error.message },
+            { json: Boolean(options.json) },
+          ) + "\n",
+        );
+        resolvedDeps.exit(exitCodeFromCategory(result.error.category));
+        return;
+      }
+      const cfg = result.value;
+      const paths = resolvedDeps.resolvePaths(cfg);
+      resolvedDeps.writeStdout(
+        formatOutput({ config: cfg, paths }, { json: Boolean(options.json) }) +
+          "\n",
+      );
+    });
+
+  config
+    .command("validate")
+    .description("Validate configuration file")
+    .option("--config <path>", "Path to config file")
+    .option("--json", "JSON output")
+    .action(async (options) => {
+      const result = await resolvedDeps.loadConfig(
+        typeof options.config === "string"
+          ? { configPath: options.config }
+          : {},
+      );
+      if (result.isErr()) {
+        resolvedDeps.writeStderr(
+          formatOutput(
+            { valid: false, error: result.error.message },
+            { json: Boolean(options.json) },
+          ) + "\n",
+        );
+        resolvedDeps.exit(exitCodeFromCategory(result.error.category));
+        return;
+      }
+      resolvedDeps.writeStdout(
+        formatOutput(
+          { valid: true, config: result.value },
+          { json: Boolean(options.json) },
+        ) + "\n",
+      );
+    });
+
+  cmd.addCommand(config);
+
+  return cmd;
+}
+
+function writeError(
+  deps: BrokerCommandDeps,
+  error: BrokerError,
+  json: boolean,
+): void {
+  deps.writeStderr(
+    formatOutput(
+      {
+        error: error._tag,
+        category: error.category,
+        message: error.message,
+        ...(error.context !== null ? { context: error.context } : {}),
+      },
+      { json },
+    ) + "\n",
+  );
+  deps.exit(exitCodeFromCategory(error.category));
+}

--- a/packages/cli/src/commands/conversation.ts
+++ b/packages/cli/src/commands/conversation.ts
@@ -1,0 +1,54 @@
+import { Command } from "commander";
+
+/**
+ * Conversation operation commands. Available in daemon and direct mode.
+ *
+ * - list: List conversations the broker participates in
+ * - info: Show group metadata
+ * - create: Create a new group conversation
+ * - add-member: Add a member to a group
+ */
+export function createConversationCommands(): Command {
+  const cmd = new Command("conversation").description(
+    "Conversation operations",
+  );
+
+  cmd
+    .command("list")
+    .description("List conversations")
+    .option("--limit <n>", "Maximum number of conversations")
+    .option("--json", "JSON output")
+    .action(async (_options) => {
+      // Routed via AdminClient or DirectClient
+    });
+
+  cmd
+    .command("info")
+    .description("Show group conversation details")
+    .argument("<group>", "Group conversation ID")
+    .option("--json", "JSON output")
+    .action(async (_group, _options) => {
+      // Routed via AdminClient or DirectClient
+    });
+
+  cmd
+    .command("create")
+    .description("Create a new group conversation")
+    .option("--members <inboxIds>", "Comma-separated member inbox IDs")
+    .option("--json", "JSON output")
+    .action(async (_options) => {
+      // Routed via AdminClient or DirectClient
+    });
+
+  cmd
+    .command("add-member")
+    .description("Add a member to a group conversation")
+    .argument("<group>", "Group conversation ID")
+    .argument("<inboxId>", "Member inbox ID to add")
+    .option("--json", "JSON output")
+    .action(async (_group, _inboxId, _options) => {
+      // Routed via AdminClient or DirectClient
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/grant.ts
+++ b/packages/cli/src/commands/grant.ts
@@ -1,0 +1,41 @@
+import { Command } from "commander";
+
+/**
+ * Grant management commands. All require daemon and admin auth.
+ *
+ * - list: List grants across active sessions
+ * - inspect: Show full grant details
+ * - revoke: Revoke a specific grant
+ */
+export function createGrantCommands(): Command {
+  const cmd = new Command("grant").description("Grant management");
+
+  cmd
+    .command("list")
+    .description("List grants across active sessions")
+    .option("--session <id>", "Filter by session ID")
+    .option("--json", "JSON output")
+    .action(async (_options) => {
+      // Routed via AdminClient
+    });
+
+  cmd
+    .command("inspect")
+    .description("Show full grant details")
+    .argument("<id>", "Grant ID")
+    .option("--json", "JSON output")
+    .action(async (_id, _options) => {
+      // Routed via AdminClient
+    });
+
+  cmd
+    .command("revoke")
+    .description("Revoke a grant")
+    .argument("<id>", "Grant ID")
+    .option("--json", "JSON output")
+    .action(async (_id, _options) => {
+      // Routed via AdminClient
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/identity.ts
+++ b/packages/cli/src/commands/identity.ts
@@ -1,0 +1,49 @@
+import { Command } from "commander";
+
+/**
+ * Identity (inbox/client) management commands.
+ *
+ * - init: Create XMTP identity and key hierarchy (direct mode)
+ * - info: Display identity details (daemon mode)
+ * - rotate-keys: Rotate operational keys (daemon mode, admin auth)
+ * - export-public: Export public key material (daemon mode)
+ */
+export function createIdentityCommands(): Command {
+  const cmd = new Command("identity").description(
+    "XMTP identity and key management",
+  );
+
+  cmd
+    .command("init")
+    .description("Create a new XMTP identity and key hierarchy")
+    .option("--json", "JSON output")
+    .action(async (_options) => {
+      // Direct mode supported -- creates identity via vault
+    });
+
+  cmd
+    .command("info")
+    .description("Display identity details")
+    .option("--json", "JSON output")
+    .action(async (_options) => {
+      // Routed via AdminClient
+    });
+
+  cmd
+    .command("rotate-keys")
+    .description("Rotate operational keys")
+    .option("--json", "JSON output")
+    .action(async (_options) => {
+      // Routed via AdminClient (admin auth required)
+    });
+
+  cmd
+    .command("export-public")
+    .description("Export public key material")
+    .option("--json", "JSON output")
+    .action(async (_options) => {
+      // Routed via AdminClient
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/message.ts
+++ b/packages/cli/src/commands/message.ts
@@ -1,0 +1,46 @@
+import { Command } from "commander";
+
+/**
+ * Message operation commands. Available in daemon and direct mode.
+ *
+ * - send: Send a text message to a group
+ * - list: List recent messages in a group
+ * - stream: Stream messages in real time (NDJSON with --json)
+ */
+export function createMessageCommands(): Command {
+  const cmd = new Command("message").description("Message operations");
+
+  cmd
+    .command("send")
+    .description("Send a text message to a group conversation")
+    .argument("<group>", "Group conversation ID")
+    .argument("<text>", "Message text")
+    .option("--json", "JSON output")
+    .action(async (_group, _text, _options) => {
+      // Routed via AdminClient or DirectClient
+    });
+
+  cmd
+    .command("list")
+    .description("List recent messages in a group")
+    .argument("<group>", "Group conversation ID")
+    .option("--limit <n>", "Maximum number of messages", "25")
+    .option("--before <timestamp>", "List messages before timestamp")
+    .option("--json", "JSON output")
+    .action(async (_group, _options) => {
+      // Routed via AdminClient or DirectClient
+    });
+
+  cmd
+    .command("stream")
+    .description("Stream messages from a group in real time")
+    .argument("<group>", "Group conversation ID")
+    .option("--json", "NDJSON output (one JSON object per line)")
+    .action(async (_group, _options) => {
+      // Routed via AdminClient or DirectClient
+      // Streaming: keeps socket open, prints NDJSON or formatted text
+      // Exits on SIGINT (exit code 130)
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -1,0 +1,301 @@
+import { Command } from "commander";
+import { Result } from "better-result";
+import type { SessionRecord } from "@xmtp-broker/contracts";
+import {
+  GrantConfig,
+  SessionConfig,
+  SessionRevocationReason,
+  ValidationError,
+  ViewConfig,
+  type BrokerError,
+  type IssuedSession,
+  type SessionRevocationReason as SessionRevocationReasonType,
+} from "@xmtp-broker/schemas";
+import { exitCodeFromCategory } from "../output/exit-codes.js";
+import { formatOutput } from "../output/formatter.js";
+import {
+  createWithDaemonClient,
+  parseJsonInput,
+  type WithDaemonClient,
+} from "./daemon-client.js";
+
+export interface SessionCommandDeps {
+  readonly withDaemonClient: WithDaemonClient;
+  readonly writeStdout: (message: string) => void;
+  readonly writeStderr: (message: string) => void;
+  readonly exit: (code: number) => void;
+}
+
+const defaultDeps: SessionCommandDeps = {
+  withDaemonClient: createWithDaemonClient(),
+  writeStdout(message) {
+    process.stdout.write(message);
+  },
+  writeStderr(message) {
+    process.stderr.write(message);
+  },
+  exit(code) {
+    process.exit(code);
+  },
+};
+
+/**
+ * Session lifecycle commands. All require daemon and admin auth.
+ *
+ * - list: Display active sessions
+ * - inspect: Show full session details
+ * - revoke: Immediately revoke a session
+ * - issue: Create a new session with view/grant configuration
+ */
+export function createSessionCommands(
+  deps: Partial<SessionCommandDeps> = {},
+): Command {
+  const resolvedDeps: SessionCommandDeps = { ...defaultDeps, ...deps };
+  const cmd = new Command("session").description(
+    "Session lifecycle management",
+  );
+
+  cmd
+    .command("list")
+    .description("List active sessions")
+    .option("--config <path>", "Path to config file")
+    .option("--agent <inboxId>", "Filter sessions by agent inbox ID")
+    .option("--json", "JSON output")
+    .action(async (options) => {
+      const json = options.json === true;
+      const result = await resolvedDeps.withDaemonClient(
+        {
+          configPath:
+            typeof options.config === "string" ? options.config : undefined,
+        },
+        (client) =>
+          client.request<readonly SessionRecord[]>(
+            "session.list",
+            typeof options.agent === "string"
+              ? { agentInboxId: options.agent }
+              : undefined,
+          ),
+      );
+
+      if (result.isErr()) {
+        writeError(resolvedDeps, result.error, json);
+        return;
+      }
+
+      const output = json ? result.value : result.value.map(summarizeSession);
+      resolvedDeps.writeStdout(formatOutput(output, { json }) + "\n");
+    });
+
+  cmd
+    .command("inspect")
+    .description("Show full session details")
+    .argument("<id>", "Session ID")
+    .option("--config <path>", "Path to config file")
+    .option("--json", "JSON output")
+    .action(async (id, options) => {
+      const result = await resolvedDeps.withDaemonClient(
+        {
+          configPath:
+            typeof options.config === "string" ? options.config : undefined,
+        },
+        (client) =>
+          client.request<SessionRecord>("session.inspect", { sessionId: id }),
+      );
+
+      if (result.isErr()) {
+        writeError(resolvedDeps, result.error, Boolean(options.json));
+        return;
+      }
+
+      resolvedDeps.writeStdout(
+        formatOutput(result.value, { json: Boolean(options.json) }) + "\n",
+      );
+    });
+
+  cmd
+    .command("revoke")
+    .description("Revoke a session")
+    .argument("<id>", "Session ID")
+    .option("--config <path>", "Path to config file")
+    .option("--reason <reason>", "Revocation reason", "owner-initiated")
+    .option("--json", "JSON output")
+    .action(async (id, options) => {
+      const reasonResult = parseReason(options.reason);
+      if (reasonResult.isErr()) {
+        writeError(resolvedDeps, reasonResult.error, Boolean(options.json));
+        return;
+      }
+
+      const result = await resolvedDeps.withDaemonClient(
+        {
+          configPath:
+            typeof options.config === "string" ? options.config : undefined,
+        },
+        (client) =>
+          client.request<{ revoked: true }>("session.revoke", {
+            sessionId: id,
+            reason: reasonResult.value,
+          }),
+      );
+
+      if (result.isErr()) {
+        writeError(resolvedDeps, result.error, Boolean(options.json));
+        return;
+      }
+
+      resolvedDeps.writeStdout(
+        formatOutput(
+          {
+            sessionId: id,
+            reason: reasonResult.value,
+            ...result.value,
+          },
+          { json: Boolean(options.json) },
+        ) + "\n",
+      );
+    });
+
+  cmd
+    .command("issue")
+    .description("Issue a new session")
+    .option("--config <path>", "Path to config file")
+    .requiredOption("--agent <inboxId>", "Target agent inbox ID")
+    .option("--ttl <seconds>", "Session TTL in seconds")
+    .requiredOption("--view <json>", "View configuration (JSON or @filepath)")
+    .requiredOption("--grant <json>", "Grant configuration (JSON or @filepath)")
+    .option("--json", "JSON output")
+    .action(async (options) => {
+      const json = options.json === true;
+      const configResult = await buildSessionConfig({
+        agent: String(options.agent),
+        ttl: typeof options.ttl === "string" ? options.ttl : undefined,
+        view: String(options.view),
+        grant: String(options.grant),
+      });
+      if (configResult.isErr()) {
+        writeError(resolvedDeps, configResult.error, json);
+        return;
+      }
+
+      const result = await resolvedDeps.withDaemonClient(
+        {
+          configPath:
+            typeof options.config === "string" ? options.config : undefined,
+        },
+        (client) =>
+          client.request<IssuedSession>("session.issue", configResult.value),
+      );
+
+      if (result.isErr()) {
+        writeError(resolvedDeps, result.error, json);
+        return;
+      }
+
+      const output = json
+        ? result.value
+        : {
+            token: result.value.token,
+            ...result.value.session,
+          };
+      resolvedDeps.writeStdout(formatOutput(output, { json }) + "\n");
+    });
+
+  return cmd;
+}
+
+function summarizeSession(session: SessionRecord): Record<string, unknown> {
+  return {
+    sessionId: session.sessionId,
+    agentInboxId: session.agentInboxId,
+    state: session.state,
+    issuedAt: session.issuedAt,
+    expiresAt: session.expiresAt,
+  };
+}
+
+async function buildSessionConfig(options: {
+  agent: string;
+  ttl?: string | undefined;
+  view: string;
+  grant: string;
+}): Promise<Result<typeof SessionConfig._type, BrokerError>> {
+  const ttlResult = parseTtl(options.ttl);
+  if (ttlResult.isErr()) {
+    return ttlResult;
+  }
+
+  const [viewResult, grantResult] = await Promise.all([
+    parseJsonInput(options.view, "view", ViewConfig),
+    parseJsonInput(options.grant, "grant", GrantConfig),
+  ]);
+  if (viewResult.isErr()) {
+    return viewResult;
+  }
+  if (grantResult.isErr()) {
+    return grantResult;
+  }
+
+  const parsedConfig = SessionConfig.safeParse({
+    agentInboxId: options.agent,
+    view: viewResult.value,
+    grant: grantResult.value,
+    ...(ttlResult.value !== undefined ? { ttlSeconds: ttlResult.value } : {}),
+  });
+  if (!parsedConfig.success) {
+    return Result.err(
+      ValidationError.create("session", "Session config did not validate", {
+        issues: parsedConfig.error.issues,
+      }),
+    );
+  }
+
+  return Result.ok(parsedConfig.data);
+}
+
+function parseReason(
+  value: unknown,
+): Result<SessionRevocationReasonType, BrokerError> {
+  const parsed = SessionRevocationReason.safeParse(value);
+  if (!parsed.success) {
+    return Result.err(
+      ValidationError.create("reason", "Invalid session revocation reason", {
+        issues: parsed.error.issues,
+      }),
+    );
+  }
+  return Result.ok(parsed.data);
+}
+
+function parseTtl(value: unknown): Result<number | undefined, BrokerError> {
+  if (value === undefined) {
+    return Result.ok(undefined);
+  }
+
+  const ttl = Number.parseInt(String(value), 10);
+  if (!Number.isInteger(ttl) || ttl <= 0) {
+    return Result.err(
+      ValidationError.create("ttl", "TTL must be a positive integer"),
+    );
+  }
+
+  return Result.ok(ttl);
+}
+
+function writeError(
+  deps: SessionCommandDeps,
+  error: BrokerError,
+  json: boolean,
+): void {
+  deps.writeStderr(
+    formatOutput(
+      {
+        error: error._tag,
+        category: error.category,
+        message: error.message,
+        ...(error.context !== null ? { context: error.context } : {}),
+      },
+      { json },
+    ) + "\n",
+  );
+  deps.exit(exitCodeFromCategory(error.category));
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,9 +1,27 @@
 import { Command } from "commander";
+import { createBrokerCommands } from "./commands/broker.js";
+import { createIdentityCommands } from "./commands/identity.js";
+import { createSessionCommands } from "./commands/session.js";
+import { createGrantCommands } from "./commands/grant.js";
+import { createAttestationCommands } from "./commands/attestation.js";
+import { createMessageCommands } from "./commands/message.js";
+import { createConversationCommands } from "./commands/conversation.js";
+import { createAdminCommands } from "./commands/admin.js";
 
 const program: Command = new Command()
   .name("xmtp-broker")
   .version("0.1.0")
   .description("Agent broker for XMTP");
+
+// Wire all command groups
+program.addCommand(createBrokerCommands());
+program.addCommand(createIdentityCommands());
+program.addCommand(createSessionCommands());
+program.addCommand(createGrantCommands());
+program.addCommand(createAttestationCommands());
+program.addCommand(createMessageCommands());
+program.addCommand(createConversationCommands());
+program.addCommand(createAdminCommands());
 
 export { program };
 
@@ -46,3 +64,20 @@ export type {
   JsonRpcNotification,
   AdminAuthFrame,
 } from "./admin/protocol.js";
+
+export { createBrokerCommands } from "./commands/broker.js";
+export { createIdentityCommands } from "./commands/identity.js";
+export { createSessionCommands } from "./commands/session.js";
+export { createGrantCommands } from "./commands/grant.js";
+export { createAttestationCommands } from "./commands/attestation.js";
+export { createMessageCommands } from "./commands/message.js";
+export { createConversationCommands } from "./commands/conversation.js";
+export { createAdminCommands } from "./commands/admin.js";
+
+export { exitCodeFromCategory, EXIT_SUCCESS } from "./output/exit-codes.js";
+export type { OutputFormatter, FormatOptions } from "./output/formatter.js";
+export {
+  createOutputFormatter,
+  formatOutput,
+  formatNdjsonLine,
+} from "./output/formatter.js";

--- a/packages/cli/src/output/exit-codes.ts
+++ b/packages/cli/src/output/exit-codes.ts
@@ -1,0 +1,19 @@
+import { ERROR_CATEGORY_META, type ErrorCategory } from "@xmtp-broker/schemas";
+
+/** Successful exit. */
+export const EXIT_SUCCESS = 0;
+
+/**
+ * Map an error category to a CLI exit code.
+ * Uses ERROR_CATEGORY_META from @xmtp-broker/schemas as the single source of truth.
+ * Falls back to the internal error exit code for unknown categories.
+ */
+export function exitCodeFromCategory(category: ErrorCategory): number {
+  const meta =
+    ERROR_CATEGORY_META[category as keyof typeof ERROR_CATEGORY_META];
+  if (meta !== undefined) {
+    return meta.exitCode;
+  }
+  // Unknown category falls back to internal
+  return ERROR_CATEGORY_META.internal.exitCode;
+}

--- a/packages/cli/src/output/formatter.ts
+++ b/packages/cli/src/output/formatter.ts
@@ -1,0 +1,119 @@
+/**
+ * Output formatting utilities for CLI commands.
+ *
+ * Supports JSON, table, and text output modes.
+ * All commands use --json for machine-readable output.
+ * Streaming commands use NDJSON (one JSON object per line).
+ */
+
+/** Formatter interface for structured output. */
+export interface OutputFormatter {
+  table(data: Record<string, unknown>[], columns?: string[]): string;
+  json(data: unknown): string;
+  text(message: string): string;
+}
+
+/** Options for formatOutput convenience function. */
+export interface FormatOptions {
+  readonly json?: boolean;
+  readonly format?: "table" | "json" | "text";
+}
+
+/** Create an OutputFormatter instance. */
+export function createOutputFormatter(): OutputFormatter {
+  return {
+    json(data: unknown): string {
+      return JSON.stringify(data, null, 2);
+    },
+
+    text(message: string): string {
+      return message;
+    },
+
+    table(data: Record<string, unknown>[], columns?: string[]): string {
+      if (data.length === 0) {
+        return "";
+      }
+
+      // Determine which columns to show
+      const cols = columns ?? Object.keys(data[0] as Record<string, unknown>);
+
+      // Calculate column widths
+      const widths = new Map<string, number>();
+      for (const col of cols) {
+        widths.set(col, col.length);
+      }
+      for (const row of data) {
+        for (const col of cols) {
+          const val = String(row[col] ?? "");
+          const current = widths.get(col) ?? 0;
+          if (val.length > current) {
+            widths.set(col, val.length);
+          }
+        }
+      }
+
+      // Build header
+      const header = cols
+        .map((col) => col.padEnd(widths.get(col) ?? 0))
+        .join("  ");
+      const separator = cols
+        .map((col) => "-".repeat(widths.get(col) ?? 0))
+        .join("  ");
+
+      // Build rows
+      const rows = data.map((row) =>
+        cols
+          .map((col) => String(row[col] ?? "").padEnd(widths.get(col) ?? 0))
+          .join("  "),
+      );
+
+      return [header, separator, ...rows].join("\n");
+    },
+  };
+}
+
+/**
+ * Format data for CLI output based on options.
+ *
+ * - json=true or format="json": pretty-printed JSON
+ * - format="table": aligned table for arrays of records
+ * - format="text": plain text
+ * - Default: key-value text for objects, table for arrays
+ */
+export function formatOutput(data: unknown, options: FormatOptions): string {
+  const formatter = createOutputFormatter();
+
+  // JSON mode takes priority
+  if (options.json === true || options.format === "json") {
+    return formatter.json(data);
+  }
+
+  // Explicit text format
+  if (options.format === "text") {
+    return typeof data === "string" ? data : String(data);
+  }
+
+  // Explicit table format or array data
+  if (
+    options.format === "table" ||
+    (Array.isArray(data) && options.format === undefined)
+  ) {
+    if (Array.isArray(data)) {
+      return formatter.table(data as Record<string, unknown>[]);
+    }
+  }
+
+  // Default: key-value rendering for objects
+  if (typeof data === "object" && data !== null && !Array.isArray(data)) {
+    const entries = Object.entries(data as Record<string, unknown>);
+    return entries.map(([key, value]) => `${key}: ${String(value)}`).join("\n");
+  }
+
+  return String(data);
+}
+
+/** Format a single data item as NDJSON (single-line JSON + newline). */
+export function formatNdjsonLine(data: unknown): string {
+  return JSON.stringify(data) + "\n";
+}


### PR DESCRIPTION
## Summary

- Defines all 8 CLI command groups using Commander.js, plus output formatting and exit code mapping
- Commands are structural — they define argument parsing and subcommand trees, routing through `AdminClient` (daemon mode). Handler wiring comes in later PRs.

## Command groups

| Group | Subcommands |
|-------|-------------|
| `broker` | start, stop, status, config show/validate |
| `identity` | init, info, rotate-keys, export-public |
| `session` | list, inspect, revoke, issue |
| `grant` | list, inspect, revoke |
| `attestation` | list, inspect, verify, revoke |
| `message` | send, list, stream |
| `conversation` | list, info, create, add-member |
| `admin` | verify-keys, export-state, audit-log |

## Output system

- **`formatter.ts`** — table/JSON/text output formatting. All commands support `--json` for machine-readable output. Streaming commands use NDJSON.
- **`exit-codes.ts`** — `exitCodeFromCategory()` maps error categories to exit codes via `ERROR_CATEGORY_META` (single source of truth from `@xmtp-broker/schemas`)

**42 tests** covering output formatting, exit code mapping, and command/argument parsing

## Spec

[`13-daemon-cli.md`](.agents/plans/v0/13-daemon-cli.md) (part 4 of 6)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)