### PR TITLE
feat(sessions): session service, ActionSpec handlers, and broker actions

### DIFF
--- a/packages/cli/src/actions/broker-actions.ts
+++ b/packages/cli/src/actions/broker-actions.ts
@@ -1,0 +1,54 @@
+import { Result } from "better-result";
+import { z } from "zod";
+import type { ActionSpec } from "@xmtp-broker/contracts";
+import type { BrokerError } from "@xmtp-broker/schemas";
+import type { DaemonStatus } from "../daemon/status.js";
+
+export interface BrokerActionDeps {
+  readonly status: () => Promise<DaemonStatus>;
+  readonly shutdown: () => Promise<Result<void, BrokerError>>;
+}
+
+function widenActionSpec<TInput, TOutput>(
+  spec: ActionSpec<TInput, TOutput, BrokerError>,
+): ActionSpec<unknown, unknown, BrokerError> {
+  return spec as ActionSpec<unknown, unknown, BrokerError>;
+}
+
+export function createBrokerActions(
+  deps: BrokerActionDeps,
+): ActionSpec<unknown, unknown, BrokerError>[] {
+  const status: ActionSpec<Record<string, never>, DaemonStatus, BrokerError> = {
+    id: "broker.status",
+    input: z.object({}),
+    handler: async () => Result.ok(await deps.status()),
+    cli: {
+      command: "broker:status",
+      rpcMethod: "broker.status",
+    },
+  };
+
+  const stop: ActionSpec<
+    { force?: boolean | undefined },
+    { stopped: true },
+    BrokerError
+  > = {
+    id: "broker.stop",
+    input: z.object({
+      force: z.boolean().optional(),
+    }),
+    handler: async () => {
+      const result = await deps.shutdown();
+      if (Result.isError(result)) {
+        return result;
+      }
+      return Result.ok({ stopped: true as const });
+    },
+    cli: {
+      command: "broker:stop",
+      rpcMethod: "broker.stop",
+    },
+  };
+
+  return [widenActionSpec(status), widenActionSpec(stop)];
+}

--- a/packages/sessions/src/__tests__/service.test.ts
+++ b/packages/sessions/src/__tests__/service.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import { InternalError } from "@xmtp-broker/schemas";
+import { createSessionService } from "../service.js";
+import { createSessionManager } from "../session-manager.js";
+import type { InternalSessionManager } from "../session-manager.js";
+import { createTestSessionConfig } from "./fixtures.js";
+
+describe("createSessionService", () => {
+  let manager: InternalSessionManager;
+  let issued: string[];
+  let service: ReturnType<typeof createSessionService>;
+
+  beforeEach(() => {
+    manager = createSessionManager({
+      defaultTtlSeconds: 60,
+      maxConcurrentPerAgent: 3,
+      renewalWindowSeconds: 10,
+      heartbeatGracePeriod: 3,
+    });
+    issued = [];
+    service = createSessionService({
+      manager,
+      keyManager: {
+        async issueSessionKey(sessionId, ttlSeconds) {
+          issued.push(`${sessionId}:${ttlSeconds}`);
+          return Result.ok({ fingerprint: `fp_${sessionId}` });
+        },
+      },
+    });
+  });
+
+  test("issues bearer credentials with session metadata", async () => {
+    const result = await service.issue(createTestSessionConfig());
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.token).toHaveLength(43);
+    expect(result.value.session.sessionId).toMatch(/^ses_[0-9a-f]{32}$/);
+    expect(result.value.session.sessionKeyFingerprint).toBe(
+      `fp_${result.value.session.sessionId}`,
+    );
+    expect(issued).toEqual([`${result.value.session.sessionId}:3600`]);
+  });
+
+  test("reuses an existing matching active session without issuing a new key", async () => {
+    const config = createTestSessionConfig();
+    const first = await service.issue(config);
+    const second = await service.issue(config);
+
+    expect(first.isOk()).toBe(true);
+    expect(second.isOk()).toBe(true);
+    if (!first.isOk() || !second.isOk()) return;
+
+    expect(second.value.token).toBe(first.value.token);
+    expect(second.value.session.sessionId).toBe(first.value.session.sessionId);
+    expect(issued).toHaveLength(1);
+  });
+
+  test("lists public session records without exposing bearer tokens", async () => {
+    const issuedSession = await service.issue(createTestSessionConfig());
+    expect(issuedSession.isOk()).toBe(true);
+    if (!issuedSession.isOk()) return;
+
+    const listed = await service.list("agent-inbox-1");
+    expect(listed.isOk()).toBe(true);
+    if (!listed.isOk()) return;
+
+    expect(listed.value).toHaveLength(1);
+    expect(listed.value[0]?.sessionId).toBe(
+      issuedSession.value.session.sessionId,
+    );
+    expect("token" in listed.value[0]!).toBe(false);
+  });
+
+  test("reports whether a session is active", async () => {
+    const issuedSession = await service.issue(createTestSessionConfig());
+    expect(issuedSession.isOk()).toBe(true);
+    if (!issuedSession.isOk()) return;
+
+    const active = await service.isActive(
+      issuedSession.value.session.sessionId,
+    );
+    expect(active.isOk()).toBe(true);
+    if (!active.isOk()) return;
+    expect(active.value).toBe(true);
+
+    await service.revoke(
+      issuedSession.value.session.sessionId,
+      "owner-initiated",
+    );
+
+    const revoked = await service.isActive(
+      issuedSession.value.session.sessionId,
+    );
+    expect(revoked.isOk()).toBe(true);
+    if (!revoked.isOk()) return;
+    expect(revoked.value).toBe(false);
+  });
+
+  test("propagates session-key issuance errors", async () => {
+    const failing = createSessionService({
+      manager,
+      keyManager: {
+        async issueSessionKey() {
+          return Result.err(InternalError.create("session key failed"));
+        },
+      },
+    });
+
+    const result = await failing.issue(createTestSessionConfig());
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+    expect(result.error.message).toContain("session key failed");
+  });
+});

