### PR TITLE
feat: Dockerfile, docker-compose, and Railway deployment templates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# Stage 1: Install dependencies
+FROM oven/bun:1 AS deps
+WORKDIR /app
+COPY package.json bun.lock ./
+COPY packages/schemas/package.json packages/schemas/
+COPY packages/contracts/package.json packages/contracts/
+COPY packages/policy/package.json packages/policy/
+COPY packages/keys/package.json packages/keys/
+COPY packages/sessions/package.json packages/sessions/
+COPY packages/seals/package.json packages/seals/
+COPY packages/core/package.json packages/core/
+COPY packages/ws/package.json packages/ws/
+COPY packages/cli/package.json packages/cli/
+COPY packages/mcp/package.json packages/mcp/
+COPY packages/sdk/package.json packages/sdk/
+COPY packages/verifier/package.json packages/verifier/
+RUN bun install --frozen-lockfile
+
+# Stage 2: Build
+FROM oven/bun:1 AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN bun run build
+
+# Stage 3: Runtime
+FROM oven/bun:1-slim AS runtime
+WORKDIR /app
+
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/packages/*/dist ./packages/
+COPY --from=build /app/packages/*/package.json ./packages/
+COPY --from=build /app/package.json ./
+
+ENV XMTP_SIGNET_DATA_DIR=/data
+ENV XMTP_SIGNET_ENV=dev
+
+EXPOSE 8080 8081
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD bun run packages/cli/dist/bin.js status --json || exit 1
+
+ENTRYPOINT ["bun", "run", "packages/cli/dist/bin.js"]
+CMD ["start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  signet:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - signet-data:/data
+    environment:
+      - XMTP_SIGNET_DATA_DIR=/data
+      - XMTP_SIGNET_ENV=dev
+      - XMTP_SIGNET_WS_PORT=8080
+      - XMTP_SIGNET_LOG_LEVEL=info
+    restart: unless-stopped
+
+volumes:
+  signet-data:

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "bun run packages/cli/dist/bin.js start",
+    "healthcheckPath": "/v1/health",
+    "healthcheckTimeout": 10,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}


### PR DESCRIPTION
## Summary
- Multi-stage Dockerfile (deps → build → slim runtime) using `oven/bun:1`
- `ENTRYPOINT` and `HEALTHCHECK` use `packages/cli/dist/bin.js` (the real executable, not the library export)
- `docker-compose.yml` with volume-backed data directory and `XMTP_SIGNET_*` prefixed env vars
- `railway.json` deployment template with correct `startCommand` and health check
- Removed unsupported `SIGNET_HTTP_*` env vars (HTTP config not yet in loader)

## Test plan
- [ ] Dockerfile builds successfully
- [ ] Container starts with correct entrypoint
- [ ] Health check targets correct binary
- [ ] Env vars match what `loadConfig` actually reads

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)