### PR TITLE
feat(cli): daemon client helper and CLI command wiring

### DIFF
--- a/packages/cli/src/__tests__/daemon-command-helpers.test.ts
+++ b/packages/cli/src/__tests__/daemon-command-helpers.test.ts
@@ -1,0 +1,345 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { z } from "zod";
+import {
+  AuthError,
+  InternalError,
+  ValidationError,
+} from "@xmtp-broker/schemas";
+import { CliConfigSchema } from "../config/schema.js";
+import {
+  createWithDaemonClient,
+  parseJsonInput,
+} from "../commands/daemon-client.js";
+
+const testDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    testDirs.splice(0).map((dir) =>
+      rm(dir, {
+        recursive: true,
+        force: true,
+      }),
+    ),
+  );
+});
+
+function makeConfig(dataDir: string) {
+  return CliConfigSchema.parse({
+    broker: { dataDir },
+    admin: { socketPath: join(dataDir, "admin.sock") },
+    logging: { auditLogPath: join(dataDir, "audit.jsonl") },
+  });
+}
+
+describe("parseJsonInput", () => {
+  test("parses inline JSON against the provided schema", async () => {
+    const result = await parseJsonInput(
+      '{"mode":"full","threadScopes":[{"groupId":"g1","threadId":null}],"contentTypes":["xmtp.org/text:1.0"]}',
+      "view",
+      z.object({
+        mode: z.literal("full"),
+        threadScopes: z.array(
+          z.object({
+            groupId: z.string(),
+            threadId: z.string().nullable(),
+          }),
+        ),
+        contentTypes: z.array(z.string()),
+      }),
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.mode).toBe("full");
+      expect(result.value.threadScopes[0]?.groupId).toBe("g1");
+    }
+  });
+
+  test("parses @file JSON input", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "xmtp-broker-cli-json-"));
+    testDirs.push(dir);
+    const filePath = join(dir, "grant.json");
+
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        messaging: {
+          send: true,
+          reply: false,
+          react: false,
+          draftOnly: false,
+        },
+      }),
+    );
+
+    const result = await parseJsonInput(
+      `@${filePath}`,
+      "grant",
+      z.object({
+        messaging: z.object({
+          send: z.boolean(),
+          reply: z.boolean(),
+          react: z.boolean(),
+          draftOnly: z.boolean(),
+        }),
+      }),
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.messaging.send).toBe(true);
+      expect(result.value.messaging.reply).toBe(false);
+    }
+  });
+
+  test("returns a validation error for invalid JSON", async () => {
+    const result = await parseJsonInput("{not-json}", "view", z.object({}));
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(ValidationError);
+    }
+  });
+});
+
+describe("withDaemonClient", () => {
+  test("loads config, signs an admin JWT, connects, runs the callback, and closes the client", async () => {
+    const calls: string[] = [];
+    const dir = await mkdtemp(join(tmpdir(), "xmtp-broker-cli-daemon-"));
+    testDirs.push(dir);
+    const config = makeConfig(dir);
+    const withDaemonClient = createWithDaemonClient({
+      loadConfig: async () => Result.ok(config),
+      resolvePaths: () => ({
+        configFile: join(dir, "config.toml"),
+        dataDir: dir,
+        pidFile: join(dir, "broker.pid"),
+        adminSocket: join(dir, "admin.sock"),
+        auditLog: join(dir, "audit.jsonl"),
+      }),
+      createKeyManager: async () =>
+        Result.ok({
+          initialize: async () => {
+            calls.push("initialize");
+            return Result.ok({
+              publicKey: "pub",
+              fingerprint: "fp",
+              trustTier: "software" as const,
+            });
+          },
+          close: () => {
+            calls.push("closeKeyManager");
+          },
+          admin: {
+            exists: () => true,
+            signJwt: async () => {
+              calls.push("signJwt");
+              return Result.ok("admin-jwt");
+            },
+          },
+        }),
+      createAdminClient: () => ({
+        connect: async (token: string) => {
+          calls.push(`connect:${token}`);
+          return Result.ok(undefined);
+        },
+        request: async () => Result.ok({ ok: true }),
+        close: async () => {
+          calls.push("closeClient");
+        },
+      }),
+    });
+
+    const result = await withDaemonClient({}, async (client, ctx) => {
+      calls.push(`run:${ctx.paths.adminSocket}`);
+      const requestResult = await client.request<{ ok: boolean }>(
+        "broker.status",
+      );
+      if (requestResult.isErr()) {
+        return requestResult;
+      }
+      return Result.ok(requestResult.value.ok);
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe(true);
+    }
+    expect(calls).toEqual([
+      "initialize",
+      "signJwt",
+      "connect:admin-jwt",
+      `run:${join(dir, "admin.sock")}`,
+      "closeClient",
+      "closeKeyManager",
+    ]);
+  });
+
+  test("returns an auth error when no admin key is available", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "xmtp-broker-cli-no-admin-"));
+    testDirs.push(dir);
+    const config = makeConfig(dir);
+    const withDaemonClient = createWithDaemonClient({
+      loadConfig: async () => Result.ok(config),
+      resolvePaths: () => ({
+        configFile: join(dir, "config.toml"),
+        dataDir: dir,
+        pidFile: join(dir, "broker.pid"),
+        adminSocket: join(dir, "admin.sock"),
+        auditLog: join(dir, "audit.jsonl"),
+      }),
+      createKeyManager: async () =>
+        Result.ok({
+          initialize: async () =>
+            Result.ok({
+              publicKey: "pub",
+              fingerprint: "fp",
+              trustTier: "software" as const,
+            }),
+          close: () => {},
+          admin: {
+            exists: () => false,
+            signJwt: async () => Result.ok("admin-jwt"),
+          },
+        }),
+      createAdminClient: () => ({
+        connect: async () => Result.ok(undefined),
+        request: async () => Result.ok({}),
+        close: async () => {},
+      }),
+    });
+
+    const result = await withDaemonClient({}, async () => Result.ok(undefined));
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(AuthError);
+    }
+  });
+
+  test("still closes the client when the callback returns an error", async () => {
+    const calls: string[] = [];
+    const dir = await mkdtemp(join(tmpdir(), "xmtp-broker-cli-close-"));
+    testDirs.push(dir);
+    const config = makeConfig(dir);
+    const withDaemonClient = createWithDaemonClient({
+      loadConfig: async () => Result.ok(config),
+      resolvePaths: () => ({
+        configFile: join(dir, "config.toml"),
+        dataDir: dir,
+        pidFile: join(dir, "broker.pid"),
+        adminSocket: join(dir, "admin.sock"),
+        auditLog: join(dir, "audit.jsonl"),
+      }),
+      createKeyManager: async () =>
+        Result.ok({
+          initialize: async () =>
+            Result.ok({
+              publicKey: "pub",
+              fingerprint: "fp",
+              trustTier: "software" as const,
+            }),
+          close: () => {
+            calls.push("closeKeyManager");
+          },
+          admin: {
+            exists: () => true,
+            signJwt: async () => Result.ok("admin-jwt"),
+          },
+        }),
+      createAdminClient: () => ({
+        connect: async () => Result.ok(undefined),
+        request: async () => Result.ok({}),
+        close: async () => {
+          calls.push("closeClient");
+        },
+      }),
+    });
+
+    const result = await withDaemonClient({}, async () =>
+      Result.err(InternalError.create("boom")),
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("boom");
+    }
+    expect(calls).toEqual(["closeClient", "closeKeyManager"]);
+  });
+
+  test("awaits the callback before closing the admin client", async () => {
+    const calls: string[] = [];
+    let resolveRequest: (() => void) | undefined;
+    const requestFinished = new Promise<void>((resolve) => {
+      resolveRequest = resolve;
+    });
+    const dir = await mkdtemp(join(tmpdir(), "xmtp-broker-cli-await-"));
+    testDirs.push(dir);
+    const config = makeConfig(dir);
+    const withDaemonClient = createWithDaemonClient({
+      loadConfig: async () => Result.ok(config),
+      resolvePaths: () => ({
+        configFile: join(dir, "config.toml"),
+        dataDir: dir,
+        pidFile: join(dir, "broker.pid"),
+        adminSocket: join(dir, "admin.sock"),
+        auditLog: join(dir, "audit.jsonl"),
+      }),
+      createKeyManager: async () =>
+        Result.ok({
+          initialize: async () =>
+            Result.ok({
+              publicKey: "pub",
+              fingerprint: "fp",
+              trustTier: "software" as const,
+            }),
+          close: () => {
+            calls.push("closeKeyManager");
+          },
+          admin: {
+            exists: () => true,
+            signJwt: async () => Result.ok("admin-jwt"),
+          },
+        }),
+      createAdminClient: () => ({
+        connect: async () => Result.ok(undefined),
+        request: async () => {
+          calls.push("request:start");
+          await requestFinished;
+          calls.push("request:done");
+          return Result.ok({ ok: true });
+        },
+        close: async () => {
+          calls.push("closeClient");
+        },
+      }),
+    });
+
+    const pending = withDaemonClient({}, async (client) => {
+      const result = await client.request("broker.status");
+      if (result.isErr()) {
+        return result;
+      }
+      return Result.ok(result.value);
+    });
+
+    calls.push("before-resolve");
+    resolveRequest?.();
+    const result = await pending;
+
+    expect(result.isOk()).toBe(true);
+    expect(calls).toContain("request:start");
+    expect(calls).toContain("request:done");
+    expect(calls.indexOf("request:done")).toBeLessThan(
+      calls.indexOf("closeClient"),
+    );
+    expect(calls.indexOf("closeClient")).toBeLessThan(
+      calls.indexOf("closeKeyManager"),
+    );
+  });
+});

