### PR TITLE
feat(cli): action confirmation flow with pending action queue

### DIFF
--- a/packages/cli/src/__tests__/ws-request-handler.test.ts
+++ b/packages/cli/src/__tests__/ws-request-handler.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import { Result } from "better-result";
 import type { SessionRecord } from "@xmtp/signet-contracts";
-import type { HarnessRequest } from "@xmtp/signet-schemas";
-import { AuthError, PermissionError } from "@xmtp/signet-schemas";
+import type { HarnessRequest, SignetEvent } from "@xmtp/signet-schemas";
+import {
+  AuthError,
+  NotFoundError,
+  PermissionError,
+} from "@xmtp/signet-schemas";
 import { createWsRequestHandler } from "../ws/request-handler.js";
+import { createPendingActionStore } from "@xmtp/signet-sessions";
 
 function makeSessionRecord(
   overrides: Partial<SessionRecord> = {},
@@ -185,6 +190,235 @@ describe("createWsRequestHandler", () => {
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error.message).toContain("not supported");
+    }
+  });
+
+  test("queues pending action for draftOnly sessions instead of rejecting", async () => {
+    const broadcastedEvents: { sessionId: string; event: SignetEvent }[] = [];
+    const pendingActions = createPendingActionStore();
+
+    const handler = createWsRequestHandler({
+      ensureCoreReady: async () => Result.ok(undefined),
+      sendMessage: async () => Result.ok({ messageId: "msg_1" }),
+      sessionManager: {
+        heartbeat: async () => Result.ok(undefined),
+      },
+      pendingActions,
+      broadcast: (sessionId, event) => {
+        broadcastedEvents.push({ sessionId, event });
+      },
+    });
+
+    const session = makeSessionRecord({
+      grant: {
+        messaging: { send: true, reply: false, react: false, draftOnly: true },
+        groupManagement: {
+          addMembers: false,
+          removeMembers: false,
+          updateMetadata: false,
+          inviteUsers: false,
+        },
+        tools: { scopes: [] },
+        egress: {
+          storeExcerpts: false,
+          useForMemory: false,
+          forwardToProviders: false,
+          quoteRevealed: false,
+          summarize: false,
+        },
+      },
+    });
+
+    const request: HarnessRequest = {
+      type: "send_message",
+      requestId: "req_draft",
+      groupId: "g1",
+      contentType: "xmtp.org/text:1.0",
+      content: { text: "draft message" },
+    };
+
+    const result = await handler(request, session);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const data = result.value as { pending: boolean; actionId: string };
+      expect(data.pending).toBe(true);
+      expect(typeof data.actionId).toBe("string");
+
+      // Verify action was stored
+      const stored = pendingActions.get(data.actionId);
+      expect(stored).not.toBeNull();
+      expect(stored?.actionType).toBe("send_message");
+      expect(stored?.sessionId).toBe("sess_123");
+    }
+
+    // Verify broadcast was called with confirmation event
+    expect(broadcastedEvents).toHaveLength(1);
+    expect(broadcastedEvents[0]?.event.type).toBe(
+      "action.confirmation_required",
+    );
+  });
+
+  test("confirm_action executes the pending action when confirmed", async () => {
+    const sendCalls: string[] = [];
+    const pendingActions = createPendingActionStore();
+
+    const handler = createWsRequestHandler({
+      ensureCoreReady: async () => Result.ok(undefined),
+      sendMessage: async (groupId, contentType, _content) => {
+        sendCalls.push(`send:${groupId}:${contentType}`);
+        return Result.ok({ messageId: "msg_confirmed" });
+      },
+      sessionManager: {
+        heartbeat: async () => Result.ok(undefined),
+      },
+      pendingActions,
+      broadcast: () => {},
+    });
+
+    // Pre-populate a pending action
+    pendingActions.add({
+      actionId: "act_confirm_1",
+      sessionId: "sess_123",
+      actionType: "send_message",
+      payload: {
+        groupId: "g1",
+        contentType: "xmtp.org/text:1.0",
+        content: { text: "hello" },
+      },
+      createdAt: "2024-01-01T00:00:00Z",
+      expiresAt: "2099-01-01T00:05:00Z",
+    });
+
+    const request: HarnessRequest = {
+      type: "confirm_action",
+      requestId: "req_confirm",
+      actionId: "act_confirm_1",
+      confirmed: true,
+    };
+
+    const result = await handler(request, makeSessionRecord());
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({ messageId: "msg_confirmed" });
+    }
+    expect(sendCalls).toEqual(["send:g1:xmtp.org/text:1.0"]);
+
+    // Action should be removed from store
+    expect(pendingActions.get("act_confirm_1")).toBeNull();
+  });
+
+  test("confirm_action discards the pending action when denied", async () => {
+    const sendCalls: string[] = [];
+    const pendingActions = createPendingActionStore();
+
+    const handler = createWsRequestHandler({
+      ensureCoreReady: async () => Result.ok(undefined),
+      sendMessage: async () => {
+        sendCalls.push("send");
+        return Result.ok({ messageId: "unused" });
+      },
+      sessionManager: {
+        heartbeat: async () => Result.ok(undefined),
+      },
+      pendingActions,
+      broadcast: () => {},
+    });
+
+    pendingActions.add({
+      actionId: "act_deny_1",
+      sessionId: "sess_123",
+      actionType: "send_message",
+      payload: {
+        groupId: "g1",
+        contentType: "xmtp.org/text:1.0",
+        content: { text: "hello" },
+      },
+      createdAt: "2024-01-01T00:00:00Z",
+      expiresAt: "2099-01-01T00:05:00Z",
+    });
+
+    const request: HarnessRequest = {
+      type: "confirm_action",
+      requestId: "req_deny",
+      actionId: "act_deny_1",
+      confirmed: false,
+    };
+
+    const result = await handler(request, makeSessionRecord());
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({ denied: true, actionId: "act_deny_1" });
+    }
+    expect(sendCalls).toEqual([]);
+    expect(pendingActions.get("act_deny_1")).toBeNull();
+  });
+
+  test("confirm_action returns not_found for unknown actionId", async () => {
+    const pendingActions = createPendingActionStore();
+
+    const handler = createWsRequestHandler({
+      ensureCoreReady: async () => Result.ok(undefined),
+      sendMessage: async () => Result.ok({ messageId: "unused" }),
+      sessionManager: {
+        heartbeat: async () => Result.ok(undefined),
+      },
+      pendingActions,
+      broadcast: () => {},
+    });
+
+    const request: HarnessRequest = {
+      type: "confirm_action",
+      requestId: "req_missing",
+      actionId: "nonexistent",
+      confirmed: true,
+    };
+
+    const result = await handler(request, makeSessionRecord());
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(NotFoundError);
+      expect(result.error.category).toBe("not_found");
+    }
+  });
+
+  test("confirm_action rejects when session does not match pending action", async () => {
+    const pendingActions = createPendingActionStore();
+
+    const handler = createWsRequestHandler({
+      ensureCoreReady: async () => Result.ok(undefined),
+      sendMessage: async () => Result.ok({ messageId: "unused" }),
+      sessionManager: {
+        heartbeat: async () => Result.ok(undefined),
+      },
+      pendingActions,
+      broadcast: () => {},
+    });
+
+    pendingActions.add({
+      actionId: "act_other",
+      sessionId: "sess_other",
+      actionType: "send_message",
+      payload: {},
+      createdAt: "2024-01-01T00:00:00Z",
+      expiresAt: "2099-01-01T00:05:00Z",
+    });
+
+    const request: HarnessRequest = {
+      type: "confirm_action",
+      requestId: "req_mismatch",
+      actionId: "act_other",
+      confirmed: true,
+    };
+
+    const result = await handler(request, makeSessionRecord());
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(PermissionError);
     }
   });
 });

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -41,6 +41,7 @@ import type { SignetRuntimeDeps } from "./runtime.js";
 import { createWsRequestHandler } from "./ws/request-handler.js";
 import { createLazyCoreUpgrade } from "./ws/core-upgrade.js";
 import { createEventProjector } from "./ws/event-projector.js";
