### PR TITLE
feat(ws): view projection pipeline for outbound events

### DIFF
--- a/packages/cli/src/__tests__/event-projector.test.ts
+++ b/packages/cli/src/__tests__/event-projector.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, test } from "bun:test";
+import type { SessionRecord } from "@xmtp/signet-contracts";
+import type { RevealStateStore } from "@xmtp/signet-contracts";
+import type { SignetEvent, MessageEvent } from "@xmtp/signet-schemas";
+import {
+  createEventProjector,
+  type EventProjectorDeps,
+} from "../ws/event-projector.js";
+
+function makeSessionRecord(
+  overrides: Partial<SessionRecord> = {},
+): SessionRecord {
+  return {
+    sessionId: "sess_123",
+    agentInboxId: "agent_1",
+    sessionKeyFingerprint: "fp_abc",
+    view: {
+      mode: "full",
+      threadScopes: [{ groupId: "g1", threadId: null }],
+      contentTypes: ["xmtp.org/text:1.0"],
+    },
+    grant: {
+      messaging: { send: true, reply: false, react: false, draftOnly: false },
+      groupManagement: {
+        addMembers: false,
+        removeMembers: false,
+        updateMetadata: false,
+        inviteUsers: false,
+      },
+      tools: { scopes: [] },
+      egress: {
+        storeExcerpts: false,
+        useForMemory: false,
+        forwardToProviders: false,
+        quoteRevealed: false,
+        summarize: false,
+      },
+    },
+    state: "active",
+    issuedAt: "2024-01-01T00:00:00Z",
+    expiresAt: "2024-01-02T00:00:00Z",
+    lastHeartbeat: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeMessageEvent(overrides: Partial<MessageEvent> = {}): MessageEvent {
+  return {
+    type: "message.visible",
+    messageId: "msg_1",
+    groupId: "g1",
+    senderInboxId: "sender_1",
+    contentType: "xmtp.org/text:1.0",
+    content: "Hello world",
+    visibility: "visible",
+    sentAt: "2024-01-01T00:00:00Z",
+    sealId: null,
+    threadId: null,
+    ...overrides,
+  };
+}
+
+function makeRevealStore(revealed: boolean): RevealStateStore {
+  return {
+    grant: () => {},
+    isRevealed: () => revealed,
+    expireStale: () => 0,
+    snapshot: () => ({ activeReveals: [] }),
+    restore: () => {},
+  };
+}
+
+function makeDeps(store: RevealStateStore | null = null): EventProjectorDeps {
+  return {
+    getRevealState: () => store,
+  };
+}
+
+describe("createEventProjector", () => {
+  describe("full mode", () => {
+    test("passes message events through unchanged", () => {
+      const projector = createEventProjector(makeDeps());
+      const session = makeSessionRecord({
+        view: {
+          mode: "full",
+          threadScopes: [{ groupId: "g1", threadId: null }],
+          contentTypes: ["xmtp.org/text:1.0"],
+        },
+      });
+      const event = makeMessageEvent();
+
+      const result = projector(event, session);
+
+      expect(result).not.toBeNull();
+      expect(result).toEqual(event);
+    });
+  });
+
+  describe("reveal-only mode", () => {
+    test("drops message events when not revealed", () => {
+      const store = makeRevealStore(false);
+      const projector = createEventProjector(makeDeps(store));
+      const session = makeSessionRecord({
+        view: {
+          mode: "reveal-only",
+          threadScopes: [{ groupId: "g1", threadId: null }],
+          contentTypes: ["xmtp.org/text:1.0"],
+        },
+      });
+      const event = makeMessageEvent();
+
+      const result = projector(event, session);
+
+      expect(result).toBeNull();
+    });
+
+    test("passes message events when revealed with visibility 'revealed'", () => {
+      const store = makeRevealStore(true);
+      const projector = createEventProjector(makeDeps(store));
+      const session = makeSessionRecord({
+        view: {
+          mode: "reveal-only",
+          threadScopes: [{ groupId: "g1", threadId: null }],
+          contentTypes: ["xmtp.org/text:1.0"],
+        },
+      });
+      const event = makeMessageEvent();
+
+      const result = projector(event, session);
+
+      expect(result).not.toBeNull();
+      const msg = result as MessageEvent;
+      expect(msg.type).toBe("message.visible");
+      expect(msg.visibility).toBe("revealed");
+      expect(msg.content).toBe("Hello world");
+    });
+  });
+
+  describe("redacted mode", () => {
+    test("passes message events with content null when not revealed", () => {
+      const store = makeRevealStore(false);
+      const projector = createEventProjector(makeDeps(store));
+      const session = makeSessionRecord({
+        view: {
+          mode: "redacted",
+          threadScopes: [{ groupId: "g1", threadId: null }],
+          contentTypes: ["xmtp.org/text:1.0"],
+        },
+      });
+      const event = makeMessageEvent();
+
+      const result = projector(event, session);
+
+      expect(result).not.toBeNull();
+      const msg = result as MessageEvent;
+      expect(msg.type).toBe("message.visible");
+      expect(msg.visibility).toBe("redacted");
+      expect(msg.content).toBeNull();
+    });
+  });
+
+  describe("non-message events", () => {
+    test("passes heartbeat events through regardless of mode", () => {
+      const store = makeRevealStore(false);
+      const projector = createEventProjector(makeDeps(store));
+      const session = makeSessionRecord({
+        view: {
+          mode: "reveal-only",
+          threadScopes: [{ groupId: "g1", threadId: null }],
+          contentTypes: ["xmtp.org/text:1.0"],
+        },
+      });
+      const heartbeat: SignetEvent = {
+        type: "heartbeat",
+        sessionId: "sess_123",
+        timestamp: "2024-01-01T00:00:00Z",
+      };
+
+      const result = projector(heartbeat, session);
+
+      expect(result).toEqual(heartbeat);
+    });
+
+    test("passes session.expired events through regardless of mode", () => {
+      const store = makeRevealStore(false);
+      const projector = createEventProjector(makeDeps(store));
+      const session = makeSessionRecord({
+        view: {
+          mode: "reveal-only",
+          threadScopes: [{ groupId: "g1", threadId: null }],
+          contentTypes: ["xmtp.org/text:1.0"],
+        },
+      });
+      const expired: SignetEvent = {
+        type: "session.expired",
+        sessionId: "sess_123",
+        reason: "timeout",
+      };
+
+      const result = projector(expired, session);
+
+      expect(result).toEqual(expired);
+    });
+  });
+
+  describe("thread-scoped filtering", () => {
+    test("passes message with matching threadId through thread-scoped session", () => {
+      const store = makeRevealStore(false);
+      const projector = createEventProjector(makeDeps(store));
+      const session = makeSessionRecord({
+        view: {
+          mode: "full",
+          threadScopes: [{ groupId: "g1", threadId: "thread-42" }],
+          contentTypes: ["xmtp.org/text:1.0"],
+        },
+      });
+      const event = makeMessageEvent({ threadId: "thread-42" });
+      const result = projector(event, session);
+      expect(result).not.toBeNull();
+    });
+
+    test("drops message with non-matching threadId in thread-scoped session", () => {
+      const store = makeRevealStore(false);
+      const projector = createEventProjector(makeDeps(store));
+      const session = makeSessionRecord({
+        view: {
+          mode: "full",
+          threadScopes: [{ groupId: "g1", threadId: "thread-42" }],
+          contentTypes: ["xmtp.org/text:1.0"],
+        },
+      });
+      const event = makeMessageEvent({ threadId: "other-thread" });
+      const result = projector(event, session);
+      expect(result).toBeNull();
+    });
+
+    test("drops message with null threadId in thread-scoped session", () => {
+      const store = makeRevealStore(false);
+      const projector = createEventProjector(makeDeps(store));
+      const session = makeSessionRecord({
+        view: {
+          mode: "full",
+          threadScopes: [{ groupId: "g1", threadId: "thread-42" }],
+          contentTypes: ["xmtp.org/text:1.0"],
+        },
+      });
+      const event = makeMessageEvent({ threadId: null });
+      const result = projector(event, session);
+      expect(result).toBeNull();
+    });
+
+    test("passes message with any threadId through group-scoped session (threadId: null)", () => {
+      const store = makeRevealStore(false);
+      const projector = createEventProjector(makeDeps(store));
+      const session = makeSessionRecord({
+        view: {
+          mode: "full",
+          threadScopes: [{ groupId: "g1", threadId: null }],
+          contentTypes: ["xmtp.org/text:1.0"],
+        },
+      });
+      const event = makeMessageEvent({ threadId: "any-thread" });
+      const result = projector(event, session);
+      expect(result).not.toBeNull();
+    });
+
+    test("projected event carries threadId through to output", () => {
+      const store = makeRevealStore(false);
+      const projector = createEventProjector(makeDeps(store));
+      const session = makeSessionRecord({
+        view: {
+          mode: "full",
+          threadScopes: [{ groupId: "g1", threadId: null }],
+          contentTypes: ["xmtp.org/text:1.0"],
+        },
+      });
+      const event = makeMessageEvent({ threadId: "thread-99" });
+      const result = projector(event, session);
+      expect(result).not.toBeNull();
+      expect((result as MessageEvent).threadId).toBe("thread-99");
+    });
+  });
+
+  describe("missing reveal store", () => {
+    test("treats messages as not revealed when store is null", () => {
+      const projector = createEventProjector(makeDeps(null));
+      const session = makeSessionRecord({
+        view: {
+          mode: "reveal-only",
+          threadScopes: [{ groupId: "g1", threadId: null }],
+          contentTypes: ["xmtp.org/text:1.0"],
+        },
+      });
+      const event = makeMessageEvent();
+
+      const result = projector(event, session);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -37,6 +37,7 @@ import type { AdminServerConfig } from "./config/schema.js";
 import type { SignetRuntimeDeps } from "./runtime.js";
 import { createWsRequestHandler } from "./ws/request-handler.js";
 import { createLazyCoreUpgrade } from "./ws/core-upgrade.js";
+import { createEventProjector } from "./ws/event-projector.js";
 
 /** Map SignetCoreImpl states to the contract's CoreState. */
 function mapSignetState(state: SignetState): CoreState {
@@ -247,6 +248,13 @@ export function createProductionDeps(): SignetRuntimeDeps {
         sessionManager: d.sessionManager,
       });
 
+      const projector = createEventProjector({
+        getRevealState(sessionId: string) {
+          const result = d.sessionManager.getRevealState(sessionId);
+          return Result.isOk(result) ? result.value : null;
+        },
+      });
+
       const wsDeps: WsServerDeps = {
         core: d.core,
         sessionManager: d.sessionManager,
@@ -255,6 +263,7 @@ export function createProductionDeps(): SignetRuntimeDeps {
           return d.sessionManager.lookupByToken(token);
         },
         requestHandler,
+        projectEvent: projector,
       };
 
       return createWsServerImpl(cfg, wsDeps);

--- a/packages/cli/src/ws/event-projector.ts
+++ b/packages/cli/src/ws/event-projector.ts
@@ -1,0 +1,84 @@
+/**
+ * Projects outbound SignetEvents through the session's view pipeline
+ * before they reach the harness. Non-message events pass through;
+ * message.visible events are filtered by scope, content type, and
+ * visibility mode via the policy engine's projectMessage.
+ */
+
+import type { SignetEvent, ContentTypeId } from "@xmtp/signet-schemas";
+import type { SessionRecord, RevealStateStore } from "@xmtp/signet-contracts";
+import { projectMessage } from "@xmtp/signet-policy";
+import type { RawMessage, ProjectionResult } from "@xmtp/signet-policy";
+
+export interface EventProjectorDeps {
+  readonly getRevealState: (sessionId: string) => RevealStateStore | null;
+}
+
+/** Always create a fresh allowlist — no caching, so view updates take effect immediately. */
+function getEffectiveAllowlist(
+  session: SessionRecord,
+): ReadonlySet<ContentTypeId> {
+  return new Set(session.view.contentTypes);
+}
+
+/**
+ * Creates a projector function that filters events based on the
+ * session's view mode. Returns null to signal the event should be
+ * dropped (not sent to this harness connection).
+ *
+ * ALL view modes (full, thread-only, redacted, reveal-only) go through
+ * projectMessage so scope and content-type filters are always enforced.
+ */
+export function createEventProjector(
+  deps: EventProjectorDeps,
+): (event: SignetEvent, session: SessionRecord) => SignetEvent | null {
+  return (event: SignetEvent, session: SessionRecord): SignetEvent | null => {
+    // Only message.visible events go through the projection pipeline
+    if (event.type !== "message.visible") {
+      return event;
+    }
+
+    // Extract threadId from event payload if present
+    const threadId: string | null =
+      "threadId" in event && typeof event.threadId === "string"
+        ? event.threadId
+        : null;
+
+    const store = deps.getRevealState(session.sessionId);
+    const isRevealed =
+      store !== null
+        ? store.isRevealed(
+            event.messageId,
+            event.groupId,
+            threadId,
+            event.senderInboxId,
+            event.contentType,
+          )
+        : false;
+
+    const rawMessage: RawMessage = {
+      messageId: event.messageId,
+      groupId: event.groupId,
+      senderInboxId: event.senderInboxId,
+      contentType: event.contentType,
+      content: event.content,
+      sentAt: event.sentAt,
+      sealId: event.sealId,
+      threadId,
+    };
+
+    const effectiveAllowlist = getEffectiveAllowlist(session);
+    const result: ProjectionResult = projectMessage(
+      rawMessage,
+      session.view,
+      effectiveAllowlist,
+      isRevealed,
+    );
+
+    if (result.action === "drop") {
+      return null;
+    }
+
+    return result.event;
+  };
+}

--- a/packages/ws/src/server.ts
+++ b/packages/ws/src/server.ts
@@ -9,6 +9,7 @@ import {
 import type {
   SignetCore,
   SessionManager,
+  SessionRecord,
   SealManager,
 } from "@xmtp/signet-contracts";
 import type { WsServerConfig } from "./config.js";
@@ -39,6 +40,11 @@ export interface WsServerDeps {
   readonly sealManager: SealManager;
   readonly tokenLookup: TokenLookup;
   readonly requestHandler: RequestHandler;
+  /** Optional event projector for view-mode filtering before broadcast. */
+  readonly projectEvent?: (
+    event: SignetEvent,
+    session: SessionRecord,
+  ) => SignetEvent | null;
 }
 
 export interface WsServer {
@@ -386,7 +392,19 @@ export function createWsServer(
     const connections = registry.getBySessionId(sessionId);
     for (const ws of connections) {
       if (ws.data.phase === "active") {
-        sendSequenced(ws, event);
+        const session = ws.data.sessionRecord;
+        if (!session) continue;
+
+        // Skip non-active sessions (will be closed on next request)
+        if (session.state !== "active") continue;
+
+        if (deps.projectEvent) {
+          const projected = deps.projectEvent(event, session);
+          if (projected === null) continue;
+          sendSequenced(ws, projected);
+        } else {
+          sendSequenced(ws, event);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Creates `event-projector.ts` that filters outbound `message.visible` events through the policy pipeline
- Adds optional `projectEvent` callback to `WsServerDeps` — applied per-connection in `broadcastToSession()`
- ALL view modes (full, thread-only, redacted, reveal-only) route through `projectMessage` — no scope/content-type bypass
- `reveal-only` mode drops unrevealed messages; `redacted` mode sends with `content: null`
- Allowlist constructed fresh per call (no caching) so view updates take effect immediately
- Extracts `threadId` from event payload when present for thread-scoped filtering

## Test plan
- [ ] Event projector drops out-of-scope messages in full mode
- [ ] Event projector drops disallowed content types in full mode
- [ ] Thread-scoped session drops messages with non-matching threadId
- [ ] Thread-scoped session passes messages with matching threadId
- [ ] Projected events carry threadId through to output

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)