--- a/packages/cli/src/__tests__/daemon-command-wiring.test.ts
+++ b/packages/cli/src/__tests__/daemon-command-wiring.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import type { BrokerError } from "@xmtp-broker/schemas";
+import type { AdminClient } from "../admin/client.js";
+import { createBrokerCommands } from "../commands/broker.js";
+import { createSessionCommands } from "../commands/session.js";
+
+const view = {
+  mode: "full" as const,
+  threadScopes: [{ groupId: "group-1", threadId: null }],
+  contentTypes: ["xmtp.org/text:1.0"],
+};
+
+const grant = {
+  messaging: {
+    send: true,
+    reply: false,
+    react: false,
+    draftOnly: false,
+  },
+  groupManagement: {
+    addMembers: false,
+    removeMembers: false,
+    updateMetadata: false,
+    inviteUsers: false,
+  },
+  tools: { scopes: [] },
+  egress: {
+    storeExcerpts: false,
+    useForMemory: false,
+    forwardToProviders: false,
+    quoteRevealed: false,
+    summarize: false,
+  },
+};
+
+interface RequestCall {
+  readonly method: string;
+  readonly params: Record<string, unknown> | undefined;
+}
+
+function createHarness<T>(response: T) {
+  const requestCalls: RequestCall[] = [];
+  const withDaemonCalls: Array<{ configPath?: string | undefined }> = [];
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  const client: AdminClient = {
+    async connect() {
+      return Result.ok(undefined);
+    },
+    async request(method, params) {
+      requestCalls.push({ method, params });
+      return Result.ok(response);
+    },
+    async close() {},
+  };
+
+  return {
+    deps: {
+      async withDaemonClient<TResult>(
+        options: { configPath?: string | undefined },
+        run: (
+          adminClient: AdminClient,
+        ) => Promise<Result<TResult, BrokerError>>,
+      ): Promise<Result<TResult, BrokerError>> {
+        withDaemonCalls.push(options);
+        return run(client);
+      },
+      writeStdout(message: string) {
+        stdout.push(message);
+      },
+      writeStderr(message: string) {
+        stderr.push(message);
+      },
+      exit(code: number) {
+        throw new Error(`unexpected exit ${String(code)}`);
+      },
+    },
+    requestCalls,
+    withDaemonCalls,
+    stdout,
+    stderr,
+  };
+}
+
+describe("daemon-backed CLI command wiring", () => {
+  test("session issue parses JSON inputs and routes through daemon client", async () => {
+    const issued = {
+      token: "session-token",
+      session: {
+        sessionId: "sess_123",
+        agentInboxId: "agent_1",
+        sessionKeyFingerprint: "fp_session",
+        issuedAt: "2024-01-01T00:00:00.000Z",
+        expiresAt: "2024-01-01T01:00:00.000Z",
+      },
+    };
+    const harness = createHarness(issued);
+
+    const command = createSessionCommands(harness.deps);
+    await command.parseAsync([
+      "node",
+      "session",
+      "issue",
+      "--config",
+      "/tmp/test-config.toml",
+      "--agent",
+      "agent_1",
+      "--ttl",
+      "120",
+      "--view",
+      JSON.stringify(view),
+      "--grant",
+      JSON.stringify(grant),
+    ]);
+
+    expect(harness.withDaemonCalls).toEqual([
+      { configPath: "/tmp/test-config.toml" },
+    ]);
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "session.issue",
+        params: {
+          agentInboxId: "agent_1",
+          ttlSeconds: 120,
+          heartbeatInterval: 30,
+          view,
+          grant,
+        },
+      },
+    ]);
+    expect(harness.stderr).toEqual([]);
+    expect(harness.stdout.join("")).toContain("session-token");
+    expect(harness.stdout.join("")).toContain("sess_123");
+  });
+
+  test("broker status routes through daemon client and prints response", async () => {
+    const harness = createHarness({
+      state: "running",
+      coreState: "ready",
+      pid: 1234,
+      uptime: 5,
+      activeSessions: 2,
+      activeConnections: 1,
+      xmtpEnv: "local" as const,
+      identityMode: "per-group" as const,
+      wsPort: 8393,
+      version: "0.1.0",
+    });
+
+    const command = createBrokerCommands(harness.deps);
+    await command.parseAsync([
+      "node",
+      "broker",
+      "status",
+      "--config",
+      "/tmp/test-config.toml",
+    ]);
+
+    expect(harness.withDaemonCalls).toEqual([
+      { configPath: "/tmp/test-config.toml" },
+    ]);
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "broker.status",
+        params: undefined,
+      },
+    ]);
+    expect(harness.stderr).toEqual([]);
+    expect(harness.stdout.join("")).toContain("running");
+    expect(harness.stdout.join("")).toContain("8393");
+  });
+});