+import { createPendingActionStore } from "@xmtp/signet-sessions";
 
 /** Map SignetCoreImpl states to the contract's CoreState. */
 function mapSignetState(state: SignetState): CoreState {
@@ -293,6 +294,12 @@ export function createProductionDeps(): SignetRuntimeDeps {
         sealManager: import("@xmtp/signet-contracts").SealManager;
       };
 
+      const pendingActions = createPendingActionStore();
+
+      // Late-bound broadcast: the WS server isn't created yet when
+      // the request handler is wired, so we capture a mutable ref.
+      let wsServerRef: WsServer | null = null;
+
       // Build the WsServerDeps with tokenLookup and requestHandler
       const ensureCoreReady = createLazyCoreUpgrade(d.core);
       const requestHandler = createWsRequestHandler({
@@ -300,6 +307,10 @@ export function createProductionDeps(): SignetRuntimeDeps {
         sendMessage: (groupId, contentType, content) =>
           d.core.sendMessage(groupId, contentType, content),
         sessionManager: d.sessionManager,
+        pendingActions,
+        broadcast: (sessionId: string, event: unknown) => {
+          wsServerRef?.broadcast(sessionId, event as import("@xmtp/signet-schemas").SignetEvent);
+        },
       });
 
       const projector = createEventProjector({
@@ -320,7 +331,10 @@ export function createProductionDeps(): SignetRuntimeDeps {
         projectEvent: projector,
       };
 
-      return createWsServerImpl(cfg, wsDeps);
+      const server = createWsServerImpl(cfg, wsDeps);
+      wsServerRef = server;
+      globalWsServerRef = server;
+      return server;
     },
 
     createAdminServer(config: unknown, deps: unknown): AdminServer {

--- a/packages/cli/src/ws/request-handler.ts
+++ b/packages/cli/src/ws/request-handler.ts
@@ -2,11 +2,14 @@ import { Result } from "better-result";
 import {
   AuthError,
   InternalError,
+  NotFoundError,
   PermissionError,
 } from "@xmtp/signet-schemas";
 import type {
   SignetError,
+  SignetEvent,
   HarnessRequest,
+  ConfirmActionRequest,
   SendMessageRequest,
   UpdateViewRequest,
   RevealContentRequest,
@@ -16,6 +19,10 @@ import type { SessionManager, SessionRecord } from "@xmtp/signet-contracts";
 import { validateSendMessage } from "@xmtp/signet-policy";
 import type { RequestHandler } from "@xmtp/signet-ws";
 import type { InternalSessionManager } from "@xmtp/signet-sessions";
+import type { PendingActionStore } from "@xmtp/signet-sessions";
+
+/** Default expiry for pending actions: 5 minutes. */
+const PENDING_ACTION_TTL_MS = 5 * 60 * 1000;
 
 export interface HarnessRequestHandlerDeps {
   readonly ensureCoreReady: () => Promise<Result<void, SignetError>>;
@@ -29,6 +36,8 @@ export interface HarnessRequestHandlerDeps {
     "heartbeat" | "lookup" | "getRevealState"
   >;
   readonly internalSessionManager?: InternalSessionManager;
+  readonly pendingActions?: PendingActionStore;
+  readonly broadcast?: (sessionId: string, event: SignetEvent) => void;
 }
 
 export function createWsRequestHandler(
@@ -37,7 +46,12 @@ export function createWsRequestHandler(
   async function handleSendMessage(
     request: SendMessageRequest,
     session: SessionRecord,
-  ): Promise<Result<{ messageId: string }, SignetError>> {
+  ): Promise<
+    Result<
+      { messageId: string } | { pending: true; actionId: string },
+      SignetError
+    >
+  > {
     if (!session.view.contentTypes.includes(request.contentType)) {
       return Result.err(
         PermissionError.create(
@@ -60,6 +74,38 @@ export function createWsRequestHandler(
     }
 
     if (validation.value.draftOnly) {
+      if (deps.pendingActions && deps.broadcast) {
+        const actionId = crypto.randomUUID();
+        const now = new Date();
+        deps.pendingActions.add({
+          actionId,
+          sessionId: session.sessionId,
+          actionType: "send_message",
+          payload: {
+            groupId: request.groupId,
+            contentType: request.contentType,
+            content: request.content,
+          },
+          createdAt: now.toISOString(),
+          expiresAt: new Date(
+            now.getTime() + PENDING_ACTION_TTL_MS,
+          ).toISOString(),
+        });
+
+        deps.broadcast(session.sessionId, {
+          type: "action.confirmation_required",
+          actionId,
+          actionType: "send_message",
+          preview: {
+            groupId: request.groupId,
+            contentType: request.contentType,
+            content: request.content,
+          },
+        });
+
+        return Result.ok({ pending: true, actionId });
+      }
+
       return Result.err(
         PermissionError.create(
           "Draft-only sessions cannot send live messages",
@@ -211,6 +257,122 @@ export function createWsRequestHandler(
     return Result.ok({ updated: true, material: false, reason: null });
   }
 
+  async function handleConfirmAction(
+    request: ConfirmActionRequest,
+    session: SessionRecord,
+  ): Promise<Result<unknown, SignetError>> {
+    if (!deps.pendingActions) {
+      return Result.err(
+        InternalError.create("Pending action store not available"),
+      );
+    }
+
+    const pending = deps.pendingActions.get(request.actionId);
+    if (pending === null) {
+      return Result.err(
+        NotFoundError.create("PendingAction", request.actionId),
+      );
+    }
+
+    if (pending.sessionId !== session.sessionId) {
+      return Result.err(
+        PermissionError.create(
+          "Pending action does not belong to this session",
+          {
+            actionId: request.actionId,
+            sessionId: session.sessionId,
+          },
+        ),
+      );
+    }
+
+    // Reject expired pending actions
+    if (
+      pending.expiresAt &&
+      new Date(pending.expiresAt).getTime() < Date.now()
+    ) {
+      deps.pendingActions.deny(request.actionId);
+      return Result.err(
+        PermissionError.create("Pending action has expired", {
+          actionId: request.actionId,
+          expiresAt: pending.expiresAt,
+        }),
+      );
+    }
+
+    if (!request.confirmed) {
+      deps.pendingActions.deny(request.actionId);
+      return Result.ok({ denied: true, actionId: request.actionId });
+    }
+
+    // Re-validate queued send_message against current session policy
+    // (session may have been narrowed since the action was queued)
+    if (pending.actionType === "send_message") {
+      const payload = pending.payload as {
+        groupId: string;
+        contentType: string;
+        content: unknown;
+      };
+
+      // Check content type still allowed
+      const allowedTypes = new Set(session.view.contentTypes);
+      if (!allowedTypes.has(payload.contentType)) {
+        deps.pendingActions.deny(request.actionId);
+        return Result.err(
+          PermissionError.create(
+            "Content type no longer allowed by session view",
+            {
+              contentType: payload.contentType,
+              sessionId: session.sessionId,
+            },
+          ),
+        );
+      }
+
+      // Re-run grant/view validation
+      const revalidation = validateSendMessage(
+        { groupId: payload.groupId, contentType: payload.contentType },
+        session.grant,
+        session.view,
+      );
+      if (revalidation.isErr()) {
+        deps.pendingActions.deny(request.actionId);
+        return revalidation;
+      }
+    }
+
+    const action = deps.pendingActions.confirm(request.actionId);
+    if (action === null) {
+      return Result.err(
+        NotFoundError.create("PendingAction", request.actionId),
+      );
+    }
+
+    // Execute the original action
+    if (action.actionType === "send_message") {
+      const payload = action.payload as {
+        groupId: string;
+        contentType: string;
+        content: unknown;
+      };
+
+      const readyResult = await deps.ensureCoreReady();
+      if (readyResult.isErr()) {
+        return readyResult;
+      }
+
+      return deps.sendMessage(
+        payload.groupId,
+        payload.contentType,
+        payload.content,
+      );
+    }
+
+    return Result.err(
+      InternalError.create(`Unknown pending action type: ${action.actionType}`),
+    );
+  }
+
   return async (
     request: HarnessRequest,
     session: SessionRecord,
@@ -224,6 +386,8 @@ export function createWsRequestHandler(
         return handleRevealContent(request, session);
       case "update_view":
         return handleUpdateView(request, session);
+      case "confirm_action":
+        return handleConfirmAction(request, session);
       default:
         return Result.err(
           InternalError.create(

--- a/packages/sessions/src/__tests__/pending-actions.test.ts
+++ b/packages/sessions/src/__tests__/pending-actions.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import {
+  createPendingActionStore,
+  type PendingAction,
+  type PendingActionStore,
+} from "../pending-actions.js";
+
+function makeAction(overrides: Partial<PendingAction> = {}): PendingAction {
+  return {
+    actionId: "act_1",
+    sessionId: "sess_1",
+    actionType: "send_message",
+    payload: { groupId: "g1", content: "hello" },
+    createdAt: "2024-01-01T00:00:00Z",
+    expiresAt: "2024-01-01T00:05:00Z",
+    ...overrides,
+  };
+}
+
+let store: PendingActionStore;
+
+beforeEach(() => {
+  store = createPendingActionStore();
+});
+
+describe("createPendingActionStore", () => {
+  test("add and get returns the action", () => {
+    const action = makeAction();
+    store.add(action);
+    expect(store.get("act_1")).toEqual(action);
+  });
+
+  test("get returns null for unknown actionId", () => {
+    expect(store.get("unknown")).toBeNull();
+  });
+
+  test("confirm removes and returns the action", () => {
+    const action = makeAction();
+    store.add(action);
+    const confirmed = store.confirm("act_1");
+    expect(confirmed).toEqual(action);
+    expect(store.get("act_1")).toBeNull();
+  });
+
+  test("confirm returns null for unknown actionId", () => {
+    expect(store.confirm("unknown")).toBeNull();
+  });
+
+  test("deny removes and returns the action", () => {
+    const action = makeAction();
+    store.add(action);
+    const denied = store.deny("act_1");
+    expect(denied).toEqual(action);
+    expect(store.get("act_1")).toBeNull();
+  });
+
+  test("deny returns null for unknown actionId", () => {
+    expect(store.deny("unknown")).toBeNull();
+  });
+
+  test("expireStale removes expired actions and returns count", () => {
+    store.add(
+      makeAction({
+        actionId: "act_expired",
+        expiresAt: "2024-01-01T00:04:00Z",
+      }),
+    );
+    store.add(
+      makeAction({ actionId: "act_valid", expiresAt: "2024-01-01T00:10:00Z" }),
+    );
+
+    // Now is after act_expired but before act_valid
+    const removed = store.expireStale(new Date("2024-01-01T00:05:00Z"));
+    expect(removed).toBe(1);
+    expect(store.get("act_expired")).toBeNull();
+    expect(store.get("act_valid")).not.toBeNull();
+  });
+
+  test("expireStale returns 0 when nothing expired", () => {
+    store.add(makeAction({ expiresAt: "2024-12-31T23:59:59Z" }));
+    const removed = store.expireStale(new Date("2024-01-01T00:00:00Z"));
+    expect(removed).toBe(0);
+  });
+
+  test("listBySession filters by sessionId", () => {
+    store.add(makeAction({ actionId: "act_a", sessionId: "sess_1" }));
+    store.add(makeAction({ actionId: "act_b", sessionId: "sess_2" }));
+    store.add(makeAction({ actionId: "act_c", sessionId: "sess_1" }));
+
+    const sess1Actions = store.listBySession("sess_1");
+    expect(sess1Actions).toHaveLength(2);
+    expect(sess1Actions.map((a) => a.actionId).sort()).toEqual([
+      "act_a",
+      "act_c",
+    ]);
+  });
+
+  test("listBySession returns empty array for unknown session", () => {
+    expect(store.listBySession("unknown")).toEqual([]);
+  });
+});

--- a/packages/sessions/src/index.ts
+++ b/packages/sessions/src/index.ts
@@ -16,3 +16,5 @@ export type { SessionActionDeps } from "./actions.js";
 export type { RevealActionDeps } from "./reveal-actions.js";
 export { createUpdateActions } from "./update-actions.js";
 export type { UpdateActionDeps } from "./update-actions.js";
+export { createPendingActionStore } from "./pending-actions.js";
+export type { PendingAction, PendingActionStore } from "./pending-actions.js";

--- a/packages/sessions/src/pending-actions.ts
+++ b/packages/sessions/src/pending-actions.ts
@@ -1,0 +1,86 @@
+/**
+ * In-memory store for pending actions awaiting owner confirmation.
+ *
+ * Actions are queued when a draft-only session attempts a side-effecting
+ * operation. The owner confirms or denies via `confirm_action` requests.
+ */
+
+export interface PendingAction {
+  readonly actionId: string;
+  readonly sessionId: string;
+  readonly actionType: string;
+  readonly payload: unknown;
+  readonly createdAt: string;
+  readonly expiresAt: string;
+}
+
+export interface PendingActionStore {
+  /** Add a pending action to the store. */
+  add(action: PendingAction): void;
+
+  /** Look up a pending action by ID. Returns null if not found. */
+  get(actionId: string): PendingAction | null;
+
+  /** Confirm an action: removes and returns it, or null if not found. */
+  confirm(actionId: string): PendingAction | null;
+
+  /** Deny an action: removes and returns it, or null if not found. */
+  deny(actionId: string): PendingAction | null;
+
+  /** Remove all expired actions. Returns the number removed. */
+  expireStale(now: Date): number;
+
+  /** List all pending actions for a given session. */
+  listBySession(sessionId: string): readonly PendingAction[];
+}
+
+export function createPendingActionStore(): PendingActionStore {
+  const actions = new Map<string, PendingAction>();
+
+  function removeAndReturn(actionId: string): PendingAction | null {
+    const action = actions.get(actionId);
+    if (action === undefined) return null;
+    actions.delete(actionId);
+    return action;
+  }
+
+  return {
+    add(action: PendingAction): void {
+      actions.set(action.actionId, action);
+    },
+
+    get(actionId: string): PendingAction | null {
+      return actions.get(actionId) ?? null;
+    },
+
+    confirm(actionId: string): PendingAction | null {
+      return removeAndReturn(actionId);
+    },
+
+    deny(actionId: string): PendingAction | null {
+      return removeAndReturn(actionId);
+    },
+
+    expireStale(now: Date): number {
+      const nowMs = now.getTime();
+      let removed = 0;
+      for (const [id, action] of actions) {
+        if (new Date(action.expiresAt).getTime() <= nowMs) {
+          actions.delete(id);
+          removed++;
+        }
+      }
+      return removed;
+    },
+
+    listBySession(sessionId: string): readonly PendingAction[] {
+      const result: PendingAction[] = [];
+      for (const action of actions.values()) {
+        if (action.sessionId === sessionId) {
+          result.push(action);
+        }
+      }
+      return result;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Creates in-memory `PendingActionStore` for queuing actions awaiting confirmation
- When `session.grant.messaging.draftOnly` is true, `send_message` queues and broadcasts `action.confirmation_required`
- `confirm_action`: confirmed re-validates against current session policy before executing, denied discards
- Pending action `expiresAt` enforced — expired actions auto-denied with `PermissionError`
- `internalSessionManager` wired into production WS request handler for `update_view` support

## Test plan
- [ ] draftOnly queues action and broadcasts confirmation event
- [ ] confirm executes stored action after re-validation
- [ ] deny discards action
- [ ] expired action rejected before execution
- [ ] policy narrowing between queue and confirm causes rejection

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)