--- a/packages/sessions/src/actions.ts
+++ b/packages/sessions/src/actions.ts
@@ -1,0 +1,116 @@
+import { Result } from "better-result";
+import { z } from "zod";
+import type { ActionSpec, SessionManager } from "@xmtp-broker/contracts";
+import type {
+  BrokerError,
+  SessionConfig as SessionConfigType,
+  SessionRevocationReason as SessionRevocationReasonType,
+} from "@xmtp-broker/schemas";
+import { SessionConfig, SessionRevocationReason } from "@xmtp-broker/schemas";
+
+export interface SessionActionDeps {
+  readonly sessionManager: SessionManager;
+}
+
+function widenActionSpec<TInput, TOutput>(
+  spec: ActionSpec<TInput, TOutput, BrokerError>,
+): ActionSpec<unknown, unknown, BrokerError> {
+  // The shared registry intentionally erases per-action input/output types.
+  return spec as ActionSpec<unknown, unknown, BrokerError>;
+}
+
+export function createSessionActions(
+  deps: SessionActionDeps,
+): ActionSpec<unknown, unknown, BrokerError>[] {
+  const issue: ActionSpec<SessionConfigType, unknown, BrokerError> = {
+    id: "session.issue",
+    input: SessionConfig,
+    handler: async (input) => deps.sessionManager.issue(input),
+    cli: {
+      command: "session:issue",
+      rpcMethod: "session.issue",
+    },
+    mcp: {
+      toolName: "broker/session/issue",
+      description: "Issue a new session",
+      readOnly: false,
+    },
+  };
+
+  const list: ActionSpec<
+    { agentInboxId?: string | undefined },
+    unknown,
+    BrokerError
+  > = {
+    id: "session.list",
+    input: z.object({
+      agentInboxId: z.string().optional(),
+    }),
+    handler: async (input) => deps.sessionManager.list(input.agentInboxId),
+    cli: {
+      command: "session:list",
+      rpcMethod: "session.list",
+    },
+    mcp: {
+      toolName: "broker/session/list",
+      description: "List active sessions",
+      readOnly: true,
+    },
+  };
+
+  const inspect: ActionSpec<{ sessionId: string }, unknown, BrokerError> = {
+    id: "session.inspect",
+    input: z.object({
+      sessionId: z.string(),
+    }),
+    handler: async (input) => deps.sessionManager.lookup(input.sessionId),
+    cli: {
+      command: "session:inspect",
+      rpcMethod: "session.inspect",
+    },
+    mcp: {
+      toolName: "broker/session/inspect",
+      description: "Inspect a session",
+      readOnly: true,
+    },
+  };
+
+  const revoke: ActionSpec<
+    { sessionId: string; reason?: SessionRevocationReasonType | undefined },
+    { revoked: true },
+    BrokerError
+  > = {
+    id: "session.revoke",
+    input: z.object({
+      sessionId: z.string(),
+      reason: SessionRevocationReason.default("owner-initiated"),
+    }),
+    handler: async (input) => {
+      const result = await deps.sessionManager.revoke(
+        input.sessionId,
+        input.reason ?? "owner-initiated",
+      );
+      if (Result.isError(result)) {
+        return result;
+      }
+      return Result.ok({ revoked: true as const });
+    },
+    cli: {
+      command: "session:revoke",
+      rpcMethod: "session.revoke",
+    },
+    mcp: {
+      toolName: "broker/session/revoke",
+      description: "Revoke a session",
+      readOnly: false,
+      destructive: true,
+    },
+  };
+
+  return [
+    widenActionSpec(issue),
+    widenActionSpec(list),
+    widenActionSpec(inspect),
+    widenActionSpec(revoke),
+  ];
+}

