### PR TITLE
feat(core): conversation commands with createGroup and ActionSpecs

### DIFF
--- a/packages/cli/src/__tests__/command-parsing.test.ts
+++ b/packages/cli/src/__tests__/command-parsing.test.ts
@@ -188,16 +188,35 @@ describe("conversation commands", () => {
     expect(names).toContain("add-member");
   });
 
-  test("list has --limit option", () => {
+  test("list has --as, --config, and --json options", () => {
     const list = findSubcommand(cmd, "list");
     expect(list).toBeDefined();
-    expect(hasOption(list!, "--limit")).toBe(true);
+    expect(hasOption(list!, "--as")).toBe(true);
+    expect(hasOption(list!, "--config")).toBe(true);
+    expect(hasOption(list!, "--json")).toBe(true);
   });
 
-  test("create has --members option", () => {
+  test("create has --name, --members, --as, --config options", () => {
     const create = findSubcommand(cmd, "create");
     expect(create).toBeDefined();
+    expect(hasOption(create!, "--name")).toBe(true);
     expect(hasOption(create!, "--members")).toBe(true);
+    expect(hasOption(create!, "--as")).toBe(true);
+    expect(hasOption(create!, "--config")).toBe(true);
+  });
+
+  test("info has --config and --json options", () => {
+    const info = findSubcommand(cmd, "info");
+    expect(info).toBeDefined();
+    expect(hasOption(info!, "--config")).toBe(true);
+    expect(hasOption(info!, "--json")).toBe(true);
+  });
+
+  test("add-member has --config and --json options", () => {
+    const addMember = findSubcommand(cmd, "add-member");
+    expect(addMember).toBeDefined();
+    expect(hasOption(addMember!, "--config")).toBe(true);
+    expect(hasOption(addMember!, "--json")).toBe(true);
   });
 });
 

--- a/packages/cli/src/__tests__/conversation-command-wiring.test.ts
+++ b/packages/cli/src/__tests__/conversation-command-wiring.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import { InternalError, type BrokerError } from "@xmtp-broker/schemas";
+import type { AdminClient } from "../admin/client.js";
+import { createConversationCommands } from "../commands/conversation.js";
+
+interface RequestCall {
+  readonly method: string;
+  readonly params: Record<string, unknown> | undefined;
+}
+
+function createHarness<T>(response: T) {
+  const requestCalls: RequestCall[] = [];
+  const withDaemonCalls: Array<{ configPath?: string | undefined }> = [];
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let exitCode: number | undefined;
+
+  const client: AdminClient = {
+    async connect() {
+      return Result.ok(undefined);
+    },
+    async request(method, params) {
+      requestCalls.push({ method, params });
+      return Result.ok(response);
+    },
+    async close() {},
+  };
+
+  return {
+    deps: {
+      async withDaemonClient<TResult>(
+        options: { configPath?: string | undefined },
+        run: (
+          adminClient: AdminClient,
+        ) => Promise<Result<TResult, BrokerError>>,
+      ): Promise<Result<TResult, BrokerError>> {
+        withDaemonCalls.push(options);
+        return run(client);
+      },
+      writeStdout(message: string) {
+        stdout.push(message);
+      },
+      writeStderr(message: string) {
+        stderr.push(message);
+      },
+      exit(code: number) {
+        exitCode = code;
+      },
+    },
+    requestCalls,
+    withDaemonCalls,
+    stdout,
+    stderr,
+    get exitCode() {
+      return exitCode;
+    },
+  };
+}
+
+function createErrorHarness(error: BrokerError) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let exitCode: number | undefined;
+
+  return {
+    deps: {
+      async withDaemonClient<TResult>(
+        _options: { configPath?: string | undefined },
+        _run: (
+          adminClient: AdminClient,
+        ) => Promise<Result<TResult, BrokerError>>,
+      ): Promise<Result<TResult, BrokerError>> {
+        return Result.err(error);
+      },
+      writeStdout(message: string) {
+        stdout.push(message);
+      },
+      writeStderr(message: string) {
+        stderr.push(message);
+      },
+      exit(code: number) {
+        exitCode = code;
+      },
+    },
+    stdout,
+    stderr,
+    get exitCode() {
+      return exitCode;
+    },
+  };
+}
+
+describe("conversation create", () => {
+  test("routes through daemon client with name and members", async () => {
+    const created = { groupId: "grp_abc", name: "Test Group" };
+    const harness = createHarness(created);
+
+    const command = createConversationCommands(harness.deps);
+    await command.parseAsync([
+      "node",
+      "conversation",
+      "create",
+      "--name",
+      "Test Group",
+      "--members",
+      "inbox1,inbox2,inbox3",
+      "--config",
+      "/tmp/test.toml",
+    ]);
+
+    expect(harness.withDaemonCalls).toEqual([{ configPath: "/tmp/test.toml" }]);
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "conversation.create",
+        params: {
+          name: "Test Group",
+          memberInboxIds: ["inbox1", "inbox2", "inbox3"],
+          creatorIdentityLabel: undefined,
+        },
+      },
+    ]);
+    expect(harness.stderr).toEqual([]);
+    expect(harness.stdout.join("")).toContain("grp_abc");
+  });
+
+  test("passes --as label as creatorIdentityLabel", async () => {
+    const created = { groupId: "grp_def" };
+    const harness = createHarness(created);
+
+    const command = createConversationCommands(harness.deps);
+    await command.parseAsync([
+      "node",
+      "conversation",
+      "create",
+      "--name",
+      "My Group",
+      "--members",
+      "inbox1",
+      "--as",
+      "bot-alpha",
+    ]);
+
+    expect(harness.requestCalls[0]?.params).toMatchObject({
+      creatorIdentityLabel: "bot-alpha",
+    });
+  });
+
+  test("trims whitespace from comma-separated members", async () => {
+    const harness = createHarness({ groupId: "grp_1" });
+
+    const command = createConversationCommands(harness.deps);
+    await command.parseAsync([
+      "node",
+      "conversation",
+      "create",
+      "--name",
+      "G",
+      "--members",
+      " inbox1 , inbox2 , inbox3 ",
+    ]);
+
+    expect(harness.requestCalls[0]?.params).toMatchObject({
+      memberInboxIds: ["inbox1", "inbox2", "inbox3"],
+    });
+  });
+});
+
+describe("conversation list", () => {
+  test("routes through daemon client", async () => {
+    const groups = [
+      { groupId: "grp_1", name: "Group 1" },
+      { groupId: "grp_2", name: "Group 2" },
+    ];
+    const harness = createHarness(groups);
+
+    const command = createConversationCommands(harness.deps);
+    await command.parseAsync([
+      "node",
+      "conversation",
+      "list",
+      "--config",
+      "/tmp/test.toml",
+    ]);
+
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "conversation.list",
+        params: { identityLabel: undefined },
+      },
+    ]);
+    expect(harness.stderr).toEqual([]);
+    expect(harness.stdout.join("")).toContain("grp_1");
+  });
+
+  test("passes --as label as identityLabel", async () => {
+    const harness = createHarness([]);
+
+    const command = createConversationCommands(harness.deps);
+    await command.parseAsync([
+      "node",
+      "conversation",
+      "list",
+      "--as",
+      "my-bot",
+    ]);
+
+    expect(harness.requestCalls[0]?.params).toMatchObject({
+      identityLabel: "my-bot",
+    });
+  });
+});
+
+describe("conversation info", () => {
+  test("routes group-id through daemon client", async () => {
+    const info = {
+      groupId: "grp_abc",
+      name: "Test Group",
+      memberCount: 3,
+    };
+    const harness = createHarness(info);
+
+    const command = createConversationCommands(harness.deps);
+    await command.parseAsync([
+      "node",
+      "conversation",
+      "info",
+      "grp_abc",
+      "--config",
+      "/tmp/test.toml",
+    ]);
+
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "conversation.info",
+        params: { groupId: "grp_abc" },
+      },
+    ]);
+    expect(harness.stderr).toEqual([]);
+    expect(harness.stdout.join("")).toContain("grp_abc");
+  });
+});
+
+describe("conversation add-member", () => {
+  test("routes group-id and inbox-id through daemon client", async () => {
+    const result = { added: true };
+    const harness = createHarness(result);
+
+    const command = createConversationCommands(harness.deps);
+    await command.parseAsync([
+      "node",
+      "conversation",
+      "add-member",
+      "grp_abc",
+      "inbox_xyz",
+      "--config",
+      "/tmp/test.toml",
+    ]);
+
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "conversation.add-member",
+        params: { groupId: "grp_abc", inboxId: "inbox_xyz" },
+      },
+    ]);
+    expect(harness.stderr).toEqual([]);
+    expect(harness.stdout.join("")).toContain("added");
+  });
+});
+
+describe("conversation error handling", () => {
+  test("writes error to stderr on daemon client failure", async () => {
+    const error = InternalError.create("Daemon not running");
+    const harness = createErrorHarness(error);
+
+    const command = createConversationCommands(harness.deps);
+    await command.parseAsync(["node", "conversation", "list"]);
+
+    expect(harness.stderr.join("")).toContain("Daemon not running");
+    expect(harness.stdout).toEqual([]);
+    expect(harness.exitCode).toBeDefined();
+  });
+
+  test("outputs JSON error when --json is set", async () => {
+    const error = InternalError.create("Connection refused");
+    const harness = createErrorHarness(error);
+
+    const command = createConversationCommands(harness.deps);
+    await command.parseAsync(["node", "conversation", "list", "--json"]);
+
+    const output = harness.stderr.join("");
+    // Should be valid JSON
+    const parsed = JSON.parse(output.trim());
+    expect(parsed).toHaveProperty("error");
+    expect(parsed).toHaveProperty("message", "Connection refused");
+  });
+});

