### PR TITLE
feat(core): Convos invite parsing and join protocol

### DIFF
--- a/.agents/plans/v0/EXECUTION-PHASE2C.md
+++ b/.agents/plans/v0/EXECUTION-PHASE2C.md
@@ -90,7 +90,105 @@ Steps 1-2 and the dev network tracer have been validated:
 | Session + WS harness (dev) | PASS | Auth, scope enforcement, heartbeat all work |
 | Production daemon | PASS | Daemon starts, connects to production XMTP |
 
-Steps 3b, 3c, and 5 need implementation based on the Convos invite discovery.
+Steps 3b, 3c, and 6 need implementation based on the Convos invite discovery.
+
+---
+
+## Pre-Flight Checklist
+
+Before starting any step, verify the baseline:
+
+```bash
+gt sync -f                    # sync with remote
+bun run build                 # clean build
+bun run test                  # all tests pass
+bun run typecheck             # no type errors
+bun run lint                  # no lint errors
+```
+
+If any check fails, fix it before proceeding.
+
+## Agent Roles
+
+### Implementer (subagent)
+
+Each step dispatches an **implementer subagent** that:
+
+1. Reads this execution plan's step description (current state, changes,
+   pseudocode) and any referenced files
+2. Creates the branch: `gt create 'v0/<name>' -am "feat(<scope>): <message>"`
+3. Writes tests first (TDD: red → green → refactor)
+4. Implements until all tests pass
+5. Runs `bun run build && bun run test && bun run typecheck && bun run lint`
+6. Reports back with: files changed, test count, any deviations from plan
+
+The implementer does NOT:
+- Modify files outside its step's scope
+- Make design decisions — if ambiguous, stop and ask
+- Skip tests or lint
+- Push or submit — that's the orchestrator's job
+
+### Reviewer (subagent)
+
+After each implementer completes, dispatch a **reviewer subagent** that:
+
+1. Reads the step description from this plan
+2. Reads all changed files
+3. Checks:
+   - Does the implementation match the described interfaces?
+   - Are all behaviors described in the step implemented?
+   - Are all error cases handled with correct error taxonomy?
+   - Are test scenarios comprehensive?
+   - Does `bun run build && bun run test && bun run typecheck && bun run lint` pass?
+4. Reports: PASS (ready to submit) or FAIL (with specific issues to fix)
+
+If FAIL, resume the implementer with the reviewer's findings. Re-review
+after fixes.
+
+### Orchestrator (you)
+
+The main conversation thread:
+
+1. Runs pre-flight checks
+2. Dispatches implementer for the current step
+3. Dispatches reviewer when implementer completes
+4. On PASS: `gt submit --no-interactive` and moves to next step
+5. On FAIL: resumes implementer, then re-reviews
+6. After all steps: runs full-stack verification
+
+## Troubleshooting
+
+### Build fails after stacking
+
+```bash
+gt restack                    # rebase all branches onto updated parents
+bun run build                 # verify
+```
+
+### Tests fail in a downstream branch
+
+```bash
+gt top                        # go to top
+gt absorb -a -f               # route fixes to correct branches
+gt submit --stack --no-interactive
+```
+
+### Spec ambiguity during implementation
+
+The implementer should **stop and report** rather than make design
+decisions. This plan is the source of truth. If the plan is ambiguous,
+the orchestrator resolves it by updating the plan, then resumes the
+implementer.
+
+### Reviewer finds issues
+
+Resume the implementer with the reviewer's specific findings. Do not
+start a new implementer — context matters. After fixes, re-run the
+reviewer.
+
+---
+
+## Steps
 
 ---
 
@@ -99,6 +197,17 @@ Steps 3b, 3c, and 5 need implementation based on the Convos invite discovery.
 **Branch:** `v0/identity-registration`
 **Scope:** `packages/core/`, `packages/cli/`
 **Estimated size:** ~250 LOC
+**Commit convention:** `feat(core): XMTP identity registration with network`
+
+**Implementer prompt context:**
+- Read this step's full description including Current State, Changes, and pseudocode
+- Read `packages/core/src/identity-store.ts` for store schema and methods
+- Read `packages/keys/src/signer-provider.ts` for `createSignerProvider()`
+- Read `packages/core/src/sdk/sdk-client-factory.ts` for `createSdkClientFactory()`
+- Read `packages/cli/src/commands/identity.ts` for the current `init` action (lines 28-117)
+- Read `packages/cli/src/start.ts` for how deps are constructed in daemon mode (reference for direct mode)
+- The key manager's `getOrCreateDbKey()` and `getOrCreateXmtpIdentityKey()` auto-provision keys — no separate keygen step needed
+- `identity init` runs without a daemon (direct mode) — construct deps inline
 
 ### Problem
 
@@ -483,6 +592,15 @@ a different inbox ID. `identity list` shows both.
 **Branch:** `v0/core-network-start`
 **Scope:** `packages/cli/`
 **Estimated size:** ~150 LOC
+**Commit convention:** `feat(cli): network startup with real XMTP clients`
+
+**Implementer prompt context:**
+- Read `packages/cli/src/runtime.ts` lines 250-323 for `BrokerRuntime.start()`
+- Read `packages/cli/src/start.ts` lines 130-163 for the `BrokerCore` adapter
+- Read `packages/core/src/broker-core.ts` lines 105-238 for `BrokerCoreImpl.start()`
+- Read `packages/cli/src/daemon/status.ts` for `DaemonStatus` schema
+- The key change is adding `core.initialize()` call after `core.initializeLocal()` in `runtime.ts`
+- Graceful degradation: network failure logs a warning, daemon continues in local mode
 
 ### Problem
 
@@ -602,11 +720,22 @@ inbox IDs. Without identities, daemon stays in local mode.
 
 ---
 
-## Step 3: Conversation Commands
+## Step 3a: Conversation Commands
 
 **Branch:** `v0/conversation-commands`
 **Scope:** `packages/core/`, `packages/cli/`
 **Estimated size:** ~300 LOC
+**Commit convention:** `feat(core): conversation create/list/info commands`
+
+**Implementer prompt context:**
+- Read `packages/cli/src/commands/conversation.ts` for existing stub commands
+- Read `packages/cli/src/commands/session.ts` for the `withDaemonClient` pattern to follow
+- Read `packages/sessions/src/actions.ts` for the ActionSpec pattern to follow
+- Read `packages/core/src/xmtp-client-factory.ts` for `XmtpClient` interface (add `createGroup`)
+- Read `packages/core/src/sdk/sdk-client.ts` for how to implement `createGroup` with `wrapSdkCall`
+- Read `packages/cli/src/runtime.ts` for where to register new ActionSpecs
+- Node.js SDK uses `client.conversations.createGroup(inboxIds: string[], opts?)` — plain strings, NOT typed identifiers
+- `BrokerCoreImpl.#registry` is private — add a public accessor or `getManagedClient(id)` method
 
 ### Problem
 
@@ -936,6 +1065,16 @@ mocked `BrokerCoreImpl` with mock `XmtpClient`:
 **Branch:** `v0/convos-join`
 **Scope:** `packages/core/`, `packages/cli/`
 **Estimated size:** ~350 LOC
+**Commit convention:** `feat(core): Convos invite parsing and join protocol`
+
+**Implementer prompt context:**
+- MUST read `.reference/convos-node-sdk/src/conversations/join.ts` first — this is the reference join flow
+- Read `.reference/convos-node-sdk/src/identities.ts` for identity creation and invite tag storage
+- Read `.reference/convos-node-sdk/src/client.ts` for per-conversation client creation
+- Read `.reference/convos-cli/` for how the CLI exposes the join command
+- Use `xmtp-expert` agent or `blz` to verify any SDK methods before coding
+- The invite URL format is `popup.convos.org/v2?i=<base64url-encoded-binary>`
+- The join protocol involves DM-based handshake — study the reference carefully before implementing
 
 ### Problem
 
@@ -1061,6 +1200,14 @@ Convos app.
 **Branch:** `v0/convos-invite`
 **Scope:** `packages/core/`, `packages/cli/`
 **Estimated size:** ~250 LOC
+**Commit convention:** `feat(core): Convos-compatible invite generation and terminal QR`
+
+**Implementer prompt context:**
+- Read `.reference/convos-node-sdk/src/conversations/create.ts` for how invite tags are generated
+- Read `packages/core/src/convos/invite-parser.ts` (from Step 3b) — generation is the inverse
+- Read the QR rendering pseudocode in this plan's Step 5 section
+- Use `qrcode` package with `type: "terminal"` for ANSI rendering — add to `cli/package.json`
+- Add `qrcode` to blessed dependencies in `CLAUDE.md`
 
 ### Problem
 
@@ -1129,6 +1276,15 @@ join flow and the user successfully joins the broker's group.
 **Branch:** `v0/dev-tracer-bullet`
 **Scope:** `.claude/skills/tracer-bullet/`, `packages/cli/src/__tests__/`
 **Estimated size:** ~200 LOC
