### PR TITLE
feat(seals): Ed25519 SealStamper backed by key hierarchy

### DIFF
--- a/packages/seals/src/__tests__/stamper.test.ts
+++ b/packages/seals/src/__tests__/stamper.test.ts
@@ -1,0 +1,187 @@
+import { describe, test, expect } from "bun:test";
+import { Result } from "better-result";
+import type { Seal, RevocationSeal } from "@xmtp/signet-schemas";
+import { createSealStamper, type SigningKeyHandle } from "../stamper.js";
+
+/** Deterministic Ed25519-like test signer backed by Web Crypto. */
+async function createTestKeyHandle(): Promise<SigningKeyHandle> {
+  const keyPair = await crypto.subtle.generateKey({ name: "Ed25519" }, true, [
+    "sign",
+    "verify",
+  ]);
+
+  const raw = await crypto.subtle.exportKey("raw", keyPair.publicKey);
+  const hex = Array.from(new Uint8Array(raw))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+
+  return {
+    fingerprint: () => hex.slice(0, 16),
+    async sign(data: Uint8Array): Promise<Uint8Array> {
+      const sig = await crypto.subtle.sign(
+        { name: "Ed25519" },
+        keyPair.privateKey,
+        data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength),
+      );
+      return new Uint8Array(sig);
+    },
+  };
+}
+
+function makeSeal(overrides?: Partial<Seal>): Seal {
+  return {
+    sealId: "seal-1",
+    previousSealId: null,
+    agentInboxId: "agent-inbox-1",
+    ownerInboxId: "owner-inbox-1",
+    groupId: "group-1",
+    threadScope: null,
+    viewMode: "full",
+    contentTypes: ["xmtp.org/text:1.0"],
+    grantedOps: ["send", "reply"],
+    toolScopes: [],
+    inferenceMode: "local",
+    inferenceProviders: [],
+    contentEgressScope: "none",
+    retentionAtProvider: "none",
+    hostingMode: "local",
+    trustTier: "unverified",
+    buildProvenanceRef: null,
+    verifierStatementRef: null,
+    sessionKeyFingerprint: null,
+    policyHash: "sha256:abc123",
+    heartbeatInterval: 30,
+    issuedAt: "2025-01-01T00:00:00.000Z",
+    expiresAt: "2025-01-02T00:00:00.000Z",
+    revocationRules: {
+      maxTtlSeconds: 86400,
+      requireHeartbeat: true,
+      ownerCanRevoke: true,
+      adminCanRemove: true,
+    },
+    issuer: "signet-1",
+    ...overrides,
+  };
+}
+
+function makeRevocation(overrides?: Partial<RevocationSeal>): RevocationSeal {
+  return {
+    sealId: "revoke-1",
+    previousSealId: "seal-1",
+    agentInboxId: "agent-inbox-1",
+    groupId: "group-1",
+    reason: "owner-initiated",
+    revokedAt: "2025-01-01T12:00:00.000Z",
+    issuer: "signet-1",
+    ...overrides,
+  };
+}
+
+describe("createSealStamper", () => {
+  describe("sign", () => {
+    test("produces a valid SealEnvelope with correct structure", async () => {
+      const keyHandle = await createTestKeyHandle();
+      const stamper = createSealStamper({ signingKey: keyHandle });
+      const seal = makeSeal();
+
+      const result = await stamper.sign(seal);
+
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+
+      const envelope = result.value;
+      expect(envelope.seal).toEqual(seal);
+      expect(envelope.signatureAlgorithm).toBe("Ed25519");
+      expect(envelope.signerKeyRef).toBe(keyHandle.fingerprint());
+      // Signature should be non-empty base64
+      expect(envelope.signature.length).toBeGreaterThan(0);
+      expect(() => atob(envelope.signature)).not.toThrow();
+    });
+
+    test("produces deterministic signatures for the same input", async () => {
+      const keyHandle = await createTestKeyHandle();
+      const stamper = createSealStamper({ signingKey: keyHandle });
+      const seal = makeSeal();
+
+      const result1 = await stamper.sign(seal);
+      const result2 = await stamper.sign(seal);
+
+      expect(Result.isOk(result1)).toBe(true);
+      expect(Result.isOk(result2)).toBe(true);
+      if (!Result.isOk(result1) || !Result.isOk(result2)) return;
+
+      expect(result1.value.signature).toBe(result2.value.signature);
+    });
+
+    test("produces different signatures for different inputs", async () => {
+      const keyHandle = await createTestKeyHandle();
+      const stamper = createSealStamper({ signingKey: keyHandle });
+
+      const seal1 = makeSeal({ sealId: "seal-1" });
+      const seal2 = makeSeal({ sealId: "seal-2" });
+
+      const result1 = await stamper.sign(seal1);
+      const result2 = await stamper.sign(seal2);
+
+      expect(Result.isOk(result1)).toBe(true);
+      expect(Result.isOk(result2)).toBe(true);
+      if (!Result.isOk(result1) || !Result.isOk(result2)) return;
+
+      expect(result1.value.signature).not.toBe(result2.value.signature);
+    });
+  });
+
+  describe("signRevocation", () => {
+    test("produces a valid SignedRevocationEnvelope", async () => {
+      const keyHandle = await createTestKeyHandle();
+      const stamper = createSealStamper({ signingKey: keyHandle });
+      const revocation = makeRevocation();
+
+      const result = await stamper.signRevocation(revocation);
+
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+
+      const envelope = result.value;
+      expect(envelope.revocation).toEqual(revocation);
+      expect(envelope.signatureAlgorithm).toBe("Ed25519");
+      expect(envelope.signerKeyRef).toBe(keyHandle.fingerprint());
+      expect(envelope.signature.length).toBeGreaterThan(0);
+      expect(() => atob(envelope.signature)).not.toThrow();
+    });
+
+    test("produces deterministic signatures for the same revocation", async () => {
+      const keyHandle = await createTestKeyHandle();
+      const stamper = createSealStamper({ signingKey: keyHandle });
+      const revocation = makeRevocation();
+
+      const result1 = await stamper.signRevocation(revocation);
+      const result2 = await stamper.signRevocation(revocation);
+
+      expect(Result.isOk(result1)).toBe(true);
+      expect(Result.isOk(result2)).toBe(true);
+      if (!Result.isOk(result1) || !Result.isOk(result2)) return;
+
+      expect(result1.value.signature).toBe(result2.value.signature);
+    });
+  });
+
+  describe("error handling", () => {
+    test("returns error when signing key fails", async () => {
+      const failingKey: SigningKeyHandle = {
+        fingerprint: () => "bad-key",
+        sign: async () => {
+          throw new Error("key material unavailable");
+        },
+      };
+      const stamper = createSealStamper({ signingKey: failingKey });
+      const seal = makeSeal();
+
+      const result = await stamper.sign(seal);
+
+      expect(Result.isError(result)).toBe(true);
+      if (!Result.isError(result)) return;
+      expect(result.error._tag).toBe("InternalError");
+    });
+  });
+});