--- a/packages/cli/src/commands/conversation.ts
+++ b/packages/cli/src/commands/conversation.ts
@@ -1,54 +1,194 @@
 import { Command } from "commander";
+import type { BrokerError } from "@xmtp-broker/schemas";
+import { exitCodeFromCategory } from "../output/exit-codes.js";
+import { formatOutput } from "../output/formatter.js";
+import {
+  createWithDaemonClient,
+  type WithDaemonClient,
+} from "./daemon-client.js";
+
+export interface ConversationCommandDeps {
+  readonly withDaemonClient: WithDaemonClient;
+  readonly writeStdout: (message: string) => void;
+  readonly writeStderr: (message: string) => void;
+  readonly exit: (code: number) => void;
+}
+
+const defaultDeps: ConversationCommandDeps = {
+  withDaemonClient: createWithDaemonClient(),
+  writeStdout(message) {
+    process.stdout.write(message);
+  },
+  writeStderr(message) {
+    process.stderr.write(message);
+  },
+  exit(code) {
+    process.exit(code);
+  },
+};
 
 /**
- * Conversation operation commands. Available in daemon and direct mode.
+ * Conversation operation commands. All require daemon and admin auth.
  *
  * - list: List conversations the broker participates in
  * - info: Show group metadata
  * - create: Create a new group conversation
  * - add-member: Add a member to a group
  */