+**Commit convention:** `test(cli): dev network tracer bullet and smoke test`
+
+**Implementer prompt context:**
+- Read `.claude/skills/tracer-bullet/SKILL.md` for the "Dev Network" story definition
+- Read `packages/cli/src/__tests__/smoke.test.ts` (Phase 2B) for the existing test pattern
+- The dev tracer is fully automated — no operator interaction needed
+- Use `describe.skipIf(!process.env.XMTP_NETWORK_TESTS)` to gate network tests
+- Timeout: 60 seconds (network operations are slow)
+- Use `bun run packages/cli/src/bin.ts` as the CLI entry point
 
 ### Problem
 
@@ -1217,6 +1373,14 @@ Bob's identity (in the same broker) receives it via the group stream.
 **Branch:** `v0/prod-tracer-bullet`
 **Scope:** `packages/cli/`, `.claude/skills/tracer-bullet/`
 **Estimated size:** ~250 LOC
+**Commit convention:** `feat(cli): production tracer bullet with QR invite`
+
+**Implementer prompt context:**
+- Read `.claude/skills/tracer-bullet/SKILL.md` for the "Production" story definition
+- Read Step 3c output for `conversation invite` and QR rendering
+- This step wires the QR code renderer and updates the tracer bullet skill
+- The production tracer uses direct inbox IDs (not Convos invite protocol)
+- Interactive pauses require `AskUserQuestion` or polling with timeouts
 
 ### Problem
 
@@ -1478,6 +1642,15 @@ reply is received by the broker's event stream.
 **Scope:** `.claude/skills/tracer-bullet/`, `packages/cli/`
 **Estimated size:** ~150 LOC (tracer story + skill update)
 **Depends on:** Steps 3b and 3c (Convos join + invite generation)
+**Commit convention:** `test(cli): Convos interop tracer bullet`
+
+**Implementer prompt context:**
+- Read `.claude/skills/tracer-bullet/SKILL.md` for existing story patterns
+- Read `packages/core/src/convos/join.ts` (from Step 3b) for the join protocol
+- Read `packages/core/src/convos/invite-generator.ts` (from Step 3c) for invite generation
+- Both sub-stories are interactive — use `AskUserQuestion` for operator input
+- Timeouts: 120 seconds per interactive pause
+- Convos invite URL format: `popup.convos.org/v2?i=<base64url-encoded-binary>`
 
 ### Problem
 
@@ -1617,6 +1790,42 @@ will be available via MCP when the MCP transport is wired.
 | 6 | — | `.claude/skills/tracer-bullet/SKILL.md` |
 
 **Total:** ~1900 LOC across 8 steps (6 numbered, 3a/3b/3c as sub-steps).
+
+## Step Summary
+
+| Step | Branch | Commit Prefix | ~LOC |
+|------|--------|---------------|------|
+| 1 | `v0/identity-registration` | `feat(core):` | 250 |
+| 2 | `v0/core-network-start` | `feat(cli):` | 150 |
+| 3a | `v0/conversation-commands` | `feat(core):` | 300 |
+| 3b | `v0/convos-join` | `feat(core):` | 350 |
+| 3c | `v0/convos-invite` | `feat(core):` | 250 |
+| 4 | `v0/dev-tracer-bullet` | `test(cli):` | 200 |
+| 5 | `v0/prod-tracer-bullet` | `feat(cli):` | 250 |
+| 6 | `v0/convos-tracer` | `test(cli):` | 150 |
+
+8 branches, 8 commits, 8 PRs. ~1900 LOC total.
+
+## Full-Stack Verification
+
+After all 8 branches are submitted:
+
+```bash
+gt top                        # go to top of stack
+bun run build                 # full build
+bun run test                  # all tests (unit only, no network)
+bun run typecheck             # type check
+bun run lint                  # lint
+
+# Network smoke tests (requires XMTP devnet access)
+XMTP_NETWORK_TESTS=1 bun test packages/cli/src/__tests__/dev-network.test.ts
+```
+
+Then submit the full stack:
+
+```bash
+gt submit --stack --no-interactive
+```
 
 ## Gotchas
 

--- a/bun.lock
+++ b/bun.lock
@@ -71,10 +71,14 @@
       "name": "@xmtp-broker/core",
       "version": "0.0.0",
       "dependencies": {
+        "@noble/curves": "^1.8.0",
+        "@noble/hashes": "^1.8.0",
         "@xmtp-broker/contracts": "workspace:*",
         "@xmtp-broker/schemas": "workspace:*",
         "@xmtp/node-sdk": "6.0.0",
         "better-result": "catalog:",
+        "long": "^5.0.0",
+        "protobufjs": "^7.4.0",
         "viem": "^2.47.4",
         "zod": "catalog:",
       },
@@ -298,6 +302,26 @@
 
     "@oxlint/win32-x64": ["@oxlint/win32-x64@0.18.1", "", { "os": "win32", "cpu": "x64" }, "sha512-W+aVE9Siqs6Oe3NDaDOTTOYsN9X3znl+whfqWK1EcLpqJXX1kdB8Hf45HkGjqnHoFoP96GRgUnXQHQvmUybjvg=="],
 
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
+
     "@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@scure/bip32": ["@scure/bip32@1.7.0", "", { "dependencies": { "@noble/curves": "~1.9.0", "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw=="],
@@ -498,6 +522,8 @@
 
     "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
@@ -545,6 +571,8 @@
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
+
+    "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 

--- a/packages/cli/src/commands/conversation.ts
+++ b/packages/cli/src/commands/conversation.ts
@@ -220,6 +220,45 @@ export function createConversationCommands(
     });
 
   cmd
+    .command("join")
+    .description("Join a Convos conversation via invite URL")
+    .argument("<invite-url>", "Convos invite URL or slug")
+    .option("--label <name>", "Label for the new identity")
+    .option("--timeout <seconds>", "Timeout in seconds", "60")
+    .option("--config <path>", "Path to config file")
+    .option("--json", "JSON output")
+    .action(async (inviteUrl: string, options) => {
+      const json = options.json === true;
+      const timeoutSeconds =
+        typeof options.timeout === "string"
+          ? parseInt(options.timeout, 10)
+          : 60;
+
+      const result = await d.withDaemonClient(
+        {
+          configPath:
+            typeof options.config === "string" ? options.config : undefined,
+        },
+        (client) =>
+          client.request<unknown>("conversation.join", {
+            inviteUrl,
+            label:
+              typeof options.label === "string" ? options.label : undefined,
+            timeoutSeconds: Number.isFinite(timeoutSeconds)
+              ? timeoutSeconds
+              : 60,
+          }),
+      );
+
+      if (result.isErr()) {
+        writeError(d, result.error, json);
+        return;
+      }
+
+      d.writeStdout(formatOutput(result.value, { json }) + "\n");
+    });
+
+  cmd
     .command("members")
     .description("List members of a group conversation")
     .argument("<group-id>", "Group conversation ID")

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,10 +16,14 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@noble/curves": "^1.8.0",
+    "@noble/hashes": "^1.8.0",
     "@xmtp-broker/contracts": "workspace:*",
     "@xmtp-broker/schemas": "workspace:*",
     "@xmtp/node-sdk": "6.0.0",
     "better-result": "catalog:",
+    "long": "^5.0.0",
+    "protobufjs": "^7.4.0",
     "viem": "^2.47.4",
     "zod": "catalog:"
   },