--- a/packages/sessions/src/service.ts
+++ b/packages/sessions/src/service.ts
@@ -1,0 +1,139 @@
+import { Result } from "better-result";
+import type {
+  BrokerError,
+  IssuedSession,
+  SessionConfig,
+  SessionRevocationReason,
+} from "@xmtp-broker/schemas";
+import type { SessionManager, SessionRecord } from "@xmtp-broker/contracts";
+import { generateSessionId } from "./token.js";
+import { computePolicyHash } from "./policy-hash.js";
+import type {
+  InternalSessionManager,
+  InternalSessionRecord,
+} from "./session-manager.js";
+
+export interface SessionServiceDeps {
+  readonly manager: InternalSessionManager;
+  readonly keyManager: {
+    issueSessionKey(
+      sessionId: string,
+      ttlSeconds: number,
+    ): Promise<Result<{ fingerprint: string }, BrokerError>>;
+    revokeSessionKey?(keyId: string): Result<void, BrokerError>;
+  };
+}
+
+function toSessionRecord(record: InternalSessionRecord): SessionRecord {
+  return {
+    sessionId: record.sessionId,
+    agentInboxId: record.agentInboxId,
+    sessionKeyFingerprint: record.sessionKeyFingerprint,
+    view: record.view,
+    grant: record.grant,
+    state: record.state,
+    issuedAt: record.issuedAt,
+    expiresAt: record.expiresAt,
+    lastHeartbeat: record.lastHeartbeat,
+  };
+}
+
+function toIssuedSession(record: InternalSessionRecord): IssuedSession {
+  return {
+    token: record.token,
+    session: {
+      sessionId: record.sessionId,
+      agentInboxId: record.agentInboxId,
+      sessionKeyFingerprint: record.sessionKeyFingerprint,
+      issuedAt: record.issuedAt,
+      expiresAt: record.expiresAt,
+    },
+  };
+}
+
+export function createSessionService(deps: SessionServiceDeps): SessionManager {
+  return {
+    async issue(config: SessionConfig) {
+      deps.manager.sweepExpired();
+
+      const policyHash = computePolicyHash(config.view, config.grant);
+      const existing = deps.manager
+        .getActiveSessions(config.agentInboxId)
+        .find((record) => record.policyHash === policyHash);
+      if (existing) {
+        return Result.ok(toIssuedSession(existing));
+      }
+
+      const sessionId = generateSessionId();
+      const ttlSeconds = config.ttlSeconds ?? 3600;
+
+      const sessionKey = await deps.keyManager.issueSessionKey(
+        sessionId,
+        ttlSeconds,
+      );
+      if (Result.isError(sessionKey)) {
+        return sessionKey;
+      }
+
+      const created = await deps.manager.createSession(
+        config,
+        sessionKey.value.fingerprint,
+        { sessionId },
+      );
+      if (Result.isError(created)) {
+        return created;
+      }
+
+      return Result.ok(toIssuedSession(created.value));
+    },
+
+    async list(agentInboxId?: string) {
+      deps.manager.sweepExpired();
+      return Result.ok(
+        deps.manager.listSessions(agentInboxId).map(toSessionRecord),
+      );
+    },
+
+    async lookup(sessionId: string) {
+      deps.manager.sweepExpired();
+      const result = deps.manager.getSessionById(sessionId);
+      if (Result.isError(result)) {
+        return result;
+      }
+      return Result.ok(toSessionRecord(result.value));
+    },
+
+    async lookupByToken(token: string) {
+      const result = deps.manager.getSessionByToken(token);
+      if (Result.isError(result)) {
+        return result;
+      }
+      return Result.ok(toSessionRecord(result.value));
+    },
+
+    async revoke(sessionId: string, reason: SessionRevocationReason) {
+      const result = deps.manager.revokeSession(sessionId, reason);
+      if (Result.isError(result)) {
+        return result;
+      }
+      return Result.ok(undefined);
+    },
+
+    async heartbeat(sessionId: string) {
+      const result = deps.manager.recordHeartbeat(sessionId);
+      if (Result.isError(result)) {
+        return result;
+      }
+      return Result.ok(undefined);
+    },
+
+    async isActive(sessionId: string) {
+      deps.manager.sweepExpired();
+      const result = deps.manager.getSessionById(sessionId);
+      if (Result.isError(result)) {
+        return result;
+      }
+      return Result.ok(result.value.state === "active");
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Introduce a SessionService that manages session CRUD (issue, list, get, revoke) backed by an in-memory store
- Define ActionSpec-based session handlers that can be wired into any transport (CLI, WS, MCP)
- Add broker-level ActionSpecs for `broker.status` and `broker.stop`

## Key changes
- `packages/sessions/src/service.ts` — SessionService with create/list/get/revoke operations and in-memory store
- `packages/sessions/src/actions.ts` — ActionSpec handlers wrapping the session service for transport-agnostic invocation
- `packages/cli/src/actions/broker-actions.ts` — Broker-level ActionSpecs (status, stop) with typed input/output
- `packages/sessions/src/__tests__/service.test.ts` — Tests for session lifecycle

## Test plan
- [ ] `cd packages/sessions && bun test` passes all session service tests
- [ ] Verify ActionSpec IDs match expected patterns (`session.issue`, `broker.status`, etc.)