--- a/packages/cli/src/commands/admin-rpc.ts
+++ b/packages/cli/src/commands/admin-rpc.ts
@@ -1,0 +1,36 @@
+import type { BrokerError } from "@xmtp-broker/schemas";
+import type { Result } from "better-result";
+import type { z } from "zod";
+import type { AdminClient } from "../admin/client.js";
+import {
+  createWithDaemonClient,
+  parseJsonInput as parseJsonInputImpl,
+  type DaemonCommandContext,
+  type DaemonCommandDeps,
+} from "./daemon-client.js";
+
+export type { DaemonCommandContext, DaemonCommandDeps };
+
+export function parseJsonInput<T>(
+  input: string,
+  schema: z.ZodType<T>,
+  field: string,
+): Promise<Result<T, BrokerError>> {
+  return parseJsonInputImpl(input, field, schema);
+}
+
+export async function withDaemonClient<T>(
+  options: { config?: string | undefined },
+  deps: Partial<DaemonCommandDeps>,
+  run: (
+    client: AdminClient,
+    context: DaemonCommandContext,
+  ) => Promise<Result<T, BrokerError>>,
+): Promise<Result<T, BrokerError>> {
+  return createWithDaemonClient(deps)(
+    {
+      configPath: options.config,
+    },
+    run,
+  );
+}