--- a/packages/core/src/__tests__/conversation-actions.test.ts
+++ b/packages/core/src/__tests__/conversation-actions.test.ts
@@ -32,6 +32,8 @@ function createMockClient(options?: {
   return {
     inboxId,
     sendMessage: async () => Result.ok("msg-1"),
+    createDm: async (peerInboxId) => Result.ok({ dmId: `dm-1`, peerInboxId }),
+    sendDmMessage: async () => Result.ok("dm-msg-1"),
     syncAll: async () => Result.ok(),
     syncGroup: async () => Result.ok(),
     getGroupInfo: async (groupId) => {

--- a/packages/core/src/__tests__/fixtures.ts
+++ b/packages/core/src/__tests__/fixtures.ts
@@ -57,6 +57,9 @@ export function createMockXmtpClient(options?: {
   return {
     inboxId,
     sendMessage: async (_groupId, _content) => Result.ok(`msg-${Date.now()}`),
+    createDm: async (peerInboxId) =>
+      Result.ok({ dmId: `dm-${Date.now()}`, peerInboxId }),
+    sendDmMessage: async (_dmId, _text) => Result.ok(`dm-msg-${Date.now()}`),
     syncAll: async () => Result.ok(),
     syncGroup: async (_groupId) => Result.ok(),
     getGroupInfo: async (groupId) => {

--- a/packages/core/src/__tests__/identity-registration.test.ts
+++ b/packages/core/src/__tests__/identity-registration.test.ts
@@ -38,6 +38,8 @@ function createMockClient(inboxId: string): XmtpClient {
   return {
     inboxId,
     sendMessage: notImplemented,
+    createDm: notImplemented,
+    sendDmMessage: notImplemented,
     syncAll: notImplemented,
     syncGroup: notImplemented,
     getGroupInfo: notImplemented,

--- a/packages/core/src/conversation-actions.ts
+++ b/packages/core/src/conversation-actions.ts
@@ -5,7 +5,13 @@ import { NotFoundError } from "@xmtp-broker/schemas";
 import type { BrokerError } from "@xmtp-broker/schemas";
 import type { SqliteIdentityStore } from "./identity-store.js";
 import type { ManagedClient } from "./client-registry.js";
-import type { XmtpGroupInfo } from "./xmtp-client-factory.js";
+import type {
+  XmtpClientFactory,
+  XmtpGroupInfo,
+} from "./xmtp-client-factory.js";
+import type { BrokerCoreConfig } from "./config.js";
+import { joinConversation } from "./convos/join.js";
+import type { SignerProviderFactory } from "./identity-registration.js";
 
 export interface ConversationActionDeps {
   readonly identityStore: SqliteIdentityStore;
@@ -13,6 +19,9 @@ export interface ConversationActionDeps {
   readonly getGroupInfo: (
     groupId: string,
   ) => Promise<Result<XmtpGroupInfo, BrokerError>>;
+  readonly clientFactory?: XmtpClientFactory;
+  readonly signerProviderFactory?: SignerProviderFactory;
+  readonly config?: Pick<BrokerCoreConfig, "dataDir" | "env" | "appVersion">;
 }
 
 /**
@@ -177,9 +186,77 @@ export function createConversationActions(
     },
   };
 
+  const join: ActionSpec<
+    {
+      inviteUrl: string;
+      label?: string | undefined;
+      timeoutSeconds?: number | undefined;
+    },
+    {
+      groupId: string;
+      identityId: string;
+      inboxId: string;
+      inviteTag: string;
+      groupName: string | undefined;
+      creatorInboxId: string;
+    },
+    BrokerError
+  > = {
+    id: "conversation.join",
+    input: z.object({
+      inviteUrl: z.string(),
+      label: z.string().optional(),
+      timeoutSeconds: z.number().positive().optional(),
+    }),
+    handler: async (input) => {
+      if (!deps.clientFactory || !deps.signerProviderFactory || !deps.config) {
+        return Result.err(
+          NotFoundError.create(
+            "join-deps",
+            "Join requires clientFactory, signerProviderFactory, and config",
+          ) as BrokerError,
+        );
+      }
+
+      const maxPollAttempts = input.timeoutSeconds
+        ? Math.ceil((input.timeoutSeconds * 1000) / 2000)
+        : undefined;
+
+      const joinOptions: {
+        label?: string;
+        maxPollAttempts?: number;
+      } = {};
+      if (input.label !== undefined) joinOptions.label = input.label;
+      if (maxPollAttempts !== undefined)
+        joinOptions.maxPollAttempts = maxPollAttempts;
+
+      return joinConversation(
+        {
+          identityStore: deps.identityStore,
+          clientFactory: deps.clientFactory,
+          signerProviderFactory: deps.signerProviderFactory,
+          config: deps.config,
+        },
+        input.inviteUrl,
+        joinOptions,
+      );
+    },
+    cli: {
+      command: "conversation:join",
+      rpcMethod: "conversation.join",
+      description: "Join a Convos conversation via invite URL",
+    },
+    mcp: {
+      toolName: "broker/conversation/join",
+      description: "Join a Convos conversation via invite URL",
+      readOnly: false,
+    },
+  };
+
   return [
     widenActionSpec(create),
     widenActionSpec(list),
     widenActionSpec(info),
+    widenActionSpec(join),
   ];
 }

--- a/packages/core/src/convos/__tests__/invite-parser.test.ts
+++ b/packages/core/src/convos/__tests__/invite-parser.test.ts
@@ -1,0 +1,421 @@
+import { describe, expect, test } from "bun:test";
+import { deflateSync } from "node:zlib";
+import protobuf from "protobufjs";
+import Long from "long";
+import { secp256k1 } from "@noble/curves/secp256k1";
+import { sha256 } from "@noble/hashes/sha256";
+import {
+  parseConvosInviteUrl,
+  verifyConvosInvite,
+  type ParsedConvosInvite,
+} from "../invite-parser.js";
+
+// --- Test helpers to construct valid invite data ---
+
+// Configure protobufjs Long support
+protobuf.util.Long = Long;
+protobuf.configure();
+
+const InvitePayloadType = new protobuf.Type("InvitePayload")
+  .add(new protobuf.Field("conversationToken", 1, "bytes"))
+  .add(new protobuf.Field("creatorInboxId", 2, "bytes"))
+  .add(new protobuf.Field("tag", 3, "string"))
+  .add(new protobuf.Field("name", 4, "string", "optional"))
+  .add(new protobuf.Field("description", 5, "string", "optional"))
+  .add(new protobuf.Field("imageURL", 6, "string", "optional"))
+  .add(
+    new protobuf.Field("conversationExpiresAtUnix", 7, "sfixed64", "optional"),
+  )
+  .add(new protobuf.Field("expiresAtUnix", 8, "sfixed64", "optional"))
+  .add(new protobuf.Field("expiresAfterUse", 9, "bool"));
+
+const SignedInviteType = new protobuf.Type("SignedInvite")
+  .add(new protobuf.Field("payload", 1, "bytes"))
+  .add(new protobuf.Field("signature", 2, "bytes"));
+
+new protobuf.Root().add(InvitePayloadType).add(SignedInviteType);
+
+interface TestInvitePayload {
+  conversationToken: Uint8Array;
+  creatorInboxId: string;
+  tag: string;
+  name?: string;
+  description?: string;
+  expiresAtUnix?: bigint;
+  conversationExpiresAtUnix?: bigint;
+  expiresAfterUse: boolean;
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+function encodeTestPayload(payload: TestInvitePayload): Uint8Array {
+  const msg = InvitePayloadType.create({
+    conversationToken: payload.conversationToken,
+    creatorInboxId: hexToBytes(payload.creatorInboxId),
+    tag: payload.tag,
+    name: payload.name,
+    description: payload.description,
+    conversationExpiresAtUnix: payload.conversationExpiresAtUnix
+      ? longFromBigInt(payload.conversationExpiresAtUnix)
+      : undefined,
+    expiresAtUnix: payload.expiresAtUnix
+      ? longFromBigInt(payload.expiresAtUnix)
+      : undefined,
+    expiresAfterUse: payload.expiresAfterUse,
+  });
+  return InvitePayloadType.encode(msg).finish();
+}
+
+function longFromBigInt(value: bigint): Long {
+  const low = Number(value & 0xffffffffn);
+  const high = Number((value >> 32n) & 0xffffffffn);
+  return new Long(low, high, false);
+}
+
+/**
+ * Sign payload bytes with secp256k1, returning 65-byte recoverable signature.
+ */
+function signPayload(
+  payloadBytes: Uint8Array,
+  privateKey: Uint8Array,
+): Uint8Array {
+  const hash = sha256(payloadBytes);
+  const sig = secp256k1.sign(hash, privateKey);
+  const compact = sig.toCompactRawBytes();
+  const result = new Uint8Array(65);
+  result.set(compact, 0);
+  result[64] = sig.recovery;
+  return result;
+}
+
+function encodeSignedInvite(
+  payloadBytes: Uint8Array,
+  signature: Uint8Array,
+): Uint8Array {
+  const msg = SignedInviteType.create({
+    payload: payloadBytes,
+    signature,
+  });
+  return SignedInviteType.encode(msg).finish();
+}
+
+function base64UrlEncode(data: Uint8Array): string {
+  return Buffer.from(data)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+const COMPRESSION_MARKER = 0x1f;
+
+/**
+ * Compress data using the Convos format:
+ * [0x1f marker][4-byte BE original size][zlib deflate data]
+ */
+function compressData(data: Uint8Array): Uint8Array {
+  const compressed = deflateSync(data);
+  const result = new Uint8Array(compressed.length + 5);
+  result[0] = COMPRESSION_MARKER;
+  // 4-byte big-endian original size
+  const size = data.length;
+  result[1] = (size >>> 24) & 0xff;
+  result[2] = (size >>> 16) & 0xff;
+  result[3] = (size >>> 8) & 0xff;
+  result[4] = size & 0xff;
+  result.set(compressed, 5);
+  return result;
+}
+
+function insertSeparators(str: string, every: number): string {
+  if (str.length <= every) return str;
+  const parts: string[] = [];
+  for (let i = 0; i < str.length; i += every) {
+    parts.push(str.slice(i, i + every));
+  }
+  return parts.join("*");
+}
+
+/** Build a complete slug from test payload and private key. */
+function buildTestSlug(
+  payload: TestInvitePayload,
+  privateKey: Uint8Array,
+  options?: { compress?: boolean; separators?: boolean },
+): string {
+  const payloadBytes = encodeTestPayload(payload);
+  const signature = signPayload(payloadBytes, privateKey);
+  const signedBytes = encodeSignedInvite(payloadBytes, signature);
+
+  let data: Uint8Array;
+  if (options?.compress !== false && signedBytes.length >= 100) {
+    data = compressData(signedBytes);
+  } else {
+    data = signedBytes;
+  }
+
+  let slug = base64UrlEncode(data);
+  if (options?.separators !== false && slug.length > 300) {
+    slug = insertSeparators(slug, 300);
+  }
+
+  return slug;
+}
+
+function buildTestUrl(slug: string): string {
+  return `https://popup.convos.org/v2?i=${encodeURIComponent(slug)}`;
+}
+
+// --- Test private key (32 bytes) ---
+const TEST_PRIVATE_KEY = new Uint8Array(32);
+TEST_PRIVATE_KEY[31] = 1; // Valid non-zero key
+
+const TEST_CREATOR_INBOX_ID =
+  "aabbccddee1122334455667788990011aabbccddee1122334455667788990011";
+
+function defaultTestPayload(
+  overrides?: Partial<TestInvitePayload>,
+): TestInvitePayload {
+  return {
+    conversationToken: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
+    creatorInboxId: TEST_CREATOR_INBOX_ID,
+    tag: "test-tag-abc123",
+    name: "Test Group",
+    expiresAfterUse: false,
+    ...overrides,
+  };
+}
+
+describe("parseConvosInviteUrl", () => {
+  test("parses a valid invite URL", () => {
+    const payload = defaultTestPayload();
+    const slug = buildTestSlug(payload, TEST_PRIVATE_KEY, {
+      compress: false,
+    });
+    const url = buildTestUrl(slug);
+
+    const result = parseConvosInviteUrl(url);
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    const parsed = result.value;
+    expect(parsed.creatorInboxId).toBe(TEST_CREATOR_INBOX_ID);
+    expect(parsed.tag).toBe("test-tag-abc123");
+    expect(parsed.name).toBe("Test Group");
+    expect(parsed.expiresAfterUse).toBe(false);
+    expect(parsed.isExpired).toBe(false);
+  });
+
+  test("parses a raw slug without URL wrapper", () => {
+    const payload = defaultTestPayload();
+    const slug = buildTestSlug(payload, TEST_PRIVATE_KEY, {
+      compress: false,
+    });
+
+    const result = parseConvosInviteUrl(slug);
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.tag).toBe("test-tag-abc123");
+  });
+
+  test("handles * separators in slug", () => {
+    const payload = defaultTestPayload({
+      description: "A".repeat(500), // make slug long enough for separators
+    });
+    const slug = buildTestSlug(payload, TEST_PRIVATE_KEY, {
+      compress: false,
+      separators: true,
+    });
+
+    // Verify separators were inserted
+    expect(slug).toContain("*");
+
+    const url = buildTestUrl(slug);
+    const result = parseConvosInviteUrl(url);
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.tag).toBe("test-tag-abc123");
+    expect(result.value.description).toBe("A".repeat(500));
+  });
+
+  test("handles compressed data", () => {
+    const payload = defaultTestPayload({
+      description: "B".repeat(500), // ensure large enough to compress
+    });
+    const slug = buildTestSlug(payload, TEST_PRIVATE_KEY, {
+      compress: true,
+      separators: false,
+    });
+
+    const result = parseConvosInviteUrl(slug);
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.tag).toBe("test-tag-abc123");
+    expect(result.value.description).toBe("B".repeat(500));
+  });
+
+  test("detects expired invite", () => {
+    const pastTime = BigInt(Math.floor(Date.now() / 1000) - 3600); // 1 hour ago
+    const payload = defaultTestPayload({
+      expiresAtUnix: pastTime,
+    });
+    const slug = buildTestSlug(payload, TEST_PRIVATE_KEY, {
+      compress: false,
+    });
+
+    const result = parseConvosInviteUrl(slug);
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.isExpired).toBe(true);
+  });
+
+  test("detects expired conversation", () => {
+    const pastTime = BigInt(Math.floor(Date.now() / 1000) - 3600);
+    const payload = defaultTestPayload({
+      conversationExpiresAtUnix: pastTime,
+    });
+    const slug = buildTestSlug(payload, TEST_PRIVATE_KEY, {
+      compress: false,
+    });
+
+    const result = parseConvosInviteUrl(slug);
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.isConversationExpired).toBe(true);
+  });
+
+  test("marks non-expired invite correctly", () => {
+    const futureTime = BigInt(Math.floor(Date.now() / 1000) + 86400); // +24h
+    const payload = defaultTestPayload({
+      expiresAtUnix: futureTime,
+    });
+    const slug = buildTestSlug(payload, TEST_PRIVATE_KEY, {
+      compress: false,
+    });
+
+    const result = parseConvosInviteUrl(slug);
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.isExpired).toBe(false);
+  });
+
+  test("returns error for invalid base64", () => {
+    const result = parseConvosInviteUrl("!!!not-valid-base64!!!");
+    expect(result.isErr()).toBe(true);
+  });
+
+  test("returns error for truncated protobuf", () => {
+    // Valid base64url but not valid protobuf
+    const result = parseConvosInviteUrl(base64UrlEncode(new Uint8Array([1])));
+    expect(result.isErr()).toBe(true);
+  });
+
+  test("parses dev.convos.org URL format", () => {
+    const payload = defaultTestPayload();
+    const slug = buildTestSlug(payload, TEST_PRIVATE_KEY, {
+      compress: false,
+    });
+    const url = `https://dev.convos.org/v2?i=${encodeURIComponent(slug)}`;
+
+    const result = parseConvosInviteUrl(url);
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.tag).toBe("test-tag-abc123");
+  });
+
+  test("preserves all optional fields", () => {
+    const payload = defaultTestPayload({
+      name: "My Group",
+      description: "A test group",
+    });
+    const slug = buildTestSlug(payload, TEST_PRIVATE_KEY, {
+      compress: false,
+    });
+
+    const result = parseConvosInviteUrl(slug);
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.name).toBe("My Group");
+    expect(result.value.description).toBe("A test group");
+  });
+});
+
+describe("verifyConvosInvite", () => {
+  test("verifies valid signature", () => {
+    const payload = defaultTestPayload();
+    const slug = buildTestSlug(payload, TEST_PRIVATE_KEY, {
+      compress: false,
+    });
+
+    const parseResult = parseConvosInviteUrl(slug);
+    expect(parseResult.isOk()).toBe(true);
+    if (!parseResult.isOk()) return;
+
+    const verifyResult = verifyConvosInvite(parseResult.value);
+    expect(verifyResult.isOk()).toBe(true);
+  });
+
+  test("tampered payload recovers a different public key", () => {
+    const payload = defaultTestPayload();
+    const slug = buildTestSlug(payload, TEST_PRIVATE_KEY, {
+      compress: false,
+    });
+
+    const parseResult = parseConvosInviteUrl(slug);
+    expect(parseResult.isOk()).toBe(true);
+    if (!parseResult.isOk()) return;
+
+    // Tamper with the payload -- recovery still works but yields a different key
+    const tampered: ParsedConvosInvite = {
+      ...parseResult.value,
+      signedInvitePayloadBytes: new Uint8Array(
+        parseResult.value.signedInvitePayloadBytes,
+      ),
+      signedInviteSignature: parseResult.value.signedInviteSignature,
+    };
+    const firstByte = tampered.signedInvitePayloadBytes[0];
+    if (firstByte !== undefined) {
+      tampered.signedInvitePayloadBytes[0] = firstByte ^ 0xff;
+    }
+
+    // Structural verification still passes (signature is syntactically valid)
+    const verifyResult = verifyConvosInvite(tampered);
+    expect(verifyResult.isOk()).toBe(true);
+
+    // But the recovered public key would differ from the original signer.
+    // Full identity verification requires comparing against a known key.
+  });
+
+  test("rejects invite with invalid signature bytes", () => {
+    const payload = defaultTestPayload();
+    const slug = buildTestSlug(payload, TEST_PRIVATE_KEY, {
+      compress: false,
+    });
+
+    const parseResult = parseConvosInviteUrl(slug);
+    expect(parseResult.isOk()).toBe(true);
+    if (!parseResult.isOk()) return;
+
+    // Replace signature with garbage
+    const tampered: ParsedConvosInvite = {
+      ...parseResult.value,
+      signedInviteSignature: new Uint8Array(65).fill(0),
+    };
+
+    const verifyResult = verifyConvosInvite(tampered);
+    expect(verifyResult.isErr()).toBe(true);
+  });
+});

--- a/packages/core/src/convos/__tests__/join.test.ts
+++ b/packages/core/src/convos/__tests__/join.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import protobuf from "protobufjs";
+import Long from "long";
+import { secp256k1 } from "@noble/curves/secp256k1";
+import { sha256 } from "@noble/hashes/sha256";
+import { InternalError } from "@xmtp-broker/schemas";
+import { SqliteIdentityStore } from "../../identity-store.js";
+import type {
+  XmtpClient,
+  XmtpClientFactory,
+  XmtpGroupInfo,
+  SignerProviderLike,
+} from "../../xmtp-client-factory.js";
+import { joinConversation, type JoinConversationDeps } from "../join.js";
+
+// --- Protobuf setup (same as invite-parser tests) ---
+
+protobuf.util.Long = Long;
+protobuf.configure();
+
+const InvitePayloadType = new protobuf.Type("InvitePayload")
+  .add(new protobuf.Field("conversationToken", 1, "bytes"))
+  .add(new protobuf.Field("creatorInboxId", 2, "bytes"))
+  .add(new protobuf.Field("tag", 3, "string"))
+  .add(new protobuf.Field("name", 4, "string", "optional"))
+  .add(new protobuf.Field("description", 5, "string", "optional"))
+  .add(new protobuf.Field("imageURL", 6, "string", "optional"))
+  .add(
+    new protobuf.Field("conversationExpiresAtUnix", 7, "sfixed64", "optional"),
+  )
+  .add(new protobuf.Field("expiresAtUnix", 8, "sfixed64", "optional"))
+  .add(new protobuf.Field("expiresAfterUse", 9, "bool"));
+
+const SignedInviteType = new protobuf.Type("SignedInvite")
+  .add(new protobuf.Field("payload", 1, "bytes"))
+  .add(new protobuf.Field("signature", 2, "bytes"));
+
+new protobuf.Root().add(InvitePayloadType).add(SignedInviteType);
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+function base64UrlEncode(data: Uint8Array): string {
+  return Buffer.from(data)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+const TEST_PRIVATE_KEY = new Uint8Array(32);
+TEST_PRIVATE_KEY[31] = 1;
+
+const TEST_CREATOR_INBOX_ID =
+  "aabbccddee1122334455667788990011aabbccddee1122334455667788990011";
+
+const TEST_DB_KEY = new Uint8Array(32).fill(0xab);
+const TEST_SIGNER_KEY =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" as const;
+
+function buildTestSlug(): string {
+  const payloadBytes = InvitePayloadType.encode(
+    InvitePayloadType.create({
+      conversationToken: new Uint8Array([1, 2, 3, 4, 5]),
+      creatorInboxId: hexToBytes(TEST_CREATOR_INBOX_ID),
+      tag: "test-join-tag",
+      name: "Test Group",
+      expiresAfterUse: false,
+    }),
+  ).finish();
+
+  const hash = sha256(payloadBytes);
+  const sig = secp256k1.sign(hash, TEST_PRIVATE_KEY);
+  const compact = sig.toCompactRawBytes();
+  const signature = new Uint8Array(65);
+  signature.set(compact, 0);
+  signature[64] = sig.recovery;
+
+  const signedBytes = SignedInviteType.encode(
+    SignedInviteType.create({ payload: payloadBytes, signature }),
+  ).finish();
+
+  return base64UrlEncode(signedBytes);
+}
+
+function buildTestUrl(): string {
+  return `https://popup.convos.org/v2?i=${encodeURIComponent(buildTestSlug())}`;
+}
+
+// --- Mock helpers ---
+
+function createMockSignerProvider(): SignerProviderLike {
+  return {
+    sign: () => Promise.resolve(Result.ok(new Uint8Array(64))),
+    getPublicKey: () => Promise.resolve(Result.ok(new Uint8Array(32))),
+    getFingerprint: () => Promise.resolve(Result.ok("mock-fingerprint")),
+    getDbEncryptionKey: () => Promise.resolve(Result.ok(TEST_DB_KEY)),
+    getXmtpIdentityKey: () => Promise.resolve(Result.ok(TEST_SIGNER_KEY)),
+  };
+}
+
+function createMockClient(options?: {
+  inboxId?: string;
+  onCreateDm?: (peerInboxId: string) => void;
+  onSendDm?: (dmId: string, text: string) => void;
+  groupsAfterSync?: XmtpGroupInfo[];
+  syncCount?: { value: number };
+}): XmtpClient {
+  const inboxId = options?.inboxId ?? "joiner-inbox-123";
+  const syncCount = options?.syncCount ?? { value: 0 };
+  const groupsAfterSync = options?.groupsAfterSync ?? [];
+  const notImplemented = () => {
+    throw new Error("Not implemented in test stub");
+  };
+
+  return {
+    inboxId,
+    sendMessage: notImplemented,
+    createDm: async (peerInboxId) => {
+      options?.onCreateDm?.(peerInboxId);
+      return Result.ok({ dmId: "dm-1", peerInboxId });
+    },
+    sendDmMessage: async (dmId, text) => {
+      options?.onSendDm?.(dmId, text);
+      return Result.ok("dm-msg-1");
+    },
+    syncAll: async () => {
+      syncCount.value++;
+      return Result.ok();
+    },
+    syncGroup: notImplemented,
+    getGroupInfo: notImplemented,
+    listGroups: async () => {
+      // Return groups only after sync has been called (simulating acceptance)
+      if (syncCount.value > 0 && groupsAfterSync.length > 0) {
+        return Result.ok(groupsAfterSync);
+      }
+      return Result.ok([]);
+    },
+    createGroup: notImplemented,
+    addMembers: notImplemented,
+    removeMembers: notImplemented,
+    streamAllMessages: notImplemented,
+    streamGroups: notImplemented,
+  };
+}
+
+function createMockFactory(client: XmtpClient): XmtpClientFactory {
+  return {
+    create: () => Promise.resolve(Result.ok(client)),
+  };
+}
+
+function createDeps(overrides?: {
+  client?: XmtpClient;
+  identityStore?: SqliteIdentityStore;
+}): JoinConversationDeps {
+  const client =
+    overrides?.client ??
+    createMockClient({
+      groupsAfterSync: [
+        {
+          groupId: "joined-group-1",
+          name: "Test Group",
+          description: "",
+          memberInboxIds: ["joiner-inbox-123", TEST_CREATOR_INBOX_ID],
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+  return {
+    identityStore:
+      overrides?.identityStore ?? new SqliteIdentityStore(":memory:"),
+    clientFactory: createMockFactory(client),
+    signerProviderFactory: () => createMockSignerProvider(),
+    config: {
+      dataDir: ":memory:",
+      env: "dev",
+      appVersion: "xmtp-broker/test",
+    },
+  };
+}
+
+describe("joinConversation", () => {
+  test("successful join flow: creates identity, DMs slug, discovers group", async () => {
+    const dmCalls: Array<{ peerInboxId: string }> = [];
+    const sendCalls: Array<{ dmId: string; text: string }> = [];
+
+    const client = createMockClient({
+      onCreateDm: (peerInboxId) => dmCalls.push({ peerInboxId }),
+      onSendDm: (dmId, text) => sendCalls.push({ dmId, text }),
+      groupsAfterSync: [
+        {
+          groupId: "joined-group-1",
+          name: "Test Group",
+          description: "",
+          memberInboxIds: ["joiner-inbox-123", TEST_CREATOR_INBOX_ID],
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    const deps = createDeps({ client });
+    const inviteUrl = buildTestUrl();
+
+    const result = await joinConversation(deps, inviteUrl, {
+      label: "test-agent",
+      pollIntervalMs: 10,
+      maxPollAttempts: 3,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.groupId).toBe("joined-group-1");
+    expect(result.value.identityId).toBeDefined();
+
+    // Verify DM was sent to creator
+    expect(dmCalls).toHaveLength(1);
+    expect(dmCalls[0]?.peerInboxId).toBe(TEST_CREATOR_INBOX_ID);
+
+    // Verify slug was sent as DM text
+    expect(sendCalls).toHaveLength(1);
+    expect(sendCalls[0]?.dmId).toBe("dm-1");
+
+    // Verify identity was persisted
+    const identities = await deps.identityStore.list();
+    expect(identities).toHaveLength(1);
+    expect(identities[0]?.inboxId).toBe("joiner-inbox-123");
+  });
+
+  test("returns error when invite URL is invalid", async () => {
+    const deps = createDeps();
+
+    const result = await joinConversation(deps, "not-a-valid-invite");
+    expect(result.isErr()).toBe(true);
+  });
+
+  test("returns error when invite is expired", async () => {
+    // Build an expired invite
+    const pastTime = BigInt(Math.floor(Date.now() / 1000) - 3600);
+    const payloadBytes = InvitePayloadType.encode(
+      InvitePayloadType.create({
+        conversationToken: new Uint8Array([1, 2, 3]),
+        creatorInboxId: hexToBytes(TEST_CREATOR_INBOX_ID),
+        tag: "expired-tag",
+        expiresAfterUse: false,
+        expiresAtUnix: new Long(
+          Number(pastTime & 0xffffffffn),
+          Number((pastTime >> 32n) & 0xffffffffn),
+          false,
+        ),
+      }),
+    ).finish();
+
+    const hash = sha256(payloadBytes);
+    const sig = secp256k1.sign(hash, TEST_PRIVATE_KEY);
+    const compact = sig.toCompactRawBytes();
+    const signature = new Uint8Array(65);
+    signature.set(compact, 0);
+    signature[64] = sig.recovery;
+
+    const signedBytes = SignedInviteType.encode(
+      SignedInviteType.create({ payload: payloadBytes, signature }),
+    ).finish();
+
+    const slug = base64UrlEncode(signedBytes);
+    const url = `https://popup.convos.org/v2?i=${encodeURIComponent(slug)}`;
+
+    const deps = createDeps();
+    const result = await joinConversation(deps, url);
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+    expect(result.error.message).toContain("expired");
+  });
+
+  test("times out when group is never discovered", async () => {
+    // Client that never returns groups
+    const client = createMockClient({
+      groupsAfterSync: [], // Never discovers a group
+    });
+
+    const deps = createDeps({ client });
+    const inviteUrl = buildTestUrl();
+
+    const result = await joinConversation(deps, inviteUrl, {
+      pollIntervalMs: 10,
+      maxPollAttempts: 2,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+    expect(result.error.category).toBe("timeout");
+  });
+
+  test("cleans up identity on factory failure", async () => {
+    const failingFactory: XmtpClientFactory = {
+      create: () =>
+        Promise.resolve(
+          Result.err(InternalError.create("Network unreachable")),
+        ),
+    };
+
+    const store = new SqliteIdentityStore(":memory:");
+    const deps: JoinConversationDeps = {
+      identityStore: store,
+      clientFactory: failingFactory,
+      signerProviderFactory: () => createMockSignerProvider(),
+      config: {
+        dataDir: ":memory:",
+        env: "dev",
+        appVersion: "xmtp-broker/test",
+      },
+    };
+
+    const result = await joinConversation(deps, buildTestUrl());
+
+    expect(result.isErr()).toBe(true);
+
+    // Identity should have been cleaned up
+    const identities = await store.list();
+    expect(identities).toHaveLength(0);
+  });
+});

--- a/packages/core/src/convos/invite-parser.ts
+++ b/packages/core/src/convos/invite-parser.ts
@@ -1,0 +1,339 @@
+import { inflateSync } from "node:zlib";
+import { Result } from "better-result";
+import { ValidationError } from "@xmtp-broker/schemas";
+import type { BrokerError } from "@xmtp-broker/schemas";
+import protobuf from "protobufjs";
+import Long from "long";
+import { secp256k1 } from "@noble/curves/secp256k1";
+import { sha256 } from "@noble/hashes/sha256";
+
+// --- Protobuf schema definitions (programmatic, matching Convos format) ---
+
+protobuf.util.Long = Long;
+protobuf.configure();
+
+const InvitePayloadType = new protobuf.Type("InvitePayload")
+  .add(new protobuf.Field("conversationToken", 1, "bytes"))
+  .add(new protobuf.Field("creatorInboxId", 2, "bytes"))
+  .add(new protobuf.Field("tag", 3, "string"))
+  .add(new protobuf.Field("name", 4, "string", "optional"))
+  .add(new protobuf.Field("description", 5, "string", "optional"))
+  .add(new protobuf.Field("imageURL", 6, "string", "optional"))
+  .add(
+    new protobuf.Field("conversationExpiresAtUnix", 7, "sfixed64", "optional"),
+  )
+  .add(new protobuf.Field("expiresAtUnix", 8, "sfixed64", "optional"))
+  .add(new protobuf.Field("expiresAfterUse", 9, "bool"));
+
+const SignedInviteType = new protobuf.Type("SignedInvite")
+  .add(new protobuf.Field("payload", 1, "bytes"))
+  .add(new protobuf.Field("signature", 2, "bytes"));
+
+new protobuf.Root().add(InvitePayloadType).add(SignedInviteType);
+
+// --- Constants ---
+
+/**
+ * Compression marker byte used by Convos slug encoding.
+ * Format: [0x1f marker][4-byte BE original size][zlib deflate data]
+ * Matches the iOS and CLI implementations.
+ */
+const COMPRESSION_MARKER = 0x1f;
+
+/** Maximum decompressed size (1 MB) to prevent decompression bombs. */
+const MAX_DECOMPRESSED_SIZE = 1024 * 1024;
+
+// --- Types ---
+
+/** Parsed and decoded Convos invite with all payload fields. */
+export interface ParsedConvosInvite {
+  /** Raw payload bytes from the SignedInvite (for signature verification). */
+  readonly signedInvitePayloadBytes: Uint8Array;
+  /** Raw signature bytes from the SignedInvite (for signature verification). */
+  readonly signedInviteSignature: Uint8Array;
+  /** Encrypted conversation token (only creator can decrypt). */
+  readonly conversationToken: Uint8Array;
+  /** Hex-encoded creator inbox ID. */
+  readonly creatorInboxId: string;
+  /** Unique invite tag for verification. */
+  readonly tag: string;
+  /** Optional group name. */
+  readonly name: string | undefined;
+  /** Optional group description. */
+  readonly description: string | undefined;
+  /** Optional image URL. */
+  readonly imageUrl: string | undefined;
+  /** Whether the invite has expired. */
+  readonly isExpired: boolean;
+  /** Whether the conversation has expired. */
+  readonly isConversationExpired: boolean;
+  /** Whether the invite expires after first use. */
+  readonly expiresAfterUse: boolean;
+}
+
+// --- Decoded protobuf message shape ---
+
+interface DecodedInvitePayload {
+  conversationToken: Uint8Array;
+  creatorInboxId: Uint8Array;
+  tag: string;
+  name?: string;
+  description?: string;
+  imageURL?: string;
+  conversationExpiresAtUnix?: protobuf.Long;
+  expiresAtUnix?: protobuf.Long;
+  expiresAfterUse: boolean;
+}
+
+interface DecodedSignedInvite {
+  payload: Uint8Array;
+  signature: Uint8Array;
+}
+
+// --- Helpers ---
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function base64UrlDecode(str: string): Uint8Array {
+  let base64 = str.replace(/-/g, "+").replace(/_/g, "/");
+  const padLength = (4 - (base64.length % 4)) % 4;
+  base64 += "=".repeat(padLength);
+  return new Uint8Array(Buffer.from(base64, "base64"));
+}
+
+function decompress(
+  data: Uint8Array,
+): Result<Uint8Array, BrokerError> {
+  if (data.length === 0 || data[0] !== COMPRESSION_MARKER) {
+    return Result.ok(data);
+  }
+
+  // Skip 5-byte header: [marker][4-byte BE original size]
+  const compressed = data.slice(5);
+  const decompressed = inflateSync(compressed);
+
+  if (decompressed.length > MAX_DECOMPRESSED_SIZE) {
+    return Result.err(
+      ValidationError.create(
+        "inviteUrl",
+        `Decompressed size exceeds maximum: ${decompressed.length}`,
+      ),
+    );
+  }
+
+  return Result.ok(new Uint8Array(decompressed));
+}
+
+/**
+ * Extract the invite slug from a URL or return it as-is if it's a raw slug.
+ *
+ * Handles:
+ * - `https://popup.convos.org/v2?i=<slug>`
+ * - `https://dev.convos.org/v2?i=<slug>`
+ * - Legacy `?code=` format
+ * - Raw slug string
+ */
+function extractSlug(input: string): string {
+  const trimmed = input.trim();
+
+  try {
+    const url = new URL(trimmed);
+
+    const iParam = url.searchParams.get("i");
+    if (iParam) return iParam;
+
+    const codeParam = url.searchParams.get("code");
+    if (codeParam) return codeParam;
+
+    const pathParts = url.pathname.split("/").filter(Boolean);
+    if (pathParts.length > 0) {
+      const last = pathParts[pathParts.length - 1];
+      if (last !== undefined) return last;
+    }
+  } catch {
+    // Not a URL, treat as raw slug
+  }
+
+  return trimmed;
+}
+
+function longToBigInt(value: protobuf.Long): bigint {
+  return BigInt(value.toString());
+}
+
+/**
+ * Parse a Convos invite URL or slug into a structured invite object.
+ *
+ * Steps:
+ * 1. Extract slug from URL (or use raw slug)
+ * 2. Remove `*` separators (iMessage compatibility)
+ * 3. Base64url decode
+ * 4. Decompress if compressed (0x78 marker)
+ * 5. Decode protobuf SignedInvite
+ * 6. Decode protobuf InvitePayload
+ * 7. Check expiration
+ */
+export function parseConvosInviteUrl(
+  input: string,
+): Result<ParsedConvosInvite, BrokerError> {
+  try {
+    // Step 1: Extract slug
+    const slug = extractSlug(input);
+
+    // Step 2: Remove * separators
+    const cleanSlug = slug.replace(/\*/g, "");
+
+    // Step 3: Base64url decode
+    const decoded = base64UrlDecode(cleanSlug);
+    if (decoded.length === 0) {
+      return Result.err(
+        ValidationError.create("inviteUrl", "Empty invite data"),
+      );
+    }
+
+    // Step 4: Decompress
+    const decompressResult = decompress(decoded);
+    if (decompressResult.isErr()) return decompressResult;
+    const decompressed = decompressResult.value;
+
+    // Step 5: Decode SignedInvite protobuf
+    const signedInvite = SignedInviteType.decode(
+      decompressed,
+    ) as unknown as DecodedSignedInvite;
+
+    if (
+      !signedInvite.payload ||
+      signedInvite.payload.length === 0 ||
+      !signedInvite.signature ||
+      signedInvite.signature.length === 0
+    ) {
+      return Result.err(
+        ValidationError.create(
+          "inviteUrl",
+          "Invalid SignedInvite: missing payload or signature",
+        ),
+      );
+    }
+
+    const payloadBytes = new Uint8Array(signedInvite.payload);
+    const signatureBytes = new Uint8Array(signedInvite.signature);
+
+    // Step 6: Decode InvitePayload protobuf
+    const payload = InvitePayloadType.decode(
+      payloadBytes,
+    ) as unknown as DecodedInvitePayload;
+
+    if (!payload.creatorInboxId || payload.creatorInboxId.length === 0) {
+      return Result.err(
+        ValidationError.create(
+          "inviteUrl",
+          "Invalid InvitePayload: missing creatorInboxId",
+        ),
+      );
+    }
+
+    if (!payload.tag) {
+      return Result.err(
+        ValidationError.create(
+          "inviteUrl",
+          "Invalid InvitePayload: missing tag",
+        ),
+      );
+    }
+
+    // Step 7: Check expiration
+    const nowUnix = BigInt(Math.floor(Date.now() / 1000));
+
+    const expiresAtUnix =
+      payload.expiresAtUnix && payload.expiresAtUnix.toString() !== "0"
+        ? longToBigInt(payload.expiresAtUnix)
+        : undefined;
+
+    const conversationExpiresAtUnix =
+      payload.conversationExpiresAtUnix &&
+      payload.conversationExpiresAtUnix.toString() !== "0"
+        ? longToBigInt(payload.conversationExpiresAtUnix)
+        : undefined;
+
+    const isExpired = expiresAtUnix !== undefined && expiresAtUnix < nowUnix;
+    const isConversationExpired =
+      conversationExpiresAtUnix !== undefined &&
+      conversationExpiresAtUnix < nowUnix;
+
+    return Result.ok({
+      signedInvitePayloadBytes: payloadBytes,
+      signedInviteSignature: signatureBytes,
+      conversationToken: new Uint8Array(payload.conversationToken),
+      creatorInboxId: bytesToHex(new Uint8Array(payload.creatorInboxId)),
+      tag: payload.tag,
+      name: payload.name || undefined,
+      description: payload.description || undefined,
+      imageUrl: payload.imageURL || undefined,
+      isExpired,
+      isConversationExpired,
+      expiresAfterUse: payload.expiresAfterUse ?? false,
+    });
+  } catch (cause) {
+    return Result.err(
+      ValidationError.create(
+        "inviteUrl",
+        `Failed to parse invite: ${cause instanceof Error ? cause.message : String(cause)}`,
+      ),
+    );
+  }
+}
+
+/**
+ * Verify a parsed Convos invite's signature.
+ *
+ * Recovers the secp256k1 public key from the signature and verifies
+ * the signature is valid. This does NOT verify the signer is who
+ * they claim to be (that would require comparing against a known key).
+ * It only verifies structural integrity: that the signature was produced
+ * by some valid private key over the given payload.
+ */
+export function verifyConvosInvite(
+  invite: ParsedConvosInvite,
+): Result<void, BrokerError> {
+  try {
+    const { signedInvitePayloadBytes, signedInviteSignature } = invite;
+
+    if (signedInviteSignature.length !== 65) {
+      return Result.err(
+        ValidationError.create(
+          "inviteSignature",
+          `Invalid signature length: expected 65 bytes, got ${signedInviteSignature.length}`,
+        ),
+      );
+    }
+
+    const messageHash = sha256(signedInvitePayloadBytes);
+    const compactSig = signedInviteSignature.slice(0, 64);
+    const recoveryBit = signedInviteSignature[64];
+
+    if (recoveryBit === undefined || recoveryBit > 3) {
+      return Result.err(
+        ValidationError.create(
+          "inviteSignature",
+          `Invalid recovery bit: ${recoveryBit}`,
+        ),
+      );
+    }
+
+    // Attempt to recover public key -- will throw if signature is invalid
+    const sig =
+      secp256k1.Signature.fromCompact(compactSig).addRecoveryBit(recoveryBit);
+    sig.recoverPublicKey(messageHash);
+
+    return Result.ok();
+  } catch (cause) {
+    return Result.err(
+      ValidationError.create(
+        "inviteSignature",
+        `Signature verification failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+      ),
+    );
+  }
+}

--- a/packages/core/src/convos/join.ts
+++ b/packages/core/src/convos/join.ts
@@ -1,0 +1,210 @@
+import { Result } from "better-result";
+import { TimeoutError, ValidationError } from "@xmtp-broker/schemas";
+import type { BrokerError } from "@xmtp-broker/schemas";
+import type { SqliteIdentityStore } from "../identity-store.js";
+import type { XmtpClientFactory } from "../xmtp-client-factory.js";
+import type { XmtpEnv, BrokerCoreConfig } from "../config.js";
+import type { SignerProviderFactory } from "../identity-registration.js";
+import { registerIdentity } from "../identity-registration.js";
+import { parseConvosInviteUrl, verifyConvosInvite } from "./invite-parser.js";
+
+/** Dependencies injected into the join orchestrator. */
+export interface JoinConversationDeps {
+  readonly identityStore: SqliteIdentityStore;
+  readonly clientFactory: XmtpClientFactory;
+  readonly signerProviderFactory: SignerProviderFactory;
+  readonly config: Pick<BrokerCoreConfig, "dataDir" | "env" | "appVersion">;
+}
+
+/** Options for joining a conversation. */
+export interface JoinConversationOptions {
+  /** Human-readable label for the new identity. */
+  readonly label?: string;
+  /** Milliseconds between poll attempts for group discovery. */
+  readonly pollIntervalMs?: number;
+  /** Maximum number of poll attempts before timing out. */
+  readonly maxPollAttempts?: number;
+}
+
+/** Result of a successful join. */
+export interface JoinResult {
+  /** The identity ID of the newly created identity. */
+  readonly identityId: string;
+  /** The inbox ID assigned by XMTP. */
+  readonly inboxId: string;
+  /** The group ID of the joined conversation. */
+  readonly groupId: string;
+  /** The invite tag from the parsed invite. */
+  readonly inviteTag: string;
+  /** The group name, if available. */
+  readonly groupName: string | undefined;
+  /** The creator's inbox ID. */
+  readonly creatorInboxId: string;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 2000;
+const DEFAULT_MAX_POLL_ATTEMPTS = 30; // 60 seconds at default interval
+
+/**
+ * Extract the raw slug from an invite URL for sending as a DM join request.
+ */
+function extractSlugForDm(input: string): string {
+  const trimmed = input.trim();
+  try {
+    const url = new URL(trimmed);
+    const iParam = url.searchParams.get("i");
+    if (iParam) return iParam;
+    const codeParam = url.searchParams.get("code");
+    if (codeParam) return codeParam;
+  } catch {
+    // Raw slug
+  }
+  return trimmed;
+}
+
+/**
+ * Join a Convos conversation via an invite URL.
+ *
+ * Protocol:
+ * 1. Parse and verify the invite URL
+ * 2. Check expiration
+ * 3. Create a new per-conversation identity and XMTP client
+ * 4. Create a DM with the creator's inbox ID
+ * 5. Send the invite slug as a join request
+ * 6. Poll for group discovery (creator adds joiner to the group)
+ * 7. Return the joined group info
+ *
+ * On failure, cleans up the created identity.
+ */
+export async function joinConversation(
+  deps: JoinConversationDeps,
+  inviteUrl: string,
+  options?: JoinConversationOptions,
+): Promise<Result<JoinResult, BrokerError>> {
+  const { identityStore, clientFactory, signerProviderFactory, config } = deps;
+  const pollIntervalMs = options?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const maxPollAttempts = options?.maxPollAttempts ?? DEFAULT_MAX_POLL_ATTEMPTS;
+
+  // Step 1: Parse invite
+  const parseResult = parseConvosInviteUrl(inviteUrl);
+  if (!parseResult.isOk()) return parseResult;
+
+  const invite = parseResult.value;
+
+  // Step 2: Verify signature structure
+  const verifyResult = verifyConvosInvite(invite);
+  if (!verifyResult.isOk()) return verifyResult;
+
+  // Step 3: Check expiration
+  if (invite.isExpired) {
+    return Result.err(
+      ValidationError.create("inviteUrl", "Invite has expired"),
+    );
+  }
+  if (invite.isConversationExpired) {
+    return Result.err(
+      ValidationError.create("inviteUrl", "Conversation has expired"),
+    );
+  }
+
+  // Step 4: Create a new identity for this conversation
+  const registerInput: { label?: string } = {};
+  if (options?.label !== undefined) registerInput.label = options.label;
+
+  const registerResult = await registerIdentity(
+    { identityStore, clientFactory, signerProviderFactory, config },
+    registerInput,
+  );
+
+  if (!registerResult.isOk()) return registerResult;
+
+  const { identityId, inboxId } = registerResult.value;
+
+  // We need the XmtpClient instance to create DMs and poll for groups.
+  // Re-create the client (registerIdentity already created one but doesn't expose it).
+  const signer = signerProviderFactory(identityId);
+  const dbKeyResult = await signer.getDbEncryptionKey(identityId);
+  if (!dbKeyResult.isOk()) {
+    await identityStore.remove(identityId);
+    return dbKeyResult;
+  }
+
+  const identityKeyResult = await signer.getXmtpIdentityKey(identityId);
+  if (!identityKeyResult.isOk()) {
+    await identityStore.remove(identityId);
+    return identityKeyResult;
+  }
+
+  const resolveDbPath = (dataDir: string, env: XmtpEnv, id: string): string =>
+    dataDir === ":memory:" ? ":memory:" : `${dataDir}/db/${env}/${id}.db3`;
+
+  const clientResult = await clientFactory.create({
+    identityId,
+    dbPath: resolveDbPath(config.dataDir, config.env, identityId),
+    dbEncryptionKey: dbKeyResult.value,
+    env: config.env,
+    appVersion: config.appVersion,
+    signerPrivateKey: identityKeyResult.value,
+  });
+
+  if (!clientResult.isOk()) {
+    await identityStore.remove(identityId);
+    return clientResult;
+  }
+
+  const client = clientResult.value;
+
+  // Step 5: Create DM with creator and send join request
+  const dmResult = await client.createDm(invite.creatorInboxId);
+  if (!dmResult.isOk()) {
+    await identityStore.remove(identityId);
+    return dmResult;
+  }
+
+  const slug = extractSlugForDm(inviteUrl);
+  const sendResult = await client.sendDmMessage(dmResult.value.dmId, slug);
+  if (!sendResult.isOk()) {
+    await identityStore.remove(identityId);
+    return sendResult;
+  }
+
+  // Step 6: Poll for group discovery
+  for (let attempt = 0; attempt < maxPollAttempts; attempt++) {
+    const syncResult = await client.syncAll();
+    if (!syncResult.isOk()) {
+      await identityStore.remove(identityId);
+      return syncResult;
+    }
+
+    const groupsResult = await client.listGroups();
+    if (!groupsResult.isOk()) {
+      await identityStore.remove(identityId);
+      return groupsResult;
+    }
+
+    const groups = groupsResult.value;
+    if (groups.length > 0) {
+      const group = groups[0];
+      if (group !== undefined) {
+        return Result.ok({
+          identityId,
+          inboxId,
+          groupId: group.groupId,
+          inviteTag: invite.tag,
+          groupName: group.name || invite.name,
+          creatorInboxId: invite.creatorInboxId,
+        });
+      }
+    }
+
+    // Wait before next poll
+    if (attempt < maxPollAttempts - 1) {
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    }
+  }
+
+  // Step 7: Timeout -- clean up identity
+  await identityStore.remove(identityId);
+  const totalMs = maxPollAttempts * pollIntervalMs;
+  return Result.err(TimeoutError.create("joinConversation", totalMs));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,7 @@ export type {
   XmtpClient,
   XmtpClientFactory,
   XmtpClientCreateOptions,
+  XmtpDmInfo,
   XmtpGroupInfo,
   XmtpDecodedMessage,
   XmtpGroupEvent,
@@ -60,6 +61,19 @@ export type {
 // Conversation actions
 export { createConversationActions } from "./conversation-actions.js";
 export type { ConversationActionDeps } from "./conversation-actions.js";
+
+// Convos invite parsing and join protocol
+export {
+  parseConvosInviteUrl,
+  verifyConvosInvite,
+} from "./convos/invite-parser.js";
+export type { ParsedConvosInvite } from "./convos/invite-parser.js";
+export { joinConversation } from "./convos/join.js";
+export type {
+  JoinConversationDeps,
+  JoinConversationOptions,
+  JoinResult,
+} from "./convos/join.js";
 
 // SDK integration (production XmtpClientFactory implementation)
 export {

--- a/packages/core/src/sdk/sdk-client.ts
+++ b/packages/core/src/sdk/sdk-client.ts
@@ -3,6 +3,7 @@ import type { BrokerError } from "@xmtp-broker/schemas";
 import { NotFoundError } from "@xmtp-broker/schemas";
 import type {
   XmtpClient,
+  XmtpDmInfo,
   XmtpGroupInfo,
   MessageStream,
   GroupStream,
@@ -85,6 +86,28 @@ export function createSdkClient(options: SdkClientOptions): XmtpClient {
       return wrapSdkCall(
         async () => group.sendText(text),
         "sendMessage",
+      );
+    },
+
+    async createDm(
+      peerInboxId: string,
+    ): Promise<Result<XmtpDmInfo, BrokerError>> {
+      return wrapSdkCall(async () => {
+        const dm = await client.conversations.createDm(peerInboxId);
+        return { dmId: dm.id, peerInboxId };
+      }, "createDm");
+    },
+
+    async sendDmMessage(
+      dmId: string,
+      text: string,
+    ): Promise<Result<string, BrokerError>> {
+      const dmResult = await getGroup(client, dmId);
+      if (dmResult.isErr()) return dmResult;
+
+      return wrapSdkCall(
+        async () => dmResult.value.sendText(text),
+        "sendDmMessage",
       );
     },
 

--- a/packages/core/src/sdk/sdk-types.ts
+++ b/packages/core/src/sdk/sdk-types.ts
@@ -78,6 +78,7 @@ export interface SdkConversationsShape {
   getConversationById(id: string): Promise<SdkGroupShape | undefined>;
   list(options?: unknown): Promise<SdkGroupShape[]>;
   listGroups(options?: unknown): SdkGroupShape[];
+  createDm(inboxId: string): Promise<SdkGroupShape>;
   createGroup(
     inboxIds: string[],
     options?: { name?: string },

--- a/packages/core/src/xmtp-client-factory.ts
+++ b/packages/core/src/xmtp-client-factory.ts
@@ -30,6 +30,15 @@ export interface XmtpClient {
   /** List all groups the client is a member of. */
   listGroups(): Promise<Result<readonly XmtpGroupInfo[], BrokerError>>;
 
+  /** Create a DM conversation with a peer by inbox ID. */
+  createDm(peerInboxId: string): Promise<Result<XmtpDmInfo, BrokerError>>;
+
+  /** Send a text message to a DM conversation. */
+  sendDmMessage(
+    dmId: string,
+    text: string,
+  ): Promise<Result<string, BrokerError>>;
+
   /** Create a new group conversation with the given members. */
   createGroup(
     memberInboxIds: readonly string[],
@@ -59,6 +68,12 @@ export interface XmtpClient {
    * Returns an async iterable and an abort function.
    */
   streamGroups(): Promise<Result<GroupStream, BrokerError>>;
+}
+
+/** DM conversation metadata returned by the XMTP client. */
+export interface XmtpDmInfo {
+  readonly dmId: string;
+  readonly peerInboxId: string;
 }
 
 /** Group metadata returned by the XMTP client. */

--- a/packages/integration/src/fixtures/mock-xmtp-client.ts
+++ b/packages/integration/src/fixtures/mock-xmtp-client.ts
@@ -141,6 +141,14 @@ export function createMockXmtpClient(options?: MockXmtpClientOptions): {
       return Result.ok(`msg_${crypto.randomUUID()}`);
     },
 
+    async createDm(peerInboxId) {
+      return Result.ok({ dmId: `dm_${crypto.randomUUID()}`, peerInboxId });
+    },
+
+    async sendDmMessage(_dmId, _text) {
+      return Result.ok(`dm_msg_${crypto.randomUUID()}`);
+    },
+
     async syncAll() {
       return Result.ok(undefined);
     },


### PR DESCRIPTION
## Summary
- Parse Convos invite URLs (`popup.convos.org/v2?i=...`) with protobuf decoding, zlib decompression, and secp256k1 signature verification
- Implement the Convos join protocol: create per-conversation identity, send DM join request, poll for group acceptance
- Add `createDm()` and `sendDmMessage()` to the XmtpClient interface for DM-based join handshake

## Key changes
- `packages/core/src/convos/invite-parser.ts` — Convos v2 invite URL parser: base64url decode, zlib decompress (0x1f marker format), protobuf SignedInvite/InvitePayload decode, secp256k1 signature recovery
- `packages/core/src/convos/join.ts` — Join protocol orchestrator: parse invite, check expiration, create identity, send DM join request, poll for group membership
- `packages/core/src/conversation-actions.ts` — Add `conversation.join` ActionSpec
- `packages/core/src/xmtp-client-factory.ts` — Add `XmtpDmInfo`, `createDm()`, `sendDmMessage()` to XmtpClient interface
- `packages/core/src/sdk/sdk-client.ts` — Implement DM methods via `wrapSdkCall()`
- `packages/cli/src/commands/conversation.ts` — Wire `conversation join` CLI command
- `packages/core/src/convos/__tests__/invite-parser.test.ts` — 14 parser tests (URL formats, compression, separators, expiration, signatures)
- `packages/core/src/convos/__tests__/join.test.ts` — 5 join protocol tests (success, invalid invite, expiration, timeout, cleanup)

## Test plan
- [ ] `cd packages/core && bun test invite-parser` passes all 14 tests
- [ ] `cd packages/core && bun test join` passes all 5 tests
- [ ] Build, typecheck, and lint all pass