### PR TITLE
feat(core): Convos-compatible invite generation and terminal QR

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "xmtp-broker",
+      "dependencies": {
+        "@noble/ciphers": "^2.1.1",
+      },
       "devDependencies": {
         "lefthook": "catalog:",
         "oxfmt": "catalog:",
@@ -71,6 +74,7 @@
       "name": "@xmtp-broker/core",
       "version": "0.0.0",
       "dependencies": {
+        "@noble/ciphers": "^2.1.1",
         "@noble/curves": "^1.8.0",
         "@noble/hashes": "^1.8.0",
         "@xmtp-broker/contracts": "workspace:*",
@@ -242,7 +246,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
-    "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+    "@noble/ciphers": ["@noble/ciphers@2.1.1", "", {}, "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw=="],
 
     "@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
@@ -677,5 +681,7 @@
     "@modelcontextprotocol/sdk/zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "@xmtp/content-type-primitives/@xmtp/node-bindings": ["@xmtp/node-bindings@1.8.0", "", {}, "sha512-dyppg1pQNsEdGH13RfsbkbXdnUdjufak6ea1YahjCROgmaJClDpMHcMcSfMzoJzASanU58MwEdCgYUF638NKgw=="],
+
+    "ox/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "format:fix": "oxfmt packages/*/src packages/*/package.json packages/*/tsconfig.json apps scripts package.json tsconfig.base.json turbo.json .lefthook.yml README.md CLAUDE.md",
     "check": "turbo run lint typecheck test"
   },
+  "dependencies": {
+    "@noble/ciphers": "^2.1.1"
+  },
   "devDependencies": {
     "lefthook": "catalog:",
     "oxfmt": "catalog:",

--- a/packages/cli/src/commands/conversation.ts
+++ b/packages/cli/src/commands/conversation.ts
@@ -163,9 +163,11 @@ export function createConversationCommands(
 
   cmd
     .command("invite")
-    .description("Generate an invite QR code for a group conversation")
+    .description("Generate a Convos-compatible invite URL for a group")
     .argument("<group-id>", "Group conversation ID")
     .option("--as <label>", "Identity label")
+    .option("--name <name>", "Override group name in invite")
+    .option("--description <desc>", "Override description in invite")
     .option("--config <path>", "Path to config file")
     .option("--format <type>", "Output format: link, qr, or both", "both")
     .option("--json", "JSON output")
@@ -174,12 +176,18 @@ export function createConversationCommands(
       const format =
         typeof options.format === "string" ? options.format : "both";
 
+      const params: Record<string, unknown> = { groupId };
+      if (typeof options.as === "string") params["identityLabel"] = options.as;
+      if (typeof options.name === "string") params["name"] = options.name;
+      if (typeof options.description === "string")
+        params["description"] = options.description;
+
       const result = await d.withDaemonClient(
         {
           configPath:
             typeof options.config === "string" ? options.config : undefined,
         },
-        (client) => client.request<unknown>("conversation.info", { groupId }),
+        (client) => client.request<unknown>("conversation.invite", params),
       );
 
       if (result.isErr()) {
@@ -187,34 +195,34 @@ export function createConversationCommands(
         return;
       }
 
-      const info = result.value as Record<string, unknown>;
-      const name = typeof info["name"] === "string" ? info["name"] : "unnamed";
-      const inviteData = JSON.stringify({
-        type: "xmtp-broker-invite",
-        groupId,
-        name,
-      });
+      const inviteResult = result.value as Record<string, unknown>;
+      const inviteUrl =
+        typeof inviteResult["inviteUrl"] === "string"
+          ? inviteResult["inviteUrl"]
+          : "";
+      const groupName =
+        typeof inviteResult["groupName"] === "string"
+          ? inviteResult["groupName"]
+          : "unnamed";
 
       if (json) {
         const { renderQrToDataUrl } = await import("../invite/qr.js");
-        const qrDataUrl = await renderQrToDataUrl(inviteData);
+        const qrDataUrl = await renderQrToDataUrl(inviteUrl);
         d.writeStdout(
-          formatOutput({ groupId, name, inviteData, qrDataUrl }, { json }) +
-            "\n",
+          formatOutput({ ...inviteResult, qrDataUrl }, { json }) + "\n",
         );
         return;
       }
 
-      d.writeStdout(`Group: ${name} (${groupId})\n`);
-      d.writeStdout(`Invite data: ${inviteData}\n`);
+      d.writeStdout(`Group: ${groupName} (${groupId})\n`);
 
       if (format === "link" || format === "both") {
-        d.writeStdout(`\nInvite payload:\n${inviteData}\n`);
+        d.writeStdout(`\nInvite URL:\n${inviteUrl}\n`);
       }
 
       if (format === "qr" || format === "both") {
         const { renderQrToTerminal } = await import("../invite/qr.js");
-        const qr = await renderQrToTerminal(inviteData);
+        const qr = await renderQrToTerminal(inviteUrl);
         d.writeStdout(`\n${qr}`);
       }
     });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@noble/ciphers": "^2.1.1",
     "@noble/curves": "^1.8.0",
     "@noble/hashes": "^1.8.0",
     "@xmtp-broker/contracts": "workspace:*",

--- a/packages/core/src/conversation-actions.ts
+++ b/packages/core/src/conversation-actions.ts
@@ -11,6 +11,7 @@ import type {
 } from "./xmtp-client-factory.js";
 import type { BrokerCoreConfig } from "./config.js";
 import { joinConversation } from "./convos/join.js";
+import { generateConvosInviteUrl } from "./convos/invite-generator.js";
 import type { SignerProviderFactory } from "./identity-registration.js";
 
 export interface ConversationActionDeps {
@@ -253,10 +254,122 @@ export function createConversationActions(
     },
   };
 
+  const invite: ActionSpec<
+    {
+      groupId: string;
+      identityLabel?: string | undefined;
+      name?: string | undefined;
+      description?: string | undefined;
+    },
+    {
+      inviteUrl: string;
+      groupId: string;
+      groupName: string;
+      creatorInboxId: string;
+      inviteTag: string;
+    },
+    BrokerError
+  > = {
+    id: "conversation.invite",
+    input: z.object({
+      groupId: z.string(),
+      identityLabel: z.string().optional(),
+      name: z.string().optional(),
+      description: z.string().optional(),
+    }),
+    handler: async (input) => {
+      if (!deps.signerProviderFactory || !deps.config) {
+        return Result.err(
+          NotFoundError.create(
+            "invite-deps",
+            "Invite requires signerProviderFactory and config",
+          ) as BrokerError,
+        );
+      }
+
+      // Resolve identity
+      const resolved = await resolveIdentity(
+        deps.identityStore,
+        input.identityLabel,
+      );
+      if (Result.isError(resolved)) return resolved;
+
+      const managed = deps.getManagedClient(resolved.value.identityId);
+      if (!managed) {
+        return Result.err(
+          NotFoundError.create(
+            "managed-client",
+            resolved.value.identityId,
+          ) as BrokerError,
+        );
+      }
+
+      // Get group info
+      const groupResult = await deps.getGroupInfo(input.groupId);
+      if (Result.isError(groupResult)) return groupResult;
+
+      // Get the secp256k1 private key for signing
+      const signer = deps.signerProviderFactory(resolved.value.identityId);
+      const keyResult = await signer.getXmtpIdentityKey(
+        resolved.value.identityId,
+      );
+      if (Result.isError(keyResult)) return keyResult;
+
+      // Strip 0x prefix for the generator
+      const walletPrivateKeyHex = keyResult.value.startsWith("0x")
+        ? keyResult.value.slice(2)
+        : keyResult.value;
+
+      // Generate a random invite tag
+      const tagBytes = crypto.getRandomValues(new Uint8Array(10));
+      const inviteTag = Array.from(tagBytes, (b) =>
+        b.toString(36).padStart(2, "0"),
+      )
+        .join("")
+        .slice(0, 10);
+
+      const env =
+        deps.config.env === "dev" || deps.config.env === "local"
+          ? (deps.config.env as "dev" | "local")
+          : ("production" as const);
+
+      const urlResult = await generateConvosInviteUrl({
+        conversationId: input.groupId,
+        creatorInboxId: managed.inboxId,
+        walletPrivateKeyHex,
+        inviteTag,
+        name: input.name ?? groupResult.value.name,
+        description: input.description ?? groupResult.value.description,
+        env,
+      });
+
+      if (Result.isError(urlResult)) return urlResult;
+
+      return Result.ok({
+        inviteUrl: urlResult.value,
+        groupId: input.groupId,
+        groupName: groupResult.value.name,
+        creatorInboxId: managed.inboxId,
+        inviteTag,
+      });
+    },
+    cli: {
+      command: "conversation:invite",
+      rpcMethod: "conversation.invite",
+      description: "Generate a Convos-compatible invite URL for a group",
+    },
+    mcp: {
+      toolName: "broker/conversation/invite",
+      description: "Generate a Convos-compatible invite URL for a group",
+      readOnly: true,
+    },
+  };
+
   return [
     widenActionSpec(create),
     widenActionSpec(list),
     widenActionSpec(info),
     widenActionSpec(join),
+    widenActionSpec(invite),
   ];
 }

--- a/packages/core/src/convos/__tests__/invite-generator.test.ts
+++ b/packages/core/src/convos/__tests__/invite-generator.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from "bun:test";
+import {
+  generateConvosInviteSlug,
+  generateConvosInviteUrl,
+} from "../invite-generator.js";
+import { parseConvosInviteUrl, verifyConvosInvite } from "../invite-parser.js";
+
+// --- Test key material ---
+
+/** 32-byte secp256k1 private key (hex, no 0x prefix). */
+const TEST_PRIVATE_KEY_HEX =
+  "0000000000000000000000000000000000000000000000000000000000000001";
+
+const TEST_CREATOR_INBOX_ID =
+  "aabbccddee1122334455667788990011aabbccddee1122334455667788990011";
+
+const TEST_CONVERSATION_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("generateConvosInviteSlug", () => {
+  test("generates a valid slug that can be roundtripped through the parser", async () => {
+    const slugResult = await generateConvosInviteSlug({
+      conversationId: TEST_CONVERSATION_ID,
+      creatorInboxId: TEST_CREATOR_INBOX_ID,
+      walletPrivateKeyHex: TEST_PRIVATE_KEY_HEX,
+      inviteTag: "test-tag-001",
+    });
+
+    expect(slugResult.isOk()).toBe(true);
+    if (!slugResult.isOk()) return;
+
+    const slug = slugResult.value;
+    expect(typeof slug).toBe("string");
+    expect(slug.length).toBeGreaterThan(0);
+
+    // Roundtrip through parser
+    const parseResult = parseConvosInviteUrl(slug);
+    expect(parseResult.isOk()).toBe(true);
+    if (!parseResult.isOk()) return;
+
+    const parsed = parseResult.value;
+    expect(parsed.tag).toBe("test-tag-001");
+    expect(parsed.creatorInboxId).toBe(TEST_CREATOR_INBOX_ID);
+    expect(parsed.isExpired).toBe(false);
+  });
+
+  test("roundtrip preserves optional name and description", async () => {
+    const slugResult = await generateConvosInviteSlug({
+      conversationId: TEST_CONVERSATION_ID,
+      creatorInboxId: TEST_CREATOR_INBOX_ID,
+      walletPrivateKeyHex: TEST_PRIVATE_KEY_HEX,
+      inviteTag: "named-group",
+      name: "My Group Chat",
+      description: "A group for testing invites",
+    });
+
+    expect(slugResult.isOk()).toBe(true);
+    if (!slugResult.isOk()) return;
+
+    const parseResult = parseConvosInviteUrl(slugResult.value);
+    expect(parseResult.isOk()).toBe(true);
+    if (!parseResult.isOk()) return;
+
+    expect(parseResult.value.name).toBe("My Group Chat");
+    expect(parseResult.value.description).toBe("A group for testing invites");
+  });
+
+  test("roundtrip preserves expiration time", async () => {
+    const futureTime = new Date(Date.now() + 86_400_000); // +24h
+
+    const slugResult = await generateConvosInviteSlug({
+      conversationId: TEST_CONVERSATION_ID,
+      creatorInboxId: TEST_CREATOR_INBOX_ID,
+      walletPrivateKeyHex: TEST_PRIVATE_KEY_HEX,
+      inviteTag: "expiring-invite",
+      expiresAt: futureTime,
+    });
+
+    expect(slugResult.isOk()).toBe(true);
+    if (!slugResult.isOk()) return;
+
+    const parseResult = parseConvosInviteUrl(slugResult.value);
+    expect(parseResult.isOk()).toBe(true);
+    if (!parseResult.isOk()) return;
+
+    expect(parseResult.value.isExpired).toBe(false);
+  });
+
+  test("generated slug passes signature verification", async () => {
+    const slugResult = await generateConvosInviteSlug({
+      conversationId: TEST_CONVERSATION_ID,
+      creatorInboxId: TEST_CREATOR_INBOX_ID,
+      walletPrivateKeyHex: TEST_PRIVATE_KEY_HEX,
+      inviteTag: "verified-tag",
+    });
+
+    expect(slugResult.isOk()).toBe(true);
+    if (!slugResult.isOk()) return;
+
+    const parseResult = parseConvosInviteUrl(slugResult.value);
+    expect(parseResult.isOk()).toBe(true);
+    if (!parseResult.isOk()) return;
+
+    const verifyResult = verifyConvosInvite(parseResult.value);
+    expect(verifyResult.isOk()).toBe(true);
+  });
+
+  test("inserts * separators for long slugs", async () => {
+    // Large description forces a long slug
+    const slugResult = await generateConvosInviteSlug({
+      conversationId: TEST_CONVERSATION_ID,
+      creatorInboxId: TEST_CREATOR_INBOX_ID,
+      walletPrivateKeyHex: TEST_PRIVATE_KEY_HEX,
+      inviteTag: "long-slug-tag",
+      description: "A".repeat(500),
+    });
+
+    expect(slugResult.isOk()).toBe(true);
+    if (!slugResult.isOk()) return;
+
+    const slug = slugResult.value;
+    // If slug > 300 chars, separators should be inserted
+    if (slug.replace(/\*/g, "").length > 300) {
+      expect(slug).toContain("*");
+    }
+
+    // Still parseable
+    const parseResult = parseConvosInviteUrl(slug);
+    expect(parseResult.isOk()).toBe(true);
+  });
+
+  test("compresses large payloads", async () => {
+    // Uncompressed slug with large description
+    const slugResult = await generateConvosInviteSlug({
+      conversationId: TEST_CONVERSATION_ID,
+      creatorInboxId: TEST_CREATOR_INBOX_ID,
+      walletPrivateKeyHex: TEST_PRIVATE_KEY_HEX,
+      inviteTag: "compress-tag",
+      description: "B".repeat(500),
+    });
+
+    expect(slugResult.isOk()).toBe(true);
+    if (!slugResult.isOk()) return;
+
+    // The slug should still parse correctly (compression is transparent)
+    const parseResult = parseConvosInviteUrl(slugResult.value);
+    expect(parseResult.isOk()).toBe(true);
+    if (!parseResult.isOk()) return;
+
+    expect(parseResult.value.description).toBe("B".repeat(500));
+  });
+});
+
+describe("generateConvosInviteUrl", () => {
+  test("generates production URL with popup.convos.org", async () => {
+    const urlResult = await generateConvosInviteUrl({
+      conversationId: TEST_CONVERSATION_ID,
+      creatorInboxId: TEST_CREATOR_INBOX_ID,
+      walletPrivateKeyHex: TEST_PRIVATE_KEY_HEX,
+      inviteTag: "prod-tag",
+      env: "production",
+    });
+
+    expect(urlResult.isOk()).toBe(true);
+    if (!urlResult.isOk()) return;
+
+    const url = urlResult.value;
+    expect(url).toMatch(/^https:\/\/popup\.convos\.org\/v2\?i=/);
+
+    // Parseable
+    const parseResult = parseConvosInviteUrl(url);
+    expect(parseResult.isOk()).toBe(true);
+  });
+
+  test("generates dev URL with dev.convos.org", async () => {
+    const urlResult = await generateConvosInviteUrl({
+      conversationId: TEST_CONVERSATION_ID,
+      creatorInboxId: TEST_CREATOR_INBOX_ID,
+      walletPrivateKeyHex: TEST_PRIVATE_KEY_HEX,
+      inviteTag: "dev-tag",
+      env: "dev",
+    });
+
+    expect(urlResult.isOk()).toBe(true);
+    if (!urlResult.isOk()) return;
+
+    const url = urlResult.value;
+    expect(url).toMatch(/^https:\/\/dev\.convos\.org\/v2\?i=/);
+
+    // Parseable
+    const parseResult = parseConvosInviteUrl(url);
+    expect(parseResult.isOk()).toBe(true);
+  });
+
+  test("defaults to production URL", async () => {
+    const urlResult = await generateConvosInviteUrl({
+      conversationId: TEST_CONVERSATION_ID,
+      creatorInboxId: TEST_CREATOR_INBOX_ID,
+      walletPrivateKeyHex: TEST_PRIVATE_KEY_HEX,
+      inviteTag: "default-tag",
+    });
+
+    expect(urlResult.isOk()).toBe(true);
+    if (!urlResult.isOk()) return;
+
+    expect(urlResult.value).toMatch(/^https:\/\/popup\.convos\.org\/v2\?i=/);
+  });
+});

--- a/packages/core/src/convos/__tests__/process-join-requests.test.ts
+++ b/packages/core/src/convos/__tests__/process-join-requests.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import type { BrokerError } from "@xmtp-broker/schemas";
+import { generateConvosInviteSlug } from "../invite-generator.js";
+import {
+  processJoinRequest,
+  type ProcessJoinRequestDeps,
+} from "../process-join-requests.js";
+
+// --- Test key material ---
+
+const TEST_PRIVATE_KEY_HEX =
+  "0000000000000000000000000000000000000000000000000000000000000001";
+
+const TEST_CREATOR_INBOX_ID =
+  "aabbccddee1122334455667788990011aabbccddee1122334455667788990011";
+
+const TEST_CONVERSATION_ID = "550e8400-e29b-41d4-a716-446655440000";
+const TEST_REQUESTER_INBOX_ID = "requester-inbox-id-abc123";
+
+/** Build a valid slug for testing. */
+async function buildValidSlug(overrides?: {
+  expiresAt?: Date;
+}): Promise<string> {
+  const result = await generateConvosInviteSlug({
+    conversationId: TEST_CONVERSATION_ID,
+    creatorInboxId: TEST_CREATOR_INBOX_ID,
+    walletPrivateKeyHex: TEST_PRIVATE_KEY_HEX,
+    inviteTag: "join-test-tag",
+    ...overrides,
+  });
+  if (!result.isOk()) throw new Error("Failed to generate slug for test");
+  return result.value;
+}
+
+function createMockDeps(overrides?: {
+  addMembersResult?: Result<void, BrokerError>;
+  getGroupTagResult?: Result<string | undefined, BrokerError>;
+}): ProcessJoinRequestDeps {
+  return {
+    walletPrivateKeyHex: TEST_PRIVATE_KEY_HEX,
+    creatorInboxId: TEST_CREATOR_INBOX_ID,
+    addMembersToGroup: async (_groupId, _inboxIds) =>
+      overrides?.addMembersResult ?? Result.ok(undefined),
+    getGroupInviteTag: async (_groupId) =>
+      overrides?.getGroupTagResult ?? Result.ok("join-test-tag"),
+  };
+}
+
+describe("processJoinRequest", () => {
+  test("processes a valid join request and adds member", async () => {
+    const slug = await buildValidSlug();
+    const deps = createMockDeps();
+
+    const result = await processJoinRequest(deps, {
+      senderInboxId: TEST_REQUESTER_INBOX_ID,
+      messageText: slug,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.groupId).toBe(TEST_CONVERSATION_ID);
+    expect(result.value.requesterInboxId).toBe(TEST_REQUESTER_INBOX_ID);
+    expect(result.value.inviteTag).toBe("join-test-tag");
+  });
+
+  test("rejects expired invite", async () => {
+    const pastDate = new Date(Date.now() - 3_600_000); // 1 hour ago
+    const slug = await buildValidSlug({ expiresAt: pastDate });
+    const deps = createMockDeps();
+
+    const result = await processJoinRequest(deps, {
+      senderInboxId: TEST_REQUESTER_INBOX_ID,
+      messageText: slug,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+
+    expect(result.error.message).toContain("expired");
+  });
+
+  test("rejects invite signed by different key", async () => {
+    // Generate with a different key
+    const differentKeyHex =
+      "0000000000000000000000000000000000000000000000000000000000000002";
+
+    const slugResult = await generateConvosInviteSlug({
+      conversationId: TEST_CONVERSATION_ID,
+      creatorInboxId: TEST_CREATOR_INBOX_ID,
+      walletPrivateKeyHex: differentKeyHex,
+      inviteTag: "wrong-key-tag",
+    });
+
+    expect(slugResult.isOk()).toBe(true);
+    if (!slugResult.isOk()) return;
+
+    // Process with the original key -- should reject
+    const deps = createMockDeps();
+    const result = await processJoinRequest(deps, {
+      senderInboxId: TEST_REQUESTER_INBOX_ID,
+      messageText: slugResult.value,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+
+    expect(result.error.message).toContain("signature");
+  });
+
+  test("rejects message that is not a valid invite slug", async () => {
+    const deps = createMockDeps();
+    const result = await processJoinRequest(deps, {
+      senderInboxId: TEST_REQUESTER_INBOX_ID,
+      messageText: "hello, I would like to join!",
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/packages/core/src/convos/invite-generator.ts
+++ b/packages/core/src/convos/invite-generator.ts
@@ -1,0 +1,359 @@
+import { deflateSync } from "node:zlib";
+import { Result } from "better-result";
+import protobuf from "protobufjs";
+import { InternalError } from "@xmtp-broker/schemas";
+import type { BrokerError } from "@xmtp-broker/schemas";
+import { chacha20poly1305 } from "@noble/ciphers/chacha.js";
+import { hkdf } from "@noble/hashes/hkdf";
+import { sha256 as nobleSha256 } from "@noble/hashes/sha256";
+import { secp256k1 } from "@noble/curves/secp256k1";
+
+// --- Protobuf schema definitions (must match invite-parser.ts) ---
+
+const InvitePayloadType = new protobuf.Type("InvitePayload")
+  .add(new protobuf.Field("conversationToken", 1, "bytes"))
+  .add(new protobuf.Field("creatorInboxId", 2, "bytes"))
+  .add(new protobuf.Field("tag", 3, "string"))
+  .add(new protobuf.Field("name", 4, "string", "optional"))
+  .add(new protobuf.Field("description_p", 5, "string", "optional"))
+  .add(new protobuf.Field("imageURL", 6, "string", "optional"))
+  .add(
+    new protobuf.Field("conversationExpiresAtUnix", 7, "sfixed64", "optional"),
+  )
+  .add(new protobuf.Field("expiresAtUnix", 8, "sfixed64", "optional"))
+  .add(new protobuf.Field("expiresAfterUse", 9, "bool"));
+
+const SignedInviteType = new protobuf.Type("SignedInvite")
+  .add(new protobuf.Field("payload", 1, "bytes"))
+  .add(new protobuf.Field("signature", 2, "bytes"));
+
+new protobuf.Root().add(InvitePayloadType).add(SignedInviteType);
+
+// --- Constants ---
+
+const FORMAT_VERSION = 1;
+const HKDF_SALT = new TextEncoder().encode("ConvosInviteV1");
+const COMPRESSION_MARKER = 0x1f;
+const SEPARATOR_INTERVAL = 300;
+
+// --- Types ---
+
+/** Options for generating a Convos invite slug. */
+export interface GenerateInviteSlugOptions {
+  /** The conversation/group ID to encrypt into the invite. */
+  readonly conversationId: string;
+  /** Hex-encoded creator inbox ID. */
+  readonly creatorInboxId: string;
+  /** Hex-encoded secp256k1 private key (without 0x prefix). */
+  readonly walletPrivateKeyHex: string;
+  /** Unique invite tag for verification. */
+  readonly inviteTag: string;
+  /** Optional group name. */
+  readonly name?: string;
+  /** Optional group description. */
+  readonly description?: string;
+  /** Optional image URL. */
+  readonly imageUrl?: string;
+  /** Optional invite expiration time. */
+  readonly expiresAt?: Date;
+  /** Whether the invite expires after first use. */
+  readonly expiresAfterUse?: boolean;
+}
+
+/** Options for generating a full Convos invite URL. */
+export interface GenerateInviteUrlOptions extends GenerateInviteSlugOptions {
+  /** XMTP environment: "production" or "dev". Defaults to "production". */
+  readonly env?: "production" | "dev" | "local";
+}
+
+// --- Key derivation ---
+
+function deriveTokenKey(
+  privateKeyBytes: Uint8Array,
+  inboxId: string,
+): Uint8Array {
+  const info = new TextEncoder().encode(`inbox:${inboxId}`);
+  return hkdf(nobleSha256, privateKeyBytes, HKDF_SALT, info, 32);
+}
+
+// --- Conversation ID packing ---
+
+function packConversationId(conversationId: string): Uint8Array {
+  const uuidMatch = conversationId.match(
+    /^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})$/i,
+  );
+  if (uuidMatch) {
+    const hex = uuidMatch.slice(1).join("");
+    const uuidBytes = hexToBytes(hex);
+    const result = new Uint8Array(1 + uuidBytes.length);
+    result[0] = 0x01;
+    result.set(uuidBytes, 1);
+    return result;
+  }
+  const strBytes = new TextEncoder().encode(conversationId);
+  if (strBytes.length <= 255) {
+    const result = new Uint8Array(2 + strBytes.length);
+    result[0] = 0x02;
+    result[1] = strBytes.length;
+    result.set(strBytes, 2);
+    return result;
+  }
+  const result = new Uint8Array(4 + strBytes.length);
+  result[0] = 0x02;
+  result[1] = 0x00;
+  result[2] = (strBytes.length >> 8) & 0xff;
+  result[3] = strBytes.length & 0xff;
+  result.set(strBytes, 4);
+  return result;
+}
+
+/**
+ * Unpack a conversation ID from the binary format.
+ * Used on the creator side when processing join requests.
+ */
+export function unpackConversationId(data: Uint8Array): string {
+  const tag = data[0];
+  if (tag === 0x01) {
+    const hexBytes = data.slice(1, 17);
+    const hex = bytesToHex(hexBytes);
+    return [
+      hex.slice(0, 8),
+      hex.slice(8, 12),
+      hex.slice(12, 16),
+      hex.slice(16, 20),
+      hex.slice(20),
+    ].join("-");
+  }
+  if (tag === 0x02) {
+    let offset = 1;
+    let length = data[offset];
+    if (length === undefined) {
+      throw new Error("Invalid packed conversation ID");
+    }
+    offset++;
+    if (length === 0) {
+      const high = data[offset];
+      const low = data[offset + 1];
+      if (high === undefined || low === undefined) {
+        throw new Error("Invalid packed conversation ID length");
+      }
+      length = (high << 8) | low;
+      offset += 2;
+    }
+    return new TextDecoder().decode(data.slice(offset, offset + length));
+  }
+  throw new Error(`Unknown conversation ID tag: ${tag}`);
+}
+
+// --- ChaCha20-Poly1305 encryption ---
+
+function encryptConversationToken(
+  conversationId: string,
+  creatorInboxId: string,
+  privateKeyBytes: Uint8Array,
+): Uint8Array {
+  const key = deriveTokenKey(privateKeyBytes, creatorInboxId);
+  const plaintext = packConversationId(conversationId);
+  const nonce = crypto.getRandomValues(new Uint8Array(12));
+  const aad = new TextEncoder().encode(creatorInboxId);
+
+  const cipher = chacha20poly1305(key, nonce, aad);
+  const ciphertext = cipher.encrypt(plaintext);
+
+  // Token format: [version=0x01][12-byte nonce][ciphertext+authTag]
+  const token = new Uint8Array(1 + 12 + ciphertext.length);
+  token[0] = FORMAT_VERSION;
+  token.set(nonce, 1);
+  token.set(ciphertext, 13);
+  return token;
+}
+
+/**
+ * Decrypt a conversation token to recover the conversation ID.
+ * Used on the creator side when processing join requests.
+ */
+export function decryptConversationToken(
+  tokenBytes: Uint8Array,
+  creatorInboxId: string,
+  privateKeyBytes: Uint8Array,
+): string {
+  if (tokenBytes[0] !== FORMAT_VERSION) {
+    throw new Error(`Unsupported token version: ${tokenBytes[0]}`);
+  }
+  const nonce = tokenBytes.slice(1, 13);
+  const ciphertextWithTag = tokenBytes.slice(13);
+  const key = deriveTokenKey(privateKeyBytes, creatorInboxId);
+  const aad = new TextEncoder().encode(creatorInboxId);
+
+  const cipher = chacha20poly1305(key, nonce, aad);
+  const plaintext = cipher.decrypt(ciphertextWithTag);
+  return unpackConversationId(plaintext);
+}
+
+// --- Hex helpers ---
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  const bytes = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+// --- secp256k1 signing ---
+
+/**
+ * Sign a message hash with secp256k1 and produce a 65-byte recoverable
+ * signature (r:32 + s:32 + recovery:1).
+ */
+function signWithRecovery(
+  messageHash: Uint8Array,
+  privateKeyBytes: Uint8Array,
+): Uint8Array {
+  const sig = secp256k1.sign(messageHash, privateKeyBytes);
+  const compact = sig.toCompactRawBytes();
+  const result = new Uint8Array(65);
+  result.set(compact, 0);
+  result[64] = sig.recovery;
+  return result;
+}
+
+// --- Base64URL ---
+
+function base64UrlEncode(data: Uint8Array): string {
+  return Buffer.from(data).toString("base64url");
+}
+
+// --- Compression ---
+
+function compressIfSmaller(data: Uint8Array): Uint8Array {
+  if (data.length <= 100) return data;
+  const compressed = deflateSync(data);
+  if (compressed.length + 5 < data.length) {
+    const result = new Uint8Array(compressed.length + 5);
+    result[0] = COMPRESSION_MARKER;
+    result[1] = (data.length >>> 24) & 0xff;
+    result[2] = (data.length >>> 16) & 0xff;
+    result[3] = (data.length >>> 8) & 0xff;
+    result[4] = data.length & 0xff;
+    result.set(new Uint8Array(compressed), 5);
+    return result;
+  }
+  return data;
+}
+
+// --- iMessage compatibility ---
+
+function insertSeparators(str: string, sep: string, every: number): string {
+  if (str.length <= every) return str;
+  const parts: string[] = [];
+  for (let i = 0; i < str.length; i += every) {
+    parts.push(str.slice(i, i + every));
+  }
+  return parts.join(sep);
+}
+
+// --- Public API ---
+
+/**
+ * Generate a Convos-compatible invite slug.
+ *
+ * Steps:
+ * 1. Encrypt conversation ID with ChaCha20-Poly1305
+ * 2. Build InvitePayload protobuf
+ * 3. Sign SHA256(payload) with secp256k1 ECDSA (recoverable)
+ * 4. Wrap in SignedInvite, optionally compress, base64url encode
+ * 5. Insert `*` separators every 300 chars (iMessage compat)
+ */
+export async function generateConvosInviteSlug(
+  opts: GenerateInviteSlugOptions,
+): Promise<Result<string, BrokerError>> {
+  try {
+    const privateKeyBytes = hexToBytes(opts.walletPrivateKeyHex);
+
+    // Step 1: Encrypt conversation ID
+    const conversationToken = encryptConversationToken(
+      opts.conversationId,
+      opts.creatorInboxId,
+      privateKeyBytes,
+    );
+
+    // Step 2: Build InvitePayload
+    const creatorInboxIdBytes = hexToBytes(opts.creatorInboxId);
+
+    const payloadObj: Record<string, unknown> = {
+      conversationToken,
+      creatorInboxId: creatorInboxIdBytes,
+      tag: opts.inviteTag,
+      expiresAfterUse: opts.expiresAfterUse ?? false,
+    };
+    if (opts.name !== undefined) payloadObj["name"] = opts.name;
+    if (opts.description !== undefined)
+      payloadObj["description_p"] = opts.description;
+    if (opts.imageUrl !== undefined) payloadObj["imageURL"] = opts.imageUrl;
+    if (opts.expiresAt !== undefined) {
+      payloadObj["expiresAtUnix"] = Math.floor(opts.expiresAt.getTime() / 1000);
+    }
+
+    const errMsg = InvitePayloadType.verify(payloadObj);
+    if (errMsg) {
+      return Result.err(
+        InternalError.create(`Invalid invite payload: ${errMsg}`),
+      );
+    }
+
+    const payloadBytes = InvitePayloadType.encode(
+      InvitePayloadType.create(payloadObj),
+    ).finish();
+
+    // Step 3: Sign SHA256(payload) with secp256k1
+    const messageHash = nobleSha256(payloadBytes);
+    const signature = signWithRecovery(messageHash, privateKeyBytes);
+
+    // Step 4: Wrap in SignedInvite
+    const signedInviteBytes = SignedInviteType.encode(
+      SignedInviteType.create({
+        payload: payloadBytes,
+        signature,
+      }),
+    ).finish();
+
+    // Compress if beneficial
+    const compressed = compressIfSmaller(signedInviteBytes);
+
+    // Step 5: Base64url encode and insert separators
+    const encoded = base64UrlEncode(compressed);
+    return Result.ok(insertSeparators(encoded, "*", SEPARATOR_INTERVAL));
+  } catch (cause) {
+    return Result.err(
+      InternalError.create(
+        `Failed to generate invite slug: ${cause instanceof Error ? cause.message : String(cause)}`,
+      ),
+    );
+  }
+}
+
+/**
+ * Generate a full Convos-compatible invite URL.
+ *
+ * Production: `https://popup.convos.org/v2?i=<slug>`
+ * Dev: `https://dev.convos.org/v2?i=<slug>`
+ */
+export async function generateConvosInviteUrl(
+  opts: GenerateInviteUrlOptions,
+): Promise<Result<string, BrokerError>> {
+  const slugResult = await generateConvosInviteSlug(opts);
+  if (!slugResult.isOk()) return slugResult;
+
+  const baseUrl =
+    opts.env === "dev" || opts.env === "local"
+      ? "https://dev.convos.org/v2"
+      : "https://popup.convos.org/v2";
+
+  return Result.ok(`${baseUrl}?i=${encodeURIComponent(slugResult.value)}`);
+}

--- a/packages/core/src/convos/process-join-requests.ts
+++ b/packages/core/src/convos/process-join-requests.ts
@@ -1,0 +1,180 @@
+import { Result } from "better-result";
+import { ValidationError } from "@xmtp-broker/schemas";
+import type { BrokerError } from "@xmtp-broker/schemas";
+import { secp256k1 } from "@noble/curves/secp256k1";
+import { sha256 } from "@noble/hashes/sha256";
+import { parseConvosInviteUrl } from "./invite-parser.js";
+import { decryptConversationToken } from "./invite-generator.js";
+
+// --- Types ---
+
+/** Dependencies injected into the join request processor. */
+export interface ProcessJoinRequestDeps {
+  /** Hex-encoded secp256k1 private key of the creator (without 0x prefix). */
+  readonly walletPrivateKeyHex: string;
+  /** Hex-encoded inbox ID of the creator. */
+  readonly creatorInboxId: string;
+  /** Add inbox IDs to a group conversation. */
+  readonly addMembersToGroup: (
+    groupId: string,
+    inboxIds: readonly string[],
+  ) => Promise<Result<void, BrokerError>>;
+  /** Get the invite tag stored in a group's appData (for verification). */
+  readonly getGroupInviteTag: (
+    groupId: string,
+  ) => Promise<Result<string | undefined, BrokerError>>;
+}
+
+/** An incoming message to evaluate as a potential join request. */
+export interface IncomingJoinMessage {
+  /** Inbox ID of the message sender (the requester). */
+  readonly senderInboxId: string;
+  /** The text content of the DM. */
+  readonly messageText: string;
+}
+
+/** Result of successfully processing a join request. */
+export interface JoinRequestResult {
+  /** The group ID the requester was added to. */
+  readonly groupId: string;
+  /** The inbox ID of the requester who was added. */
+  readonly requesterInboxId: string;
+  /** The invite tag from the processed invite. */
+  readonly inviteTag: string;
+}
+
+// --- Hex helper ---
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  const bytes = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+/**
+ * Verify that an invite's signature was produced by a specific private key.
+ *
+ * Recovers the signer's public key from the secp256k1 ECDSA signature
+ * and compares it to the public key derived from the given private key.
+ */
+function verifySignatureMatchesKey(
+  payloadBytes: Uint8Array,
+  signatureBytes: Uint8Array,
+  privateKeyBytes: Uint8Array,
+): boolean {
+  if (signatureBytes.length !== 65) return false;
+
+  const messageHash = sha256(payloadBytes);
+  const compactSig = signatureBytes.slice(0, 64);
+  const recoveryBit = signatureBytes[64];
+
+  if (recoveryBit === undefined || recoveryBit > 3) return false;
+
+  try {
+    const sig =
+      secp256k1.Signature.fromCompact(compactSig).addRecoveryBit(recoveryBit);
+    const recoveredPubKey = sig.recoverPublicKey(messageHash);
+
+    // Derive expected public key from private key
+    const expectedPubKey = secp256k1.getPublicKey(privateKeyBytes, false);
+
+    return (
+      recoveredPubKey.toHex(false) ===
+      Buffer.from(expectedPubKey).toString("hex")
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Process an incoming DM as a potential Convos join request.
+ *
+ * Steps:
+ * 1. Parse the message text as an invite slug
+ * 2. Check expiration
+ * 3. Verify the invite was signed by the creator's wallet key
+ * 4. Verify creator inbox ID matches
+ * 5. Decrypt conversation token to get group ID
+ * 6. Add the requester to the group
+ */
+export async function processJoinRequest(
+  deps: ProcessJoinRequestDeps,
+  message: IncomingJoinMessage,
+): Promise<Result<JoinRequestResult, BrokerError>> {
+  // Step 1: Parse the message as an invite slug
+  const parseResult = parseConvosInviteUrl(message.messageText);
+  if (!parseResult.isOk()) return parseResult;
+
+  const invite = parseResult.value;
+
+  // Step 2: Check expiration
+  if (invite.isExpired) {
+    return Result.err(ValidationError.create("invite", "Invite has expired"));
+  }
+  if (invite.isConversationExpired) {
+    return Result.err(
+      ValidationError.create("invite", "Conversation has expired"),
+    );
+  }
+
+  // Step 3: Verify signature matches creator's wallet key
+  const privateKeyBytes = hexToBytes(deps.walletPrivateKeyHex);
+
+  const signatureValid = verifySignatureMatchesKey(
+    invite.signedInvitePayloadBytes,
+    invite.signedInviteSignature,
+    privateKeyBytes,
+  );
+
+  if (!signatureValid) {
+    return Result.err(
+      ValidationError.create(
+        "invite",
+        "Invite signature does not match creator wallet key",
+      ),
+    );
+  }
+
+  // Step 4: Verify creator inbox ID matches
+  if (invite.creatorInboxId !== deps.creatorInboxId) {
+    return Result.err(
+      ValidationError.create(
+        "invite",
+        "Invite creator inbox ID does not match",
+      ),
+    );
+  }
+
+  // Step 5: Decrypt conversation token to get group ID
+  let groupId: string;
+  try {
+    groupId = decryptConversationToken(
+      invite.conversationToken,
+      invite.creatorInboxId,
+      privateKeyBytes,
+    );
+  } catch (cause) {
+    return Result.err(
+      ValidationError.create(
+        "invite",
+        `Failed to decrypt conversation token: ${cause instanceof Error ? cause.message : String(cause)}`,
+      ),
+    );
+  }
+
+  // Step 6: Add the requester to the group
+  const addResult = await deps.addMembersToGroup(groupId, [
+    message.senderInboxId,
+  ]);
+  if (!addResult.isOk()) return addResult;
+
+  return Result.ok({
+    groupId,
+    requesterInboxId: message.senderInboxId,
+    inviteTag: invite.tag,
+  });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,6 +75,26 @@ export type {
   JoinResult,
 } from "./convos/join.js";
 
+// Convos invite generation
+export {
+  generateConvosInviteSlug,
+  generateConvosInviteUrl,
+  decryptConversationToken,
+  unpackConversationId,
+} from "./convos/invite-generator.js";
+export type {
+  GenerateInviteSlugOptions,
+  GenerateInviteUrlOptions,
+} from "./convos/invite-generator.js";
+
+// Convos join request processing
+export { processJoinRequest } from "./convos/process-join-requests.js";
+export type {
+  ProcessJoinRequestDeps,
+  IncomingJoinMessage,
+  JoinRequestResult,
+} from "./convos/process-join-requests.js";
+
 // SDK integration (production XmtpClientFactory implementation)
 export {
   createSdkClientFactory,


### PR DESCRIPTION
## Summary
- Generate Convos-compatible invite URLs with ChaCha20-Poly1305 encrypted conversation tokens and secp256k1 signed payloads
- Add creator-side join request processing: parse incoming DM slugs, verify signature against creator's wallet key, decrypt conversation token, add requester to group
- Upgrade `conversation invite` CLI command to produce real Convos-format URLs with terminal QR codes

## Key changes
- `packages/core/src/convos/invite-generator.ts` — Generate Convos v2 invites: HKDF-SHA256 key derivation, ChaCha20-Poly1305 AEAD encryption, secp256k1 signing, protobuf encoding, zlib compression, base64url with iMessage separators
- `packages/core/src/convos/process-join-requests.ts` — Process incoming join requests: parse slug, verify signature matches creator's key, verify inbox ID, decrypt conversation token, add requester to group
- `packages/core/src/conversation-actions.ts` — Add `conversation.invite` ActionSpec
- `packages/cli/src/commands/conversation.ts` — Update invite command to use Convos invite generator
- `packages/core/src/convos/__tests__/invite-generator.test.ts` — 9 generator tests (roundtrip, compression, URLs)
- `packages/core/src/convos/__tests__/process-join-requests.test.ts` — 4 join request processing tests

## Test plan
- [ ] `cd packages/core && bun test invite-generator` passes all 9 tests
- [ ] `cd packages/core && bun test process-join-requests` passes all 4 tests
- [ ] Generated invite URLs are parseable by invite-parser (roundtrip verified)