### PR TITLE
feat(handler): TypeScript client SDK for harness developers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -81,6 +81,20 @@
         "typescript": "catalog:",
       },
     },
+    "packages/handler": {
+      "name": "@xmtp-broker/handler",
+      "version": "0.0.0",
+      "dependencies": {
+        "@xmtp-broker/contracts": "workspace:*",
+        "@xmtp-broker/schemas": "workspace:*",
+        "better-result": "catalog:",
+        "zod": "catalog:",
+      },
+      "devDependencies": {
+        "bun-types": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "packages/integration": {
       "name": "@xmtp-broker/integration",
       "dependencies": {
@@ -297,6 +311,8 @@
     "@xmtp-broker/contracts": ["@xmtp-broker/contracts@workspace:packages/contracts"],
 
     "@xmtp-broker/core": ["@xmtp-broker/core@workspace:packages/core"],
+
+    "@xmtp-broker/handler": ["@xmtp-broker/handler@workspace:packages/handler"],
 
     "@xmtp-broker/integration": ["@xmtp-broker/integration@workspace:packages/integration"],
 

--- a/packages/handler/package.json
+++ b/packages/handler/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@xmtp-broker/handler",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "bun build ./src/index.ts --outdir ./dist --target bun && tsc --declaration --emitDeclarationOnly --outDir ./dist",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint .",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@xmtp-broker/contracts": "workspace:*",
+    "@xmtp-broker/schemas": "workspace:*",
+    "better-result": "catalog:",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "bun-types": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/handler/src/__tests__/event-stream.test.ts
+++ b/packages/handler/src/__tests__/event-stream.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect } from "bun:test";
+import { createEventStream } from "../event-stream.js";
+import type { BrokerEvent } from "@xmtp-broker/schemas";
+import { take } from "./mock-server.js";
+
+function makeEvent(text: string): BrokerEvent {
+  return {
+    type: "message.visible",
+    messageId: `msg_${text}`,
+    groupId: "g1",
+    senderInboxId: "sender_1",
+    contentType: "xmtp.org/text:1.0",
+    content: { text },
+    visibility: "visible",
+    sentAt: "2024-01-01T00:00:00Z",
+    attestationId: null,
+  };
+}
+
+describe("EventStream", () => {
+  test("delivers pushed events via async iteration", async () => {
+    const stream = createEventStream();
+    stream.push(makeEvent("hello"));
+    stream.push(makeEvent("world"));
+
+    const items = await take(stream, 2);
+    expect(items).toHaveLength(2);
+    expect(items[0]?.type).toBe("message.visible");
+    expect(items[1]?.type).toBe("message.visible");
+  });
+
+  test("delivers events in order", async () => {
+    const stream = createEventStream();
+    stream.push(makeEvent("first"));
+    stream.push(makeEvent("second"));
+    stream.push(makeEvent("third"));
+
+    const items = await take(stream, 3);
+    expect((items[0] as { messageId: string }).messageId).toBe("msg_first");
+    expect((items[1] as { messageId: string }).messageId).toBe("msg_second");
+    expect((items[2] as { messageId: string }).messageId).toBe("msg_third");
+  });
+
+  test("completes the async iterable on complete()", async () => {
+    const stream = createEventStream();
+    stream.push(makeEvent("one"));
+    stream.complete();
+
+    const items: BrokerEvent[] = [];
+    for await (const item of stream) {
+      items.push(item);
+    }
+    expect(items).toHaveLength(1);
+  });
+
+  test("waits for events when queue is empty", async () => {
+    const stream = createEventStream();
+
+    // Push after a delay
+    setTimeout(() => {
+      stream.push(makeEvent("delayed"));
+    }, 50);
+
+    const items = await take(stream, 1);
+    expect(items).toHaveLength(1);
+    expect((items[0] as { messageId: string }).messageId).toBe("msg_delayed");
+  });
+});

--- a/packages/handler/src/__tests__/handler.test.ts
+++ b/packages/handler/src/__tests__/handler.test.ts
@@ -1,0 +1,234 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { AuthError, InternalError, PermissionError } from "@xmtp-broker/schemas";
+import type { HandlerState } from "../types.js";
+import {
+  createMockServer,
+  createTestHandler,
+  waitForState,
+  type TestHarness,
+} from "./mock-server.js";
+import { createBrokerHandler } from "../handler.js";
+
+let harness: TestHarness;
+
+afterEach(async () => {
+  if (harness) {
+    await harness.cleanup();
+  }
+});
+
+describe("Handler lifecycle", () => {
+  test("initial state is disconnected", () => {
+    harness = createTestHandler();
+    expect(harness.handler.state).toBe("disconnected");
+  });
+
+  test("session is null before connect", () => {
+    harness = createTestHandler();
+    expect(harness.handler.session).toBeNull();
+  });
+
+  test("connect transitions to connected", async () => {
+    harness = createTestHandler();
+    const result = await harness.handler.connect();
+    expect(result.isOk()).toBe(true);
+    expect(harness.handler.state).toBe("connected");
+  });
+
+  test("session is populated after connect", async () => {
+    harness = createTestHandler();
+    await harness.handler.connect();
+    const session = harness.handler.session;
+    expect(session).not.toBeNull();
+    expect(session?.sessionId).toBe("sess_test");
+    expect(session?.agentInboxId).toBe("agent_inbox_1");
+    expect(session?.expiresAt).toBeTruthy();
+  });
+
+  test("auth failure transitions to closed", async () => {
+    harness = createTestHandler({
+      serverOptions: { authBehavior: "reject" },
+    });
+    const result = await harness.handler.connect();
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(AuthError);
+    }
+    expect(harness.handler.state).toBe("closed");
+  });
+
+  test("disconnect transitions to closed", async () => {
+    harness = createTestHandler();
+    await harness.handler.connect();
+    const result = await harness.handler.disconnect();
+    expect(result.isOk()).toBe(true);
+    expect(harness.handler.state).toBe("closed");
+  });
+
+  test("state change callbacks fire in order", async () => {
+    harness = createTestHandler();
+    const states: HandlerState[] = [];
+    harness.handler.onStateChange((s) => states.push(s));
+
+    await harness.handler.connect();
+    expect(states).toEqual(["connecting", "authenticating", "connected"]);
+  });
+
+  test("unsubscribe stops callbacks", async () => {
+    harness = createTestHandler();
+    const states: HandlerState[] = [];
+    const unsub = harness.handler.onStateChange((s) => states.push(s));
+
+    unsub();
+    await harness.handler.connect();
+    expect(states).toHaveLength(0);
+  });
+});
+
+describe("Disconnected rejection", () => {
+  test("sendMessage while disconnected returns error", async () => {
+    harness = createTestHandler();
+    const result = await harness.handler.sendMessage("g1", {
+      type: "text",
+      text: "nope",
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.category).toBe("validation");
+    }
+  });
+});
+
+describe("Backpressure", () => {
+  test("backpressure frame emits error via onError", async () => {
+    harness = createTestHandler();
+    await harness.handler.connect();
+
+    const errors: Array<{ category: string }> = [];
+    harness.handler.onError((e) => errors.push(e));
+
+    harness.sendBackpressure({ buffered: 200, limit: 256 });
+    // Give the event loop a tick
+    await Bun.sleep(50);
+
+    expect(errors).toHaveLength(1);
+    expect(harness.handler.state).toBe("connected");
+  });
+});
+
+describe("Non-retryable close codes", () => {
+  test("close code 4004 transitions to closed without reconnection", async () => {
+    harness = createTestHandler({
+      config: {
+        reconnect: { enabled: true, baseDelayMs: 50, maxDelayMs: 200 },
+      },
+    });
+    await harness.handler.connect();
+
+    harness.closeWith(4004, "session revoked");
+    await waitForState(harness.handler, "closed");
+    expect(harness.handler.state).toBe("closed");
+  });
+});
+
+describe("Auth timeout", () => {
+  test("connect rejects when server never sends auth response", async () => {
+    const mock = createMockServer({ authBehavior: "no-response" });
+    const handler = createBrokerHandler({
+      url: mock.url,
+      token: "test-token",
+      reconnect: { enabled: false, maxAttempts: 0, baseDelayMs: 100, maxDelayMs: 100, jitter: false },
+      requestTimeoutMs: 500,
+    });
+
+    const result = await handler.connect();
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(InternalError);
+      expect(result.error.message).toContain("500ms");
+    }
+
+    await handler.disconnect();
+    await mock.server.stop();
+  });
+});
+
+describe("Error category preservation", () => {
+  test("permission error from broker returns PermissionError", async () => {
+    // Custom server that responds to requests with a permission error
+    const bunServer = Bun.serve({
+      port: 0,
+      fetch(req, server) {
+        server.upgrade(req, { data: {} });
+        return undefined;
+      },
+      websocket: {
+        open() {},
+        message(ws, message) {
+          const data = JSON.parse(
+            typeof message === "string" ? message : message.toString(),
+          ) as Record<string, unknown>;
+
+          if (data["type"] === "auth") {
+            ws.send(
+              JSON.stringify({
+                type: "authenticated",
+                connectionId: "conn_1",
+                session: {
+                  sessionId: "sess_test",
+                  agentInboxId: "agent_1",
+                  sessionKeyFingerprint: "fp_1",
+                  issuedAt: "2024-01-01T00:00:00Z",
+                  expiresAt: "2025-01-01T00:00:00Z",
+                },
+                view: {},
+                grant: {},
+                resumedFromSeq: null,
+              }),
+            );
+            return;
+          }
+
+          // Respond to all requests with a permission error
+          if ("requestId" in data) {
+            ws.send(
+              JSON.stringify({
+                ok: false,
+                requestId: data["requestId"],
+                error: {
+                  code: 4003,
+                  category: "permission",
+                  message: "Not allowed to send to this group",
+                  context: null,
+                },
+              }),
+            );
+          }
+        },
+        close() {},
+      },
+    });
+
+    const handler = createBrokerHandler({
+      url: `ws://127.0.0.1:${bunServer.port}/`,
+      token: "test-token",
+      reconnect: { enabled: false, maxAttempts: 0, baseDelayMs: 100, maxDelayMs: 100, jitter: false },
+      requestTimeoutMs: 5000,
+    });
+
+    await handler.connect();
+    const result = await handler.sendMessage("g1", {
+      type: "text",
+      text: "hello",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(PermissionError);
+      expect(result.error.category).toBe("permission");
+    }
+
+    await handler.disconnect();
+    bunServer.stop(true);
+  });
+});

--- a/packages/handler/src/__tests__/integration.test.ts
+++ b/packages/handler/src/__tests__/integration.test.ts
@@ -1,0 +1,126 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import type { BrokerEvent } from "@xmtp-broker/schemas";
+import {
+  createTestHandler,
+  waitForState,
+  take,
+  type TestHarness,
+} from "./mock-server.js";
+
+let harness: TestHarness;
+
+afterEach(async () => {
+  if (harness) {
+    await harness.cleanup();
+  }
+});
+
+describe("Integration: full round-trip", () => {
+  test("connect, receive events, send message, disconnect", async () => {
+    harness = createTestHandler();
+    await harness.handler.connect();
+
+    // Emit events from mock server
+    harness.emitEvent({
+      type: "message.visible",
+      messageId: "msg_1",
+      groupId: "g1",
+      senderInboxId: "sender_1",
+      contentType: "xmtp.org/text:1.0",
+      content: { text: "hello" },
+      visibility: "visible",
+      sentAt: "2024-01-01T00:00:00Z",
+      attestationId: null,
+    });
+
+    const events = await take(harness.handler.events, 1);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe("message.visible");
+
+    // Send a message
+    const result = await harness.handler.sendMessage("g1", {
+      type: "text",
+      text: "world",
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.groupId).toBe("g1");
+      expect(result.value.messageId).toBeTruthy();
+    }
+
+    // Disconnect
+    await harness.handler.disconnect();
+    expect(harness.handler.state).toBe("closed");
+  });
+
+  test("concurrent requests resolve independently", async () => {
+    harness = createTestHandler();
+    await harness.handler.connect();
+
+    const [r1, r2] = await Promise.all([
+      harness.handler.sendMessage("g1", { type: "text", text: "one" }),
+      harness.handler.sendMessage("g2", { type: "text", text: "two" }),
+    ]);
+
+    expect(r1.isOk()).toBe(true);
+    expect(r2.isOk()).toBe(true);
+    if (r1.isOk() && r2.isOk()) {
+      expect(r1.value.groupId).toBe("g1");
+      expect(r2.value.groupId).toBe("g2");
+    }
+  });
+
+  test("reconnection after drop resumes events", async () => {
+    harness = createTestHandler({
+      config: {
+        reconnect: {
+          enabled: true,
+          baseDelayMs: 50,
+          maxDelayMs: 200,
+          maxAttempts: 3,
+        },
+      },
+    });
+    await harness.handler.connect();
+
+    // Emit one event before dropping
+    harness.emitEvent({
+      type: "heartbeat",
+      sessionId: "sess_test",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+
+    const firstEvents = await take(harness.handler.events, 1);
+    expect(firstEvents).toHaveLength(1);
+
+    // Drop and wait for reconnect
+    harness.dropConnection();
+    await waitForState(harness.handler, "connected", 5000);
+
+    // Should be connected again
+    expect(harness.handler.state).toBe("connected");
+  });
+
+  test("event stream completes on disconnect", async () => {
+    harness = createTestHandler();
+    await harness.handler.connect();
+
+    harness.emitEvent({
+      type: "heartbeat",
+      sessionId: "sess_test",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+
+    // Disconnect after a small delay so iterator can pick up the event
+    setTimeout(async () => {
+      await harness.handler.disconnect();
+    }, 100);
+
+    const items: BrokerEvent[] = [];
+    for await (const event of harness.handler.events) {
+      items.push(event);
+    }
+    // Should have gotten the heartbeat and then exited
+    expect(items.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/handler/src/__tests__/mock-server.ts
+++ b/packages/handler/src/__tests__/mock-server.ts
@@ -1,0 +1,366 @@
+import type { BrokerEvent } from "@xmtp-broker/schemas";
+import type { ServerWebSocket } from "bun";
+
+/** Wire data for an incoming auth frame from the handler SDK. */
+interface AuthFrameData {
+  type: "auth";
+  token: string;
+  lastSeenSeq: number | null;
+}
+
+/** Wire data for a harness request. */
+interface RequestData {
+  type: string;
+  requestId: string;
+  [key: string]: unknown;
+}
+
+/** Options for mock server behavior. */
+export interface MockServerOptions {
+  /** How the server handles auth. Default: "accept" */
+  authBehavior?: "accept" | "reject" | "no-response";
+  /** Whether to auto-respond to requests. Default: true */
+  autoRespond?: boolean;
+  /** Valid token(s) to accept. Default: "test-token" */
+  validToken?: string;
+}
+
+/** Handle for the per-connection state. */
+interface ConnectionState {
+  ws: ServerWebSocket<{ connectionId: string }>;
+  authenticated: boolean;
+  seq: number;
+  lastSeenSeq: number | null;
+}
+
+/** Mock broker server that implements the WS wire protocol. */
+export interface MockBrokerServer {
+  readonly port: number;
+  readonly connections: number;
+  stop(): Promise<void>;
+}
+
+export interface TestHarness {
+  handler: import("../types.js").BrokerHandler;
+  server: MockBrokerServer;
+  /** Push an event to all authenticated connections. */
+  emitEvent: (event: BrokerEvent) => void;
+  /** Drop all connections (simulate transport failure). */
+  dropConnection: () => void;
+  /** Close all connections with a specific code. */
+  closeWith: (code: number, reason: string) => void;
+  /** Send a backpressure frame to all authenticated connections. */
+  sendBackpressure: (frame: { buffered: number; limit: number }) => void;
+  /** Clean up server and handler. */
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * Create a mock broker server on a random port.
+ * Returns a Bun.serve() instance that simulates the broker's wire protocol.
+ */
+export function createMockServer(options: MockServerOptions = {}): {
+  server: MockBrokerServer;
+  emitEvent: (event: BrokerEvent) => void;
+  dropConnection: () => void;
+  closeWith: (code: number, reason: string) => void;
+  sendBackpressure: (frame: { buffered: number; limit: number }) => void;
+  url: string;
+} {
+  const {
+    authBehavior = "accept",
+    autoRespond = true,
+    validToken = "test-token",
+  } = options;
+
+  const activeConnections = new Map<string, ConnectionState>();
+
+  const bunServer = Bun.serve({
+    port: 0,
+    fetch(req, server) {
+      const url = new URL(req.url);
+      if (url.pathname === "/v1/agent") {
+        const connectionId = crypto.randomUUID();
+        const upgraded = server.upgrade(req, {
+          data: { connectionId },
+        });
+        if (!upgraded) {
+          return new Response("Upgrade failed", { status: 500 });
+        }
+        return undefined;
+      }
+      return new Response("Not found", { status: 404 });
+    },
+    websocket: {
+      open(ws: ServerWebSocket<{ connectionId: string }>) {
+        activeConnections.set(ws.data.connectionId, {
+          ws,
+          authenticated: false,
+          seq: 0,
+          lastSeenSeq: null,
+        });
+      },
+      message(
+        ws: ServerWebSocket<{ connectionId: string }>,
+        message: string | Buffer,
+      ) {
+        const conn = activeConnections.get(ws.data.connectionId);
+        if (!conn) return;
+
+        let data: Record<string, unknown>;
+        try {
+          data = JSON.parse(
+            typeof message === "string" ? message : message.toString(),
+          ) as Record<string, unknown>;
+        } catch {
+          ws.close(4009, "Invalid JSON");
+          return;
+        }
+
+        if (!conn.authenticated) {
+          // Expect auth frame
+          const authData = data as unknown as AuthFrameData;
+          if (authData.type !== "auth") {
+            ws.close(4009, "Expected auth frame");
+            return;
+          }
+
+          conn.lastSeenSeq = authData.lastSeenSeq;
+
+          if (authBehavior === "reject") {
+            ws.send(
+              JSON.stringify({
+                type: "auth_error",
+                code: 4001,
+                message: "Invalid token",
+              }),
+            );
+            ws.close(4001, "Auth failed");
+            return;
+          }
+
+          if (authBehavior === "no-response") {
+            // Don't respond at all
+            return;
+          }
+
+          if (authData.token !== validToken) {
+            ws.send(
+              JSON.stringify({
+                type: "auth_error",
+                code: 4001,
+                message: "Invalid token",
+              }),
+            );
+            ws.close(4001, "Auth failed");
+            return;
+          }
+
+          conn.authenticated = true;
+          ws.send(
+            JSON.stringify({
+              type: "authenticated",
+              connectionId: ws.data.connectionId,
+              session: {
+                sessionId: "sess_test",
+                agentInboxId: "agent_inbox_1",
+                sessionKeyFingerprint: "fp_test",
+                issuedAt: "2024-01-01T00:00:00Z",
+                expiresAt: "2025-01-01T00:00:00Z",
+              },
+              view: {
+                mode: "full",
+                contentTypeAllowlist: ["xmtp.org/text:1.0"],
+              },
+              grant: {
+                messaging: {
+                  send: true,
+                  reply: true,
+                  react: true,
+                  draftOnly: false,
+                },
+              },
+              resumedFromSeq: authData.lastSeenSeq,
+            }),
+          );
+          return;
+        }
+
+        // Authenticated -- handle requests
+        if (autoRespond) {
+          const reqData = data as unknown as RequestData;
+          if (reqData.requestId) {
+            ws.send(
+              JSON.stringify({
+                ok: true,
+                requestId: reqData.requestId,
+                data: {
+                  messageId: `msg_${reqData.requestId}`,
+                  groupId: (reqData.groupId as string) ?? "g_unknown",
+                  sentAt: new Date().toISOString(),
+                },
+              }),
+            );
+          }
+        }
+      },
+      close(ws: ServerWebSocket<{ connectionId: string }>) {
+        activeConnections.delete(ws.data.connectionId);
+      },
+    },
+  });
+
+  const port = bunServer.port;
+  const url = `ws://127.0.0.1:${port}/v1/agent`;
+
+  function emitEvent(event: BrokerEvent): void {
+    for (const conn of activeConnections.values()) {
+      if (conn.authenticated) {
+        conn.seq += 1;
+        conn.ws.send(
+          JSON.stringify({
+            seq: conn.seq,
+            event,
+          }),
+        );
+      }
+    }
+  }
+
+  function dropConnection(): void {
+    for (const conn of activeConnections.values()) {
+      // Close with abnormal closure to trigger reconnection
+      conn.ws.close(1006, "Abnormal closure");
+    }
+  }
+
+  function closeWith(code: number, reason: string): void {
+    for (const conn of activeConnections.values()) {
+      conn.ws.close(code, reason);
+    }
+  }
+
+  function sendBackpressure(frame: { buffered: number; limit: number }): void {
+    for (const conn of activeConnections.values()) {
+      if (conn.authenticated) {
+        conn.ws.send(
+          JSON.stringify({
+            type: "backpressure",
+            buffered: frame.buffered,
+            limit: frame.limit,
+          }),
+        );
+      }
+    }
+  }
+
+  const server: MockBrokerServer = {
+    get port() {
+      return port;
+    },
+    get connections() {
+      return activeConnections.size;
+    },
+    async stop() {
+      for (const conn of activeConnections.values()) {
+        conn.ws.close(1001, "Server stopping");
+      }
+      activeConnections.clear();
+      bunServer.stop(true);
+    },
+  };
+
+  return {
+    server,
+    emitEvent,
+    dropConnection,
+    closeWith,
+    sendBackpressure,
+    url,
+  };
+}
+
+/** Helper: wait for a handler to reach a specific state. */
+export function waitForState(
+  handler: import("../types.js").BrokerHandler,
+  targetState: import("../types.js").HandlerState,
+  timeoutMs = 5000,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (handler.state === targetState) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      unsub();
+      reject(
+        new Error(
+          `Timed out waiting for state '${targetState}', current: '${handler.state}'`,
+        ),
+      );
+    }, timeoutMs);
+    const unsub = handler.onStateChange((newState) => {
+      if (newState === targetState) {
+        clearTimeout(timer);
+        unsub();
+        resolve();
+      }
+    });
+  });
+}
+
+/** Helper: take N items from an async iterable. */
+export async function take<T>(
+  iterable: AsyncIterable<T>,
+  count: number,
+): Promise<T[]> {
+  const items: T[] = [];
+  for await (const item of iterable) {
+    items.push(item);
+    if (items.length >= count) break;
+  }
+  return items;
+}
+
+/** Create a full test harness: mock server + handler. */
+export function createTestHandler(options?: {
+  config?: Partial<import("../config.js").BrokerHandlerConfig>;
+  serverOptions?: MockServerOptions;
+}): TestHarness {
+  const { createBrokerHandler } = require("../handler.js") as {
+    createBrokerHandler: typeof import("../handler.js").createBrokerHandler;
+  };
+
+  const {
+    server,
+    emitEvent,
+    dropConnection,
+    closeWith,
+    sendBackpressure,
+    url,
+  } = createMockServer(options?.serverOptions);
+
+  const handler = createBrokerHandler({
+    url: options?.config?.url ?? url,
+    token: options?.config?.token ?? "test-token",
+    reconnect: options?.config?.reconnect ?? { enabled: false },
+    requestTimeoutMs: options?.config?.requestTimeoutMs ?? 5000,
+  });
+
+  return {
+    handler,
+    server,
+    emitEvent,
+    dropConnection,
+    closeWith,
+    sendBackpressure,
+    async cleanup() {
+      try {
+        await handler.disconnect();
+      } catch {
+        // ignore
+      }
+      await server.stop();
+    },
+  };
+}

--- a/packages/handler/src/__tests__/reconnection.test.ts
+++ b/packages/handler/src/__tests__/reconnection.test.ts
@@ -1,0 +1,100 @@
+import { describe, test, expect } from "bun:test";
+import {
+  calculateDelay,
+  isRetryable,
+  createReconnectionTracker,
+} from "../reconnection.js";
+import type { ReconnectConfig } from "../reconnection.js";
+
+const DEFAULT_CONFIG: ReconnectConfig = {
+  enabled: true,
+  maxAttempts: 10,
+  baseDelayMs: 1_000,
+  maxDelayMs: 30_000,
+  jitter: false,
+};
+
+describe("isRetryable", () => {
+  test("returns false for non-retryable close codes", () => {
+    expect(isRetryable(4001)).toBe(false); // auth failed
+    expect(isRetryable(4002)).toBe(false); // auth timeout
+    expect(isRetryable(4004)).toBe(false); // session revoked
+    expect(isRetryable(4009)).toBe(false); // protocol error
+  });
+
+  test("returns true for retryable close codes", () => {
+    expect(isRetryable(1001)).toBe(true); // going away
+    expect(isRetryable(1006)).toBe(true); // abnormal closure
+    expect(isRetryable(4003)).toBe(true); // session expired
+    expect(isRetryable(4005)).toBe(true); // policy change
+    expect(isRetryable(4008)).toBe(true); // backpressure
+  });
+});
+
+describe("calculateDelay", () => {
+  test("returns base delay for attempt 0", () => {
+    expect(calculateDelay(0, DEFAULT_CONFIG)).toBe(1_000);
+  });
+
+  test("doubles delay each attempt", () => {
+    expect(calculateDelay(1, DEFAULT_CONFIG)).toBe(2_000);
+    expect(calculateDelay(2, DEFAULT_CONFIG)).toBe(4_000);
+    expect(calculateDelay(3, DEFAULT_CONFIG)).toBe(8_000);
+  });
+
+  test("caps delay at maxDelayMs", () => {
+    expect(calculateDelay(10, DEFAULT_CONFIG)).toBe(30_000);
+    expect(calculateDelay(20, DEFAULT_CONFIG)).toBe(30_000);
+  });
+
+  test("applies jitter when enabled", () => {
+    const config: ReconnectConfig = { ...DEFAULT_CONFIG, jitter: true };
+    const delay = calculateDelay(3, config);
+    // With jitter, delay should be between 0 and 8_000
+    expect(delay).toBeGreaterThanOrEqual(0);
+    expect(delay).toBeLessThanOrEqual(8_000);
+  });
+});
+
+describe("ReconnectionTracker", () => {
+  test("starts at attempt 0", () => {
+    const tracker = createReconnectionTracker(DEFAULT_CONFIG);
+    expect(tracker.attempt).toBe(0);
+    expect(tracker.exhausted).toBe(false);
+  });
+
+  test("increments attempt on nextDelay", () => {
+    const tracker = createReconnectionTracker(DEFAULT_CONFIG);
+    tracker.nextDelay();
+    expect(tracker.attempt).toBe(1);
+    tracker.nextDelay();
+    expect(tracker.attempt).toBe(2);
+  });
+
+  test("reports exhausted when max attempts exceeded", () => {
+    const config: ReconnectConfig = { ...DEFAULT_CONFIG, maxAttempts: 2 };
+    const tracker = createReconnectionTracker(config);
+    tracker.nextDelay(); // attempt 1
+    tracker.nextDelay(); // attempt 2
+    expect(tracker.exhausted).toBe(true);
+  });
+
+  test("never exhausts when maxAttempts is 0 (unlimited)", () => {
+    const config: ReconnectConfig = { ...DEFAULT_CONFIG, maxAttempts: 0 };
+    const tracker = createReconnectionTracker(config);
+    for (let i = 0; i < 100; i++) {
+      tracker.nextDelay();
+    }
+    expect(tracker.exhausted).toBe(false);
+  });
+
+  test("resets attempt counter", () => {
+    const tracker = createReconnectionTracker(DEFAULT_CONFIG);
+    tracker.nextDelay();
+    tracker.nextDelay();
+    expect(tracker.attempt).toBe(2);
+    tracker.reset();
+    expect(tracker.attempt).toBe(0);
+    expect(tracker.exhausted).toBe(false);
+  });
+});

--- a/packages/handler/src/__tests__/request-tracker.test.ts
+++ b/packages/handler/src/__tests__/request-tracker.test.ts
@@ -1,0 +1,90 @@
+import { describe, test, expect } from "bun:test";
+import { Result } from "better-result";
+import { createRequestTracker } from "../request-tracker.js";
+import { TimeoutError, InternalError } from "@xmtp-broker/schemas";
+
+describe("RequestTracker", () => {
+  test("resolves a tracked request with success", async () => {
+    const tracker = createRequestTracker(5000);
+    const promise = tracker.track("req_1");
+
+    tracker.resolve("req_1", Result.ok({ messageId: "msg_1" }));
+
+    const result = await promise;
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect((result.value as { messageId: string }).messageId).toBe("msg_1");
+    }
+  });
+
+  test("resolves a tracked request with error", async () => {
+    const tracker = createRequestTracker(5000);
+    const promise = tracker.track("req_2");
+
+    tracker.resolve(
+      "req_2",
+      Result.err(InternalError.create("Something went wrong")),
+    );
+
+    const result = await promise;
+    expect(result.isErr()).toBe(true);
+  });
+
+  test("times out a pending request", async () => {
+    const tracker = createRequestTracker(100);
+    const result = await tracker.track("req_timeout");
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(TimeoutError);
+    }
+  });
+
+  test("resolves multiple concurrent requests independently", async () => {
+    const tracker = createRequestTracker(5000);
+    const p1 = tracker.track("req_a");
+    const p2 = tracker.track("req_b");
+
+    tracker.resolve("req_b", Result.ok({ id: "b" }));
+    tracker.resolve("req_a", Result.ok({ id: "a" }));
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1.isOk()).toBe(true);
+    expect(r2.isOk()).toBe(true);
+    if (r1.isOk() && r2.isOk()) {
+      expect((r1.value as { id: string }).id).toBe("a");
+      expect((r2.value as { id: string }).id).toBe("b");
+    }
+  });
+
+  test("rejectAll rejects all pending requests", async () => {
+    const tracker = createRequestTracker(5000);
+    const p1 = tracker.track("req_c");
+    const p2 = tracker.track("req_d");
+
+    tracker.rejectAll(InternalError.create("Disconnected"));
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1.isErr()).toBe(true);
+    expect(r2.isErr()).toBe(true);
+  });
+
+  test("tracks pending count", () => {
+    const tracker = createRequestTracker(5000);
+    expect(tracker.pending).toBe(0);
+
+    tracker.track("req_e");
+    tracker.track("req_f");
+    expect(tracker.pending).toBe(2);
+
+    tracker.resolve("req_e", Result.ok(null));
+    expect(tracker.pending).toBe(1);
+  });
+
+  test("ignores resolve for unknown requestId", () => {
+    const tracker = createRequestTracker(5000);
+    // Should not throw
+    tracker.resolve("unknown", Result.ok(null));
+    expect(tracker.pending).toBe(0);
+  });
+});

--- a/packages/handler/src/config.ts
+++ b/packages/handler/src/config.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+
+/** Reconnection settings (all fields have defaults). */
+export type ReconnectOptions = {
+  enabled: boolean;
+  maxAttempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  jitter: boolean;
+};
+
+/** Input type for reconnect options (all optional with defaults). */
+type ReconnectOptionsInput = {
+  enabled?: boolean | undefined;
+  maxAttempts?: number | undefined;
+  baseDelayMs?: number | undefined;
+  maxDelayMs?: number | undefined;
+  jitter?: boolean | undefined;
+};
+
+/** Parsed broker handler configuration (all defaults applied). */
+export type BrokerHandlerConfig = {
+  url: string;
+  token: string;
+  reconnect: ReconnectOptions;
+  requestTimeoutMs: number;
+};
+
+/** Input to BrokerHandlerConfigSchema (fields with defaults are optional). */
+type BrokerHandlerConfigInput = {
+  url: string;
+  token: string;
+  reconnect?: ReconnectOptionsInput | undefined;
+  requestTimeoutMs?: number | undefined;
+};
+
+export const BrokerHandlerConfigSchema: z.ZodType<
+  BrokerHandlerConfig,
+  z.ZodTypeDef,
+  BrokerHandlerConfigInput
+> = z
+  .object({
+    url: z
+      .string()
+      .url()
+      .describe("Broker WebSocket URL (e.g., ws://localhost:8393/v1/agent)"),
+    token: z
+      .string()
+      .min(1)
+      .describe("Session bearer token obtained from broker admin"),
+    reconnect: z
+      .object({
+        enabled: z
+          .boolean()
+          .default(true)
+          .describe("Enable automatic reconnection"),
+        maxAttempts: z
+          .number()
+          .int()
+          .nonnegative()
+          .default(10)
+          .describe("Maximum reconnection attempts (0 = unlimited)"),
+        baseDelayMs: z
+          .number()
+          .int()
+          .positive()
+          .default(1_000)
+          .describe("Base delay for exponential backoff"),
+        maxDelayMs: z
+          .number()
+          .int()
+          .positive()
+          .default(30_000)
+          .describe("Maximum delay between reconnection attempts"),
+        jitter: z
+          .boolean()
+          .default(true)
+          .describe("Add random jitter to backoff delays"),
+      })
+      .default({})
+      .describe("Reconnection settings"),
+    requestTimeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .default(30_000)
+      .describe("Timeout for individual request/response round-trips"),
+  })
+  .describe("Broker handler configuration");

--- a/packages/handler/src/connection.ts
+++ b/packages/handler/src/connection.ts
@@ -1,0 +1,6 @@
+/**
+ * Connection module -- re-exports from handler.
+ * The handler.ts file contains the WebSocket lifecycle management
+ * integrated with the handler factory for simpler state sharing.
+ */
+export { createBrokerHandler } from "./handler.js";

--- a/packages/handler/src/event-stream.ts
+++ b/packages/handler/src/event-stream.ts
@@ -1,0 +1,69 @@
+import type { BrokerEvent } from "@xmtp-broker/schemas";
+
+/**
+ * AsyncIterable event queue that receives events from the WebSocket
+ * message handler and delivers them to harness consumers.
+ */
+export interface EventStream extends AsyncIterable<BrokerEvent> {
+  /** Push an event into the queue. */
+  push(event: BrokerEvent): void;
+  /** Signal that no more events will arrive. */
+  complete(): void;
+}
+
+/**
+ * Create a new event stream backed by an async queue.
+ * Events are buffered and delivered in order via async iteration.
+ * The iterator completes when complete() is called and the buffer is drained.
+ */
+export function createEventStream(): EventStream {
+  const buffer: BrokerEvent[] = [];
+  let done = false;
+  let waiter: ((value: IteratorResult<BrokerEvent>) => void) | null = null;
+
+  function push(event: BrokerEvent): void {
+    if (done) return;
+    if (waiter) {
+      const resolve = waiter;
+      waiter = null;
+      resolve({ value: event, done: false });
+    } else {
+      buffer.push(event);
+    }
+  }
+
+  function complete(): void {
+    done = true;
+    if (waiter) {
+      const resolve = waiter;
+      waiter = null;
+      resolve({ value: undefined as unknown as BrokerEvent, done: true });
+    }
+  }
+
+  const asyncIterator: AsyncIterator<BrokerEvent> = {
+    next(): Promise<IteratorResult<BrokerEvent>> {
+      const buffered = buffer.shift();
+      if (buffered !== undefined) {
+        return Promise.resolve({ value: buffered, done: false });
+      }
+      if (done) {
+        return Promise.resolve({
+          value: undefined as unknown as BrokerEvent,
+          done: true,
+        });
+      }
+      return new Promise((resolve) => {
+        waiter = resolve;
+      });
+    },
+  };
+
+  return {
+    push,
+    complete,
+    [Symbol.asyncIterator]() {
+      return asyncIterator;
+    },
+  };
+}

--- a/packages/handler/src/handler.ts
+++ b/packages/handler/src/handler.ts
@@ -1,0 +1,590 @@
+import { Result } from "better-result";
+import {
+  AuthError,
+  InternalError,
+  NotFoundError,
+  PermissionError,
+  ValidationError,
+} from "@xmtp-broker/schemas";
+import type { BrokerEvent, BrokerError } from "@xmtp-broker/schemas";
+import type { BrokerHandlerConfig } from "./config.js";
+import type {
+  BrokerHandler,
+  HandlerState,
+  SessionInfo,
+  MessageContent,
+  MessageSent,
+  ReactionSent,
+  Conversation,
+  ConversationInfo,
+  StateChangeCallback,
+  ErrorCallback,
+} from "./types.js";
+import { createEventStream } from "./event-stream.js";
+import type { EventStream } from "./event-stream.js";
+import { createRequestTracker } from "./request-tracker.js";
+import type { RequestTracker } from "./request-tracker.js";
+import { isRetryable, createReconnectionTracker } from "./reconnection.js";
+import type { ReconnectionTracker } from "./reconnection.js";
+import { createHeartbeatMonitor } from "./heartbeat-monitor.js";
+import type { HeartbeatMonitor } from "./heartbeat-monitor.js";
+
+/** Authenticated frame from the broker. */
+interface AuthenticatedFrameData {
+  type: "authenticated";
+  connectionId: string;
+  session: {
+    sessionId: string;
+    agentInboxId: string;
+    sessionKeyFingerprint: string;
+    issuedAt: string;
+    expiresAt: string;
+  };
+  view: Record<string, unknown>;
+  grant: Record<string, unknown>;
+  resumedFromSeq: number | null;
+}
+
+/** Auth error frame from the broker. */
+interface AuthErrorFrameData {
+  type: "auth_error";
+  code: number;
+  message: string;
+}
+
+/** Sequenced event frame from the broker. */
+interface SequencedFrameData {
+  seq: number;
+  event: BrokerEvent;
+}
+
+/** Backpressure frame from the broker. */
+interface BackpressureFrameData {
+  type: "backpressure";
+  buffered: number;
+  limit: number;
+}
+
+/** Request response frame from the broker. */
+interface ResponseFrameData {
+  ok: boolean;
+  requestId: string;
+  data?: unknown;
+  error?: {
+    code: number;
+    category: string;
+    message: string;
+    context: Record<string, unknown> | null;
+  };
+}
+
+/**
+ * Validate that a value is an object containing the expected string fields.
+ * Returns the value narrowed to a Record, or null if validation fails.
+ */
+function hasStringFields<K extends string>(
+  value: unknown,
+  fields: readonly K[],
+): Record<K, string> | null {
+  if (typeof value !== "object" || value === null) return null;
+  const obj = value as Record<string, unknown>;
+  for (const field of fields) {
+    if (typeof obj[field] !== "string") return null;
+  }
+  return obj as Record<K, string>;
+}
+
+/** Create a BrokerHandler. Does NOT connect -- call connect() separately. */
+export function createBrokerHandler(
+  config: BrokerHandlerConfig,
+): BrokerHandler {
+  let state: HandlerState = "disconnected";
+  let ws: WebSocket | null = null;
+  let sessionInfo: SessionInfo | null = null;
+  let lastSeenSeq: number | null = null;
+  let eventStream: EventStream = createEventStream();
+  const requestTracker: RequestTracker = createRequestTracker(
+    config.requestTimeoutMs,
+  );
+  const stateListeners = new Set<StateChangeCallback>();
+  const errorListeners = new Set<ErrorCallback>();
+  let heartbeatMonitor: HeartbeatMonitor | null = null;
+  let reconnectionTracker: ReconnectionTracker | null = null;
+
+  if (config.reconnect.enabled) {
+    reconnectionTracker = createReconnectionTracker({
+      enabled: config.reconnect.enabled,
+      maxAttempts: config.reconnect.maxAttempts,
+      baseDelayMs: config.reconnect.baseDelayMs,
+      maxDelayMs: config.reconnect.maxDelayMs,
+      jitter: config.reconnect.jitter,
+    });
+  }
+
+  function setState(newState: HandlerState): void {
+    const prev = state;
+    if (prev === newState) return;
+    state = newState;
+    for (const listener of stateListeners) {
+      listener(newState, prev);
+    }
+  }
+
+  function emitError(error: BrokerError): void {
+    for (const listener of errorListeners) {
+      listener(error);
+    }
+  }
+
+  function handleConnectionDead(): void {
+    heartbeatMonitor?.stop();
+    if (ws) {
+      // Close the socket — the close listener will call attemptReconnect().
+      ws.close();
+    } else {
+      // No socket to close, trigger reconnect directly.
+      attemptReconnect();
+    }
+  }
+
+  function attemptReconnect(): void {
+    if (!reconnectionTracker || !config.reconnect.enabled) {
+      setState("disconnected");
+      eventStream.complete();
+      return;
+    }
+
+    if (reconnectionTracker.exhausted) {
+      emitError(InternalError.create("Max reconnection attempts exceeded"));
+      setState("disconnected");
+      eventStream.complete();
+      return;
+    }
+
+    setState("reconnecting");
+    const delay = reconnectionTracker.nextDelay();
+    setTimeout(() => {
+      if (state !== "reconnecting") return;
+      connectInternal().catch(() => {
+        attemptReconnect();
+      });
+    }, delay);
+  }
+
+  function handleFrame(raw: string): void {
+    let data: Record<string, unknown>;
+    try {
+      data = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      emitError(ValidationError.create("frame", "Invalid JSON from broker"));
+      return;
+    }
+
+    // Check for backpressure frame
+    if (data["type"] === "backpressure") {
+      const bp = data as unknown as BackpressureFrameData;
+      emitError(
+        InternalError.create(
+          `Backpressure: ${bp.buffered}/${bp.limit} buffered`,
+          { buffered: bp.buffered, limit: bp.limit },
+        ),
+      );
+      return;
+    }
+
+    // Check for response frame (has requestId and ok)
+    if ("requestId" in data && "ok" in data) {
+      const resp = data as unknown as ResponseFrameData;
+      if (resp.ok) {
+        requestTracker.resolve(resp.requestId, Result.ok(resp.data));
+      } else {
+        const errMsg = resp.error?.message ?? "Request failed";
+        const errCtx = resp.error?.context ?? undefined;
+        const category = resp.error?.category;
+
+        let brokerError: BrokerError;
+        switch (category) {
+          case "auth":
+            brokerError = AuthError.create(errMsg, errCtx);
+            break;
+          case "validation":
+            brokerError = ValidationError.create("response", errMsg);
+            break;
+          case "not_found":
+            brokerError = NotFoundError.create("resource", errMsg);
+            break;
+          case "permission":
+            brokerError = PermissionError.create(errMsg, errCtx);
+            break;
+          default:
+            brokerError = InternalError.create(errMsg, errCtx);
+            break;
+        }
+
+        requestTracker.resolve(resp.requestId, Result.err(brokerError));
+      }
+      return;
+    }
+
+    // Check for sequenced event frame (has seq + event)
+    if ("seq" in data && "event" in data) {
+      const frame = data as unknown as SequencedFrameData;
+      lastSeenSeq = frame.seq;
+
+      // Record heartbeat events for dead-connection detection
+      if (
+        typeof frame.event === "object" &&
+        frame.event !== null &&
+        "type" in frame.event &&
+        frame.event.type === "heartbeat"
+      ) {
+        heartbeatMonitor?.recordHeartbeat();
+      }
+
+      eventStream.push(frame.event);
+      return;
+    }
+  }
+
+  async function connectInternal(): Promise<Result<void, BrokerError>> {
+    setState("connecting");
+
+    return new Promise((resolve) => {
+      const socket = new WebSocket(config.url);
+      ws = socket;
+
+      let authHandled = false;
+
+      // Auth timeout: if broker accepts the WebSocket but never sends an
+      // auth response, reject rather than hanging forever.
+      const authTimeout = setTimeout(() => {
+        if (!authHandled) {
+          authHandled = true;
+          socket.close(4000, "Auth timeout");
+          setState("closed");
+          resolve(
+            Result.err(
+              InternalError.create(
+                `Auth response not received within ${config.requestTimeoutMs}ms`,
+              ),
+            ),
+          );
+        }
+      }, config.requestTimeoutMs);
+
+      socket.addEventListener("open", () => {
+        setState("authenticating");
+        socket.send(
+          JSON.stringify({
+            type: "auth",
+            token: config.token,
+            lastSeenSeq,
+          }),
+        );
+      });
+
+      socket.addEventListener("message", (event) => {
+        const raw =
+          typeof event.data === "string" ? event.data : event.data.toString();
+
+        if (!authHandled) {
+          // First message should be auth response
+          let data: Record<string, unknown>;
+          try {
+            data = JSON.parse(raw) as Record<string, unknown>;
+          } catch {
+            clearTimeout(authTimeout);
+            setState("closed");
+            resolve(
+              Result.err(AuthError.create("Invalid auth response from broker")),
+            );
+            return;
+          }
+
+          if (data["type"] === "authenticated") {
+            authHandled = true;
+            clearTimeout(authTimeout);
+            const authData = data as unknown as AuthenticatedFrameData;
+            sessionInfo = {
+              connectionId: authData.connectionId,
+              sessionId: authData.session.sessionId,
+              agentInboxId: authData.session.agentInboxId,
+              view: authData.view,
+              grant: authData.grant,
+              expiresAt: authData.session.expiresAt,
+            };
+
+            // Start heartbeat monitoring
+            heartbeatMonitor = createHeartbeatMonitor({
+              intervalMs: 30_000,
+              missedBeforeDead: 3,
+            });
+            heartbeatMonitor.start(handleConnectionDead);
+
+            // Reset reconnection counter on successful connect
+            reconnectionTracker?.reset();
+
+            setState("connected");
+            resolve(Result.ok(undefined));
+          } else if (data["type"] === "auth_error") {
+            authHandled = true;
+            clearTimeout(authTimeout);
+            const authErr = data as unknown as AuthErrorFrameData;
+            setState("closed");
+            resolve(
+              Result.err(
+                AuthError.create(authErr.message, {
+                  code: authErr.code,
+                }),
+              ),
+            );
+          }
+          return;
+        }
+
+        // Post-auth messages
+        handleFrame(raw);
+      });
+
+      socket.addEventListener("close", (event) => {
+        heartbeatMonitor?.stop();
+
+        if (!authHandled) {
+          authHandled = true;
+          clearTimeout(authTimeout);
+          if (!isRetryable(event.code)) {
+            setState("closed");
+            resolve(
+              Result.err(
+                AuthError.create(
+                  event.reason || "Connection closed during auth",
+                ),
+              ),
+            );
+          } else {
+            // Connection failed during auth, try reconnect
+            requestTracker.rejectAll(InternalError.create("Connection lost"));
+            attemptReconnect();
+            resolve(
+              Result.err(InternalError.create("Connection lost during auth")),
+            );
+          }
+          return;
+        }
+
+        // Post-auth close
+        ws = null;
+        requestTracker.rejectAll(InternalError.create("Connection closed"));
+
+        if (!isRetryable(event.code)) {
+          setState("closed");
+          eventStream.complete();
+        } else if (state !== "closed") {
+          attemptReconnect();
+        }
+      });
+
+      socket.addEventListener("error", () => {
+        // Error events are followed by close events, handled above
+      });
+    });
+  }
+
+  async function sendRequest(
+    request: Record<string, unknown>,
+  ): Promise<Result<unknown, BrokerError>> {
+    if (state !== "connected" || !ws) {
+      return Result.err(
+        ValidationError.create("state", "Not connected to broker"),
+      );
+    }
+
+    const requestId = crypto.randomUUID();
+    const promise = requestTracker.track(requestId);
+
+    ws.send(JSON.stringify({ ...request, requestId }));
+
+    return promise;
+  }
+
+  const handler: BrokerHandler = {
+    async connect(): Promise<Result<void, BrokerError>> {
+      if (state === "closed") {
+        return Result.err(
+          ValidationError.create(
+            "state",
+            "Handler is closed and cannot be reused",
+          ),
+        );
+      }
+      if (state === "connected") {
+        return Result.ok(undefined);
+      }
+      if (
+        state === "connecting" ||
+        state === "authenticating" ||
+        state === "reconnecting"
+      ) {
+        return Result.err(
+          ValidationError.create(
+            "state",
+            `Connection already in progress (state: ${state})`,
+          ),
+        );
+      }
+      // Create fresh event stream on connect
+      eventStream = createEventStream();
+      return connectInternal();
+    },
+
+    async disconnect(): Promise<Result<void, BrokerError>> {
+      heartbeatMonitor?.stop();
+      requestTracker.rejectAll(InternalError.create("Disconnecting"));
+
+      if (ws) {
+        ws.close(1000, "Client disconnect");
+        ws = null;
+      }
+
+      setState("closed");
+      eventStream.complete();
+      return Result.ok(undefined);
+    },
+
+    get events(): AsyncIterable<BrokerEvent> {
+      return eventStream;
+    },
+
+    async sendMessage(
+      groupId: string,
+      content: MessageContent,
+    ): Promise<Result<MessageSent, BrokerError>> {
+      const contentType =
+        content.type === "text" ? "xmtp.org/text:1.0" : content.contentType;
+      const payload =
+        content.type === "text" ? { text: content.text } : content.content;
+
+      const result = await sendRequest({
+        type: "send_message",
+        groupId,
+        contentType,
+        content: payload,
+      });
+
+      if (result.isErr()) return Result.err(result.error);
+      const data = hasStringFields(result.value, [
+        "messageId",
+        "groupId",
+        "sentAt",
+      ]);
+      if (data === null) {
+        return Result.err(
+          ValidationError.create(
+            "response",
+            "Missing required fields: messageId, groupId, sentAt",
+          ),
+        );
+      }
+      return Result.ok({
+        messageId: data.messageId,
+        groupId: data.groupId,
+        sentAt: data.sentAt,
+      });
+    },
+
+    async sendReaction(
+      groupId: string,
+      messageId: string,
+      reaction: string,
+    ): Promise<Result<ReactionSent, BrokerError>> {
+      const result = await sendRequest({
+        type: "send_reaction",
+        groupId,
+        messageId,
+        action: "added",
+        content: reaction,
+      });
+
+      if (result.isErr()) return Result.err(result.error);
+      const data = hasStringFields(result.value, [
+        "messageId",
+        "groupId",
+        "sentAt",
+      ]);
+      if (data === null) {
+        return Result.err(
+          ValidationError.create(
+            "response",
+            "Missing required fields: messageId, groupId, sentAt",
+          ),
+        );
+      }
+      return Result.ok({
+        messageId: data.messageId,
+        groupId: data.groupId,
+        sentAt: data.sentAt,
+      });
+    },
+
+    async listConversations(): Promise<Result<Conversation[], BrokerError>> {
+      const result = await sendRequest({
+        type: "list_conversations",
+      });
+
+      if (result.isErr()) return Result.err(result.error);
+      if (!Array.isArray(result.value)) {
+        return Result.err(
+          ValidationError.create(
+            "response",
+            "Expected array for list_conversations response",
+          ),
+        );
+      }
+      return Result.ok(result.value as Conversation[]);
+    },
+
+    async getConversationInfo(
+      groupId: string,
+    ): Promise<Result<ConversationInfo, BrokerError>> {
+      const result = await sendRequest({
+        type: "get_conversation_info",
+        groupId,
+      });
+
+      if (result.isErr()) return Result.err(result.error);
+      if (typeof result.value !== "object" || result.value === null) {
+        return Result.err(
+          ValidationError.create(
+            "response",
+            "Expected object for get_conversation_info response",
+          ),
+        );
+      }
+      return Result.ok(result.value as ConversationInfo);
+    },
+
+    get session(): SessionInfo | null {
+      return sessionInfo;
+    },
+
+    get state(): HandlerState {
+      return state;
+    },
+
+    onStateChange(callback: StateChangeCallback): () => void {
+      stateListeners.add(callback);
+      return () => {
+        stateListeners.delete(callback);
+      };
+    },
+
+    onError(callback: ErrorCallback): () => void {
+      errorListeners.add(callback);
+      return () => {
+        errorListeners.delete(callback);
+      };
+    },
+  };
+
+  return handler;
+}

--- a/packages/handler/src/heartbeat-monitor.ts
+++ b/packages/handler/src/heartbeat-monitor.ts
@@ -1,0 +1,56 @@
+/** Configuration for heartbeat monitoring. */
+export interface HeartbeatConfig {
+  readonly intervalMs: number;
+  readonly missedBeforeDead: number;
+}
+
+/** Monitor broker heartbeats and detect dead connections. */
+export interface HeartbeatMonitor {
+  /** Start monitoring. Calls onDead when heartbeats are missed. */
+  start(onDead: () => void): void;
+  /** Record a received heartbeat. */
+  recordHeartbeat(): void;
+  /** Stop monitoring and clear timers. */
+  stop(): void;
+}
+
+/**
+ * Create a heartbeat monitor.
+ * Fires onDead when no heartbeat is received within
+ * intervalMs * missedBeforeDead milliseconds.
+ */
+export function createHeartbeatMonitor(
+  config: HeartbeatConfig,
+): HeartbeatMonitor {
+  let timer: Timer | null = null;
+  let deadCallback: (() => void) | null = null;
+  const thresholdMs = config.intervalMs * config.missedBeforeDead;
+
+  function resetTimer(): void {
+    if (timer !== null) {
+      clearTimeout(timer);
+    }
+    if (deadCallback) {
+      timer = setTimeout(() => {
+        deadCallback?.();
+      }, thresholdMs);
+    }
+  }
+
+  return {
+    start(onDead: () => void): void {
+      deadCallback = onDead;
+      resetTimer();
+    },
+    recordHeartbeat(): void {
+      resetTimer();
+    },
+    stop(): void {
+      deadCallback = null;
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    },
+  };
+}

--- a/packages/handler/src/index.ts
+++ b/packages/handler/src/index.ts
@@ -1,0 +1,16 @@
+// Public API
+export { createBrokerHandler } from "./handler.js";
+export { BrokerHandlerConfigSchema } from "./config.js";
+export type { BrokerHandlerConfig } from "./config.js";
+export type {
+  BrokerHandler,
+  HandlerState,
+  SessionInfo,
+  StateChangeCallback,
+  ErrorCallback,
+  MessageContent,
+  MessageSent,
+  ReactionSent,
+  Conversation,
+  ConversationInfo,
+} from "./types.js";

--- a/packages/handler/src/reconnection.ts
+++ b/packages/handler/src/reconnection.ts
@@ -1,0 +1,70 @@
+/** Non-retryable close codes -- auth failures that won't succeed on retry. */
+const NON_RETRYABLE_CODES = new Set([4001, 4002, 4004, 4009]);
+
+/** Check if a close code is retryable. */
+export function isRetryable(code: number): boolean {
+  return !NON_RETRYABLE_CODES.has(code);
+}
+
+/** Configuration for reconnection backoff. */
+export interface ReconnectConfig {
+  readonly enabled: boolean;
+  readonly maxAttempts: number;
+  readonly baseDelayMs: number;
+  readonly maxDelayMs: number;
+  readonly jitter: boolean;
+}
+
+/**
+ * Calculate the delay for a given reconnection attempt.
+ * Uses exponential backoff: min(baseDelayMs * 2^attempt, maxDelayMs)
+ * With optional full jitter: random(0, delay).
+ */
+export function calculateDelay(
+  attempt: number,
+  config: ReconnectConfig,
+): number {
+  const exponential = config.baseDelayMs * Math.pow(2, attempt);
+  const capped = Math.min(exponential, config.maxDelayMs);
+  if (config.jitter) {
+    return Math.floor(Math.random() * (capped + 1));
+  }
+  return capped;
+}
+
+/** Tracks reconnection state. */
+export interface ReconnectionTracker {
+  /** Current attempt number. */
+  readonly attempt: number;
+  /** Whether max attempts have been exceeded. */
+  readonly exhausted: boolean;
+  /** Get delay for next attempt and increment counter. */
+  nextDelay(): number;
+  /** Reset attempt counter (on successful reconnect). */
+  reset(): void;
+}
+
+/** Create a reconnection tracker with the given config. */
+export function createReconnectionTracker(
+  config: ReconnectConfig,
+): ReconnectionTracker {
+  let attempt = 0;
+
+  return {
+    get attempt() {
+      return attempt;
+    },
+    get exhausted() {
+      if (config.maxAttempts === 0) return false;
+      return attempt >= config.maxAttempts;
+    },
+    nextDelay() {
+      const delay = calculateDelay(attempt, config);
+      attempt += 1;
+      return delay;
+    },
+    reset() {
+      attempt = 0;
+    },
+  };
+}

--- a/packages/handler/src/request-tracker.ts
+++ b/packages/handler/src/request-tracker.ts
@@ -1,0 +1,60 @@
+import type { BrokerError } from "@xmtp-broker/schemas";
+import { TimeoutError } from "@xmtp-broker/schemas";
+import { Result } from "better-result";
+
+/** A pending request awaiting a response. */
+export interface PendingRequest {
+  readonly requestId: string;
+  readonly resolve: (result: Result<unknown, BrokerError>) => void;
+  readonly timer: Timer;
+}
+
+/** Tracks in-flight requests by requestId with timeout. */
+export interface RequestTracker {
+  /** Register a new request. Returns a promise that resolves on response or timeout. */
+  track(requestId: string): Promise<Result<unknown, BrokerError>>;
+  /** Resolve a pending request with a result. */
+  resolve(requestId: string, result: Result<unknown, BrokerError>): void;
+  /** Reject all pending requests (e.g., on disconnect). */
+  rejectAll(error: BrokerError): void;
+  /** Number of pending requests. */
+  readonly pending: number;
+}
+
+/** Create a request tracker with the given timeout. */
+export function createRequestTracker(timeoutMs: number): RequestTracker {
+  const pending = new Map<string, PendingRequest>();
+
+  return {
+    track(requestId: string): Promise<Result<unknown, BrokerError>> {
+      return new Promise((resolve) => {
+        const timer = setTimeout(() => {
+          pending.delete(requestId);
+          resolve(Result.err(TimeoutError.create("request", timeoutMs)));
+        }, timeoutMs);
+
+        pending.set(requestId, { requestId, resolve, timer });
+      });
+    },
+
+    resolve(requestId: string, result: Result<unknown, BrokerError>): void {
+      const entry = pending.get(requestId);
+      if (!entry) return;
+      clearTimeout(entry.timer);
+      pending.delete(requestId);
+      entry.resolve(result);
+    },
+
+    rejectAll(error: BrokerError): void {
+      for (const entry of pending.values()) {
+        clearTimeout(entry.timer);
+        entry.resolve(Result.err(error));
+      }
+      pending.clear();
+    },
+
+    get pending() {
+      return pending.size;
+    },
+  };
+}

--- a/packages/handler/src/types.ts
+++ b/packages/handler/src/types.ts
@@ -1,0 +1,115 @@
+import type { BrokerEvent, BrokerError } from "@xmtp-broker/schemas";
+import type { Result } from "better-result";
+
+/** Connection state machine states. */
+export type HandlerState =
+  | "disconnected"
+  | "connecting"
+  | "authenticating"
+  | "connected"
+  | "reconnecting"
+  | "closed";
+
+/** Callback fired on state transitions. */
+export type StateChangeCallback = (
+  newState: HandlerState,
+  previousState: HandlerState,
+) => void;
+
+/** Callback fired for connection/protocol errors. */
+export type ErrorCallback = (error: BrokerError) => void;
+
+/** Read-only session info derived from AuthenticatedFrame. */
+export interface SessionInfo {
+  readonly connectionId: string;
+  readonly sessionId: string;
+  readonly agentInboxId: string;
+  readonly view: Record<string, unknown>;
+  readonly grant: Record<string, unknown>;
+  readonly expiresAt: string;
+}
+
+/** Content for sendMessage. */
+export type MessageContent =
+  | { readonly type: "text"; readonly text: string }
+  | {
+      readonly type: "custom";
+      readonly contentType: string;
+      readonly content: unknown;
+    };
+
+/** Successful message send result. */
+export interface MessageSent {
+  readonly messageId: string;
+  readonly groupId: string;
+  readonly sentAt: string;
+}
+
+/** Successful reaction send result. */
+export interface ReactionSent {
+  readonly messageId: string;
+  readonly groupId: string;
+  readonly sentAt: string;
+}
+
+/** Conversation summary for list results. */
+export interface Conversation {
+  readonly groupId: string;
+  readonly name: string | null;
+  readonly memberCount: number;
+  readonly lastMessageAt: string | null;
+}
+
+/** Detailed conversation info. */
+export interface ConversationInfo {
+  readonly groupId: string;
+  readonly name: string | null;
+  readonly members: readonly string[];
+  readonly createdAt: string;
+  readonly lastMessageAt: string | null;
+}
+
+/** The public BrokerHandler interface. */
+export interface BrokerHandler {
+  /** Open the WebSocket connection and authenticate. */
+  connect(): Promise<Result<void, BrokerError>>;
+
+  /** Close the connection gracefully. */
+  disconnect(): Promise<Result<void, BrokerError>>;
+
+  /** Typed async iterable of broker events. */
+  readonly events: AsyncIterable<BrokerEvent>;
+
+  /** Send a text message to a conversation. */
+  sendMessage(
+    groupId: string,
+    content: MessageContent,
+  ): Promise<Result<MessageSent, BrokerError>>;
+
+  /** Send a reaction to a message. */
+  sendReaction(
+    groupId: string,
+    messageId: string,
+    reaction: string,
+  ): Promise<Result<ReactionSent, BrokerError>>;
+
+  /** List conversations visible to this session. */
+  listConversations(): Promise<Result<Conversation[], BrokerError>>;
+
+  /** Get detailed info about a conversation. */
+  getConversationInfo(
+    groupId: string,
+  ): Promise<Result<ConversationInfo, BrokerError>>;
+
+  /** Current session info. */
+  readonly session: SessionInfo | null;
+
+  /** Current connection state. */
+  readonly state: HandlerState;
+
+  /** Register a listener for state changes. Returns unsubscribe. */
+  onStateChange(callback: StateChangeCallback): () => void;
+
+  /** Register a listener for errors. Returns unsubscribe. */
+  onError(callback: ErrorCallback): () => void;
+}

--- a/packages/handler/tsconfig.json
+++ b/packages/handler/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "src/__tests__"]
+}


### PR DESCRIPTION
## Summary

- Creates `packages/handler/` — a TypeScript client SDK that harness developers install to connect their agents to the broker
- Wraps the WebSocket transport with a developer-friendly API: typed events, Result-based requests, automatic reconnection
- Depends only on type packages (`schemas`, `contracts`) + `better-result` — no XMTP SDK, no broker runtime

## Public API

```typescript
const handler = createBrokerHandler({ url, token });
await handler.connect();

for await (const event of handler.events) {
  // typed BrokerEvent stream
}

const result = await handler.sendMessage(groupId, { type: "text", text: "hello" });
```

## Components

| File | Purpose |
|------|---------|
| `handler.ts` | `createBrokerHandler()` with full state machine (disconnected → connecting → authenticating → connected → reconnecting → closed) |
| `event-stream.ts` | `AsyncIterable<BrokerEvent>` backed by async queue |
| `request-tracker.ts` | Pending request map with UUID correlation and timeout |
| `reconnection.ts` | Exponential backoff with jitter, retryable/non-retryable close code classification |
| `heartbeat-monitor.ts` | Dead connection detection via missed heartbeat timer |

## Features

- **Typed event stream** — `for await (const event of handler.events)`
- **Result-based requests** — `sendMessage()`, `sendReaction()`, `listConversations()`, `getConversationInfo()`
- **Automatic reconnection** — exponential backoff, `lastSeenSeq` replay, configurable max attempts
- **State change callbacks** — `onStateChange()`, `onError()`
- **Session info** — view, grant, and expiry from the `AuthenticatedFrame`

**37 tests** including integration tests with a mock broker WebSocket server

## Spec

[`15-handler-sdk.md`](.agents/plans/v0/15-handler-sdk.md)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)