--- a/packages/seals/src/index.ts
+++ b/packages/seals/src/index.ts
@@ -24,6 +24,10 @@ export type { SealInput, SealBuildResult } from "./build.js";
 // Input delta computation
 export { computeInputDelta } from "./compute-delta.js";
 
+// Seal stamper
+export { createSealStamper } from "./stamper.js";
+export type { SigningKeyHandle, StamperDeps } from "./stamper.js";
+
 // Seal manager
 export { createSealManager } from "./manager.js";
 export type {

--- a/packages/seals/src/stamper.ts
+++ b/packages/seals/src/stamper.ts
@@ -1,0 +1,93 @@
+import { Result } from "better-result";
+import { InternalError } from "@xmtp/signet-schemas";
+import type { Seal, RevocationSeal, SignetError } from "@xmtp/signet-schemas";
+import type {
+  SealStamper,
+  SealEnvelope,
+  SignedRevocationEnvelope,
+} from "@xmtp/signet-contracts";
+import { canonicalize } from "./canonicalize.js";
+
+/** Opaque handle to a signing key -- hides key material from callers. */
+export interface SigningKeyHandle {
+  /** Sign arbitrary bytes and return the raw signature. */
+  sign(data: Uint8Array): Promise<Uint8Array>;
+  /** Current fingerprint of the key. Method so it survives key rotation. */
+  fingerprint(): string;
+}
+
+/** Dependencies for creating a SealStamper. */
+export interface StamperDeps {
+  /** The signing key this stamper will use for all operations. */
+  readonly signingKey: SigningKeyHandle;
+}
+
+/** Check if a value is a structured SignetError (has _tag and category). */
+function isSignetError(e: unknown): e is SignetError {
+  return (
+    e instanceof Error &&
+    "_tag" in e &&
+    typeof (e as Record<string, unknown>)["_tag"] === "string" &&
+    "category" in e &&
+    typeof (e as Record<string, unknown>)["category"] === "string"
+  );
+}
+
+/**
+ * Creates a `SealStamper` backed by a single `SigningKeyHandle`.
+ *
+ * The stamper canonicalizes the payload, signs the bytes, and wraps
+ * the result in a `SealEnvelope` / `SignedRevocationEnvelope`.
+ */
+export function createSealStamper(deps: StamperDeps): SealStamper {
+  const { signingKey } = deps;
+
+  async function signPayload(
+    payload: unknown,
+  ): Promise<Result<string, SignetError>> {
+    try {
+      const bytes = canonicalize(payload);
+      const signature = await signingKey.sign(bytes);
+      const base64 = btoa(String.fromCharCode(...signature));
+      return Result.ok(base64);
+    } catch (e) {
+      // Preserve structured SignetErrors from the key layer
+      if (isSignetError(e)) {
+        return Result.err(e);
+      }
+      return Result.err(
+        InternalError.create("Seal signing failed", {
+          cause: String(e),
+        }),
+      );
+    }
+  }
+
+  return {
+    async sign(payload: Seal): Promise<Result<SealEnvelope, SignetError>> {
+      const sigResult = await signPayload(payload);
+      if (Result.isError(sigResult)) return sigResult;
+
+      return Result.ok({
+        seal: payload,
+        signature: sigResult.value,
+        signatureAlgorithm: "Ed25519",
+        signerKeyRef: signingKey.fingerprint(),
+      });
+    },
+
+    async signRevocation(
+      payload: RevocationSeal,
+    ): Promise<Result<SignedRevocationEnvelope, SignetError>> {
+      const sigResult = await signPayload(payload);
+      if (Result.isError(sigResult)) return sigResult;
+
+      return Result.ok({
+        revocation: payload,
+        signature: sigResult.value,
+        signatureAlgorithm: "Ed25519",
+        signerKeyRef: signingKey.fingerprint(),
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Creates `SealStamper` implementation in seals package backed by a `SigningKeyHandle`
- `SigningKeyHandle.fingerprint` is a method (not property) so it survives key rotation
- Canonicalizes seal payloads and signs with Ed25519
- Preserves structured `SignetError` types from the key layer (no collapse to `InternalError`)
- Returns `SealEnvelope` / `SignedRevocationEnvelope` with signature, algorithm, and `signerKeyRef`

## Test plan
- [ ] Fingerprint freshness: `signerKeyRef` reflects current key after simulated rotation
- [ ] Structured error propagation: `NotFoundError` from key layer preserved in Result
- [ ] Sign and signRevocation produce valid envelopes

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)