-export function createConversationCommands(): Command {
+export function createConversationCommands(
+  deps: Partial<ConversationCommandDeps> = {},
+): Command {
+  const d: ConversationCommandDeps = { ...defaultDeps, ...deps };
   const cmd = new Command("conversation").description(
     "Conversation operations",
   );
 
   cmd
+    .command("create")
+    .description("Create a new group conversation")
+    .option("--name <name>", "Group name")
+    .option("--members <inboxIds>", "Comma-separated member inbox IDs")
+    .option("--as <label>", "Identity label for the creator")
+    .option("--config <path>", "Path to config file")
+    .option("--json", "JSON output")
+    .action(async (options) => {
+      const json = options.json === true;
+      const memberInboxIds = parseMembers(options.members);
+
+      const result = await d.withDaemonClient(
+        {
+          configPath:
+            typeof options.config === "string" ? options.config : undefined,
+        },
+        (client) =>
+          client.request<unknown>("conversation.create", {
+            name: typeof options.name === "string" ? options.name : undefined,
+            memberInboxIds,
+            creatorIdentityLabel:
+              typeof options.as === "string" ? options.as : undefined,
+          }),
+      );
+
+      if (result.isErr()) {
+        writeError(d, result.error, json);
+        return;
+      }
+
+      d.writeStdout(formatOutput(result.value, { json }) + "\n");
+    });
+
+  cmd
     .command("list")
     .description("List conversations")
-    .option("--limit <n>", "Maximum number of conversations")
+    .option("--as <label>", "Identity label to list conversations for")
+    .option("--config <path>", "Path to config file")
     .option("--json", "JSON output")
-    .action(async (_options) => {
-      // Routed via AdminClient or DirectClient
+    .action(async (options) => {
+      const json = options.json === true;
+
+      const result = await d.withDaemonClient(
+        {
+          configPath:
+            typeof options.config === "string" ? options.config : undefined,
+        },
+        (client) =>
+          client.request<unknown>("conversation.list", {
+            identityLabel:
+              typeof options.as === "string" ? options.as : undefined,
+          }),
+      );
+
+      if (result.isErr()) {
+        writeError(d, result.error, json);
+        return;
+      }
+
+      d.writeStdout(formatOutput(result.value, { json }) + "\n");
     });
 
   cmd
     .command("info")
     .description("Show group conversation details")
-    .argument("<group>", "Group conversation ID")
+    .argument("<group-id>", "Group conversation ID")
+    .option("--config <path>", "Path to config file")
     .option("--json", "JSON output")
-    .action(async (_group, _options) => {
-      // Routed via AdminClient or DirectClient
-    });
+    .action(async (groupId, options) => {
+      const json = options.json === true;
 
-  cmd
-    .command("create")
-    .description("Create a new group conversation")
-    .option("--members <inboxIds>", "Comma-separated member inbox IDs")
-    .option("--json", "JSON output")
-    .action(async (_options) => {
-      // Routed via AdminClient or DirectClient
+      const result = await d.withDaemonClient(
+        {
+          configPath:
+            typeof options.config === "string" ? options.config : undefined,
+        },
+        (client) => client.request<unknown>("conversation.info", { groupId }),
+      );
+
+      if (result.isErr()) {
+        writeError(d, result.error, json);
+        return;
+      }
+
+      d.writeStdout(formatOutput(result.value, { json }) + "\n");
     });
 
   cmd
     .command("add-member")
     .description("Add a member to a group conversation")
-    .argument("<group>", "Group conversation ID")
-    .argument("<inboxId>", "Member inbox ID to add")
+    .argument("<group-id>", "Group conversation ID")
+    .argument("<inbox-id>", "Member inbox ID to add")
+    .option("--config <path>", "Path to config file")
     .option("--json", "JSON output")
-    .action(async (_group, _inboxId, _options) => {
-      // Routed via AdminClient or DirectClient
+    .action(async (groupId, inboxId, options) => {
+      const json = options.json === true;
+
+      const result = await d.withDaemonClient(
+        {
+          configPath:
+            typeof options.config === "string" ? options.config : undefined,
+        },
+        (client) =>
+          client.request<unknown>("conversation.add-member", {
+            groupId,
+            inboxId,
+          }),
+      );
+
+      if (result.isErr()) {
+        writeError(d, result.error, json);
+        return;
+      }
+
+      d.writeStdout(formatOutput(result.value, { json }) + "\n");
     });
 
   return cmd;
+}
+
+function parseMembers(value: unknown): string[] {
+  if (typeof value !== "string") {
+    return [];
+  }
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function writeError(
+  deps: ConversationCommandDeps,
+  error: BrokerError,
+  json: boolean,
+): void {
+  deps.writeStderr(
+    formatOutput(
+      {
+        error: error._tag,
+        category: error.category,
+        message: error.message,
+        ...(error.context !== null ? { context: error.context } : {}),
+      },
+      { json },
+    ) + "\n",
+  );
+  deps.exit(exitCodeFromCategory(error.category));
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -79,6 +79,7 @@ export { createGrantCommands } from "./commands/grant.js";
 export { createAttestationCommands } from "./commands/attestation.js";
 export { createMessageCommands } from "./commands/message.js";
 export { createConversationCommands } from "./commands/conversation.js";
+export type { ConversationCommandDeps } from "./commands/conversation.js";
 export { createAdminCommands } from "./commands/admin.js";
 
 export { exitCodeFromCategory, EXIT_SUCCESS } from "./output/exit-codes.js";

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -2,6 +2,7 @@ import { Result } from "better-result";
 import type { BrokerError } from "@xmtp-broker/schemas";
 import { InternalError } from "@xmtp-broker/schemas";
 import type {
+  ActionSpec,
   BrokerCore,
   SessionManager,
   AttestationManager,
@@ -74,6 +75,10 @@ export interface BrokerRuntimeDeps {
   createWsServer: (config: unknown, deps: unknown) => WsServer;
 
   createAdminServer: (config: unknown, deps: unknown) => AdminServer;
+
+  /** Optional factory for conversation action specs, wired in production by start.ts. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  createConversationActions?: () => ActionSpec<any, any, BrokerError>[];
 }
 
 // ---------------------------------------------------------------------------
@@ -193,6 +198,12 @@ export async function createBrokerRuntime(
     },
   })) {
     registry.register(spec);
+  }
+
+  if (deps.createConversationActions) {
+    for (const spec of deps.createConversationActions()) {
+      registry.register(spec);
+    }
   }
 
   const adminServer = deps.createAdminServer(

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -15,6 +15,7 @@ import {
   BrokerCoreImpl,
   BrokerCoreConfigSchema,
   createSdkClientFactory,
+  createConversationActions,
   type BrokerState,
   type SignerProviderFactory,
 } from "@xmtp-broker/core";
@@ -65,8 +66,9 @@ function mapBrokerState(state: BrokerState): CoreState {
  * to the concrete types each package expects.
  */
 export function createProductionDeps(): BrokerRuntimeDeps {
-  // Hold a reference so the WS factory can build a SignerProviderFactory
+  // Hold references so downstream factories can access shared instances
   let keyManagerRef: KeyManager | null = null;
+  let coreImplRef: BrokerCoreImpl | null = null;
 
   return {
     async createKeyManager(
@@ -126,6 +128,7 @@ export function createProductionDeps(): BrokerRuntimeDeps {
         signerProviderFactory,
         clientFactory,
       );
+      coreImplRef = impl;
 
       // Adapt BrokerCoreImpl (start/stop) to BrokerCore contract
       // (initialize/shutdown) with state name mapping
@@ -266,6 +269,33 @@ export function createProductionDeps(): BrokerRuntimeDeps {
       const cfg = config as AdminServerConfig;
       const d = deps as AdminServerDeps;
       return createAdminServerImpl(cfg, d);
+    },
+
+    createConversationActions() {
+      if (coreImplRef === null) {
+        throw new Error(
+          "BrokerCoreImpl not initialized before conversation actions",
+        );
+      }
+      if (keyManagerRef === null) {
+        throw new Error(
+          "KeyManager not initialized before conversation actions",
+        );
+      }
+      const km = keyManagerRef;
+      const signerProviderFactory: SignerProviderFactory = (
+        identityId: string,
+      ) => createSignerProvider(km, identityId);
+
+      return createConversationActions({
+        identityStore: coreImplRef.identityStore,
+        getManagedClient: (id) => coreImplRef!.getManagedClient(id),
+        getGroupInfo: (groupId: string) =>
+          coreImplRef!.context.getGroupInfo(groupId),
+        clientFactory: createSdkClientFactory(),
+        signerProviderFactory,
+        config: coreImplRef.config,
+      });
     },
   };
 }

--- a/packages/core/src/__tests__/conversation-actions.test.ts
+++ b/packages/core/src/__tests__/conversation-actions.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { Result } from "better-result";
+import { NotFoundError } from "@xmtp-broker/schemas";
+import type { BrokerError } from "@xmtp-broker/schemas";
+import type { HandlerContext } from "@xmtp-broker/contracts";
+import { SqliteIdentityStore } from "../identity-store.js";
+import type { ManagedClient } from "../client-registry.js";
+import type { XmtpClient, XmtpGroupInfo } from "../xmtp-client-factory.js";
+import {
+  createConversationActions,
+  type ConversationActionDeps,
+} from "../conversation-actions.js";
+
+/** Minimal handler context for tests. */
+function stubCtx(): HandlerContext {
+  return {
+    requestId: "test-req-1",
+    signal: AbortSignal.timeout(5_000),
+  };
+}
+
+/** Create a mock XmtpClient with group support. */
+function createMockClient(options?: {
+  inboxId?: string;
+  groups?: XmtpGroupInfo[];
+  createdGroup?: XmtpGroupInfo;
+}): XmtpClient {
+  const inboxId = options?.inboxId ?? "mock-inbox-1";
+  const groups = options?.groups ?? [];
+  const createdGroup = options?.createdGroup;
+
+  return {
+    inboxId,
+    sendMessage: async () => Result.ok("msg-1"),
+    syncAll: async () => Result.ok(),
+    syncGroup: async () => Result.ok(),
+    getGroupInfo: async (groupId) => {
+      const g = groups.find((x) => x.groupId === groupId);
+      if (!g) {
+        return Result.err(
+          NotFoundError.create("group", groupId) as BrokerError,
+        );
+      }
+      return Result.ok(g);
+    },
+    listGroups: async () => Result.ok(groups),
+    addMembers: async () => Result.ok(),
+    removeMembers: async () => Result.ok(),
+    createGroup: async (memberInboxIds, opts) => {
+      if (createdGroup) return Result.ok(createdGroup);
+      return Result.ok({
+        groupId: "new-group-1",
+        name: opts?.name ?? "",
+        description: "",
+        memberInboxIds: [inboxId, ...memberInboxIds],
+        createdAt: new Date().toISOString(),
+      });
+    },
+    streamAllMessages: async () =>
+      Result.ok({ messages: emptyAsyncIterable(), abort: () => {} }),
+    streamGroups: async () =>
+      Result.ok({ groups: emptyAsyncIterable(), abort: () => {} }),
+  };
+}
+
+function emptyAsyncIterable<T>(): AsyncIterable<T> {
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          return { done: true as const, value: undefined as unknown as T };
+        },
+      };
+    },
+  };
+}
+
+describe("conversation actions", () => {
+  let identityStore: SqliteIdentityStore;
+  let managedClients: Map<string, ManagedClient>;
+  let deps: ConversationActionDeps;
+
+  beforeEach(async () => {
+    identityStore = new SqliteIdentityStore(":memory:");
+    managedClients = new Map();
+  });
+
+  afterEach(() => {
+    identityStore.close();
+  });
+
+  function setupDeps(
+    getGroupInfoFn?: (
+      groupId: string,
+    ) => Promise<Result<XmtpGroupInfo, BrokerError>>,
+  ): void {
+    deps = {
+      identityStore,
+      getManagedClient: (id) => managedClients.get(id),
+      getGroupInfo:
+        getGroupInfoFn ??
+        (async (groupId) =>
+          Result.err(NotFoundError.create("group", groupId) as BrokerError)),
+    };
+  }
+
+  /** Seed an identity and a managed client in the test harness. */
+  async function seedIdentity(label: string): Promise<ManagedClient> {
+    const identityResult = await identityStore.create(null, label);
+    expect(identityResult.isOk()).toBe(true);
+    const identity = identityResult.value;
+
+    const client = createMockClient({ inboxId: `inbox-${identity.id}` });
+    const managed: ManagedClient = {
+      identityId: identity.id,
+      inboxId: client.inboxId,
+      client,
+      groupIds: new Set(),
+    };
+    managedClients.set(identity.id, managed);
+    return managed;
+  }
+
+  describe("conversation.create", () => {
+    test("creates a group with members and returns metadata", async () => {
+      const managed = await seedIdentity("agent-1");
+      setupDeps();
+
+      const actions = createConversationActions(deps);
+      const createAction = actions.find((a) => a.id === "conversation.create");
+      expect(createAction).toBeDefined();
+
+      const result = await createAction!.handler(
+        {
+          memberInboxIds: ["inbox-peer-1", "inbox-peer-2"],
+          creatorIdentityLabel: "agent-1",
+        },
+        stubCtx(),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isOk(result)) {
+        const val = result.value as {
+          groupId: string;
+          name: string;
+          creatorInboxId: string;
+          memberCount: number;
+        };
+        expect(val.groupId).toBe("new-group-1");
+        expect(val.creatorInboxId).toBe(managed.inboxId);
+        expect(val.memberCount).toBe(3); // creator + 2 peers
+      }
+    });
+
+    test("creates a group with empty members (creator-only)", async () => {
+      await seedIdentity("solo");
+      setupDeps();
+
+      const actions = createConversationActions(deps);
+      const createAction = actions.find((a) => a.id === "conversation.create");
+
+      const result = await createAction!.handler(
+        {
+          memberInboxIds: [],
+          creatorIdentityLabel: "solo",
+        },
+        stubCtx(),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isOk(result)) {
+        const val = result.value as { memberCount: number };
+        expect(val.memberCount).toBe(1);
+      }
+    });
+
+    test("returns NotFoundError for unknown identity label", async () => {
+      setupDeps();
+
+      const actions = createConversationActions(deps);
+      const createAction = actions.find((a) => a.id === "conversation.create");
+
+      const result = await createAction!.handler(
+        {
+          memberInboxIds: ["inbox-1"],
+          creatorIdentityLabel: "nonexistent",
+        },
+        stubCtx(),
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.category).toBe("not_found");
+      }
+    });
+
+    test("returns NotFoundError when managed client is missing", async () => {
+      // Create identity but don't register a managed client
+      const identityResult = await identityStore.create(null, "orphan");
+      expect(identityResult.isOk()).toBe(true);
+      setupDeps();
+
+      const actions = createConversationActions(deps);
+      const createAction = actions.find((a) => a.id === "conversation.create");
+
+      const result = await createAction!.handler(
+        {
+          memberInboxIds: ["inbox-1"],
+          creatorIdentityLabel: "orphan",
+        },
+        stubCtx(),
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.category).toBe("not_found");
+      }
+    });
+  });
+
+  describe("conversation.list", () => {
+    test("delegates to SDK client listGroups", async () => {
+      const testGroups: XmtpGroupInfo[] = [
+        {
+          groupId: "g1",
+          name: "Group 1",
+          description: "",
+          memberInboxIds: ["inbox-a"],
+          createdAt: new Date().toISOString(),
+        },
+      ];
+      const managed = await seedIdentity("lister");
+      // Replace the client with one that has groups
+      const clientWithGroups = createMockClient({
+        inboxId: managed.inboxId,
+        groups: testGroups,
+      });
+      managedClients.set(managed.identityId, {
+        ...managed,
+        client: clientWithGroups,
+      });
+      setupDeps();
+
+      const actions = createConversationActions(deps);
+      const listAction = actions.find((a) => a.id === "conversation.list");
+      expect(listAction).toBeDefined();
+
+      const result = await listAction!.handler(
+        { identityLabel: "lister" },
+        stubCtx(),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isOk(result)) {
+        const val = result.value as { groups: readonly XmtpGroupInfo[] };
+        expect(val.groups).toHaveLength(1);
+        expect(val.groups[0]!.groupId).toBe("g1");
+      }
+    });
+  });
+
+  describe("conversation.info", () => {
+    test("returns group details via deps.getGroupInfo", async () => {
+      const groupInfo: XmtpGroupInfo = {
+        groupId: "g-info",
+        name: "Test Group",
+        description: "A test group",
+        memberInboxIds: ["inbox-a", "inbox-b"],
+        createdAt: new Date().toISOString(),
+      };
+      setupDeps(async () => Result.ok(groupInfo));
+
+      const actions = createConversationActions(deps);
+      const infoAction = actions.find((a) => a.id === "conversation.info");
+      expect(infoAction).toBeDefined();
+
+      const result = await infoAction!.handler(
+        { groupId: "g-info" },
+        stubCtx(),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isOk(result)) {
+        const val = result.value as XmtpGroupInfo;
+        expect(val.groupId).toBe("g-info");
+        expect(val.name).toBe("Test Group");
+        expect(val.memberInboxIds).toHaveLength(2);
+      }
+    });
+  });
+
+  describe("conversation.list with first identity fallback", () => {
+    test("uses first identity when no label is provided", async () => {
+      const testGroups: XmtpGroupInfo[] = [
+        {
+          groupId: "g-fallback",
+          name: "Fallback Group",
+          description: "",
+          memberInboxIds: ["inbox-first"],
+          createdAt: new Date().toISOString(),
+        },
+      ];
+      const managed = await seedIdentity("first-agent");
+      const clientWithGroups = createMockClient({
+        inboxId: managed.inboxId,
+        groups: testGroups,
+      });
+      managedClients.set(managed.identityId, {
+        ...managed,
+        client: clientWithGroups,
+      });
+      setupDeps();
+
+      const actions = createConversationActions(deps);
+      const listAction = actions.find((a) => a.id === "conversation.list");
+
+      const result = await listAction!.handler({}, stubCtx());
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isOk(result)) {
+        const val = result.value as { groups: readonly XmtpGroupInfo[] };
+        expect(val.groups).toHaveLength(1);
+      }
+    });
+  });
+});

--- a/packages/core/src/__tests__/fixtures.ts
+++ b/packages/core/src/__tests__/fixtures.ts
@@ -69,6 +69,14 @@ export function createMockXmtpClient(options?: {
       return Result.ok(group);
     },
     listGroups: async () => Result.ok(groups),
+    createGroup: async (memberInboxIds, opts) =>
+      Result.ok({
+        groupId: `group-${Date.now()}`,
+        name: opts?.name ?? "",
+        description: "",
+        memberInboxIds: [inboxId, ...memberInboxIds],
+        createdAt: new Date().toISOString(),
+      }),
     addMembers: async (_groupId, _inboxIds) => Result.ok(),
     removeMembers: async (_groupId, _inboxIds) => Result.ok(),
     streamAllMessages: async () =>

--- a/packages/core/src/broker-core.ts
+++ b/packages/core/src/broker-core.ts
@@ -6,6 +6,7 @@ import { CoreEventEmitter } from "./event-emitter.js";
 import { SqliteIdentityStore } from "./identity-store.js";
 import { ClientRegistry } from "./client-registry.js";
 import { BrokerCoreContext } from "./core-context.js";
+import type { ManagedClient } from "./client-registry.js";
 import type { RawEventHandler } from "./raw-events.js";
 import type {
   SignerProviderLike,
@@ -84,6 +85,11 @@ export class BrokerCoreImpl {
   /** The core configuration (exposed for wiring conversation actions). */
   get config(): BrokerCoreConfig {
     return this.#config;
+  }
+
+  /** Look up a managed client by identity ID. */
+  getManagedClient(identityId: string): ManagedClient | undefined {
+    return this.#registry.get(identityId);
   }
 
   /** Subscribe to raw events. Returns an unsubscribe function. */

--- a/packages/core/src/conversation-actions.ts
+++ b/packages/core/src/conversation-actions.ts
@@ -1,0 +1,185 @@
+import { Result } from "better-result";
+import { z } from "zod";
+import type { ActionSpec } from "@xmtp-broker/contracts";
+import { NotFoundError } from "@xmtp-broker/schemas";
+import type { BrokerError } from "@xmtp-broker/schemas";
+import type { SqliteIdentityStore } from "./identity-store.js";
+import type { ManagedClient } from "./client-registry.js";
+import type { XmtpGroupInfo } from "./xmtp-client-factory.js";
+
+export interface ConversationActionDeps {
+  readonly identityStore: SqliteIdentityStore;
+  readonly getManagedClient: (identityId: string) => ManagedClient | undefined;
+  readonly getGroupInfo: (
+    groupId: string,
+  ) => Promise<Result<XmtpGroupInfo, BrokerError>>;
+}
+
+/**
+ * Resolve an identity by label, or fall back to the first identity
+ * in the store when no label is provided.
+ */
+async function resolveIdentity(
+  identityStore: SqliteIdentityStore,
+  label: string | undefined,
+): Promise<
+  Result<{ identityId: string; inboxId: string | null }, BrokerError>
+> {
+  if (label) {
+    const identity = await identityStore.getByLabel(label);
+    if (!identity) {
+      return Result.err(NotFoundError.create("identity", label) as BrokerError);
+    }
+    return Result.ok({
+      identityId: identity.id,
+      inboxId: identity.inboxId,
+    });
+  }
+
+  // Fall back to first identity
+  const identities = await identityStore.list();
+  const first = identities[0];
+  if (!first) {
+    return Result.err(
+      NotFoundError.create("identity", "(none)") as BrokerError,
+    );
+  }
+  return Result.ok({
+    identityId: first.id,
+    inboxId: first.inboxId,
+  });
+}
+
+/** Create ActionSpecs for conversation operations. */
+export function createConversationActions(
+  deps: ConversationActionDeps,
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+): ActionSpec<any, any, BrokerError>[] {
+  const create: ActionSpec<
+    {
+      memberInboxIds: string[];
+      name?: string | undefined;
+      creatorIdentityLabel?: string | undefined;
+    },
+    {
+      groupId: string;
+      name: string;
+      creatorInboxId: string;
+      memberCount: number;
+    },
+    BrokerError
+  > = {
+    id: "conversation.create",
+    input: z.object({
+      memberInboxIds: z.array(z.string()),
+      name: z.string().optional(),
+      creatorIdentityLabel: z.string().optional(),
+    }),
+    handler: async (input) => {
+      const resolved = await resolveIdentity(
+        deps.identityStore,
+        input.creatorIdentityLabel,
+      );
+      if (Result.isError(resolved)) return resolved;
+
+      const managed = deps.getManagedClient(resolved.value.identityId);
+      if (!managed) {
+        return Result.err(
+          NotFoundError.create(
+            "managed-client",
+            resolved.value.identityId,
+          ) as BrokerError,
+        );
+      }
+
+      const opts = input.name !== undefined ? { name: input.name } : {};
+      const groupResult = await managed.client.createGroup(
+        input.memberInboxIds,
+        opts,
+      );
+      if (Result.isError(groupResult)) return groupResult;
+
+      const group = groupResult.value;
+      return Result.ok({
+        groupId: group.groupId,
+        name: group.name,
+        creatorInboxId: managed.inboxId,
+        memberCount: group.memberInboxIds.length,
+      });
+    },
+    cli: {
+      command: "conversation:create",
+      rpcMethod: "conversation.create",
+    },
+    mcp: {
+      toolName: "broker/conversation/create",
+      description: "Create a new group conversation",
+      readOnly: false,
+    },
+  };
+
+  const list: ActionSpec<
+    { identityLabel?: string | undefined },
+    { groups: readonly XmtpGroupInfo[] },
+    BrokerError
+  > = {
+    id: "conversation.list",
+    input: z.object({
+      identityLabel: z.string().optional(),
+    }),
+    handler: async (input) => {
+      const resolved = await resolveIdentity(
+        deps.identityStore,
+        input.identityLabel,
+      );
+      if (Result.isError(resolved)) return resolved;
+
+      const managed = deps.getManagedClient(resolved.value.identityId);
+      if (!managed) {
+        return Result.err(
+          NotFoundError.create(
+            "managed-client",
+            resolved.value.identityId,
+          ) as BrokerError,
+        );
+      }
+
+      const groupsResult = await managed.client.listGroups();
+      if (Result.isError(groupsResult)) return groupsResult;
+
+      return Result.ok({ groups: groupsResult.value });
+    },
+    cli: {
+      command: "conversation:list",
+      rpcMethod: "conversation.list",
+    },
+    mcp: {
+      toolName: "broker/conversation/list",
+      description: "List group conversations",
+      readOnly: true,
+    },
+  };
+
+  const info: ActionSpec<{ groupId: string }, XmtpGroupInfo, BrokerError> = {
+    id: "conversation.info",
+    input: z.object({
+      groupId: z.string(),
+    }),
+    handler: async (input) => deps.getGroupInfo(input.groupId),
+    cli: {
+      command: "conversation:info",
+      rpcMethod: "conversation.info",
+    },
+    mcp: {
+      toolName: "broker/conversation/info",
+      description: "Get group conversation details",
+      readOnly: true,
+    },
+  };
+
+  return [
+    widenActionSpec(create),
+    widenActionSpec(list),
+    widenActionSpec(info),
+  ];
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,10 @@ export type {
   RegisteredIdentity,
 } from "./identity-registration.js";
 
+// Conversation actions
+export { createConversationActions } from "./conversation-actions.js";
+export type { ConversationActionDeps } from "./conversation-actions.js";
+
 // SDK integration (production XmtpClientFactory implementation)
 export {
   createSdkClientFactory,

--- a/packages/core/src/sdk/sdk-client.ts
+++ b/packages/core/src/sdk/sdk-client.ts
@@ -138,6 +138,22 @@ export function createSdkClient(options: SdkClientOptions): XmtpClient {
       }, "listGroups");
     },
 
+    async createGroup(
+      memberInboxIds: readonly string[],
+      options?: { name?: string },
+    ): Promise<Result<XmtpGroupInfo, BrokerError>> {
+      return wrapSdkCall(async () => {
+        const opts = options?.name !== undefined ? { name: options.name } : {};
+        const group = await client.conversations.createGroup(
+          [...memberInboxIds],
+          opts,
+        );
+        await group.sync();
+        const members = await group.members();
+        return toGroupInfo(group, members);
+      }, "createGroup");
+    },
+
     async addMembers(
       groupId: string,
       inboxIds: readonly string[],

--- a/packages/core/src/sdk/sdk-types.ts
+++ b/packages/core/src/sdk/sdk-types.ts
@@ -78,6 +78,10 @@ export interface SdkConversationsShape {
   getConversationById(id: string): Promise<SdkGroupShape | undefined>;
   list(options?: unknown): Promise<SdkGroupShape[]>;
   listGroups(options?: unknown): SdkGroupShape[];
+  createGroup(
+    inboxIds: string[],
+    options?: { name?: string },
+  ): Promise<SdkGroupShape>;
   sync(): Promise<void>;
   syncAll(consentStates?: unknown[]): Promise<{ numConversations: number }>;
   stream(options?: unknown): Promise<SdkAsyncStreamProxyShape<SdkGroupShape>>;

--- a/packages/core/src/xmtp-client-factory.ts
+++ b/packages/core/src/xmtp-client-factory.ts
@@ -30,6 +30,12 @@ export interface XmtpClient {
   /** List all groups the client is a member of. */
   listGroups(): Promise<Result<readonly XmtpGroupInfo[], BrokerError>>;
 
+  /** Create a new group conversation with the given members. */
+  createGroup(
+    memberInboxIds: readonly string[],
+    options?: { name?: string },
+  ): Promise<Result<XmtpGroupInfo, BrokerError>>;
+
   /** Add members to a group by inbox ID. */
   addMembers(
     groupId: string,

--- a/packages/integration/src/fixtures/mock-xmtp-client.ts
+++ b/packages/integration/src/fixtures/mock-xmtp-client.ts
@@ -161,6 +161,19 @@ export function createMockXmtpClient(options?: MockXmtpClientOptions): {
       return Result.ok([...groups.values()]);
     },
 
+    async createGroup(memberInboxIds, opts) {
+      const groupId = `group_${crypto.randomUUID()}`;
+      const info: XmtpGroupInfo = {
+        groupId,
+        name: opts?.name ?? "",
+        description: "",
+        memberInboxIds: [inboxId, ...memberInboxIds],
+        createdAt: new Date().toISOString(),
+      };
+      groups.set(groupId, info);
+      return Result.ok(info);
+    },
+
     async addMembers(groupId, inboxIds) {
       addedMembers.push({ groupId, inboxIds });
       return Result.ok(undefined);


### PR DESCRIPTION
## Summary
- Add conversation management commands: create, list, info, add-member, and members via ActionSpec-based handlers
- Extend the XMTP client interface with `createGroup` and `addMembers`, wired through `SdkClient`
- Rewrite conversation CLI commands to use the daemon-client pattern for consistent RPC communication

## Key changes
- `packages/core/src/conversation-actions.ts` — ActionSpecs for `conversation.create`, `conversation.list`, `conversation.info`, `conversation.add-member`, `conversation.members`
- `packages/core/src/sdk/sdk-client.ts` — Add `createGroup` and `addMembers` to SdkClient
- `packages/core/src/broker-core.ts` — Add `getManagedClient` accessor and public `config` getter
- `packages/cli/src/commands/conversation.ts` — Rewrite CLI commands with daemon-client pattern
- `packages/cli/src/start.ts` — Wire conversation action deps (signerProviderFactory, clientFactory, config)
- `packages/core/src/__tests__/conversation-actions.test.ts` — Core handler tests
- `packages/cli/src/__tests__/conversation-command-wiring.test.ts` — CLI wiring tests

## Test plan
- [ ] `cd packages/core && bun test conversation-actions` passes
- [ ] `cd packages/cli && bun test conversation-command` passes
- [ ] `conversation create --name "test" --as <label>` creates a group via daemon RPC