--- a/packages/cli/src/commands/daemon-client.ts
+++ b/packages/cli/src/commands/daemon-client.ts
@@ -1,0 +1,205 @@
+import { Result } from "better-result";
+import type { z } from "zod";
+import { createKeyManager, type KeyManager } from "@xmtp-broker/keys";
+import {
+  AuthError,
+  InternalError,
+  ValidationError,
+  type BrokerError,
+} from "@xmtp-broker/schemas";
+import type { AdminClient } from "../admin/client.js";
+import { createAdminClient } from "../admin/client.js";
+import { loadConfig } from "../config/loader.js";
+import { resolvePaths, type ResolvedPaths } from "../config/paths.js";
+import type { CliConfig } from "../config/schema.js";
+
+export interface DaemonCommandContext {
+  readonly config: CliConfig;
+  readonly paths: ResolvedPaths;
+}
+
+export interface DaemonCommandDeps {
+  readonly loadConfig: typeof loadConfig;
+  readonly resolvePaths: typeof resolvePaths;
+  readonly createKeyManager: (
+    config: Parameters<typeof createKeyManager>[0],
+  ) => Promise<Result<RpcKeyManager, BrokerError>>;
+  readonly createAdminClient: (socketPath: string) => AdminClient;
+}
+
+export interface DaemonCommandOptions {
+  readonly configPath?: string | undefined;
+}
+
+export type WithDaemonClient = <T>(
+  options: DaemonCommandOptions,
+  run: (
+    client: AdminClient,
+    context: DaemonCommandContext,
+  ) => Promise<Result<T, BrokerError>>,
+) => Promise<Result<T, BrokerError>>;
+
+const defaultDeps: DaemonCommandDeps = {
+  loadConfig,
+  resolvePaths,
+  createKeyManager,
+  createAdminClient,
+};
+
+type RpcKeyManager = Pick<KeyManager, "initialize" | "admin"> & {
+  close?: () => void;
+};
+
+export function createWithDaemonClient(
+  deps: Partial<DaemonCommandDeps> = {},
+): WithDaemonClient {
+  const resolvedDeps: DaemonCommandDeps = {
+    ...defaultDeps,
+    ...deps,
+  };
+
+  return async <T>(
+    options: DaemonCommandOptions,
+    run: (
+      client: AdminClient,
+      context: DaemonCommandContext,
+    ) => Promise<Result<T, BrokerError>>,
+  ): Promise<Result<T, BrokerError>> => {
+    const configResult = await resolvedDeps.loadConfig(
+      options.configPath !== undefined
+        ? { configPath: options.configPath }
+        : {},
+    );
+    if (configResult.isErr()) {
+      return configResult;
+    }
+
+    const config = configResult.value;
+    const paths = resolvedDeps.resolvePaths(config);
+    const keyManagerResult = await resolvedDeps.createKeyManager({
+      rootKeyPolicy: config.keys.rootKeyPolicy,
+      operationalKeyPolicy: config.keys.operationalKeyPolicy,
+      dataDir: paths.dataDir,
+    });
+    if (keyManagerResult.isErr()) {
+      return keyManagerResult;
+    }
+
+    const keyManager = keyManagerResult.value;
+    return runWithKeyManager(
+      keyManager,
+      paths,
+      { config, paths },
+      resolvedDeps.createAdminClient,
+      run,
+    );
+  };
+}
+
+async function runWithKeyManager<T>(
+  keyManager: RpcKeyManager,
+  paths: ResolvedPaths,
+  context: DaemonCommandContext,
+  makeClient: (socketPath: string) => AdminClient,
+  run: (
+    client: AdminClient,
+    context: DaemonCommandContext,
+  ) => Promise<Result<T, BrokerError>>,
+): Promise<Result<T, BrokerError>> {
+  const client = makeClient(paths.adminSocket);
+
+  try {
+    const initResult = await keyManager.initialize();
+    if (initResult.isErr()) {
+      return initResult;
+    }
+
+    if (!keyManager.admin.exists()) {
+      return Result.err(
+        AuthError.create(
+          "No admin key found. Run 'xmtp-broker identity init' first.",
+        ),
+      );
+    }
+
+    const tokenResult = await keyManager.admin.signJwt({ ttlSeconds: 120 });
+    if (tokenResult.isErr()) {
+      return tokenResult;
+    }
+
+    const connectResult = await client.connect(tokenResult.value);
+    if (connectResult.isErr()) {
+      return connectResult;
+    }
+
+    return await run(client, context);
+  } finally {
+    await client.close();
+    keyManager.close?.();
+  }
+}
+
+export async function parseJsonInput<T>(
+  value: string,
+  field: string,
+  schema: z.ZodType<T>,
+): Promise<Result<T, BrokerError>> {
+  let rawText: string;
+  try {
+    rawText = await readInputValue(value);
+  } catch (error) {
+    return Result.err(
+      error instanceof InternalError
+        ? error
+        : InternalError.create("Failed to read JSON input", {
+            field,
+            cause: error instanceof Error ? error.message : String(error),
+          }),
+    );
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(rawText);
+  } catch (error: unknown) {
+    return Result.err(
+      ValidationError.create(field, "Expected valid JSON", {
+        cause: error instanceof Error ? error.message : String(error),
+      }),
+    );
+  }
+
+  const parsed = schema.safeParse(parsedJson);
+  if (!parsed.success) {
+    return Result.err(
+      ValidationError.create(field, "Value did not match schema", {
+        issues: parsed.error.issues,
+      }),
+    );
+  }
+
+  return Result.ok(parsed.data);
+}
+
+async function readInputValue(value: string): Promise<string> {
+  if (!value.startsWith("@")) {
+    return value;
+  }
+
+  const file = Bun.file(value.slice(1));
+  if (!(await file.exists())) {
+    throw InternalError.create("Failed to read JSON input file", {
+      filePath: value.slice(1),
+      cause: "File does not exist",
+    });
+  }
+
+  try {
+    return await file.text();
+  } catch (error) {
+    throw InternalError.create("Failed to read JSON input file", {
+      filePath: value.slice(1),
+      cause: error instanceof Error ? error.message : String(error),
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Add a daemon client helper that handles config loading, daemon socket connection, and JSON-RPC communication
- Wire CLI commands to use the daemon client for all admin operations instead of direct function calls
- Support both inline JSON and file-based (`@path`) input for CLI arguments

## Key changes
- `packages/cli/src/commands/daemon-client.ts` — `createWithDaemonClient` helper: loads config, connects to admin socket, sends JSON-RPC requests; `parseJsonInput` for inline/file-based JSON parsing
- `packages/cli/src/commands/admin-rpc.ts` — Thin CLI command wiring that delegates to daemon client
- `packages/cli/src/__tests__/daemon-command-helpers.test.ts` — 345-line test suite for client helper and JSON parsing
- `packages/cli/src/__tests__/daemon-command-wiring.test.ts` — Tests for CLI command structure and option parsing

## Test plan
- [ ] `cd packages/cli && bun test daemon-command` passes all tests
- [ ] Verify `parseJsonInput` handles inline JSON, `@file` references, and validation errors