### PR TITLE
feat(mcp): harness-facing MCP transport with session-scoped tools

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -114,6 +114,25 @@
         "typescript": "catalog:",
       },
     },
+    "packages/mcp": {
+      "name": "@xmtp-broker/mcp",
+      "version": "0.0.0",
+      "bin": {
+        "xmtp-broker-mcp": "./src/bin/mcp-server.ts",
+      },
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.27.1",
+        "@xmtp-broker/contracts": "workspace:*",
+        "@xmtp-broker/schemas": "workspace:*",
+        "better-result": "catalog:",
+        "zod": "catalog:",
+        "zod-to-json-schema": "3.24.5",
+      },
+      "devDependencies": {
+        "bun-types": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "packages/policy": {
       "name": "@xmtp-broker/policy",
       "version": "0.0.0",
@@ -199,6 +218,10 @@
 
     "@clack/prompts": ["@clack/prompts@0.11.0", "", { "dependencies": { "@clack/core": "0.5.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
+
     "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
     "@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
@@ -279,6 +302,8 @@
 
     "@xmtp-broker/keys": ["@xmtp-broker/keys@workspace:packages/keys"],
 
+    "@xmtp-broker/mcp": ["@xmtp-broker/mcp@workspace:packages/mcp"],
+
     "@xmtp-broker/policy": ["@xmtp-broker/policy@workspace:packages/policy"],
 
     "@xmtp-broker/schemas": ["@xmtp-broker/schemas@workspace:packages/schemas"],
@@ -297,11 +322,113 @@
 
     "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
     "better-result": ["better-result@2.7.0", "", { "dependencies": { "@clack/prompts": "^0.11.0" }, "bin": { "better-result": "bin/cli.mjs" } }, "sha512-7zrmXjAK8u8Z6SOe4R65XObOR5X+Y2I/VVku3t5cPOGQ8/WsBcfFmfnIPiEl5EBMDOzPHRwbiPbMtQBKYdw7RA=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.3.1", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.12.8", "", {}, "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "isows": ["isows@1.0.7", "", { "peerDependencies": { "ws": "*" } }, "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg=="],
+
+    "jose": ["jose@6.2.1", "", {}, "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "lefthook": ["lefthook@1.13.6", "", { "optionalDependencies": { "lefthook-darwin-arm64": "1.13.6", "lefthook-darwin-x64": "1.13.6", "lefthook-freebsd-arm64": "1.13.6", "lefthook-freebsd-x64": "1.13.6", "lefthook-linux-arm64": "1.13.6", "lefthook-linux-x64": "1.13.6", "lefthook-openbsd-arm64": "1.13.6", "lefthook-openbsd-x64": "1.13.6", "lefthook-windows-arm64": "1.13.6", "lefthook-windows-x64": "1.13.6" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-ojj4/4IJ29Xn4drd5emqVgilegAPN3Kf0FQM2p/9+lwSTpU+SZ1v4Ig++NF+9MOa99UKY8bElmVrLhnUUNFh5g=="],
 
@@ -325,19 +452,85 @@
 
     "lefthook-windows-x64": ["lefthook-windows-x64@1.13.6", "", { "os": "win32", "cpu": "x64" }, "sha512-mOZoM3FQh3o08M8PQ/b3IYuL5oo36D9ehczIw1dAgp1Ly+Tr4fJ96A+4SEJrQuYeRD4mex9bR7Ps56I73sBSZA=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
     "ox": ["ox@0.14.5", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-HgmHmBveYO40H/R3K6TMrwYtHsx/u6TAB+GpZlgJCoW0Sq5Ttpjih0IZZiwGQw7T6vdW4IAyobYrE2mdAvyF8Q=="],
 
     "oxfmt": ["oxfmt@0.40.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.40.0", "@oxfmt/binding-android-arm64": "0.40.0", "@oxfmt/binding-darwin-arm64": "0.40.0", "@oxfmt/binding-darwin-x64": "0.40.0", "@oxfmt/binding-freebsd-x64": "0.40.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.40.0", "@oxfmt/binding-linux-arm-musleabihf": "0.40.0", "@oxfmt/binding-linux-arm64-gnu": "0.40.0", "@oxfmt/binding-linux-arm64-musl": "0.40.0", "@oxfmt/binding-linux-ppc64-gnu": "0.40.0", "@oxfmt/binding-linux-riscv64-gnu": "0.40.0", "@oxfmt/binding-linux-riscv64-musl": "0.40.0", "@oxfmt/binding-linux-s390x-gnu": "0.40.0", "@oxfmt/binding-linux-x64-gnu": "0.40.0", "@oxfmt/binding-linux-x64-musl": "0.40.0", "@oxfmt/binding-openharmony-arm64": "0.40.0", "@oxfmt/binding-win32-arm64-msvc": "0.40.0", "@oxfmt/binding-win32-ia32-msvc": "0.40.0", "@oxfmt/binding-win32-x64-msvc": "0.40.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-g0C3I7xUj4b4DcagevM9kgH6+pUHytikxUcn3/VUkvzTNaaXBeyZqb7IBsHwojeXm4mTBEC/aBjBTMVUkZwWUQ=="],
 
     "oxlint": ["oxlint@0.18.1", "", { "optionalDependencies": { "@oxlint/darwin-arm64": "0.18.1", "@oxlint/darwin-x64": "0.18.1", "@oxlint/linux-arm64-gnu": "0.18.1", "@oxlint/linux-arm64-musl": "0.18.1", "@oxlint/linux-x64-gnu": "0.18.1", "@oxlint/linux-x64-musl": "0.18.1", "@oxlint/win32-arm64": "0.18.1", "@oxlint/win32-x64": "0.18.1" }, "bin": { "oxlint": "bin/oxlint", "oxc_language_server": "bin/oxc_language_server" } }, "sha512-JGcQvbhd00Qb+nq4f9sYYRh7mZIb0K/7rbMepNdJDMzo8pbmBpx1N2XOG61RjHDsNnY6ImAmVk3h4QVwFenwUQ=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "smol-toml": ["smol-toml@1.6.0", "", {}, "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw=="],
 
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "turbo": ["turbo@2.8.17", "", { "optionalDependencies": { "turbo-darwin-64": "2.8.17", "turbo-darwin-arm64": "2.8.17", "turbo-linux-64": "2.8.17", "turbo-linux-arm64": "2.8.17", "turbo-windows-64": "2.8.17", "turbo-windows-arm64": "2.8.17" }, "bin": { "turbo": "bin/turbo" } }, "sha512-YwPsNSqU2f/RXU/+Kcb7cPkPZARxom4+me7LKEdN5jsvy2tpfze3zDZ4EiGrJnvOm9Avu9rK0aaYsP7qZ3iz7A=="],
 
@@ -353,13 +546,29 @@
 
     "turbo-windows-arm64": ["turbo-windows-arm64@2.8.17", "", { "os": "win32", "cpu": "arm64" }, "sha512-crpfeMPkfECd4V1PQ/hMoiyVcOy04+bWedu/if89S15WhOalHZ2BYUi6DOJhZrszY+mTT99OwpOsj4wNfb/GHQ=="],
 
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "viem": ["viem@2.47.4", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.5", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-h0Wp/SYmJO/HB4B/em1OZ3W1LaKrmr7jzaN7talSlZpo0LCn0V6rZ5g923j6sf4VUSrqp/gUuWuHFc7UcoIp8A=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
     "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.24.5", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g=="],
+
+    "@modelcontextprotocol/sdk/zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "@xmtp/content-type-primitives/@xmtp/node-bindings": ["@xmtp/node-bindings@1.8.0", "", {}, "sha512-dyppg1pQNsEdGH13RfsbkbXdnUdjufak6ea1YahjCROgmaJClDpMHcMcSfMzoJzASanU58MwEdCgYUF638NKgw=="],
   }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@xmtp-broker/mcp",
+  "version": "0.0.0",
+  "private": true,
+  "bin": {
+    "xmtp-broker-mcp": "./src/bin/mcp-server.ts"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "bun build ./src/index.ts --outdir ./dist --target bun && tsc --declaration --emitDeclarationOnly --outDir ./dist",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint .",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.27.1",
+    "@xmtp-broker/contracts": "workspace:*",
+    "@xmtp-broker/schemas": "workspace:*",
+    "better-result": "catalog:",
+    "zod": "catalog:",
+    "zod-to-json-schema": "3.24.5"
+  },
+  "devDependencies": {
+    "bun-types": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/mcp/src/__tests__/call-handler.test.ts
+++ b/packages/mcp/src/__tests__/call-handler.test.ts
@@ -1,0 +1,152 @@
+import { describe, test, expect } from "bun:test";
+import { Result } from "better-result";
+import { PermissionError } from "@xmtp-broker/schemas";
+import { handleCallTool } from "../call-handler.js";
+import {
+  createSendSpec,
+  createTestRegistry,
+  makeSessionRecord,
+  createMockSignerProvider,
+} from "./fixtures.js";
+
+function makeCallContext() {
+  return {
+    brokerId: "broker_1",
+    signerProvider: createMockSignerProvider(),
+    sessionRecord: makeSessionRecord(),
+    requestTimeoutMs: 30_000,
+  };
+}
+
+describe("handleCallTool", () => {
+  test("valid request routes to handler and returns success", async () => {
+    const registry = createTestRegistry();
+    const ctx = makeCallContext();
+
+    const result = await handleCallTool(
+      {
+        name: "broker/message/send",
+        arguments: {
+          conversationId: "conv_1",
+          content: { text: "hello" },
+        },
+      },
+      registry,
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content[0]?.text ?? "");
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data.messageId).toBe("msg_1");
+  });
+
+  test("invalid input returns validation error with isError true", async () => {
+    const registry = createTestRegistry();
+    const ctx = makeCallContext();
+
+    const result = await handleCallTool(
+      {
+        name: "broker/message/send",
+        arguments: {
+          // missing required conversationId
+          content: { text: "hello" },
+        },
+      },
+      registry,
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0]?.text ?? "");
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error.category).toBe("validation");
+  });
+
+  test("handler success wrapped in MCP content", async () => {
+    const registry = createTestRegistry();
+    const ctx = makeCallContext();
+
+    const result = await handleCallTool(
+      {
+        name: "broker/message/list",
+        arguments: { conversationId: "conv_1" },
+      },
+      registry,
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]?.type).toBe("text");
+  });
+
+  test("handler error wrapped in MCP content with isError true", async () => {
+    const failSpec = createSendSpec(async () =>
+      Result.err(PermissionError.create("Not allowed", { action: "send" })),
+    );
+    const registry = createTestRegistry([failSpec]);
+    const ctx = makeCallContext();
+
+    const result = await handleCallTool(
+      {
+        name: "broker/message/send",
+        arguments: {
+          conversationId: "conv_1",
+          content: { text: "hello" },
+        },
+      },
+      registry,
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0]?.text ?? "");
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error.category).toBe("permission");
+  });
+
+  test("unknown tool returns error", async () => {
+    const registry = createTestRegistry();
+    const ctx = makeCallContext();
+
+    const result = await handleCallTool(
+      {
+        name: "broker/nonexistent/tool",
+        arguments: {},
+      },
+      registry,
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0]?.text ?? "");
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error.category).toBe("not_found");
+  });
+
+  test("handler throw caught and wrapped as internal error", async () => {
+    const throwSpec = createSendSpec(async () => {
+      throw new Error("Unexpected crash");
+    });
+    const registry = createTestRegistry([throwSpec]);
+    const ctx = makeCallContext();
+
+    const result = await handleCallTool(
+      {
+        name: "broker/message/send",
+        arguments: {
+          conversationId: "conv_1",
+          content: { text: "hello" },
+        },
+      },
+      registry,
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0]?.text ?? "");
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error.category).toBe("internal");
+  });
+});

--- a/packages/mcp/src/__tests__/context-factory.test.ts
+++ b/packages/mcp/src/__tests__/context-factory.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect } from "bun:test";
+import { createHandlerContext } from "../context-factory.js";
+import { makeSessionRecord, createMockSignerProvider } from "./fixtures.js";
+
+describe("createHandlerContext", () => {
+  const sessionRecord = makeSessionRecord();
+  const signerProvider = createMockSignerProvider();
+
+  test("context has requestId in UUID format", () => {
+    const ctx = createHandlerContext({
+      brokerId: "broker_1",
+      signerProvider,
+      sessionId: sessionRecord.sessionId,
+      requestTimeoutMs: 30_000,
+    });
+
+    expect(ctx.requestId).toBeDefined();
+    // UUID v4 format
+    expect(ctx.requestId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  test("context has signal as AbortSignal", () => {
+    const ctx = createHandlerContext({
+      brokerId: "broker_1",
+      signerProvider,
+      sessionId: sessionRecord.sessionId,
+      requestTimeoutMs: 30_000,
+    });
+
+    expect(ctx.signal).toBeInstanceOf(AbortSignal);
+    expect(ctx.signal.aborted).toBe(false);
+  });
+
+  test("context has sessionId from session record", () => {
+    const ctx = createHandlerContext({
+      brokerId: "broker_1",
+      signerProvider,
+      sessionId: "sess_custom",
+      requestTimeoutMs: 30_000,
+    });
+
+    expect(ctx.sessionId).toBe("sess_custom");
+  });
+
+  test("context does NOT have adminAuth", () => {
+    const ctx = createHandlerContext({
+      brokerId: "broker_1",
+      signerProvider,
+      sessionId: sessionRecord.sessionId,
+      requestTimeoutMs: 30_000,
+    });
+
+    expect(ctx.adminAuth).toBeUndefined();
+  });
+});

--- a/packages/mcp/src/__tests__/fixtures.ts
+++ b/packages/mcp/src/__tests__/fixtures.ts
@@ -1,0 +1,277 @@
+import { z } from "zod";
+import { Result } from "better-result";
+import { NotFoundError } from "@xmtp-broker/schemas";
+import type {
+  ActionSpec,
+  ActionRegistry,
+  SessionManager,
+  SessionRecord,
+  McpSurface,
+  HandlerContext,
+  SignerProvider,
+} from "@xmtp-broker/contracts";
+import { createActionRegistry } from "@xmtp-broker/contracts";
+
+// ---------------------------------------------------------------------------
+// Session fixtures
+// ---------------------------------------------------------------------------
+
+export function makeSessionRecord(
+  overrides: Partial<SessionRecord> = {},
+): SessionRecord {
+  return {
+    sessionId: "sess_test",
+    agentInboxId: "agent_test",
+    sessionKeyFingerprint: "fp_test",
+    view: {
+      mode: "full",
+      threadScopes: [{ groupId: "g1", threadId: null }],
+      contentTypes: ["xmtp.org/text:1.0"],
+    },
+    grant: {
+      messaging: { send: true, reply: true, react: true, draftOnly: false },
+      groupManagement: {
+        addMembers: false,
+        removeMembers: false,
+        updateMetadata: false,
+        inviteUsers: false,
+      },
+      tools: { scopes: [] },
+      egress: {
+        storeExcerpts: false,
+        useForMemory: false,
+        forwardToProviders: false,
+        quoteRevealed: false,
+        summarize: false,
+      },
+    },
+    state: "active",
+    issuedAt: "2024-01-01T00:00:00Z",
+    expiresAt: "2099-01-01T00:00:00Z",
+    lastHeartbeat: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock SessionManager
+// ---------------------------------------------------------------------------
+
+export interface MockSessionManagerState {
+  sessions: Map<string, SessionRecord>;
+  tokenMap: Map<string, string>; // token -> sessionId
+}
+
+export function createMockSessionManager(
+  validToken = "valid_token",
+  record: SessionRecord = makeSessionRecord(),
+): SessionManager & { _state: MockSessionManagerState } {
+  const sessions = new Map<string, SessionRecord>();
+  sessions.set(record.sessionId, record);
+  const tokenMap = new Map<string, string>();
+  tokenMap.set(validToken, record.sessionId);
+
+  return {
+    _state: { sessions, tokenMap },
+    async issue() {
+      return Result.ok({
+        token: validToken,
+        session: {
+          sessionId: record.sessionId,
+          agentInboxId: record.agentInboxId,
+          sessionKeyFingerprint: record.sessionKeyFingerprint,
+          issuedAt: record.issuedAt,
+          expiresAt: record.expiresAt,
+        },
+      });
+    },
+    async list(agentInboxId?: string) {
+      const records = [...sessions.values()].filter(
+        (session) =>
+          agentInboxId === undefined || session.agentInboxId === agentInboxId,
+      );
+      return Result.ok(records);
+    },
+    async lookup(sessionId: string) {
+      const s = sessions.get(sessionId);
+      if (!s) return Result.err(NotFoundError.create("session", sessionId));
+      return Result.ok(s);
+    },
+    async lookupByToken(token: string) {
+      const sessionId = tokenMap.get(token);
+      if (!sessionId) {
+        return Result.err(NotFoundError.create("session", token));
+      }
+      const s = sessions.get(sessionId);
+      if (!s) return Result.err(NotFoundError.create("session", token));
+      return Result.ok(s);
+    },
+    async revoke() {
+      return Result.ok(undefined);
+    },
+    async heartbeat() {
+      return Result.ok(undefined);
+    },
+    async isActive(sessionId: string) {
+      const s = sessions.get(sessionId);
+      return Result.ok(s?.state === "active");
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock SignerProvider
+// ---------------------------------------------------------------------------
+
+export function createMockSignerProvider(): SignerProvider {
+  return {
+    async sign() {
+      return Result.ok(new Uint8Array([1, 2, 3]));
+    },
+    async getPublicKey() {
+      return Result.ok(new Uint8Array([4, 5, 6]));
+    },
+    async getFingerprint() {
+      return Result.ok("fp_mock");
+    },
+    async getDbEncryptionKey() {
+      return Result.ok(new Uint8Array(32));
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ActionSpec factories
+// ---------------------------------------------------------------------------
+
+const MessageSendInputSchema = z.object({
+  conversationId: z.string(),
+  content: z.object({ text: z.string() }),
+});
+
+const MessageSendOutputSchema = z.object({
+  messageId: z.string(),
+});
+
+const MessageListInputSchema = z.object({
+  conversationId: z.string(),
+  limit: z.number().int().positive().optional(),
+});
+
+const MessageListOutputSchema = z.object({
+  messages: z.array(z.object({ messageId: z.string(), text: z.string() })),
+});
+
+export function createTestActionSpec(
+  id: string,
+  mcp?: McpSurface,
+): ActionSpec<unknown, unknown> {
+  return {
+    id,
+    handler: async (_input: unknown, _ctx: HandlerContext) => {
+      return Result.ok({ messageId: "msg_test" });
+    },
+    input: MessageSendInputSchema,
+    output: MessageSendOutputSchema,
+    mcp,
+  };
+}
+
+export function createSendSpec(
+  handlerOverride?: ActionSpec<unknown, unknown>["handler"],
+): ActionSpec<unknown, unknown> {
+  return {
+    id: "message.send",
+    handler: handlerOverride ?? (async () => Result.ok({ messageId: "msg_1" })),
+    input: MessageSendInputSchema,
+    output: MessageSendOutputSchema,
+    mcp: {
+      toolName: "broker/message/send",
+      description: "Send a message to a conversation",
+      readOnly: false,
+    },
+  };
+}
+
+export function createListSpec(
+  handlerOverride?: ActionSpec<unknown, unknown>["handler"],
+): ActionSpec<unknown, unknown> {
+  return {
+    id: "message.list",
+    handler:
+      handlerOverride ??
+      (async () =>
+        Result.ok({
+          messages: [{ messageId: "msg_1", text: "hello" }],
+        })),
+    input: MessageListInputSchema,
+    output: MessageListOutputSchema,
+    mcp: {
+      toolName: "broker/message/list",
+      description: "List messages in a conversation",
+      readOnly: true,
+    },
+  };
+}
+
+export function createReadOnlySpec(): ActionSpec<unknown, unknown> {
+  return {
+    id: "conversation.list",
+    handler: async () => Result.ok({ conversations: [] }),
+    input: z.object({}),
+    mcp: {
+      toolName: "broker/conversation/list",
+      description: "List conversations",
+      readOnly: true,
+    },
+  };
+}
+
+export function createDestructiveSpec(): ActionSpec<unknown, unknown> {
+  return {
+    id: "conversation.delete",
+    handler: async () => Result.ok(undefined),
+    input: z.object({ conversationId: z.string() }),
+    mcp: {
+      toolName: "broker/conversation/delete",
+      description: "Delete a conversation",
+      readOnly: false,
+      destructive: true,
+    },
+  };
+}
+
+export function createAdminOnlySpec(): ActionSpec<unknown, unknown> {
+  return {
+    id: "session.revoke",
+    handler: async () => Result.ok(undefined),
+    input: z.object({ sessionId: z.string() }),
+    // No mcp metadata -- admin only
+    cli: {
+      command: "session:revoke",
+      options: [
+        {
+          flag: "--session-id <id>",
+          description: "Session ID",
+          field: "sessionId",
+          required: true,
+        },
+      ],
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Registry helpers
+// ---------------------------------------------------------------------------
+
+export function createTestRegistry(
+  specs?: readonly ActionSpec<unknown, unknown>[],
+): ActionRegistry {
+  const registry = createActionRegistry();
+  const defaultSpecs = specs ?? [createSendSpec(), createListSpec()];
+  for (const spec of defaultSpecs) {
+    registry.register(spec);
+  }
+  return registry;
+}

--- a/packages/mcp/src/__tests__/output-formatter.test.ts
+++ b/packages/mcp/src/__tests__/output-formatter.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect } from "bun:test";
+import type { ActionResult } from "@xmtp-broker/contracts";
+import { formatActionResult } from "../output-formatter.js";
+
+describe("formatActionResult", () => {
+  const baseMeta = {
+    requestId: "req_1",
+    timestamp: "2024-01-01T00:00:00.000Z",
+    durationMs: 42,
+  };
+
+  test("formats success ActionResult as MCP content with isError false", () => {
+    const result: ActionResult<{ messageId: string }> = {
+      ok: true,
+      data: { messageId: "msg_1" },
+      meta: baseMeta,
+    };
+
+    const formatted = formatActionResult(result);
+
+    expect(formatted.isError).toBe(false);
+    expect(formatted.content).toHaveLength(1);
+    expect(formatted.content[0]?.type).toBe("text");
+
+    const parsed = JSON.parse(formatted.content[0]?.text ?? "");
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data.messageId).toBe("msg_1");
+    expect(parsed.meta.requestId).toBe("req_1");
+  });
+
+  test("formats error ActionResult as MCP content with isError true", () => {
+    const result: ActionResult<never> = {
+      ok: false,
+      error: {
+        _tag: "ValidationError",
+        category: "validation",
+        message: "Invalid input",
+        context: null,
+      },
+      meta: baseMeta,
+    };
+
+    const formatted = formatActionResult(result);
+
+    expect(formatted.isError).toBe(true);
+    expect(formatted.content).toHaveLength(1);
+
+    const parsed = JSON.parse(formatted.content[0]?.text ?? "");
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error.category).toBe("validation");
+  });
+
+  test("serializes full envelope as formatted JSON", () => {
+    const result: ActionResult<{ data: number }> = {
+      ok: true,
+      data: { data: 42 },
+      meta: baseMeta,
+    };
+
+    const formatted = formatActionResult(result);
+    const text = formatted.content[0]?.text ?? "";
+
+    // Should be formatted with indentation
+    expect(text).toContain("\n");
+    expect(text).toContain("  ");
+
+    // Should round-trip through JSON.parse
+    const parsed = JSON.parse(text);
+    expect(parsed.data.data).toBe(42);
+  });
+
+  test("preserves error context in formatted output", () => {
+    const result: ActionResult<never> = {
+      ok: false,
+      error: {
+        _tag: "NotFoundError",
+        category: "not_found",
+        message: "Conversation not found",
+        context: { resourceType: "conversation", resourceId: "conv_99" },
+      },
+      meta: baseMeta,
+    };
+
+    const formatted = formatActionResult(result);
+    const parsed = JSON.parse(formatted.content[0]?.text ?? "");
+
+    expect(parsed.error.context.resourceType).toBe("conversation");
+    expect(parsed.error.context.resourceId).toBe("conv_99");
+  });
+});

--- a/packages/mcp/src/__tests__/session-guard.test.ts
+++ b/packages/mcp/src/__tests__/session-guard.test.ts
@@ -1,0 +1,83 @@
+import { describe, test, expect } from "bun:test";
+import { validateSession, checkSessionLiveness } from "../session-guard.js";
+import { makeSessionRecord, createMockSessionManager } from "./fixtures.js";
+
+describe("validateSession", () => {
+  test("valid token resolves to session record", async () => {
+    const record = makeSessionRecord();
+    const manager = createMockSessionManager("valid_token", record);
+
+    const result = await validateSession("valid_token", manager);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.sessionId).toBe("sess_test");
+    }
+  });
+
+  test("invalid token returns auth error", async () => {
+    const manager = createMockSessionManager("valid_token");
+
+    const result = await validateSession("bad_token", manager);
+
+    expect(result.isOk()).toBe(false);
+    if (!result.isOk()) {
+      expect(result.error.category).toBe("auth");
+    }
+  });
+});
+
+describe("checkSessionLiveness", () => {
+  test("active non-expired session passes", async () => {
+    const record = makeSessionRecord({
+      expiresAt: "2099-01-01T00:00:00Z",
+      state: "active",
+    });
+    const manager = createMockSessionManager("valid_token", record);
+
+    const result = await checkSessionLiveness(record, manager);
+
+    expect(result.isOk()).toBe(true);
+  });
+
+  test("expired session returns auth error", async () => {
+    const record = makeSessionRecord({
+      expiresAt: "2020-01-01T00:00:00Z",
+      state: "active",
+    });
+    const manager = createMockSessionManager("valid_token", record);
+
+    const result = await checkSessionLiveness(record, manager);
+
+    expect(result.isOk()).toBe(false);
+    if (!result.isOk()) {
+      expect(result.error.category).toBe("auth");
+    }
+  });
+
+  test("revoked session returns auth error", async () => {
+    const record = makeSessionRecord({
+      expiresAt: "2099-01-01T00:00:00Z",
+      state: "revoked",
+    });
+    const manager = createMockSessionManager("valid_token", record);
+    // Update the session in the manager state to be inactive
+    manager._state.sessions.set(record.sessionId, record);
+
+    const result = await checkSessionLiveness(record, manager);
+
+    expect(result.isOk()).toBe(false);
+    if (!result.isOk()) {
+      expect(result.error.category).toBe("auth");
+    }
+  });
+
+  test("session check uses mock session manager", async () => {
+    const record = makeSessionRecord();
+    const manager = createMockSessionManager("valid_token", record);
+
+    const result = await checkSessionLiveness(record, manager);
+
+    expect(result.isOk()).toBe(true);
+  });
+});

--- a/packages/mcp/src/__tests__/tool-registration.test.ts
+++ b/packages/mcp/src/__tests__/tool-registration.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect } from "bun:test";
+import { actionSpecToMcpTool } from "../tool-registration.js";
+import {
+  createSendSpec,
+  createListSpec,
+  createReadOnlySpec,
+  createDestructiveSpec,
+  createAdminOnlySpec,
+  createTestRegistry,
+} from "./fixtures.js";
+
+describe("actionSpecToMcpTool", () => {
+  test("converts ActionSpec with mcp metadata to MCP tool", () => {
+    const spec = createSendSpec();
+    const tool = actionSpecToMcpTool(spec);
+
+    expect(tool).toBeDefined();
+    expect(tool.name).toBe("broker/message/send");
+    expect(tool.description).toBe("Send a message to a conversation");
+  });
+
+  test("uses toolName from McpSurface", () => {
+    const spec = createListSpec();
+    const tool = actionSpecToMcpTool(spec);
+
+    expect(tool.name).toBe("broker/message/list");
+  });
+
+  test("converts input schema via zodToJsonSchema", () => {
+    const spec = createSendSpec();
+    const tool = actionSpecToMcpTool(spec);
+
+    // JSON Schema should have properties for conversationId and content
+    const schema = tool.inputSchema as Record<string, unknown>;
+    const properties = schema["properties"] as Record<string, unknown>;
+    expect(properties).toBeDefined();
+    expect(properties["conversationId"]).toBeDefined();
+    expect(properties["content"]).toBeDefined();
+
+    // Should have required fields
+    const required = schema["required"] as string[];
+    expect(required).toContain("conversationId");
+    expect(required).toContain("content");
+  });
+
+  test("sets readOnlyHint from McpSurface.readOnly", () => {
+    const readOnlySpec = createReadOnlySpec();
+    const tool = actionSpecToMcpTool(readOnlySpec);
+
+    expect(tool.annotations?.readOnlyHint).toBe(true);
+    expect(tool.annotations?.destructiveHint).toBe(false);
+  });
+
+  test("sets destructiveHint from McpSurface.destructive", () => {
+    const spec = createDestructiveSpec();
+    const tool = actionSpecToMcpTool(spec);
+
+    expect(tool.annotations?.destructiveHint).toBe(true);
+    expect(tool.annotations?.readOnlyHint).toBe(false);
+  });
+
+  test("returns undefined for spec without mcp metadata", () => {
+    const spec = createAdminOnlySpec();
+    const tool = actionSpecToMcpTool(spec);
+
+    expect(tool).toBeUndefined();
+  });
+
+  test("empty registry produces no tools", () => {
+    const registry = createTestRegistry([]);
+    const mcpSpecs = registry.listForSurface("mcp");
+
+    expect(mcpSpecs).toHaveLength(0);
+  });
+});

--- a/packages/mcp/src/bin/mcp-server.ts
+++ b/packages/mcp/src/bin/mcp-server.ts
@@ -1,0 +1,106 @@
+#!/usr/bin/env bun
+
+/**
+ * Standalone MCP server entry point.
+ * Reads XMTP_BROKER_SESSION_TOKEN from env, creates server,
+ * starts stdio transport.
+ */
+
+import { createMcpServer } from "../server.js";
+import { createActionRegistry } from "@xmtp-broker/contracts";
+import { Result } from "better-result";
+import { InternalError } from "@xmtp-broker/schemas";
+
+const sessionToken = process.env["XMTP_BROKER_SESSION_TOKEN"];
+if (!sessionToken) {
+  console.error("XMTP_BROKER_SESSION_TOKEN is required");
+  process.exit(1);
+}
+
+// In a real deployment, these deps would come from the broker runtime.
+// This entry point is a minimal wiring layer.
+const registry = createActionRegistry();
+
+const server = createMcpServer(
+  {
+    mode: "stdio",
+    sessionToken,
+  },
+  {
+    registry,
+    brokerId: process.env["XMTP_BROKER_ID"] ?? "broker_default",
+    signerProvider: {
+      // Placeholder -- real signer injected by daemon
+      async sign() {
+        throw new Error("SignerProvider not configured");
+      },
+      async getPublicKey() {
+        throw new Error("SignerProvider not configured");
+      },
+      async getFingerprint() {
+        throw new Error("SignerProvider not configured");
+      },
+      async getDbEncryptionKey() {
+        throw new Error("SignerProvider not configured");
+      },
+      async getXmtpIdentityKey() {
+        throw new Error("SignerProvider not configured");
+      },
+    },
+    sessionManager: {
+      // Placeholder -- real session manager injected by daemon
+      async issue() {
+        return Result.err(
+          InternalError.create("SessionManager not configured"),
+        );
+      },
+      async list() {
+        return Result.err(
+          InternalError.create("SessionManager not configured"),
+        );
+      },
+      async lookup() {
+        return Result.err(
+          InternalError.create("SessionManager not configured"),
+        );
+      },
+      async lookupByToken() {
+        return Result.err(
+          InternalError.create("SessionManager not configured"),
+        );
+      },
+      async revoke() {
+        return Result.err(
+          InternalError.create("SessionManager not configured"),
+        );
+      },
+      async heartbeat() {
+        return Result.err(
+          InternalError.create("SessionManager not configured"),
+        );
+      },
+      async isActive() {
+        return Result.err(
+          InternalError.create("SessionManager not configured"),
+        );
+      },
+    },
+  },
+);
+
+const result = await server.start();
+if (!result.isOk()) {
+  console.error("Failed to start MCP server:", result.error.message);
+  process.exit(1);
+}
+
+// Handle shutdown signals
+process.on("SIGINT", async () => {
+  await server.stop();
+  process.exit(0);
+});
+
+process.on("SIGTERM", async () => {
+  await server.stop();
+  process.exit(0);
+});

--- a/packages/mcp/src/call-handler.ts
+++ b/packages/mcp/src/call-handler.ts
@@ -1,0 +1,148 @@
+import { Result } from "better-result";
+import {
+  ValidationError,
+  NotFoundError,
+  InternalError,
+} from "@xmtp-broker/schemas";
+import type { ActionResultMeta, BrokerError } from "@xmtp-broker/schemas";
+import type {
+  ActionRegistry,
+  ActionSpec,
+  SignerProvider,
+  SessionRecord,
+} from "@xmtp-broker/contracts";
+import { toActionResult } from "@xmtp-broker/contracts";
+import type { McpContentResponse } from "./output-formatter.js";
+import { formatActionResult } from "./output-formatter.js";
+import { createHandlerContext } from "./context-factory.js";
+
+/**
+ * Parameters for call-handler context construction.
+ */
+export interface CallHandlerContext {
+  readonly brokerId: string;
+  readonly signerProvider: SignerProvider;
+  readonly sessionRecord: SessionRecord;
+  readonly requestTimeoutMs: number;
+}
+
+/**
+ * MCP CallTool request shape.
+ */
+export interface CallToolRequest {
+  readonly name: string;
+  readonly arguments: Record<string, unknown>;
+}
+
+/**
+ * Handle an MCP CallTool request.
+ * Looks up the ActionSpec by tool name, validates input, invokes
+ * the handler, and formats the result as MCP content.
+ */
+export async function handleCallTool(
+  request: CallToolRequest,
+  registry: ActionRegistry,
+  ctx: CallHandlerContext,
+): Promise<McpContentResponse> {
+  const startTime = Date.now();
+
+  // Find the spec by MCP tool name
+  const spec = findSpecByToolName(request.name, registry);
+  if (!spec) {
+    return formatNotFound(request.name, startTime);
+  }
+
+  // Validate input against the spec's Zod schema
+  const parseResult = spec.input.safeParse(request.arguments);
+  if (!parseResult.success) {
+    return formatValidationError(parseResult.error, startTime);
+  }
+
+  // Build handler context
+  const handlerCtx = createHandlerContext({
+    brokerId: ctx.brokerId,
+    signerProvider: ctx.signerProvider,
+    sessionId: ctx.sessionRecord.sessionId,
+    requestTimeoutMs: ctx.requestTimeoutMs,
+  });
+
+  // Invoke the handler
+  try {
+    const result = await spec.handler(parseResult.data, handlerCtx);
+    const actionResult = toActionResult(
+      result,
+      buildMeta(handlerCtx.requestId, startTime),
+    );
+    return formatActionResult(actionResult);
+  } catch (error: unknown) {
+    return formatInternalError(error, startTime, handlerCtx.requestId);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function buildMeta(requestId: string, startTime: number): ActionResultMeta {
+  return {
+    requestId,
+    timestamp: new Date().toISOString(),
+    durationMs: Date.now() - startTime,
+  };
+}
+
+function findSpecByToolName(
+  toolName: string,
+  registry: ActionRegistry,
+): ActionSpec<unknown, unknown, BrokerError> | undefined {
+  const mcpSpecs = registry.listForSurface("mcp");
+  return mcpSpecs.find((spec) => spec.mcp?.toolName === toolName);
+}
+
+function formatNotFound(
+  toolName: string,
+  startTime: number,
+): McpContentResponse {
+  const error = NotFoundError.create("tool", toolName);
+  const result = toActionResult(
+    Result.err(error),
+    buildMeta("unknown", startTime),
+  );
+  return formatActionResult(result);
+}
+
+function formatValidationError(
+  zodError: {
+    issues: ReadonlyArray<{
+      path: (string | number)[];
+      message: string;
+    }>;
+  },
+  startTime: number,
+): McpContentResponse {
+  const firstIssue = zodError.issues[0];
+  const field = firstIssue?.path.join(".") ?? "unknown";
+  const reason = firstIssue?.message ?? "Validation failed";
+  const error = ValidationError.create(field, reason, {
+    issues: zodError.issues,
+  });
+  const result = toActionResult(
+    Result.err(error),
+    buildMeta("unknown", startTime),
+  );
+  return formatActionResult(result);
+}
+
+function formatInternalError(
+  error: unknown,
+  startTime: number,
+  requestId: string,
+): McpContentResponse {
+  const message = error instanceof Error ? error.message : "Unknown error";
+  const internalError = InternalError.create(`Handler threw: ${message}`);
+  const result = toActionResult(
+    Result.err(internalError),
+    buildMeta(requestId, startTime),
+  );
+  return formatActionResult(result);
+}

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+/**
+ * MCP server configuration schema.
+ * Validated at server creation time.
+ */
+export const McpServerConfigSchema: z.ZodObject<{
+  mode: z.ZodDefault<z.ZodEnum<["stdio", "embedded"]>>;
+  serverName: z.ZodDefault<z.ZodString>;
+  serverVersion: z.ZodDefault<z.ZodString>;
+  toolPrefix: z.ZodDefault<z.ZodString>;
+  sessionToken: z.ZodString;
+  requestTimeoutMs: z.ZodDefault<z.ZodNumber>;
+}> = z.object({
+  mode: z
+    .enum(["stdio", "embedded"])
+    .default("stdio")
+    .describe("Transport mode: stdio for standalone, embedded for daemon"),
+  serverName: z
+    .string()
+    .default("xmtp-broker")
+    .describe("Server name advertised during MCP initialization"),
+  serverVersion: z
+    .string()
+    .default("0.1.0")
+    .describe("Server version advertised during MCP initialization"),
+  toolPrefix: z
+    .string()
+    .default("broker")
+    .describe("Prefix for all tool names (e.g., broker/message/send)"),
+  sessionToken: z
+    .string()
+    .describe("Session bearer token for authenticating the MCP caller"),
+  requestTimeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .default(30_000)
+    .describe("Timeout for handler execution"),
+});
+
+export type McpServerConfig = z.infer<typeof McpServerConfigSchema>;

--- a/packages/mcp/src/context-factory.ts
+++ b/packages/mcp/src/context-factory.ts
@@ -1,0 +1,28 @@
+import type { HandlerContext, SignerProvider } from "@xmtp-broker/contracts";
+
+/**
+ * Parameters for building a HandlerContext for MCP callers.
+ */
+export interface ContextFactoryParams {
+  readonly brokerId: string;
+  readonly signerProvider: SignerProvider;
+  readonly sessionId: string;
+  readonly requestTimeoutMs: number;
+}
+
+/**
+ * Build a HandlerContext for an MCP tool call.
+ * Session-scoped: includes sessionId, no adminAuth.
+ */
+export function createHandlerContext(
+  params: ContextFactoryParams,
+): HandlerContext {
+  return {
+    brokerId: params.brokerId,
+    signerProvider: params.signerProvider,
+    requestId: crypto.randomUUID(),
+    signal: AbortSignal.timeout(params.requestTimeoutMs),
+    sessionId: params.sessionId,
+    // No adminAuth -- MCP is session-scoped, not admin
+  };
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,31 @@
+// Configuration
+export { McpServerConfigSchema, type McpServerConfig } from "./config.js";
+
+// Server
+export {
+  createMcpServer,
+  type McpServerDeps,
+  type McpServerInstance,
+  type McpServerState,
+} from "./server.js";
+
+// Tool registration
+export {
+  actionSpecToMcpTool,
+  type McpToolRegistration,
+} from "./tool-registration.js";
+
+// Call handler
+export { handleCallTool, type CallToolRequest } from "./call-handler.js";
+
+// Output formatting
+export {
+  formatActionResult,
+  type McpContentResponse,
+} from "./output-formatter.js";
+
+// Context factory
+export { createHandlerContext } from "./context-factory.js";
+
+// Session guard
+export { validateSession, checkSessionLiveness } from "./session-guard.js";

--- a/packages/mcp/src/output-formatter.ts
+++ b/packages/mcp/src/output-formatter.ts
@@ -1,0 +1,32 @@
+import type { ActionResult } from "@xmtp-broker/contracts";
+
+/**
+ * MCP content block shape returned to MCP clients.
+ */
+export interface McpContentResponse {
+  readonly content: ReadonlyArray<{
+    readonly type: "text";
+    readonly text: string;
+  }>;
+  readonly isError: boolean;
+}
+
+/**
+ * Format an ActionResult envelope as an MCP content response.
+ * Both success and error cases serialize the full envelope as
+ * formatted JSON. The isError flag tells the MCP client whether
+ * the tool invocation succeeded.
+ */
+export function formatActionResult<T>(
+  result: ActionResult<T>,
+): McpContentResponse {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+    isError: !result.ok,
+  };
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,0 +1,223 @@
+import { Result } from "better-result";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { ActionResultMeta } from "@xmtp-broker/schemas";
+import { InternalError, AuthError } from "@xmtp-broker/schemas";
+import type {
+  ActionRegistry,
+  SessionManager,
+  SessionRecord,
+  SignerProvider,
+} from "@xmtp-broker/contracts";
+import type { McpServerConfig } from "./config.js";
+import { McpServerConfigSchema } from "./config.js";
+import {
+  actionSpecToMcpTool,
+  type McpToolRegistration,
+} from "./tool-registration.js";
+import { handleCallTool } from "./call-handler.js";
+import { validateSession, checkSessionLiveness } from "./session-guard.js";
+import { formatActionResult } from "./output-formatter.js";
+import { toActionResult } from "@xmtp-broker/contracts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type McpServerState = "idle" | "running" | "stopping" | "stopped";
+
+export interface McpServerDeps {
+  readonly registry: ActionRegistry;
+  readonly brokerId: string;
+  readonly signerProvider: SignerProvider;
+  readonly sessionManager: SessionManager;
+}
+
+export interface McpServerInstance {
+  start(): Promise<Result<void, InternalError | AuthError>>;
+  stop(): Promise<Result<void, InternalError>>;
+  readonly state: McpServerState;
+  readonly toolCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildMeta(requestId: string, startTime: number): ActionResultMeta {
+  return {
+    requestId,
+    timestamp: new Date().toISOString(),
+    durationMs: Date.now() - startTime,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createMcpServer(
+  rawConfig: Partial<McpServerConfig> & { sessionToken: string },
+  deps: McpServerDeps,
+): McpServerInstance {
+  const config = McpServerConfigSchema.parse(rawConfig);
+
+  let state: McpServerState = "idle";
+  let cachedSession: SessionRecord | undefined;
+  let sdkServer: Server | undefined;
+  const tools: McpToolRegistration[] = [];
+
+  return {
+    get state() {
+      return state;
+    },
+
+    get toolCount() {
+      return tools.length;
+    },
+
+    async start() {
+      // Validate session token
+      const sessionResult = await validateSession(
+        config.sessionToken,
+        deps.sessionManager,
+      );
+      if (!sessionResult.isOk()) {
+        return Result.err(AuthError.create("Invalid session token at startup"));
+      }
+      cachedSession = sessionResult.value;
+
+      // Discover MCP tools from registry
+      const mcpSpecs = deps.registry.listForSurface("mcp");
+      for (const spec of mcpSpecs) {
+        const tool = actionSpecToMcpTool(spec);
+        if (tool) {
+          tools.push(tool);
+        }
+      }
+
+      // Create MCP SDK Server
+      sdkServer = new Server(
+        { name: config.serverName, version: config.serverVersion },
+        { capabilities: { tools: {} } },
+      );
+
+      // Register ListTools handler
+      sdkServer.setRequestHandler(ListToolsRequestSchema, async () => {
+        return {
+          tools: tools.map((t) => ({
+            name: t.name,
+            description: t.description,
+            inputSchema: t.inputSchema,
+            annotations: t.annotations,
+          })),
+        };
+      });
+
+      // Register CallTool handler
+      sdkServer.setRequestHandler(CallToolRequestSchema, async (request) => {
+        const startTime = Date.now();
+
+        if (!cachedSession) {
+          const error = AuthError.create("No active session");
+          const actionResult = toActionResult(
+            Result.err(error),
+            buildMeta("unknown", startTime),
+          );
+          const formatted = formatActionResult(actionResult);
+          return {
+            content: formatted.content as Array<{
+              type: "text";
+              text: string;
+            }>,
+            isError: formatted.isError,
+          };
+        }
+
+        // Session liveness check
+        const livenessResult = await checkSessionLiveness(
+          cachedSession,
+          deps.sessionManager,
+        );
+        if (!livenessResult.isOk()) {
+          state = "stopping";
+          const error = livenessResult.error;
+          const actionResult = toActionResult(
+            Result.err(error),
+            buildMeta("unknown", startTime),
+          );
+          const formatted = formatActionResult(actionResult);
+          return {
+            content: formatted.content as Array<{
+              type: "text";
+              text: string;
+            }>,
+            isError: formatted.isError,
+          };
+        }
+
+        const callResult = await handleCallTool(
+          {
+            name: request.params.name,
+            arguments: (request.params.arguments ?? {}) as Record<
+              string,
+              unknown
+            >,
+          },
+          deps.registry,
+          {
+            brokerId: deps.brokerId,
+            signerProvider: deps.signerProvider,
+            sessionRecord: cachedSession,
+            requestTimeoutMs: config.requestTimeoutMs,
+          },
+        );
+
+        return {
+          content: callResult.content as Array<{
+            type: "text";
+            text: string;
+          }>,
+          isError: callResult.isError,
+        };
+      });
+
+      // Connect transport
+      if (config.mode === "stdio") {
+        const transport = new StdioServerTransport();
+        await sdkServer.connect(transport);
+      } else {
+        // Embedded mode requires an external transport to be connected.
+        // Mark as running but callers must connect a transport via the
+        // MCP SDK server before making requests.
+        return Result.err(
+          InternalError.create(
+            "Embedded mode is not yet supported: no transport available",
+          ),
+        );
+      }
+
+      state = "running";
+      return Result.ok(undefined);
+    },
+
+    async stop() {
+      state = "stopping";
+
+      try {
+        if (sdkServer) {
+          await sdkServer.close();
+        }
+      } catch {
+        // Best-effort close
+      }
+
+      state = "stopped";
+      return Result.ok(undefined);
+    },
+  };
+}

--- a/packages/mcp/src/session-guard.ts
+++ b/packages/mcp/src/session-guard.ts
@@ -1,0 +1,55 @@
+import { Result } from "better-result";
+import { AuthError } from "@xmtp-broker/schemas";
+import type { SessionManager, SessionRecord } from "@xmtp-broker/contracts";
+
+/**
+ * Validate a session token at startup. Resolves the token to a
+ * SessionRecord via the session manager's lookupByToken method.
+ */
+export async function validateSession(
+  token: string,
+  sessionManager: SessionManager,
+): Promise<Result<SessionRecord, AuthError>> {
+  const lookupResult = await sessionManager.lookupByToken(token);
+  if (!lookupResult.isOk()) {
+    return Result.err(AuthError.create("Invalid session token"));
+  }
+  return Result.ok(lookupResult.value);
+}
+
+/**
+ * Check session liveness on each tool call.
+ * Verifies the session has not expired or been revoked.
+ */
+export async function checkSessionLiveness(
+  session: SessionRecord,
+  sessionManager: SessionManager,
+): Promise<Result<void, AuthError>> {
+  // Expiry check
+  const expiresAt = new Date(session.expiresAt).getTime();
+  if (Date.now() >= expiresAt) {
+    return Result.err(
+      AuthError.create("Session expired", { sessionId: session.sessionId }),
+    );
+  }
+
+  // Revocation check via isActive
+  const activeResult = await sessionManager.isActive(session.sessionId);
+  if (!activeResult.isOk()) {
+    return Result.err(
+      AuthError.create("Session check failed", {
+        sessionId: session.sessionId,
+      }),
+    );
+  }
+
+  if (!activeResult.value) {
+    return Result.err(
+      AuthError.create("Session revoked", {
+        sessionId: session.sessionId,
+      }),
+    );
+  }
+
+  return Result.ok(undefined);
+}

--- a/packages/mcp/src/tool-registration.ts
+++ b/packages/mcp/src/tool-registration.ts
@@ -1,0 +1,44 @@
+import { zodToJsonSchema } from "zod-to-json-schema";
+import type { ActionSpec } from "@xmtp-broker/contracts";
+import type { BrokerError } from "@xmtp-broker/schemas";
+
+/**
+ * MCP tool registration shape. Produced from an ActionSpec
+ * with MCP surface metadata.
+ */
+export interface McpToolRegistration {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: Record<string, unknown>;
+  readonly annotations?: {
+    readonly readOnlyHint?: boolean;
+    readonly destructiveHint?: boolean;
+  };
+}
+
+/**
+ * Convert an ActionSpec into an MCP tool registration.
+ * Returns undefined if the spec has no MCP surface metadata.
+ */
+export function actionSpecToMcpTool(
+  spec: ActionSpec<unknown, unknown, BrokerError>,
+): McpToolRegistration | undefined {
+  if (!spec.mcp) {
+    return undefined;
+  }
+
+  const jsonSchema = zodToJsonSchema(spec.input, {
+    $refStrategy: "none",
+    errorMessages: true,
+  });
+
+  return {
+    name: spec.mcp.toolName,
+    description: spec.mcp.description,
+    inputSchema: jsonSchema as Record<string, unknown>,
+    annotations: {
+      readOnlyHint: spec.mcp.readOnly,
+      destructiveHint: spec.mcp.destructive ?? false,
+    },
+  };
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "src/__tests__"]
+}


### PR DESCRIPTION
## Summary

- Creates `packages/mcp/` — exposes broker ActionSpecs as MCP tools for AI agents (Claude Code, Cursor, etc.)
- **Harness-facing**: MCP callers authenticate with session tokens and operate within view/grant scope, same as WebSocket. No admin tools exposed.
- Built on `@modelcontextprotocol/sdk` with `zod-to-json-schema` for input schema conversion

## Architecture

Transport adapters query the `ActionRegistry` for specs with `mcp` metadata, convert Zod schemas to JSON Schema, and register them as MCP tools. All domain logic stays in handlers — the MCP package is pure protocol wiring.

## Components

| File | Purpose |
|------|---------|
| `tool-registration.ts` | `actionSpecToMcpTool()` — ActionSpec → MCP tool with JSON Schema and annotations |
| `call-handler.ts` | Route CallTool requests: find spec → validate input → invoke handler → format result |
| `session-guard.ts` | Token validation at startup, per-call liveness check (expiry + revocation) |
| `context-factory.ts` | Build `HandlerContext` with `sessionId` (no `adminAuth`) |
| `output-formatter.ts` | `ActionResult` → MCP text content block with `isError` flag |
| `server.ts` | Wire it all together with MCP SDK `Server` |
| `bin/mcp-server.ts` | Standalone stdio entry point |

## Deployment modes

- **Stdio** (default): Standalone process, communicates via stdin/stdout
- **Embedded**: Runs inside the broker daemon, shares runtime context

**27 tests** covering tool registration, call routing, output formatting, context construction, and session validation

## Spec

[`14-mcp-transport.md`](.agents/plans/v0/14-mcp-transport.md)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)