### PR TITLE
docs: update historical plans to use signet/seal terminology

### DIFF
--- a/.agents/docs/design/cli-broker-interaction.md
+++ b/.agents/docs/design/cli-broker-interaction.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-The xmtp-broker is a daemon that owns the XMTP client, keys, sessions, grants, and WebSocket server. The CLI is the primary human interface for operating and administering the broker. It is not a wrapper around the existing `@xmtp/cli` binary -- it shares the same SDK (`@xmtp/node-sdk`) and uses the broker's own Zod schemas and handler contract.
+The xmtp-signet is a daemon that owns the XMTP client, keys, sessions, grants, and WebSocket server. The CLI is the primary human interface for operating and administering the broker. It is not a wrapper around the existing `@xmtp/cli` binary -- it shares the same SDK (`@xmtp/node-sdk`) and uses the broker's own Zod schemas and handler contract.
 
 Three interaction modes define how different actors reach the broker:
 
@@ -55,7 +55,7 @@ Developers and scripts run CLI commands without a running daemon. The CLI spins 
 | Auth | Raw XMTP keys (from env or keyfile) |
 | Scope | Full XMTP access -- no broker policy enforcement |
 | Key type | Inbox key (raw) |
-| Capabilities | Everything the XMTP SDK supports, no sessions/grants/attestations |
+| Capabilities | Everything the XMTP SDK supports, no sessions/grants/seals |
 
 Direct mode is explicitly lower-security than daemon mode. It exists because spinning up a full daemon for `xmtp-broker message send "hello"` during development is unnecessary friction.
 
@@ -76,7 +76,7 @@ Think of it like a database: the DBA manages users, permissions, and backups but
 | Send messages | Yes | No |
 | Receive/decrypt messages | Yes | No |
 | Join/leave groups | Yes | No |
-| Sign attestations | Yes | No |
+| Sign seals | Yes | No |
 | Start/stop daemon | No | Yes |
 | Issue sessions | No | Yes |
 | Revoke sessions/grants | No | Yes |
@@ -93,7 +93,7 @@ The broker already implements a three-tier key hierarchy:
 Root Key (hardware-bound or encrypted at rest)
   |
   +-- Operational Key (Ed25519, per-identity or per-group)
-  |     Used for XMTP signing, attestation signing
+  |     Used for XMTP signing, seal signing
   |
   +-- Session Key (ephemeral, in-memory)
         Used for JWT signing, harness auth
@@ -114,7 +114,7 @@ The admin key can _trigger_ a key rotation, but it never holds or derives the in
 
 ## Command Taxonomy
 
-Commands are grouped by domain concept. Each group maps to the broker's service interfaces (`BrokerCore`, `SessionManager`, `AttestationManager`, etc.).
+Commands are grouped by domain concept. Each group maps to the broker's service interfaces (`SignetCore`, `SessionManager`, `SealManager`, etc.).
 
 ### `broker` -- Daemon Lifecycle
 
@@ -161,16 +161,16 @@ xmtp-broker grant revoke <id>        # Revoke a specific grant
 
 All grant commands require the daemon and admin auth.
 
-### `attestation` -- Attestation Lifecycle
+### `seal` -- Seal Lifecycle
 
 ```bash
 xmtp-broker attestation list         # List attestations by group or agent
 xmtp-broker attestation inspect <id> # Show attestation content, signatures, chain
-xmtp-broker attestation verify <id>  # Run 6-check verification on an attestation
+xmtp-broker attestation verify <id>  # Run 6-check verification on a seal
 xmtp-broker attestation revoke <id>  # Revoke and publish revocation to group
 ```
 
-All attestation commands require the daemon. `verify` and `inspect` may work with reduced functionality in direct mode if given raw attestation data.
+All seal commands require the daemon. `verify` and `inspect` may work with reduced functionality in direct mode if given raw seal data.
 
 ### `message` -- Message Operations
 
@@ -211,7 +211,7 @@ Admin commands always require the daemon and admin auth. They are separated from
 | `identity`    | Yes            | --                | `init` only |
 | `session`     | Yes            | --                | No          |
 | `grant`       | Yes            | --                | No          |
-| `attestation` | Yes            | --                | Partial     |
+| `seal` | Yes            | --                | Partial     |
 | `message`     | Yes            | Yes (via session) | Yes (raw)   |
 | `conversation`| Yes            | Partial           | Yes (raw)   |
 | `admin`       | Yes            | --                | No          |
@@ -312,7 +312,7 @@ Exit code (0 = success, 1+ = error category)
 All domain logic uses the existing transport-agnostic handler signature:
 
 ```typescript
-type Handler<TInput, TOutput, TError extends BrokerError> = (
+type Handler<TInput, TOutput, TError extends SignetError> = (
   input: TInput,
   ctx: HandlerContext,
 ) => Promise<Result<TOutput, TError>>;
@@ -374,7 +374,7 @@ Direct mode intentionally lacks broker features:
 |---------|:-----------:|:-----------:|
 | Policy enforcement | Yes | No |
 | Session/grant system | Yes | No |
-| Attestation publishing | Yes | No |
+| Seal publishing | Yes | No |
 | Concurrent harness connections | Yes | No |
 | Key hierarchy (three-tier) | Yes | Partial (root key only) |
 | Audit logging | Yes | No |
@@ -392,7 +392,7 @@ Today the CLI is a standalone binary: `xmtp-broker`. The eventual target is a su
 - No CLI package yet.
 - `@xmtp/node-sdk` integration planned but not yet wired into `packages/core`.
 
-### Phase 2: Broker CLI (`@xmtp-broker/cli`)
+### Phase 2: Broker CLI (`@xmtp/signet-cli`)
 
 Built with Commander.js on Bun. Commander is lightweight, well-documented, and composes cleanly with the broker's existing Zod schemas for argument validation.
 
@@ -424,7 +424,7 @@ Eventually the broker CLI merges into `@xmtp/cli` as a subcommand namespace (`xm
 
 | Step | Owner | Notes |
 |------|-------|-------|
-| Build `@xmtp-broker/cli` with Commander | Broker team | Phase 2 |
+| Build `@xmtp/signet-cli` with Commander | Broker team | Phase 2 |
 | Implement daemon lifecycle (start/stop/socket) | Broker team | Phase 2 |
 | Implement admin key system | Broker team | Phase 2 |
 | Wire `@xmtp/node-sdk` into `packages/core` | Broker team | Phase 2 |
@@ -451,4 +451,4 @@ Eventually the broker CLI merges into `@xmtp/cli` as a subcommand namespace (`xm
 
 9. **Audit trail persistence.** Admin commands should be logged. Where? Local file? Structured log? Forwarded to an external system? What's the minimum viable audit trail for v0?
 
-10. **CLI package location.** `@xmtp-broker/cli` as a separate package in the broker monorepo (`packages/cli/`). Follows the existing package convention and keeps CLI concerns isolated from runtime packages.
+10. **CLI package location.** `@xmtp/signet-cli` as a separate package in the broker monorepo (`packages/cli/`). Follows the existing package convention and keeps CLI concerns isolated from runtime packages.

--- a/.agents/docs/design/phase2-decision-log.md
+++ b/.agents/docs/design/phase2-decision-log.md
@@ -32,7 +32,7 @@
 
 **Context:** PRD calls for SDK adapters. We have broker-side transports (WebSocket, MCP) but no package for harness developers to connect their agents.
 
-**Decision:** Add **Spec 15: Handler SDK** (`@xmtp-broker/handler`).
+**Decision:** Add **Spec 15: Handler SDK** (`@xmtp/signet-handler`).
 
 - Thin TypeScript client that connects to the broker WebSocket
 - Handles auth handshake, reconnection, sequence replay
@@ -51,7 +51,7 @@
 
 - Messaging and group management grants: enforced at the broker boundary (already spec'd)
 - Content type allowlists: enforced by the policy engine (already spec'd)
-- Tool and egress posture: declared in the attestation (honesty-based, per PRD)
+- Tool and egress posture: declared in the seal (honesty-based, per PRD)
 - **Future idea:** Tool grant registry where broker gates `tool_call` requests that flow through it. Only useful once tool calls are a first-class XMTP concept.
 
 ---
@@ -77,10 +77,10 @@
 
 Test scenarios to cover:
 1. **Full happy path**: Harness connects via WebSocket → authenticates with session token → receives filtered message stream → sends a message through a grant → sees the response
-2. **Attestation lifecycle**: Issue attestation → publish to group → refresh → verify chain → revoke
+2. **Seal lifecycle**: Issue seal → publish to group → refresh → verify chain → revoke
 3. **Policy enforcement**: View filters messages correctly across all 5 view modes. Grant denies unauthorized actions. Content type allowlist blocks unlisted types.
 4. **Session lifecycle**: Issue → heartbeat → expire → reconnect with replay → revoke mid-session
-5. **Key hierarchy**: Root key → derive operational → derive session → sign attestation → verify signature chain
+5. **Key hierarchy**: Root key → derive operational → derive session → sign seal → verify signature chain
 6. **WebSocket edge cases**: Auth timeout, backpressure, reconnection replay, graceful shutdown drain
 7. **Cross-package wiring**: Verify that contracts interfaces actually match their implementations (no signature drift between spec and code)
 
@@ -95,9 +95,9 @@ This becomes the regression suite that protects Phase 2 from breaking Phase 1.
 **Decision:** Clarify in spec 11 (not a new spec). The flow is:
 
 - When per-group identity is on, creating or joining a group means a new identity is created for that group. It's one atomic operation — not "add broker identity first, then create another."
-- `BrokerCore` calls `ClientRegistry` which calls `SdkClientFactory.create()` with a fresh identity
+- `SignetCore` calls `ClientRegistry` which calls `SdkClientFactory.create()` with a fresh identity
 - The new identity is the one that joins/creates the group
-- Add a paragraph to spec 11 clarifying this delegation from BrokerCore → ClientRegistry → SdkClientFactory
+- Add a paragraph to spec 11 clarifying this delegation from SignetCore → ClientRegistry → SdkClientFactory
 
 ---
 
@@ -144,9 +144,9 @@ v0/docs (current top)
 
 ### Q10: Summary-only view mode
 
-**Context:** Schema field exists in attestations. PLAN.md said "implementation deferred to Phase 2." We're now in Phase 2.
+**Context:** Schema field exists in seals. PLAN.md said "implementation deferred to Phase 2." We're now in Phase 2.
 
-**Decision:** Keep deferred. No current use case driving it. Summary-only requires the broker to generate content (LLM integration), which is a fundamentally different architectural concern. The schema field stays so attestations can declare it if needed later. Don't implement until there's a real use case.
+**Decision:** Keep deferred. No current use case driving it. Summary-only requires the broker to generate content (LLM integration), which is a fundamentally different architectural concern. The schema field stays so seals can declare it if needed later. Don't implement until there's a real use case.
 
 ---
 

--- a/.agents/docs/init/xmtp-signet.md
+++ b/.agents/docs/init/xmtp-signet.md
@@ -1,4 +1,4 @@
-# XMTP Agent Broker PRD
+# XMTP Agent Signet PRD
 
 **Version:** 0.2.1
 **Status:** Draft
@@ -6,15 +6,15 @@
 
 ## Summary
 
-This document proposes an **agent broker** architecture for XMTP-based applications and agents.
+This document proposes an **agent signet** architecture for XMTP-based applications and agents.
 
 The core idea is simple:
 
-- A **broker** is the real XMTP client.
-- The broker owns the raw XMTP signer, installation continuity, local encrypted database, and message sync.
+- A **signet** is the real XMTP client.
+- The signet owns the raw XMTP signer, installation continuity, local encrypted database, and message sync.
 - An **agent harness** never touches the raw XMTP client directly.
 - Instead, the harness connects to the broker over a controlled interface and receives a filtered **view** of one or more conversations and a scoped **grant** of allowed actions.
-- The permissions and scope of the view and grant are represented by group-visible **attestations**.
+- The permissions and scope of the view and grant are represented by group-visible **seals**.
 
 This model is designed to support agents in XMTP and Convos without pretending that a standard group member can somehow be cryptographically blind to ordinary group messages. It creates a practical, harness-agnostic security boundary that works with local brokers, self-hosted brokers, and managed broker deployments.
 
@@ -63,7 +63,7 @@ The current state:
 
 This proposal does not solve trust by decree. It moves us from **opaque trust** to **inspectable trust**.
 
-Concretely, that means a brokered agent can publish signed, group-visible attestations describing its current permissions, hosting mode, and scope, and agent-authored messages can reference the attestation they were produced under.
+Concretely, that means a brokered agent can publish signed, group-visible seals describing its current permissions, hosting mode, and scope, and agent-authored messages can reference the seal they were produced under.
 
 That still does not prove the operator is honest. But it gives the group something cryptographic and inspectable to verify, which is strictly better than the current state where agents can make claims and nobody can tell what is actually behind them.
 
@@ -80,7 +80,7 @@ In this model:
 - The broker is the real XMTP participant runtime.
 - The agent consumes a derived and policy-filtered interface.
 - Permissions are enforced at the broker boundary.
-- Group-visible attestation messages communicate the current capability state of an agent.
+- Group-visible seal messages communicate the current capability state of an agent.
 - The same conceptual model works across local, self-hosted, and managed deployments.
 
 ### What we are not proposing
@@ -149,7 +149,7 @@ Responsibilities:
 - Sync, receive, and store the real conversation state.
 - Enforce policy for views, grants, and message projection.
 - Issue sessions to agent harnesses.
-- Publish group-visible capability attestations.
+- Publish group-visible capability seals.
 - Manage per-agent isolation when serving multiple agents.
 
 The term “broker” is preferred over “gateway” to avoid confusion with XMTP Gateway Service and other gateway terminology in the ecosystem.
@@ -161,12 +161,12 @@ Each agent has its own XMTP inbox. The broker holds the signer for that inbox an
 This means:
 
 - The group sees each agent as a distinct participant with its own inbox identity.
-- Attestations are about a specific agent, not about the broker as a whole.
+- Seals are about a specific agent, not about the broker as a whole.
 - One broker can manage multiple agent inboxes, each joining different groups independently.
 - There is no “ventriloquist” problem where one broker identity speaks as multiple agents.
 - The broker is infrastructure, not a participant. It does not appear in group membership.
 
-When a single broker serves multiple agents in the same group, each agent has its own inbox, its own attestation, its own view, and its own grant. The broker maintains strict isolation between agents internally — Agent A’s view must not leak into Agent B’s derived state.
+When a single broker serves multiple agents in the same group, each agent has its own inbox, its own seal, its own view, and its own grant. The broker maintains strict isolation between agents internally — Agent A’s view must not leak into Agent B’s derived state.
 
 ### View
 
@@ -246,13 +246,13 @@ Suggested initial view modes as convenience labels:
 
 A view mode is only a convenience label. The underlying view object (including the content type allowlist) and grant object should remain explicit and authoritative.
 
-### Attestation
+### Seal
 
-An **attestation** is a signed assertion about an agent’s current permissions, scope, and operating posture.
+A **seal** is a signed assertion about an agent’s current permissions, scope, and operating posture.
 
-Attestations are meant to be visible to the group and updated whenever permissions change materially.
+Seals are meant to be visible to the group and updated whenever permissions change materially.
 
-Attestations establish shared understanding of:
+Seals establish shared understanding of:
 
 - Who owns the agent.
 - Which inbox the agent uses.
@@ -263,11 +263,11 @@ Attestations establish shared understanding of:
 - The hosting mode and trust posture.
 - What changed since the previous state.
 
-#### Attestation noise and materiality
+#### Seal noise and materiality
 
-Not every internal state change should produce a group-visible attestation. The system should distinguish **material changes** from **routine operations**.
+Not every internal state change should produce a group-visible seal. The system should distinguish **material changes** from **routine operations**.
 
-Material changes that produce group-visible attestations:
+Material changes that produce group-visible seals:
 
 - View mode or scope changes.
 - Grant additions or removals.
@@ -370,7 +370,7 @@ It includes:
 - Grant definitions (action permissions).
 - Reveal state.
 - Group policy state.
-- Attestations.
+- Seals.
 - Revocations.
 
 #### Derived plane
@@ -410,7 +410,7 @@ The system should define one capability model and multiple connection adapters, 
 
 When an agent sends conversation content to an external LLM provider, the privacy story changes fundamentally. This is arguably the single most consequential thing a group member would want to know about an agent.
 
-Egress and inference posture must be declared as structured, first-class fields in the attestation — not buried in a generic policy blob.
+Egress and inference posture must be declared as structured, first-class fields in the seal — not buried in a generic policy blob.
 
 ### Required egress fields
 
@@ -419,11 +419,11 @@ Egress and inference posture must be declared as structured, first-class fields 
 - `contentEgressScope` — What content leaves the broker boundary: `full-messages` | `summaries-only` | `tool-calls-only` | `none`
 - `retentionAtProvider` — `none` | `session` | `persistent` | `unknown`
 
-These fields are **required** in every attestation. If the value cannot be determined, the field must be set to `unknown` rather than omitted. Silent omission is not allowed. Every attestation takes an explicit position, even if that position is “I don’t know.”
+These fields are **required** in every seal. If the value cannot be determined, the field must be set to `unknown` rather than omitted. Silent omission is not allowed. Every seal takes an explicit position, even if that position is “I don’t know.”
 
 ### Envelope declaration
 
-For agent frameworks that dynamically switch inference providers (such as OpenClaw), the attestation should declare the **envelope** of possible providers, not the instantaneous state. If the agent may route to Anthropic, OpenAI, or a local model depending on the query, the attestation declares all three and sets `inferenceMode` to `hybrid`.
+For agent frameworks that dynamically switch inference providers (such as OpenClaw), the seal should declare the **envelope** of possible providers, not the instantaneous state. If the agent may route to Anthropic, OpenAI, or a local model depending on the query, the seal declares all three and sets `inferenceMode` to `hybrid`.
 
 Overstating the envelope is acceptable. Understating it is not.
 
@@ -431,25 +431,25 @@ Overstating the envelope is acceptable. Understating it is not.
 
 In v1, these fields are self-reported by the broker. An unverified broker claiming `inferenceMode: local` gets treated with the same skepticism as any other unverified claim. A source-verified or runtime-attested broker making that claim is more credible. The schema does not solve trust — it gives trust something structured to attach to.
 
-## Attestation Model
+## Seal Model
 
-### Why attestations matter
+### Why seals matter
 
-Attestations make agent posture legible to the conversation itself.
+Seals make agent posture legible to the conversation itself.
 
-Without attestations, permissions live only in the owner’s client or broker config. That is not enough for a multi-party environment.
+Without seals, permissions live only in the owner’s client or broker config. That is not enough for a multi-party environment.
 
-### Attestation signing in v1
+### Seal signing in v1
 
-In v1, the broker signs attestations using the agent’s inbox key (which the broker holds). The attestation includes the `ownerInboxId` field, which creates a social accountability link — the group can see who is responsible for the agent — even though the owner is not cryptographically co-signing every update.
+In v1, the broker signs seals using the agent’s inbox key (which the broker holds). The seal includes the `ownerInboxId` field, which creates a social accountability link — the group can see who is responsible for the agent — even though the owner is not cryptographically co-signing every update.
 
-Clients verify the signature against the agent’s inbox, confirming the attestation came from the entity that controls that agent.
+Clients verify the signature against the agent’s inbox, confirming the seal came from the entity that controls that agent.
 
-In future versions, optional owner co-signing could be added for high-stakes permission changes (such as upgrading from `reveal-only` to `full` visibility), while keeping routine attestations broker-signed only.
+In future versions, optional owner co-signing could be added for high-stakes permission changes (such as upgrading from `reveal-only` to `full` visibility), while keeping routine seals broker-signed only.
 
-### Attestation lifecycle
+### Seal lifecycle
 
-An attestation should be published when a material change occurs:
+A seal should be published when a material change occurs:
 
 - An agent is added.
 - Permissions are first granted.
@@ -459,10 +459,10 @@ An attestation should be published when a material change occurs:
 - The ownership or hosting mode changes.
 - A verifier statement is updated.
 
-### Suggested attestation fields
+### Suggested seal fields
 
-- `attestationId`
-- `previousAttestationId`
+- `sealId`
+- `previousSealId`
 - `agentInboxId`
 - `ownerInboxId`
 - `groupId`
@@ -489,7 +489,7 @@ An attestation should be published when a material change occurs:
 
 ### Message provenance
 
-Agent-authored messages should reference the attestation under which they were produced.
+Agent-authored messages should reference the seal under which they were produced.
 
 This gives clients the ability to render:
 
@@ -497,15 +497,15 @@ This gives clients the ability to render:
 - Whether a message was generated under different permissions than the current state.
 - Whether permissions changed mid-conversation.
 
-### Trust model for attestations
+### Trust model for seals
 
-The system should not rely on self-attestation from the agent alone.
+The system should not rely on self-sealing from the agent alone.
 
 The more trustworthy path is:
 
-- The broker signs the attestation with the agent’s inbox key.
-- The attestation is posted into the group.
-- Agent messages reference the current attestation.
+- The broker signs the seal with the agent’s inbox key.
+- The seal is posted into the group.
+- Agent messages reference the current seal.
 - Clients compare references over time.
 - Verifier statements (when available) add external validation.
 
@@ -533,7 +533,7 @@ Runtime attestation gets you to: “this live hosted broker is likely running th
 
 The design should be **TEE-agnostic and verifier-agnostic** — AWS Nitro today, other attested runtimes tomorrow, or purely source/build-verified self-hosting for users who do not want enclave dependencies.
 
-### Layer 4: Capability Attestation
+### Layer 4: Capability Seal
 
 What gets posted into the group. Describes what this broker claims the agent can do right now. This is the app/XIP layer — the view, the grant, the hosting mode, the egress posture.
 
@@ -560,7 +560,7 @@ The trust chain maps to three practical tiers that clients can render:
 - Hosted runtime proves measurement via remote attestation.
 - Secrets are released only to approved measurements.
 
-The group-visible attestation includes a `trustTier` field reflecting the highest tier the broker can currently demonstrate.
+The group-visible seal includes a `trustTier` field reflecting the highest tier the broker can currently demonstrate.
 
 ## Broker Verification
 
@@ -582,7 +582,7 @@ The verifier identity is just an XMTP inbox. The verification statement is a sig
 1. Broker sends a verification request containing: broker inbox identity, challenge nonce, artifact digest, build provenance bundle, optional runtime attestation evidence, requested verification class.
 1. Verifier checks policy and evidence.
 1. Verifier replies over XMTP with a signed verification statement.
-1. Broker references that statement in its group-visible capability attestation via the `verifierStatementRef` field.
+1. Broker references that statement in its group-visible capability seal via the `verifierStatementRef` field.
 1. Clients validate: the verifier issuer, the signature, expiry, evidence class, and whether subsequent agent messages still point to a current statement.
 
 ### Multiple issuers
@@ -650,7 +650,7 @@ The broker-mediated model adds a mandatory dependency: if the broker goes down, 
 
 ### Heartbeat and staleness
 
-The attestation includes a `heartbeatInterval` field indicating the expected liveness cadence. Clients should render an “agent unreachable” or “last active N minutes ago” indicator when the interval is exceeded. This does not require noisy group-visible messages — it can be inferred from session keepalives or lightweight structured signals.
+The seal includes a `heartbeatInterval` field indicating the expected liveness cadence. Clients should render an “agent unreachable” or “last active N minutes ago” indicator when the interval is exceeded. This does not require noisy group-visible messages — it can be inferred from session keepalives or lightweight structured signals.
 
 ### Broker recovery: inbound messages
 
@@ -670,22 +670,22 @@ Revocation should be **immediate, visible, and fail-closed**. If there is any am
 
 ### Normal revocation
 
-The owner instructs the broker to revoke the agent. The broker immediately terminates the agent’s session, posts a revocation attestation to the group, and stops projecting any view to that agent.
+The owner instructs the broker to revoke the agent. The broker immediately terminates the agent’s session, posts a revocation seal to the group, and stops projecting any view to that agent.
 
 ### Owner loses access
 
 If the owner’s device is lost or the owner leaves the group, two safety valves apply:
 
-- **Mandatory expiration:** Attestations must have an `expiresAt` field. A broker with no owner contact eventually stops being authorized.
+- **Mandatory expiration:** Seals must have an `expiresAt` field. A broker with no owner contact eventually stops being authorized.
 - **Group admin override:** Group admins can remove the agent’s inbox from the group at the XMTP group permissions level, which effectively kills access regardless of what the broker thinks.
 
 ### Session expiry without rotation
 
-If a session expires and the harness does not re-authenticate, the broker automatically stops projecting the view. No silent continuation on stale credentials. The broker posts a session-expired attestation so the group knows the agent is no longer active under valid authorization.
+If a session expires and the harness does not re-authenticate, the broker automatically stops projecting the view. No silent continuation on stale credentials. The broker posts a session-expired seal so the group knows the agent is no longer active under valid authorization.
 
 ### In-flight messages during revocation
 
-If the agent has a message in transit when revocation hits, the broker drops it. A message that arrives at the broker after the revocation attestation was posted should never reach the group. Better to lose a message than to have an agent act after its permissions were pulled.
+If the agent has a message in transit when revocation hits, the broker drops it. A message that arrives at the broker after the revocation seal was posted should never reach the group. Better to lose a message than to have an agent act after its permissions were pulled.
 
 ## Threat Model
 
@@ -707,15 +707,15 @@ Mitigation includes hardware-backed key storage (Secure Enclave, TPM), standard 
 
 ### Compromised broker host (self-hosted / managed)
 
-What they gain: full raw message access for all agents the broker manages, all signer material, and the ability to forge attestations. The hosted environment is the real client boundary, and compromise of it is equivalent to owning every agent on that broker.
+What they gain: full raw message access for all agents the broker manages, all signer material, and the ability to forge seals. The hosted environment is the real client boundary, and compromise of it is equivalent to owning every agent on that broker.
 
-Mitigations: short-lived sessions limit exposure window, mandatory attestation expiry forces periodic renewal, runtime attestation (Tier 3) can detect environment tampering, and the broker’s attestation history creates a forensic trail.
+Mitigations: short-lived sessions limit exposure window, mandatory seal expiry forces periodic renewal, runtime attestation (Tier 3) can detect environment tampering, and the broker’s seal history creates a forensic trail.
 
 ### Malicious operator (managed deployment)
 
-What they gain: the same access as a compromised host, but with the added ability to operate covertly over time. A malicious managed broker operator can silently exfiltrate messages, forge attestations, and impersonate agents.
+What they gain: the same access as a compromised host, but with the added ability to operate covertly over time. A malicious managed broker operator can silently exfiltrate messages, forge seals, and impersonate agents.
 
-Mitigations: the `hostingMode` field in attestations discloses managed deployment, allowing clients to render appropriate trust indicators. Runtime attestation (Tier 3) with TEE-backed key release is the strongest counter. Verifier statements from independent issuers provide a cross-check. But fundamentally, a managed broker requires trust in the operator — the system should be honest about that.
+Mitigations: the `hostingMode` field in seals discloses managed deployment, allowing clients to render appropriate trust indicators. Runtime attestation (Tier 3) with TEE-backed key release is the strongest counter. Verifier statements from independent issuers provide a cross-check. But fundamentally, a managed broker requires trust in the operator — the system should be honest about that.
 
 ### Network adversary
 
@@ -736,13 +736,13 @@ That owner can:
 
 ### Group visibility
 
-Even in the owner-driven model, the resulting permissions are visible to the group via attestations. Group members can inspect what an agent can see and do at any time.
+Even in the owner-driven model, the resulting permissions are visible to the group via seals. Group members can inspect what an agent can see and do at any time.
 
 ### Power asymmetry in v1
 
-The v1 model creates a known power asymmetry. If Alice adds an agent with `full` visibility, Bob can see that via the attestation, but he has no direct mechanism to override or restrict the agent’s permissions — his recourse is limited to leaving the group or asking Alice to change the configuration.
+The v1 model creates a known power asymmetry. If Alice adds an agent with `full` visibility, Bob can see that via the seal, but he has no direct mechanism to override or restrict the agent’s permissions — his recourse is limited to leaving the group or asking Alice to change the configuration.
 
-This is an accepted limitation of v1. The attestation model makes the situation transparent, which is a meaningful improvement over the current state where Bob has no visibility at all.
+This is an accepted limitation of v1. The seal model makes the situation transparent, which is a meaningful improvement over the current state where Bob has no visibility at all.
 
 ### Future group governance
 
@@ -767,7 +767,7 @@ Possible Convos additions:
 - Trust tier indicators.
 - Permission editing UI.
 - Reveal toggles on messages and threads.
-- Timeline cards for attestation changes (material changes only).
+- Timeline cards for seal changes (material changes only).
 - Agent ownership labeling.
 - Hosting mode labeling.
 - Inference and egress disclosure (e.g. “processes locally” or “sends to Anthropic, session only”).
@@ -868,7 +868,7 @@ All deployment modes share:
 
 - The same broker protocol.
 - The same view and grant model.
-- The same attestation model.
+- The same seal model.
 - The same client UX semantics.
 
 They do not share the same trust boundary.
@@ -887,7 +887,7 @@ Recommended outputs:
 
 - Broker protocol spec.
 - View, grant, and session spec.
-- Attestation schema.
+- Seal schema.
 - Reference verifier implementation (deployable to Cloudflare Workers or Railway).
 - Broker reference implementations.
 - One-click deployment templates.
@@ -910,7 +910,7 @@ Recommended outputs:
 
 - Cloudflare handles control-plane tasks.
 - A stateful raw broker runs elsewhere.
-- Good fit for global session management, fanout, and attestation coordination.
+- Good fit for global session management, fanout, and seal coordination.
 
 ### Platform considerations
 
@@ -933,7 +933,7 @@ A one-click deployment experience should:
 - Generate broker secrets inside the target environment.
 - Avoid showing long-lived secrets back to the user in plaintext when possible.
 - Support user-controlled recovery and rotation.
-- Publish broker identity and attestation fingerprints.
+- Publish broker identity and seal fingerprints.
 - Make the hosting mode visible to the client.
 
 ### Honest security posture for hosted deployment
@@ -972,7 +972,7 @@ Suggested event types:
 - `session.started`
 - `session.expired`
 - `session.reauthorization_required`
-- `attestation.updated`
+- `seal.updated`
 - `view.updated`
 - `grant.updated`
 - `message.visible`
@@ -1008,7 +1008,7 @@ That is true whether the broker is local or hosted.
 - A malicious host or operator may still exfiltrate data in hosted environments.
 - An agent can still remember or infer content it has already seen.
 - Egress to an LLM provider weakens privacy relative to pure client-to-client messaging.
-- Attestation fields beyond the trust chain are self-reported in v1.
+- Seal fields beyond the trust chain are self-reported in v1.
 
 ### Hard requirements
 
@@ -1019,7 +1019,7 @@ That is true whether the broker is local or hosted.
 - Privilege escalation requires root key authorization (biometric or equivalent).
 - Clear session expiration and rotation.
 - Clear revocation flow with fail-closed behavior.
-- Mandatory `expiresAt` on all attestations.
+- Mandatory `expiresAt` on all seals.
 
 ## Key Management and Hardware Binding
 
@@ -1051,7 +1051,7 @@ The broker should maintain a three-tier derived key hierarchy:
 
 - Derived from the root key.
 - Protected by `passcode` or `open` policy depending on deployment mode.
-- Used for: routine message signing, attestation publishing, session issuance, and day-to-day broker operations.
+- Used for: routine message signing, seal publishing, session issuance, and day-to-day broker operations.
 - Does not require biometric authentication per operation, allowing the broker to function autonomously for routine tasks.
 
 #### Session keys
@@ -1064,7 +1064,7 @@ The broker should maintain a three-tier derived key hierarchy:
 
 ### Privilege escalation and biometric gating
 
-Routine broker operations — sending messages, publishing routine attestations, managing sessions — should flow through the operational key without requiring per-operation authentication. This allows agents to function autonomously within their granted permissions.
+Routine broker operations — sending messages, publishing routine seals, managing sessions — should flow through the operational key without requiring per-operation authentication. This allows agents to function autonomously within their granted permissions.
 
 Operations that cross a privilege threshold should require root key authorization, which means biometric (or equivalent) authentication:
 
@@ -1114,7 +1114,7 @@ For hosted brokers, the Secure Enclave is not available. The equivalent pattern 
 - Key release conditioned on runtime attestation measurements.
 - The architectural boundary is the same — the broker can use the key but never see it — just implemented with different hardware.
 
-The attestation’s `trustTier` and `hostingMode` fields should reflect whether hardware-backed key storage is in use.
+The seal’s `trustTier` and `hostingMode` fields should reflect whether hardware-backed key storage is in use.
 
 ## Key Rotation
 
@@ -1127,35 +1127,35 @@ Secure Enclave keys are non-exportable and device-bound by hardware design. Movi
 1. Authenticate on the new machine (biometric enrollment).
 1. The broker creates new enclave-backed keys on the new hardware.
 1. The broker performs an XMTP installation rotation — the agent’s inbox identity persists, but the signing key material rotates.
-1. The broker publishes an updated attestation reflecting the new key material and any updated verifier statements.
+1. The broker publishes an updated seal reflecting the new key material and any updated verifier statements.
 1. The old machine’s keys are revoked.
 
 This is cleaner than a “recovery key” approach because it avoids ever having exportable root material. There are no seed phrases or recovery keys to secure, leak, or lose. The agent’s identity continuity is maintained through XMTP’s installation management, not through key portability.
 
 ### Periodic rotation
 
-Even without a machine change, operational keys should support periodic rotation as a security hygiene measure. The broker should be able to rotate operational keys without disrupting active sessions — new sessions use the new key, existing sessions continue until their natural expiry, and the attestation is updated to reflect the rotation.
+Even without a machine change, operational keys should support periodic rotation as a security hygiene measure. The broker should be able to rotate operational keys without disrupting active sessions — new sessions use the new key, existing sessions continue until their natural expiry, and the seal is updated to reflect the rotation.
 
-### Rotation attestation
+### Rotation seal
 
-Any key rotation event is a material change and should produce a group-visible attestation update. The group should be able to see that key material changed, when it changed, and that the new material chains back to a valid root.
+Any key rotation event is a material change and should produce a group-visible seal update. The group should be able to see that key material changed, when it changed, and that the new material chains back to a valid root.
 
 ## Candidate XIP Directions
 
 This proposal is intentionally app-layer first, but several pieces are candidates for future XIPs.
 
-### Capability Attestation XIP (recommended first)
+### Capability Seal XIP (recommended first)
 
-Standardize a portable, signed attestation format for agent capabilities.
+Standardize a portable, signed seal format for agent capabilities.
 
 Potential scope:
 
-- Required attestation fields (including structured egress/inference fields).
+- Required seal fields (including structured egress/inference fields).
 - View and grant semantics.
 - Update semantics and materiality thresholds.
 - Revocation semantics.
 - Ownership and issuer model.
-- Attestation references in agent-authored messages.
+- Seal references in agent-authored messages.
 
 This is recommended as the first XIP because it is the foundation everything else references.
 
@@ -1169,13 +1169,13 @@ Potential scope:
 - Verification statement format.
 - Issuer / expiry / revocation semantics.
 - Standard verification classes (self-asserted, source-verified, build-provenance-verified, runtime-attested).
-- Standard way for attestations to reference verifier statements.
+- Standard way for seals to reference verifier statements.
 
 ### Agent Message Provenance XIP
 
 Standardize how agent-authored messages indicate:
 
-- Which attestation they were produced under.
+- Which seal they were produced under.
 - Whether the agent was acting with full, reveal-only, or other view modes.
 - Whether tool use or external actions were involved.
 
@@ -1255,14 +1255,14 @@ Convos can add flavor to this model without waiting for protocol-level changes.
 - Attach to local broker.
 - Attach to self-hosted broker.
 - Inspect active session details.
-- Inspect attestation history.
+- Inspect seal history.
 - Export broker fingerprints and configuration.
 
 ## Rollout Strategy
 
 ### Phase 1
 
-- Define broker, view, grant, attestation, and session concepts.
+- Define broker, view, grant, seal, and session concepts.
 - Ship local broker reference implementation with Secure Enclave-backed key management.
 - Implement derived key hierarchy (root → operational → session).
 - Ship open source reference verifier (Cloudflare Workers / Railway).
@@ -1276,10 +1276,10 @@ Convos can add flavor to this model without waiting for protocol-level changes.
 - Add self-hosted deployment templates.
 - Add MCP and SDK adapters.
 - Add permission editing UX.
-- Add attestation timeline UX (material changes only).
+- Add seal timeline UX (material changes only).
 - Add action confirmations and richer tool scopes.
 - Verifier-over-XMTP flow operational.
-- Draft Capability Attestation XIP based on implementation learnings.
+- Draft Capability Seal XIP based on implementation learnings.
 
 ### Phase 3
 
@@ -1293,8 +1293,8 @@ Convos can add flavor to this model without waiting for protocol-level changes.
 
 ## Open Questions
 
-- What is the exact minimum viable attestation schema?
-- How should clients render stale or expired attestations?
+- What is the exact minimum viable seal schema?
+- How should clients render stale or expired seals?
 - How should reveal history be represented in UX?
 - Should session issuance be tied to explicit per-thread scopes by default?
 - How much policy should be in-group versus off-chain broker config?
@@ -1331,7 +1331,7 @@ The proposal is successful if it achieves the following:
 - Users misunderstand the difference between local and hosted modes.
 - The view and grant model feels too complex.
 - Too much UX ceremony discourages agent usage.
-- Attestations become noisy despite the materiality threshold.
+- Seals become noisy despite the materiality threshold.
 - Group members feel powerless under the v1 owner-only governance model.
 
 ### Mitigations
@@ -1355,13 +1355,13 @@ Start with:
 - Derived key hierarchy with biometric-gated privilege escalation.
 - WebSocket as the primary live interface.
 - Structured view and grant model.
-- Group-visible capability attestations with structured egress disclosure.
+- Group-visible capability seals with structured egress disclosure.
 - An open source reference verifier deployable to Cloudflare Workers or Railway.
 - Convos as a rich UX proving ground.
 - Self-hosted templates for Fly and Railway.
 - A Cloudflare-friendly hybrid control-plane design.
 
-Use implementation learnings to identify which parts should become formal XIPs, starting with Capability Attestation.
+Use implementation learnings to identify which parts should become formal XIPs, starting with Capability Seal.
 
 ## Appendix: Crisp Framing
 
@@ -1370,10 +1370,10 @@ The simplest way to explain the proposal is:
 - The **broker** is the real XMTP client.
 - The **view** is what the agent is allowed to see.
 - The **grant** is what the agent is allowed to do.
-- The **attestation** is what the group is told about that view and grant.
+- The **seal** is what the group is told about that view and grant.
 - The **session** is how the harness connects to it.
 - The **verifier** is how the group can check whether the broker is what it claims.
 
 Or more simply:
 
-**The group trusts the attestation. The broker enforces the view and grant. The agent never touches the raw client. The verifier keeps the broker honest.**
+**The group trusts the seal. The broker enforces the view and grant. The agent never touches the raw client. The verifier keeps the broker honest.**

--- a/.agents/notes/codex-review-2026-03-13-blockers-and-plan.md
+++ b/.agents/notes/codex-review-2026-03-13-blockers-and-plan.md
@@ -9,11 +9,11 @@ Scope: capture the review findings, map them to the current code, and give a con
 The current stack has six blocking issues:
 
 1. A required source file is not included in the submitted patch, so a clean checkout does not build.
-2. `BrokerCoreImpl` reuses one identity-bound signer provider for every XMTP client.
+2. `SignetCoreImpl` reuses one identity-bound signer provider for every XMTP client.
 3. Shared-identity startup does not register actual group membership, so group-routed operations fail after restart.
 4. Startup ignores the result of the initial `syncAll()`, so the broker can report `running` while unsynchronized.
 5. Database encryption keys are derived from public material, which breaks the at-rest secrecy requirement.
-6. Revoked attestation pairs can be refreshed, which bypasses the revocation guard.
+6. Revoked seal pairs can be refreshed, which bypasses the revocation guard.
 
 ## Findings
 
@@ -28,7 +28,7 @@ Current state:
 - `compute-delta.ts` exists locally, but it is currently untracked in `git status --short`.
 
 Why this is blocking:
-- A fresh checkout or CI run will fail to build `@xmtp-broker/attestations` because the export target is missing from the submitted patch.
+- A fresh checkout or CI run will fail to build `@xmtp/signet-seals` because the export target is missing from the submitted patch.
 
 Fix plan:
 - Add `packages/attestations/src/compute-delta.ts` to the patch/commit.
@@ -45,7 +45,7 @@ Files:
 - `packages/keys/src/signer-provider.ts`
 
 Current state:
-- `BrokerCoreImpl.start()` loops through persisted identities.
+- `SignetCoreImpl.start()` loops through persisted identities.
 - Each `clientFactory.create()` call receives `this.#signerProvider`.
 - `createSignerProvider(manager, identityId)` produces a provider bound to a single identity.
 
@@ -54,12 +54,12 @@ Why this is blocking:
 - That breaks the per-identity isolation model the broker depends on.
 
 Recommended fix:
-- Change `BrokerCoreImpl` to depend on a signer-provider factory instead of a single provider instance.
+- Change `SignetCoreImpl` to depend on a signer-provider factory instead of a single provider instance.
 - During startup, create a fresh provider per identity and pass that provider into `clientFactory.create()`.
 - Keep the identity-specific DB encryption lookup on that per-identity provider so the signer and DB key source stay aligned.
 
 Suggested TDD:
-- Add a `broker-core` test with two persisted identities.
+- Add a `signet-core` test with two persisted identities.
 - Assert that `clientFactory.create()` is called with two distinct providers.
 - If practical, assert the providers report different fingerprints or are tagged to different identity IDs in the test double.
 
@@ -89,7 +89,7 @@ Recommended fix:
 - Treat the runtime registry as the source of truth for active group ownership after startup hydration.
 
 Sanity check while fixing:
-- `BrokerCoreContext.getInboxId()` currently routes through `identityStore.getByGroupId()`, which only works for one persisted `group_id`.
+- `SignetCoreContext.getInboxId()` currently routes through `identityStore.getByGroupId()`, which only works for one persisted `group_id`.
 - For shared mode, either:
   - switch `getInboxId(groupId)` to resolve through the hydrated runtime registry, or
   - add a durable group-to-identity mapping model.
@@ -124,7 +124,7 @@ Recommended fix:
 - Avoid starting streams or heartbeats for a client that failed initial recovery.
 
 Suggested TDD:
-- Add a `broker-core` test where `syncAll()` returns `Result.err(...)`.
+- Add a `signet-core` test where `syncAll()` returns `Result.err(...)`.
 - Assert:
   - `start()` returns `Err`
   - state ends in `"error"`
@@ -169,7 +169,7 @@ Verification:
 - `bun test packages/keys/src/__tests__/signer-provider.test.ts`
 - `bun test packages/keys/src/__tests__/key-manager.test.ts`
 
-### 6. P1: Revoked attestation pairs can still be refreshed
+### 6. P1: Revoked seal pairs can still be refreshed
 
 Files:
 - `packages/attestations/src/manager.ts`
@@ -180,7 +180,7 @@ Current state:
 - `refresh()` does not.
 
 Why this is blocking:
-- A revoked agent/group pair can mint a fresh attestation via `refresh(attestationId)`.
+- A revoked agent/group pair can mint a fresh seal via `refresh(attestationId)`.
 - That bypasses the intended terminal revocation guard.
 
 Recommended fix:
@@ -189,7 +189,7 @@ Recommended fix:
 
 Suggested TDD:
 - Add a manager test that:
-  - issues an attestation
+  - issues a seal
   - revokes it
   - attempts `refresh(originalAttestationId)`
   - expects `Err`
@@ -206,7 +206,7 @@ Recommended order:
    - Stage and commit `packages/attestations/src/compute-delta.ts`.
    - Run `bun run build`.
 
-2. Fix `BrokerCoreImpl` identity isolation first.
+2. Fix `SignetCoreImpl` identity isolation first.
    - Introduce a per-identity signer-provider creation path.
    - Add the multi-identity regression test.
 
@@ -219,7 +219,7 @@ Recommended order:
    - Replace public-key HKDF with a vault-secret-backed key source.
    - Keep restart determinism and identity isolation tests green.
 
-5. Close the revocation bypass in the attestations package.
+5. Close the revocation bypass in the seals package.
    - Add the refresh-after-revoke regression test.
    - Make `refresh()` enforce the terminal revocation rule.
 

--- a/.agents/notes/outfitter-patterns/agents-md-and-conventions.md
+++ b/.agents/notes/outfitter-patterns/agents-md-and-conventions.md
@@ -1,6 +1,6 @@
 # AGENTS.md Structure and Development Conventions
 
-Extracted from `outfitter/stack` as reference for xmtp-broker's agent-facing documentation.
+Extracted from `outfitter/stack` as reference for xmtp-signet's agent-facing documentation.
 
 ## CLAUDE.md vs AGENTS.md
 
@@ -82,7 +82,7 @@ env var override > explicit option > environment profile > package default
 
 Agents know exactly what CI checks and can predict what will fail.
 
-## Adaptation Notes for xmtp-broker
+## Adaptation Notes for xmtp-signet
 
 **Adopt:**
 - Single AGENTS.md as source of truth (symlink CLAUDE.md to it, already done)
@@ -94,11 +94,11 @@ Agents know exactly what CI checks and can predict what will fail.
 - Environment precedence chain pattern
 
 **Adapt:**
-- xmtp-broker is much simpler initially — AGENTS.md can be shorter
+- xmtp-signet is much simpler initially — AGENTS.md can be shorter
 - CI section can wait until CI exists
 - Package tiers will be different (broker core, transports, key management)
 
-**Development principles for xmtp-broker (draft):**
+**Development principles for xmtp-signet (draft):**
 
 ### Non-Negotiable
 - **TDD-First** — Write the test before the code. Always.

--- a/.agents/notes/outfitter-patterns/error-handling-and-result.md
+++ b/.agents/notes/outfitter-patterns/error-handling-and-result.md
@@ -1,6 +1,6 @@
 # Error Handling and Result Pattern
 
-Extracted from `outfitter/stack` as reference for xmtp-broker error handling.
+Extracted from `outfitter/stack` as reference for xmtp-signet error handling.
 
 ## Core Principle: No Throw
 
@@ -83,7 +83,7 @@ Unified lookup: `errorCategoryMeta(category)` returns `{ exitCode, statusCode, j
 
 Only transient errors are retryable: `timeout`, `rate_limit`, `network`. Permanent errors (validation, not_found, permission, auth, internal) require human intervention.
 
-## Adaptation Notes for xmtp-broker
+## Adaptation Notes for xmtp-signet
 
 **Adopt:**
 - Result type for all handler returns (use `better-result` or similar)

--- a/.agents/notes/outfitter-patterns/schema-first-architecture.md
+++ b/.agents/notes/outfitter-patterns/schema-first-architecture.md
@@ -1,6 +1,6 @@
 # Schema-First Architecture
 
-Extracted from `outfitter/stack` as reference for xmtp-broker's type and validation strategy.
+Extracted from `outfitter/stack` as reference for xmtp-signet's type and validation strategy.
 
 ## Core Idea
 
@@ -77,9 +77,9 @@ const ReactionContentSchema = z.object({ reference: z.string(), action: z.enum([
 // The broker validates incoming content against the schema before projecting to the agent
 ```
 
-## Attestation Schema
+## Seal Schema
 
-The broker's attestation model is a natural fit for schema-first design:
+The broker's seal model is a natural fit for schema-first design:
 
 ```typescript
 const AttestationSchema = z.object({
@@ -106,17 +106,17 @@ type Attestation = z.infer<typeof AttestationSchema>;
 ```
 
 This schema:
-- Validates attestations at the broker boundary
-- Types all internal attestation handling
+- Validates seals at the broker boundary
+- Types all internal seal handling
 - Auto-generates JSON Schema for MCP tool definitions
-- Self-documents the attestation format
-- Can be versioned as the attestation spec evolves
+- Self-documents the seal format
+- Can be versioned as the seal spec evolves
 
-## Adaptation Notes for xmtp-broker
+## Adaptation Notes for xmtp-signet
 
 **Adopt from day one:**
 - Zod as the schema library (lightweight, composable, excellent TS inference)
-- Schema-first for all broker domain types: views, grants, attestations, sessions, events
+- Schema-first for all broker domain types: views, grants, seals, sessions, events
 - `z.infer<>` for all TypeScript types — no manual interfaces
 - Validate at boundaries (incoming harness requests, config, env vars), trust types internally
 - `zodToJsonSchema()` when MCP transport is added later
@@ -124,12 +124,12 @@ This schema:
 **Key schemas to define early:**
 - `ViewSchema` — view mode, content type allowlist, thread scope
 - `GrantSchema` — messaging caps, group management caps, tool caps, egress caps
-- `AttestationSchema` — full attestation structure
+- `SealSchema` — full seal structure
 - `SessionSchema` — session config, expiry, binding
 - `BrokerEventSchema` — union of all canonical event types
 - `HarnessRequestSchema` — union of all harness -> broker requests
 
-**Why this matters for xmtp-broker specifically:**
-- The attestation format will eventually become a XIP — having it schema-defined from day one means the spec is always in sync with the code
+**Why this matters for xmtp-signet specifically:**
+- The seal format will eventually become a XIP — having it schema-defined from day one means the spec is always in sync with the code
 - Multiple transports (WebSocket, MCP, CLI) will all need the same validation — one schema serves all
 - Agent harnesses in different languages can consume the JSON Schema version

--- a/.agents/notes/outfitter-patterns/shared-handler-surfaces.md
+++ b/.agents/notes/outfitter-patterns/shared-handler-surfaces.md
@@ -1,6 +1,6 @@
 # Shared Handler Surfaces: Define Once, Expose Everywhere
 
-Extracted from `outfitter/stack` and adapted for xmtp-broker's multi-transport architecture.
+Extracted from `outfitter/stack` and adapted for xmtp-signet's multi-transport architecture.
 
 ## Core Pattern
 
@@ -30,7 +30,7 @@ A single `ActionSpec` object bundles everything needed to expose a domain handle
 ## ActionSpec Shape
 
 ```typescript
-interface ActionSpec<TInput, TOutput, TError extends BrokerError> {
+interface ActionSpec<TInput, TOutput, TError extends SignetError> {
   readonly id: string;
   readonly handler: Handler<TInput, TOutput, TError>;
   readonly input: z.ZodType<TInput>;
@@ -135,7 +135,7 @@ Each transport reads the ActionResult envelope and translates it:
 | Error detail | stderr + exit code | error content block | `error` field in response |
 | Pagination | `--cursor` flag, footer hint | in text content | in response frame |
 
-## Adaptation Notes for xmtp-broker
+## Adaptation Notes for xmtp-signet
 
 **What to adopt directly:**
 - ActionSpec bundling handler + schema + surface metadata

--- a/.agents/notes/outfitter-patterns/transport-agnostic-handlers.md
+++ b/.agents/notes/outfitter-patterns/transport-agnostic-handlers.md
@@ -1,6 +1,6 @@
 # Transport-Agnostic Handler Patterns
 
-Extracted from `outfitter/stack` as reference for xmtp-broker's broker interface design.
+Extracted from `outfitter/stack` as reference for xmtp-signet's broker interface design.
 
 ## Core Idea
 
@@ -124,11 +124,11 @@ All responses follow a consistent envelope:
 }
 ```
 
-## Adaptation Notes for xmtp-broker
+## Adaptation Notes for xmtp-signet
 
 **Key insight**: The broker's "derived plane" interface is essentially another transport surface. The same pattern applies:
 
-- **Broker core handlers** contain the domain logic (view filtering, grant enforcement, attestation management)
+- **Broker core handlers** contain the domain logic (view filtering, grant enforcement, seal management)
 - **WebSocket transport** adapts handlers for the primary live interface
 - **MCP transport** can expose the same handlers as MCP tools (later)
 - **CLI transport** can expose them as commands (later)

--- a/.agents/notes/outfitter-patterns/workspace-and-tooling.md
+++ b/.agents/notes/outfitter-patterns/workspace-and-tooling.md
@@ -1,6 +1,6 @@
 # Workspace and Tooling Patterns
 
-Extracted from `outfitter/stack` as reference for xmtp-broker scaffolding.
+Extracted from `outfitter/stack` as reference for xmtp-signet scaffolding.
 
 ## Bun Workspace
 
@@ -90,7 +90,7 @@ Build tool: **bunup** (Bun's native bundler) with a lock script to serialize bui
 - Entry points: `./dist/index.js` with types at `./dist/index.d.ts`
 - Three-tier hierarchy: Foundation (contracts, types) -> Runtime (cli, mcp, config, logging) -> Tooling (outfitter CLI, presets, docs)
 
-## Adaptation Notes for xmtp-broker
+## Adaptation Notes for xmtp-signet
 
 **Adopt directly:**
 - Bun workspace with `.bun-version` pin

--- a/.agents/plans/v0/01-repo-scaffolding.md
+++ b/.agents/plans/v0/01-repo-scaffolding.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This spec defines the workspace structure, build tooling, and developer conventions for xmtp-broker. It is the foundation every other spec depends on — nothing compiles, tests, or lints until this is in place.
+This spec defines the workspace structure, build tooling, and developer conventions for xmtp-signet. It is the foundation every other spec depends on — nothing compiles, tests, or lints until this is in place.
 
 The broker is a Bun-first TypeScript monorepo using workspaces from day one. The monorepo structure enforces the three-tier architecture (Foundation, Runtime, Transport) through package boundaries rather than convention alone. Each tier maps to a set of packages with explicit dependency rules: dependencies flow downward only.
 
@@ -45,15 +45,15 @@ xmtp-broker/
 ├── .reference/                 # Read-only reference codebases (gitignored)
 ├── apps/                          # Runnable entrypoints (empty for now)
 ├── packages/
-│   ├── schemas/                # @xmtp-broker/schemas
-│   ├── contracts/              # @xmtp-broker/contracts
-│   ├── core/                   # @xmtp-broker/core
-│   ├── policy/                 # @xmtp-broker/policy
-│   ├── sessions/               # @xmtp-broker/sessions
-│   ├── attestations/           # @xmtp-broker/attestations
-│   ├── keys/                   # @xmtp-broker/keys
-│   ├── ws/                     # @xmtp-broker/ws
-│   └── verifier/               # @xmtp-broker/verifier
+│   ├── schemas/                # @xmtp/signet-schemas
+│   ├── contracts/              # @xmtp/signet-contracts
+│   ├── core/                   # @xmtp/signet-core
+│   ├── policy/                 # @xmtp/signet-policy
+│   ├── sessions/               # @xmtp/signet-sessions
+│   ├── seals/                  # @xmtp/signet-seals
+│   ├── keys/                   # @xmtp/signet-keys
+│   ├── ws/                     # @xmtp/signet-ws
+│   └── verifier/               # @xmtp/signet-verifier
 ├── package.json                # Workspace root
 ├── tsconfig.base.json          # Shared TypeScript config
 ├── turbo.json                  # Build orchestration
@@ -130,7 +130,7 @@ Pin the Bun version. CI reads this file. Developers use `bun upgrade` to match.
 
 ```jsonc
 {
-  "name": "@xmtp-broker/<name>",
+  "name": "@xmtp/signet-<name>",
   "version": "0.0.0",
   "private": true,
   "type": "module",
@@ -158,14 +158,14 @@ Pin the Bun version. CI reads this file. Developers use `bun upgrade` to match.
 | Package | Runtime deps | Workspace deps |
 |---------|-------------|----------------|
 | `schemas` | `zod`, `better-result` | — |
-| `contracts` | `better-result` | `@xmtp-broker/schemas` |
-| `core` | `@xmtp/node-sdk`, `better-result` | `@xmtp-broker/schemas`, `@xmtp-broker/contracts` |
-| `policy` | `better-result` | `@xmtp-broker/schemas`, `@xmtp-broker/contracts` |
-| `sessions` | `better-result` | `@xmtp-broker/schemas`, `@xmtp-broker/contracts` |
-| `attestations` | `better-result` | `@xmtp-broker/schemas`, `@xmtp-broker/contracts` |
-| `keys` | `better-result` | `@xmtp-broker/schemas`, `@xmtp-broker/contracts` |
-| `ws` | `better-result` | `@xmtp-broker/schemas`, `@xmtp-broker/contracts`, `@xmtp-broker/core`, `@xmtp-broker/policy`, `@xmtp-broker/sessions` |
-| `verifier` | `better-result`, `zod` | `@xmtp-broker/schemas` |
+| `contracts` | `better-result` | `@xmtp/signet-schemas` |
+| `core` | `@xmtp/node-sdk`, `better-result` | `@xmtp/signet-schemas`, `@xmtp/signet-contracts` |
+| `policy` | `better-result` | `@xmtp/signet-schemas`, `@xmtp/signet-contracts` |
+| `sessions` | `better-result` | `@xmtp/signet-schemas`, `@xmtp/signet-contracts` |
+| `attestations` | `better-result` | `@xmtp/signet-schemas`, `@xmtp/signet-contracts` |
+| `keys` | `better-result` | `@xmtp/signet-schemas`, `@xmtp/signet-contracts` |
+| `ws` | `better-result` | `@xmtp/signet-schemas`, `@xmtp/signet-contracts`, `@xmtp/signet-core`, `@xmtp/signet-policy`, `@xmtp/signet-sessions` |
+| `verifier` | `better-result`, `zod` | `@xmtp/signet-schemas` |
 
 Workspace deps use `"workspace:*"` in the `dependencies` field.
 
@@ -470,40 +470,40 @@ package.json                                    # Workspace root
 tsconfig.base.json                              # Shared TS config
 turbo.json                                      # Build orchestration
 
-packages/schemas/package.json                   # @xmtp-broker/schemas
+packages/schemas/package.json                   # @xmtp/signet-schemas
 packages/schemas/tsconfig.json                  # Extends base
 packages/schemas/src/index.ts                   # Export stub
 packages/schemas/src/__tests__/smoke.test.ts    # Smoke test
 
-packages/contracts/package.json                 # @xmtp-broker/contracts
+packages/contracts/package.json                 # @xmtp/signet-contracts
 packages/contracts/tsconfig.json
 packages/contracts/src/index.ts
 
-packages/core/package.json                      # @xmtp-broker/core
+packages/core/package.json                      # @xmtp/signet-core
 packages/core/tsconfig.json
 packages/core/src/index.ts
 
-packages/policy/package.json                    # @xmtp-broker/policy
+packages/policy/package.json                    # @xmtp/signet-policy
 packages/policy/tsconfig.json
 packages/policy/src/index.ts
 
-packages/sessions/package.json                  # @xmtp-broker/sessions
+packages/sessions/package.json                  # @xmtp/signet-sessions
 packages/sessions/tsconfig.json
 packages/sessions/src/index.ts
 
-packages/attestations/package.json              # @xmtp-broker/attestations
-packages/attestations/tsconfig.json
-packages/attestations/src/index.ts
+packages/seals/package.json                     # @xmtp/signet-seals
+packages/seals/tsconfig.json
+packages/seals/src/index.ts
 
-packages/keys/package.json                      # @xmtp-broker/keys
+packages/keys/package.json                      # @xmtp/signet-keys
 packages/keys/tsconfig.json
 packages/keys/src/index.ts
 
-packages/ws/package.json                        # @xmtp-broker/ws
+packages/ws/package.json                        # @xmtp/signet-ws
 packages/ws/tsconfig.json
 packages/ws/src/index.ts
 
-packages/verifier/package.json                  # @xmtp-broker/verifier
+packages/verifier/package.json                  # @xmtp/signet-verifier
 packages/verifier/tsconfig.json
 packages/verifier/src/index.ts
 ```

--- a/.agents/plans/v0/02-schemas.md
+++ b/.agents/plans/v0/02-schemas.md
@@ -1,25 +1,25 @@
 # 02-schemas
 
-**Package:** `@xmtp-broker/schemas`
+**Package:** `@xmtp/signet-schemas`
 **Spec version:** 0.1.0
 
 ## Overview
 
 The schemas package is the foundation of the entire broker system. It defines every Zod schema, inferred TypeScript type, and error class used across all other packages. No runtime logic lives here -- only shapes, validation, and error taxonomy.
 
-Cross-package interfaces (service contracts, provider interfaces, event types) live in `@xmtp-broker/contracts`, not here. The split principle: **schemas** = "what shape is the data?" while **contracts** = "what can components do to each other?" See [02b-contracts](02b-contracts.md) for the contracts package spec.
+Cross-package interfaces (service contracts, provider interfaces, event types) live in `@xmtp/signet-contracts`, not here. The split principle: **schemas** = "what shape is the data?" while **contracts** = "what can components do to each other?" See [02b-contracts](02b-contracts.md) for the contracts package spec.
 
-Every other package in the broker monorepo imports from `@xmtp-broker/schemas`. Nothing imports into it except `@xmtp-broker/contracts`. This zero-dependency position means changes here cascade everywhere, so the schemas must be stable, well-described, and complete from day one.
+Every other package in the broker monorepo imports from `@xmtp/signet-schemas`. Nothing imports into it except `@xmtp/signet-contracts`. This zero-dependency position means changes here cascade everywhere, so the schemas must be stable, well-described, and complete from day one.
 
 All schemas carry `.describe()` annotations so they can be converted to JSON Schema for MCP tool definitions, documentation generation, and cross-language harness consumption. All TypeScript types are derived via `z.infer<>` -- no manual interfaces, no type duplication.
 
-Fields that are conceptually optional use `.nullable()` with an explicit `null` value, never `.optional()`. This ensures every attestation, event, and request has a predictable shape regardless of which fields are populated.
+Fields that are conceptually optional use `.nullable()` with an explicit `null` value, never `.optional()`. This ensures every seal, event, and request has a predictable shape regardless of which fields are populated.
 
 ## Dependencies
 
 **Imports:** `zod` (sole runtime dependency)
 
-**Imported by:** `@xmtp-broker/contracts` (directly), and transitively by every other `@xmtp-broker/*` package
+**Imported by:** `@xmtp/signet-contracts` (directly), and transitively by every other `@xmtp/signet-*` package
 
 ## Public Interfaces
 
@@ -198,9 +198,9 @@ const GrantConfig = z.object({
 type GrantConfig = z.infer<typeof GrantConfig>;
 ```
 
-### Attestation Schema
+### Seal Schema
 
-The full attestation schema. All fields are present; optional fields use `null`. This is the shape posted to the group as a structured content type.
+The full seal schema. All fields are present; optional fields use `null`. This is the shape posted to the group as a structured content type.
 
 ```typescript
 const InferenceMode = z.enum([
@@ -250,7 +250,7 @@ type TrustTier = z.infer<typeof TrustTier>;
 
 const RevocationRules = z.object({
   maxTtlSeconds: z.number().int().positive()
-    .describe("Maximum attestation lifetime in seconds"),
+    .describe("Maximum seal lifetime in seconds"),
   requireHeartbeat: z.boolean()
     .describe("Whether missed heartbeats trigger auto-revocation"),
   ownerCanRevoke: z.boolean()
@@ -264,7 +264,7 @@ type RevocationRules = z.infer<typeof RevocationRules>;
 const AttestationSchema = z.object({
   attestationId: z.string().describe("Unique identifier for this attestation"),
   previousAttestationId: z.string().nullable()
-    .describe("ID of the attestation this supersedes, null for initial"),
+    .describe("ID of the seal this supersedes, null for initial"),
   agentInboxId: z.string().describe("XMTP inbox ID of the agent"),
   ownerInboxId: z.string().describe("XMTP inbox ID of the agent's owner"),
   groupId: z.string().describe("Group this attestation applies to"),
@@ -298,14 +298,14 @@ const AttestationSchema = z.object({
   heartbeatInterval: z.number().int().positive().default(30)
     .describe("Expected heartbeat cadence in seconds"),
   issuedAt: z.string().datetime()
-    .describe("ISO 8601 timestamp when this attestation was issued"),
+    .describe("ISO 8601 timestamp when this seal was issued"),
   expiresAt: z.string().datetime()
-    .describe("ISO 8601 timestamp when this attestation expires"),
+    .describe("ISO 8601 timestamp when this seal expires"),
   revocationRules: RevocationRules
     .describe("Rules governing revocation of this attestation"),
   issuer: z.string()
-    .describe("Identity of the attestation issuer (broker's signing identity)"),
-}).describe("Group-visible capability attestation for an agent");
+    .describe("Identity of the seal issuer (broker's signing identity)"),
+}).describe("Group-visible capability seal for an agent");
 
 type Attestation = z.infer<typeof AttestationSchema>;
 ```
@@ -413,15 +413,15 @@ const SessionRevocationReason = z.enum([
 type SessionRevocationReason = z.infer<typeof SessionRevocationReason>;
 
 const RevocationAttestation = z.object({
-  attestationId: z.string().describe("ID of this revocation attestation"),
+  attestationId: z.string().describe("ID of this revocation seal"),
   previousAttestationId: z.string()
-    .describe("ID of the attestation being revoked"),
+    .describe("ID of the seal being revoked"),
   agentInboxId: z.string().describe("Agent being revoked"),
   groupId: z.string().describe("Group the revocation applies to"),
   reason: AgentRevocationReason.describe("Why the agent was revoked"),
   revokedAt: z.string().datetime().describe("When the revocation took effect"),
   issuer: z.string().describe("Identity of the revocation issuer"),
-}).describe("Group-visible revocation of an agent's attestation");
+}).describe("Group-visible revocation of an agent's seal");
 
 type RevocationAttestation = z.infer<typeof RevocationAttestation>;
 ```
@@ -451,13 +451,13 @@ const MessageEvent = z.object({
   visibility: MessageVisibility.describe("How this message is projected"),
   sentAt: z.string().datetime().describe("When the message was sent"),
   attestationId: z.string().nullable()
-    .describe("Attestation ID if sent by a brokered agent, null otherwise"),
+    .describe("Seal ID if sent by a brokered agent, null otherwise"),
 }).describe("A message projected to the agent according to its view");
 
 const AttestationEvent = z.object({
   type: z.literal("attestation.updated").describe("Event type discriminator"),
-  attestation: AttestationSchema.describe("The updated attestation"),
-}).describe("Attestation was published or updated");
+  attestation: AttestationSchema.describe("The updated seal"),
+}).describe("Seal was published or updated");
 
 const SessionStartedEvent = z.object({
   type: z.literal("session.started").describe("Event type discriminator"),
@@ -701,7 +701,7 @@ function errorCategoryMeta(category: ErrorCategory): ErrorCategoryMeta {
  * Base interface for all broker errors. Discriminated by `_tag`.
  * Never constructed directly -- use the static factory on each subclass.
  */
-interface BrokerError extends Error {
+interface SignetError extends Error {
   readonly _tag: string;
   readonly code: number;
   readonly category: ErrorCategory;
@@ -716,7 +716,7 @@ Each class has a static `create()` factory, a numeric code, and maps to one cate
 ```typescript
 // -- validation (code range 1000-1099) --
 
-class ValidationError extends Error implements BrokerError {
+class ValidationError extends Error implements SignetError {
   readonly _tag = "ValidationError";
   readonly code = 1000;
   readonly category = "validation" as const;
@@ -735,7 +735,7 @@ class ValidationError extends Error implements BrokerError {
 
 // -- not_found (1100-1199) --
 
-class NotFoundError extends Error implements BrokerError {
+class NotFoundError extends Error implements SignetError {
   readonly _tag = "NotFoundError";
   readonly code = 1100;
   readonly category = "not_found" as const;
@@ -754,7 +754,7 @@ class NotFoundError extends Error implements BrokerError {
 
 // -- permission (1200-1299) --
 
-class PermissionError extends Error implements BrokerError {
+class PermissionError extends Error implements SignetError {
   readonly _tag = "PermissionError";
   readonly code = 1200;
   readonly category = "permission" as const;
@@ -768,7 +768,7 @@ class PermissionError extends Error implements BrokerError {
   }
 }
 
-class GrantDeniedError extends Error implements BrokerError {
+class GrantDeniedError extends Error implements SignetError {
   readonly _tag = "GrantDeniedError";
   readonly code = 1210;
   readonly category = "permission" as const;
@@ -787,7 +787,7 @@ class GrantDeniedError extends Error implements BrokerError {
 
 // -- auth (1300-1399) --
 
-class AuthError extends Error implements BrokerError {
+class AuthError extends Error implements SignetError {
   readonly _tag = "AuthError";
   readonly code = 1300;
   readonly category = "auth" as const;
@@ -801,7 +801,7 @@ class AuthError extends Error implements BrokerError {
   }
 }
 
-class SessionExpiredError extends Error implements BrokerError {
+class SessionExpiredError extends Error implements SignetError {
   readonly _tag = "SessionExpiredError";
   readonly code = 1310;
   readonly category = "auth" as const;
@@ -820,7 +820,7 @@ class SessionExpiredError extends Error implements BrokerError {
 
 // -- internal (1400-1499) --
 
-class InternalError extends Error implements BrokerError {
+class InternalError extends Error implements SignetError {
   readonly _tag = "InternalError";
   readonly code = 1400;
   readonly category = "internal" as const;
@@ -836,7 +836,7 @@ class InternalError extends Error implements BrokerError {
 
 // -- timeout (1500-1599) --
 
-class TimeoutError extends Error implements BrokerError {
+class TimeoutError extends Error implements SignetError {
   readonly _tag = "TimeoutError";
   readonly code = 1500;
   readonly category = "timeout" as const;
@@ -855,7 +855,7 @@ class TimeoutError extends Error implements BrokerError {
 
 // -- cancelled (1600-1699) --
 
-class CancelledError extends Error implements BrokerError {
+class CancelledError extends Error implements SignetError {
   readonly _tag = "CancelledError";
   readonly code = 1600;
   readonly category = "cancelled" as const;
@@ -871,7 +871,7 @@ class CancelledError extends Error implements BrokerError {
 
 // -- domain-specific --
 
-class AttestationError extends Error implements BrokerError {
+class AttestationError extends Error implements SignetError {
   readonly _tag = "AttestationError";
   readonly code = 1010;
   readonly category = "validation" as const;
@@ -892,7 +892,7 @@ class AttestationError extends Error implements BrokerError {
 ### Discriminated Error Matching
 
 ```typescript
-type AnyBrokerError =
+type AnySignetError =
   | ValidationError
   | NotFoundError
   | PermissionError
@@ -906,8 +906,8 @@ type AnyBrokerError =
 
 /** Type-safe error matching by _tag discriminant. */
 function matchError<T>(
-  error: AnyBrokerError,
-  handlers: { [K in AnyBrokerError["_tag"]]: (e: Extract<AnyBrokerError, { _tag: K }>) => T },
+  error: AnySignetError,
+  handlers: { [K in AnySignetError["_tag"]]: (e: Extract<AnySignetError, { _tag: K }>) => T },
 ): T {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (handlers as any)[error._tag](error);
@@ -922,7 +922,7 @@ This package has no runtime behavior beyond validation. All schemas are pure dec
 
 1. `ViewConfig` and `GrantConfig` are independently composable -- any view mode can pair with any grant configuration.
 2. The effective content type allowlist for an agent is `intersection(broker.allowlist, agent.view.contentTypes)`. The schemas define the agent's requested list; the policy engine computes the effective list at runtime.
-3. Attestation `grantedOps` is a string array derived from the `GrantConfig` at attestation time. The mapping from structured grants to string identifiers is defined in the attestation package, not here.
+3. Attestation `grantedOps` is a string array derived from the `GrantConfig` at seal time. The mapping from structured grants to string identifiers is defined in the seal package, not here.
 
 ### Nullable vs Optional Convention
 
@@ -942,24 +942,24 @@ This package defines errors but does not produce them at runtime. Error producti
 
 ## Open Questions Resolved
 
-**Q: What is the exact minimum viable attestation schema?** (PRD Open Questions)
-**A:** Full schema from day one with all 24 fields. Fields that may not be populated use `null`. Rationale: prevents schema drift, clients always know the shape, and the attestation format is a candidate XIP -- better to define it completely now than to add fields later and break consumers.
+**Q: What is the exact minimum viable seal schema?** (PRD Open Questions)
+**A:** Full schema from day one with all 24 fields. Fields that may not be populated use `null`. Rationale: prevents schema drift, clients always know the shape, and the seal format is a candidate XIP -- better to define it completely now than to add fields later and break consumers.
 
 **Q: Should session issuance be tied to explicit per-thread scopes by default?** (PRD Open Questions)
 **A:** No. Sessions scope to agent + groups via `ViewConfig.threadScopes`. Thread filtering is a view concern within a session, not a session-level binding. Rationale: simpler session model; thread scoping changes are non-material view updates that don't require session reauthorization.
 
 **Q: What is the appropriate default heartbeat interval?** (PRD Open Questions)
-**A:** 30 seconds, configurable per-agent via `SessionConfig.heartbeatInterval` and reflected in the attestation's `heartbeatInterval` field. Rationale: balances liveness visibility with noise; 30s is fast enough to detect outages within a minute, slow enough to avoid overhead.
+**A:** 30 seconds, configurable per-agent via `SessionConfig.heartbeatInterval` and reflected in the seal's `heartbeatInterval` field. Rationale: balances liveness visibility with noise; 30s is fast enough to detect outages within a minute, slow enough to avoid overhead.
 
 **Q: How should content type allowlist updates be surfaced?** (PRD Open Questions)
-**A:** Adding content types to the allowlist is a material change that produces a new attestation. The attestation's `contentTypes` array reflects the current effective list, and `previousAttestationId` creates a diff chain. The broker logs the delta internally. Rationale: consistent with the materiality rules -- any change to what an agent can see is material.
+**A:** Adding content types to the allowlist is a material change that produces a new seal. The seal's `contentTypes` array reflects the current effective list, and `previousSealId` creates a diff chain. The broker logs the delta internally. Rationale: consistent with the materiality rules -- any change to what an agent can see is material.
 
 ## Deferred
 
 - **Conflict and rate_limit error categories**: The v0 taxonomy covers 7 categories. `conflict` (AlreadyExistsError) and `rate_limit` (RateLimitError) will be added when transports mature and produce those conditions. Adding them now would create dead code.
 - **Network error category**: Deferred until the broker has external service dependencies that produce transient network failures distinct from timeouts.
 - **Custom content type registration API**: The `CONTENT_TYPE_SCHEMAS` record is extensible at the code level. A runtime registration API (e.g., `registerContentType(id, schema)`) is deferred to Phase 2 when plugin architecture is designed.
-- **Attestation signature schema**: The attestation schema defines the payload shape. The signed envelope schemas (`SignedAttestationEnvelope`, `SignedRevocationEnvelope`) live in `@xmtp-broker/contracts` as protocol wire formats.
+- **Attestation signature schema**: The seal schema defines the payload shape. The signed envelope schemas (`SignedAttestationEnvelope`, `SignedRevocationEnvelope`) live in `@xmtp/signet-contracts` as protocol wire formats.
 - **Zod-to-JSON-Schema utility**: The `zodToJsonSchema()` conversion for MCP is a transport concern. This package provides the Zod schemas; the MCP adapter converts them.
 
 ## Testing Strategy
@@ -1040,7 +1040,7 @@ packages/schemas/
     errors/
       index.ts                  # Re-exports all error types
       category.ts               # ErrorCategory, ErrorCategoryMeta, errorCategoryMeta()
-      base.ts                   # BrokerError interface, AnyBrokerError union, matchError()
+      base.ts                   # SignetError interface, AnySignetError union, matchError()
       validation.ts             # ValidationError, AttestationError
       not-found.ts              # NotFoundError
       permission.ts             # PermissionError, GrantDeniedError

--- a/.agents/plans/v0/02b-contracts.md
+++ b/.agents/plans/v0/02b-contracts.md
@@ -1,11 +1,11 @@
 # 02b — Contracts
 
-**Package:** `@xmtp-broker/contracts`
+**Package:** `@xmtp/signet-contracts`
 **Spec version:** 0.1.0
 
 ## Overview
 
-The contracts package defines cross-package interfaces that runtime packages implement and consume. It sits between `@xmtp-broker/schemas` (data shapes) and the runtime tier, providing a stable interface layer that decouples packages from each other's implementations.
+The contracts package defines cross-package interfaces that runtime packages implement and consume. It sits between `@xmtp/signet-schemas` (data shapes) and the runtime tier, providing a stable interface layer that decouples packages from each other's implementations.
 
 **Split principle:** Schemas answer "what shape is the data?" while contracts answer "what can components do to each other?" This keeps `schemas` zero-dep beyond Zod, and gives runtime packages a single place to find the interfaces they implement or depend on.
 
@@ -13,7 +13,7 @@ This package contains no runtime logic -- only TypeScript interfaces, type alias
 
 ## Dependencies
 
-**Imports:** `@xmtp-broker/schemas` (sole workspace dependency), `better-result` (for `Result` type in interface signatures)
+**Imports:** `@xmtp/signet-schemas` (sole workspace dependency), `better-result` (for `Result` type in interface signatures)
 
 **Imported by:** All runtime packages (`core`, `policy`, `sessions`, `attestations`, `keys`), transport packages (`ws`)
 
@@ -25,31 +25,31 @@ Interfaces implemented by runtime packages to provide their core functionality. 
 
 | Interface | Source spec | Description |
 |-----------|-----------|-------------|
-| `BrokerCore` | 03 | Top-level broker lifecycle: initialize, shutdown, state transitions |
+| `SignetCore` | 03 | Top-level broker lifecycle: initialize, shutdown, state transitions |
 | `SessionManager` | 05 | Session issuance, lookup, revocation, heartbeat processing |
-| `AttestationManager` | 06 | Attestation lifecycle: issue, refresh, revoke, query |
+| `SealManager` | 06 | Seal lifecycle: issue, refresh, revoke, query |
 
 ```typescript
-interface BrokerCore {
+interface SignetCore {
   readonly state: CoreState;
-  initialize(): Promise<Result<void, BrokerError>>;
-  shutdown(): Promise<Result<void, BrokerError>>;
-  getGroupInfo(groupId: string): Promise<Result<GroupInfo, BrokerError>>;
+  initialize(): Promise<Result<void, SignetError>>;
+  shutdown(): Promise<Result<void, SignetError>>;
+  getGroupInfo(groupId: string): Promise<Result<GroupInfo, SignetError>>;
 }
 
 interface SessionManager {
-  issue(config: SessionConfig): Promise<Result<SessionToken, BrokerError>>;
-  lookup(sessionId: string): Promise<Result<SessionRecord, BrokerError>>;
-  revoke(sessionId: string, reason: SessionRevocationReason): Promise<Result<void, BrokerError>>;
-  heartbeat(sessionId: string): Promise<Result<void, BrokerError>>;
-  isActive(sessionId: string): Promise<Result<boolean, BrokerError>>;
+  issue(config: SessionConfig): Promise<Result<SessionToken, SignetError>>;
+  lookup(sessionId: string): Promise<Result<SessionRecord, SignetError>>;
+  revoke(sessionId: string, reason: SessionRevocationReason): Promise<Result<void, SignetError>>;
+  heartbeat(sessionId: string): Promise<Result<void, SignetError>>;
+  isActive(sessionId: string): Promise<Result<boolean, SignetError>>;
 }
 
-interface AttestationManager {
-  issue(sessionId: string, groupId: string): Promise<Result<SignedAttestation, BrokerError>>;
-  refresh(attestationId: string): Promise<Result<SignedAttestation, BrokerError>>;
-  revoke(attestationId: string, reason: AgentRevocationReason): Promise<Result<void, BrokerError>>;
-  current(agentInboxId: string, groupId: string): Promise<Result<SignedAttestation | null, BrokerError>>;
+interface SealManager {
+  issue(sessionId: string, groupId: string): Promise<Result<SignedAttestation, SignetError>>;
+  refresh(attestationId: string): Promise<Result<SignedAttestation, SignetError>>;
+  revoke(attestationId: string, reason: AgentRevocationReason): Promise<Result<void, SignetError>>;
+  current(agentInboxId: string, groupId: string): Promise<Result<SignedAttestation | null, SignetError>>;
 }
 ```
 
@@ -60,32 +60,32 @@ Interfaces that abstract external dependencies. Runtime packages depend on these
 | Interface | Source spec | Description |
 |-----------|-----------|-------------|
 | `SignerProvider` | 03/07 | Abstracts key material for signing operations |
-| `AttestationSigner` | 06 | Signs attestation payloads |
-| `AttestationPublisher` | 06 | Publishes signed attestations to groups |
+| `AttestationSigner` | 06 | Signs seal payloads |
+| `AttestationPublisher` | 06 | Publishes signed seals to groups |
 | `RevealStateStore` | 04 | Persists and queries reveal grant state |
 
 ```typescript
 interface SignerProvider {
-  sign(data: Uint8Array): Promise<Result<Uint8Array, BrokerError>>;
-  getPublicKey(): Promise<Result<Uint8Array, BrokerError>>;
-  getFingerprint(): Promise<Result<string, BrokerError>>;
+  sign(data: Uint8Array): Promise<Result<Uint8Array, SignetError>>;
+  getPublicKey(): Promise<Result<Uint8Array, SignetError>>;
+  getFingerprint(): Promise<Result<string, SignetError>>;
 }
 
 interface AttestationSigner {
-  sign(payload: Attestation): Promise<Result<SignedAttestation, BrokerError>>;
-  signRevocation(payload: RevocationAttestation): Promise<Result<SignedRevocationEnvelope, BrokerError>>;
+  sign(payload: Attestation): Promise<Result<SignedAttestation, SignetError>>;
+  signRevocation(payload: RevocationAttestation): Promise<Result<SignedRevocationEnvelope, SignetError>>;
 }
 
 interface AttestationPublisher {
-  publish(groupId: string, attestation: SignedAttestation): Promise<Result<void, BrokerError>>;
-  publishRevocation(groupId: string, revocation: SignedRevocationEnvelope): Promise<Result<void, BrokerError>>;
+  publish(groupId: string, attestation: SignedAttestation): Promise<Result<void, SignetError>>;
+  publishRevocation(groupId: string, revocation: SignedRevocationEnvelope): Promise<Result<void, SignetError>>;
 }
 
 interface RevealStateStore {
-  grant(revealGrant: RevealGrant): Promise<Result<void, BrokerError>>;
-  revoke(revealId: string): Promise<Result<void, BrokerError>>;
-  activeReveals(sessionId: string): Promise<Result<RevealState, BrokerError>>;
-  isRevealed(sessionId: string, messageId: string): Promise<Result<boolean, BrokerError>>;
+  grant(revealGrant: RevealGrant): Promise<Result<void, SignetError>>;
+  revoke(revealId: string): Promise<Result<void, SignetError>>;
+  activeReveals(sessionId: string): Promise<Result<RevealState, SignetError>>;
+  isRevealed(sessionId: string, messageId: string): Promise<Result<boolean, SignetError>>;
 }
 ```
 
@@ -174,15 +174,15 @@ type GrantError = GrantDeniedError | PermissionError;
 
 ### Protocol Wire Formats
 
-Signed envelope schemas for attestations published to groups. These are Zod schemas (not plain interfaces) because they define wire formats that must be validated at boundaries. They live in contracts rather than schemas because they compose schemas with signing metadata that only makes sense in the context of the attestation/signing contracts.
+Signed envelope schemas for seals published to groups. These are Zod schemas (not plain interfaces) because they define wire formats that must be validated at boundaries. They live in contracts rather than schemas because they compose schemas with signing metadata that only makes sense in the context of the seal/signing contracts.
 
 ```typescript
 const SignedAttestationEnvelope = z.object({
-  attestation: AttestationSchema.describe("The attestation payload"),
-  signature: z.string().describe("Base64-encoded signature over the canonical attestation bytes"),
+  attestation: AttestationSchema.describe("The seal payload"),
+  signature: z.string().describe("Base64-encoded signature over the canonical seal bytes"),
   signingAlgorithm: z.string().describe("Algorithm used to produce the signature"),
   signingKeyRef: z.string().describe("Reference to the key that produced the signature"),
-}).describe("Signed attestation ready for group publication");
+}).describe("Signed seal ready for group publication");
 
 type SignedAttestation = z.infer<typeof SignedAttestationEnvelope>;
 
@@ -204,7 +204,7 @@ packages/contracts/
   tsconfig.json
   src/
     index.ts                    # Re-exports all public API
-    services.ts                 # BrokerCore, SessionManager, AttestationManager
+    services.ts                 # SignetCore, SessionManager, SealManager
     providers.ts                # SignerProvider, AttestationSigner, AttestationPublisher, RevealStateStore
     core-types.ts               # CoreState, CoreContext, GroupInfo, RawMessage, RawEvent
     session-types.ts            # SessionRecord, MaterialityCheck
@@ -220,7 +220,7 @@ Each source file stays well under 200 LOC. Interfaces are pure declarations with
 
 ```jsonc
 {
-  "name": "@xmtp-broker/contracts",
+  "name": "@xmtp/signet-contracts",
   "version": "0.0.0",
   "private": true,
   "type": "module",
@@ -237,7 +237,7 @@ Each source file stays well under 200 LOC. Interfaces are pure declarations with
     "test": "bun test"
   },
   "dependencies": {
-    "@xmtp-broker/schemas": "workspace:*",
+    "@xmtp/signet-schemas": "workspace:*",
     "better-result": "catalog:",
     "zod": "catalog:"
   },
@@ -249,7 +249,7 @@ Each source file stays well under 200 LOC. Interfaces are pure declarations with
 
 ## Notes
 
-- **Minimize re-exports.** Each item has one canonical home. Runtime packages import interfaces from `@xmtp-broker/contracts`, data shapes from `@xmtp-broker/schemas`. Neither re-exports from the other.
+- **Minimize re-exports.** Each item has one canonical home. Runtime packages import interfaces from `@xmtp/signet-contracts`, data shapes from `@xmtp/signet-schemas`. Neither re-exports from the other.
 - **No circular deps.** `contracts` imports from `schemas` only. Runtime packages import from both `schemas` and `contracts` but never from each other's internals.
 - **Interface evolution.** Adding a new optional method to a service interface is non-breaking. Adding a required method requires coordinating across implementing packages -- treat it as a material change.
-- **`zod` in contracts.** The signed envelope schemas are the only Zod usage in this package. They exist here (not in `schemas`) because they compose attestation schemas with signing metadata that is part of the contract, not the data shape.
+- **`zod` in contracts.** The signed envelope schemas are the only Zod usage in this package. They exist here (not in `schemas`) because they compose seal schemas with signing metadata that is part of the contract, not the data shape.

--- a/.agents/plans/v0/03-broker-core.md
+++ b/.agents/plans/v0/03-broker-core.md
@@ -1,6 +1,6 @@
 # 03-broker-core
 
-**Package:** `@xmtp-broker/core`
+**Package:** `@xmtp/signet-core`
 **Spec version:** 0.1.0
 
 ## Overview
@@ -11,26 +11,26 @@ The core's primary job is lifecycle management. It starts XMTP clients (one per 
 
 Per-group identity is default-on. Following the convos-node-sdk pattern (ADR 002), each group conversation gets its own wallet key, database encryption key, and XMTP client instance. This provides maximum isolation: compromising one identity reveals nothing about others, and group membership lists never cross-contaminate. The feature is configurable -- simpler deployments can disable it and use a single identity across groups.
 
-The core exposes a `BrokerCore` service with a start/stop lifecycle, an `EventEmitter`-style interface for raw events, and a context object that downstream consumers use to send messages or query state through the core's sealed boundary.
+The core exposes a `SignetCore` service with a start/stop lifecycle, an `EventEmitter`-style interface for raw events, and a context object that downstream consumers use to send messages or query state through the core's sealed boundary.
 
 ## Dependencies
 
 **Imports:**
 - `@xmtp/node-sdk` -- XMTP Client, Conversations, Group, Signer types
-- `@xmtp-broker/contracts` -- `SignerProvider`, `RawEvent`, `CoreContext`, `BrokerCore`, `CoreState`, `GroupInfo` (canonical interface definitions)
-- `@xmtp-broker/schemas` -- event schemas, error types, content type definitions
+- `@xmtp/signet-contracts` -- `SignerProvider`, `RawEvent`, `CoreContext`, `SignetCore`, `CoreState`, `GroupInfo` (canonical interface definitions)
+- `@xmtp/signet-schemas` -- event schemas, error types, content type definitions
 - `better-result` -- Result type for fallible operations
 - `zod` -- runtime validation at the XMTP boundary
 
 **Imported by:**
-- `@xmtp-broker/policy` -- subscribes to raw events, uses core context for actions
-- `@xmtp-broker/sessions` -- queries core for agent identity info
-- `@xmtp-broker/attestations` -- uses core context to publish attestation messages
-- `@xmtp-broker/ws` -- indirectly, through the policy/session layer
+- `@xmtp/signet-policy` -- subscribes to raw events, uses core context for actions
+- `@xmtp/signet-sessions` -- queries core for agent identity info
+- `@xmtp/signet-seals` -- uses core context to publish seal messages
+- `@xmtp/signet-ws` -- indirectly, through the policy/session layer
 
 ## Public Interfaces
 
-> **Note:** The following interfaces are canonically defined in `@xmtp-broker/contracts`: `SignerProvider`, `RawEvent` (union), `CoreContext`, `GroupInfo`, `BrokerCore`, `CoreState`. This package implements them. The descriptions below document behavior and usage; the contracts package is the source of truth for the type signatures.
+> **Note:** The following interfaces are canonically defined in `@xmtp/signet-contracts`: `SignerProvider`, `RawEvent` (union), `CoreContext`, `GroupInfo`, `SignetCore`, `CoreState`. This package implements them. The descriptions below document behavior and usage; the contracts package is the source of truth for the type signatures.
 
 ### Configuration
 
@@ -48,7 +48,7 @@ const IdentityModeSchema = z.enum([
   "shared",
 ]).describe("Whether each group gets a unique identity or shares one");
 
-const BrokerCoreConfigSchema = z.object({
+const SignetCoreConfigSchema = z.object({
   dataDir: z.string().describe("Base directory for all broker data"),
   env: XmtpEnvSchema.default("dev")
     .describe("XMTP network environment"),
@@ -62,7 +62,7 @@ const BrokerCoreConfigSchema = z.object({
     .describe("App version string sent to XMTP network"),
 }).describe("Broker core configuration");
 
-type BrokerCoreConfig = z.infer<typeof BrokerCoreConfigSchema>;
+type SignetCoreConfig = z.infer<typeof SignetCoreConfigSchema>;
 ```
 
 ### Identity Store
@@ -107,7 +107,7 @@ interface IdentityStore {
 
 ### Signer Adapter
 
-The core does not manage raw key bytes directly. It delegates signing to a `SignerProvider` injected at construction. This allows the key management package (`@xmtp-broker/keys`) to provide hardware-backed signers while the core remains key-agnostic.
+The core does not manage raw key bytes directly. It delegates signing to a `SignerProvider` injected at construction. This allows the key management package (`@xmtp/signet-keys`) to provide hardware-backed signers while the core remains key-agnostic.
 
 ```typescript
 import type { Signer } from "@xmtp/node-sdk";
@@ -192,7 +192,7 @@ interface CoreContext {
     groupId: string,
     contentType: string,
     content: unknown,
-  ): Promise<Result<{ messageId: string }, BrokerError>>;
+  ): Promise<Result<{ messageId: string }, SignetError>>;
 
   /** Get group metadata. */
   getGroupInfo(
@@ -206,19 +206,19 @@ interface CoreContext {
   addMembers(
     groupId: string,
     inboxIds: readonly string[],
-  ): Promise<Result<void, BrokerError>>;
+  ): Promise<Result<void, SignetError>>;
 
   /** Remove members from a group. */
   removeMembers(
     groupId: string,
     inboxIds: readonly string[],
-  ): Promise<Result<void, BrokerError>>;
+  ): Promise<Result<void, SignetError>>;
 
   /** Get the inbox ID for a given group's identity. */
   getInboxId(groupId: string): Promise<Result<string, NotFoundError>>;
 
   /** Force a sync for a specific group. */
-  syncGroup(groupId: string): Promise<Result<void, BrokerError>>;
+  syncGroup(groupId: string): Promise<Result<void, SignetError>>;
 }
 
 interface GroupInfo {
@@ -230,18 +230,18 @@ interface GroupInfo {
 }
 ```
 
-### BrokerCore Service
+### SignetCore Service
 
 ```typescript
 type RawEventHandler = (event: RawEvent) => void;
 
 /** The core service managing the raw XMTP plane. */
-interface BrokerCore {
+interface SignetCore {
   /** Start the core: initialize clients, begin streaming. */
-  start(): Promise<Result<void, BrokerError>>;
+  start(): Promise<Result<void, SignetError>>;
 
   /** Stop the core: close streams, disconnect clients. */
-  stop(): Promise<Result<void, BrokerError>>;
+  stop(): Promise<Result<void, SignetError>>;
 
   /** Subscribe to raw events. Returns an unsubscribe function. */
   on(handler: RawEventHandler): () => void;
@@ -258,7 +258,7 @@ type CoreState = "idle" | "starting" | "running" | "stopping" | "stopped" | "err
 
 ## Zod Schemas
 
-Core-specific schemas are defined above (`BrokerCoreConfigSchema`, `XmtpEnvSchema`, `IdentityModeSchema`). All other schemas (events, errors, content types) are imported from `@xmtp-broker/schemas` as defined in `02-schemas.md`.
+Core-specific schemas are defined above (`SignetCoreConfigSchema`, `XmtpEnvSchema`, `IdentityModeSchema`). All other schemas (events, errors, content types) are imported from `@xmtp/signet-schemas` as defined in `02-schemas.md`.
 
 Raw event types are plain TypeScript interfaces, not Zod schemas, because they are internal to the runtime tier and never cross a serialization boundary.
 
@@ -287,7 +287,7 @@ State transitions are synchronous and guarded: `start()` only works from `idle`,
 
 ### Startup Sequence
 
-1. Validate `BrokerCoreConfig` with Zod.
+1. Validate `SignetCoreConfig` with Zod.
 2. Initialize `IdentityStore` from `dataDir`.
 3. Load all existing identities.
 4. For each identity, obtain a `Signer` and `dbEncryptionKey` from the `SignerProvider`.
@@ -492,10 +492,10 @@ function createMockXmtpClient(options?: {
   messages?: RawMessageEvent[];
 }): Client;
 
-/** Create a BrokerCore with all dependencies mocked. */
-function createTestBrokerCore(
-  overrides?: Partial<BrokerCoreConfig>,
-): { core: BrokerCore; mocks: TestMocks };
+/** Create a SignetCore with all dependencies mocked. */
+function createTestSignetCore(
+  overrides?: Partial<SignetCoreConfig>,
+): { core: SignetCore; mocks: TestMocks };
 
 interface TestMocks {
   signerProvider: SignerProvider;
@@ -513,8 +513,8 @@ packages/core/
   tsconfig.json
   src/
     index.ts                    # Re-exports public API
-    config.ts                   # BrokerCoreConfigSchema, XmtpEnvSchema, IdentityModeSchema
-    broker-core.ts              # BrokerCore implementation (start/stop lifecycle)
+    config.ts                   # SignetCoreConfigSchema, XmtpEnvSchema, IdentityModeSchema
+    broker-core.ts              # SignetCore implementation (start/stop lifecycle)
     core-context.ts             # CoreContext implementation (sealed action interface)
     identity-store.ts           # IdentityStore implementation (file-based, under dataDir)
     client-registry.ts          # ManagedClient map, stream management

--- a/.agents/plans/v0/04-policy-engine.md
+++ b/.agents/plans/v0/04-policy-engine.md
@@ -1,6 +1,6 @@
 # 04-policy-engine
 
-**Package:** `@xmtp-broker/policy`
+**Package:** `@xmtp/signet-policy`
 **Spec version:** 0.1.0
 
 ## Overview
@@ -14,17 +14,17 @@ The policy engine does not know about WebSocket, MCP, or any transport. It does 
 ## Dependencies
 
 **Imports:**
-- `@xmtp-broker/contracts` -- `PolicyDelta`, `RawMessage`, `RevealStateStore`, `GrantError` (canonical interface definitions)
-- `@xmtp-broker/schemas` -- `ViewConfig`, `ViewMode`, `GrantConfig`, `ContentTypeId`, `BASELINE_CONTENT_TYPES`, `RevealRequest`, `RevealGrant`, `RevealState`, `MessageEvent`, `MessageVisibility`, `BrokerError`, `GrantDeniedError`, `ValidationError`, `PermissionError`
+- `@xmtp/signet-contracts` -- `PolicyDelta`, `RawMessage`, `RevealStateStore`, `GrantError` (canonical interface definitions)
+- `@xmtp/signet-schemas` -- `ViewConfig`, `ViewMode`, `GrantConfig`, `ContentTypeId`, `BASELINE_CONTENT_TYPES`, `RevealRequest`, `RevealGrant`, `RevealState`, `MessageEvent`, `MessageVisibility`, `SignetError`, `GrantDeniedError`, `ValidationError`, `PermissionError`
 - `better-result` -- `Result`, `ok`, `err`
 
 **Imported by:**
-- `@xmtp-broker/ws` (transport adapter calls pipeline functions, orchestration)
-- `@xmtp-broker/attestations` (imports `isMaterialChange` -- this package is the canonical owner of materiality logic)
+- `@xmtp/signet-ws` (transport adapter calls pipeline functions, orchestration)
+- `@xmtp/signet-seals` (imports `isMaterialChange` -- this package is the canonical owner of materiality logic)
 
 ## Public Interfaces
 
-> **Note:** The following interfaces are canonically defined in `@xmtp-broker/contracts`: `PolicyDelta`, `RawMessage`, `RevealStateStore`, `GrantError`. This package implements them. This package is also the **canonical owner** of the `isMaterialChange` logic -- `@xmtp-broker/attestations` imports materiality from here rather than defining its own.
+> **Note:** The following interfaces are canonically defined in `@xmtp/signet-contracts`: `PolicyDelta`, `RawMessage`, `RevealStateStore`, `GrantError`. This package implements them. This package is also the **canonical owner** of the `isMaterialChange` logic -- `@xmtp/signet-seals` imports materiality from here rather than defining its own.
 
 ### View Projection Pipeline
 
@@ -237,7 +237,7 @@ interface PolicyDelta {
 
 /**
  * Classifies whether a set of policy changes is material
- * (triggers attestation) or routine (silent).
+ * (triggers seal) or routine (silent).
  */
 function isMaterialChange(deltas: readonly PolicyDelta[]): boolean;
 
@@ -250,7 +250,7 @@ function requiresReauthorization(deltas: readonly PolicyDelta[]): boolean;
 
 ## Zod Schemas
 
-This package defines no new Zod schemas. All schemas are imported from `@xmtp-broker/schemas` (see [02-schemas.md](02-schemas.md)). The `RawMessage` and `PolicyDelta` interfaces are internal TypeScript types, not schema-validated boundaries -- they flow between trusted internal components.
+This package defines no new Zod schemas. All schemas are imported from `@xmtp/signet-schemas` (see [02-schemas.md](02-schemas.md)). The `RawMessage` and `PolicyDelta` interfaces are internal TypeScript types, not schema-validated boundaries -- they flow between trusted internal components.
 
 ## Behaviors
 
@@ -439,7 +439,7 @@ Group member ──reveal_content request──▶ Broker
 
 #### Who Can Reveal
 
-In v0, only the agent's owner (the member identified by `ownerInboxId` in the attestation) can grant reveals. This matches the single-owner governance model.
+In v0, only the agent's owner (the member identified by `ownerInboxId` in the seal) can grant reveals. This matches the single-owner governance model.
 
 #### Reveal Scope Resolution
 
@@ -461,7 +461,7 @@ The reveal state store is in-memory during a session. On session creation, the s
 
 The classifier examines each `PolicyDelta` and returns `true` if any delta is material.
 
-**Material fields** (trigger attestation):
+**Material fields** (trigger seal):
 - `view.mode`
 - `view.threadScopes` (adding or removing scopes)
 - `view.contentTypes` (adding types -- removing is also material since it changes what the agent sees)
@@ -480,7 +480,7 @@ The classifier examines each `PolicyDelta` and returns `true` if any delta is ma
 - `grant.egress.*` changing from `false` to `true`
 - `grant.groupManagement.*` changing from `false` to `true`
 
-The `requiresReauthorization` function checks a stricter subset: only privilege escalations (expanding from `false` to `true` or from a narrower to a broader mode). Privilege reductions are material (new attestation) but do not require reauthorization.
+The `requiresReauthorization` function checks a stricter subset: only privilege escalations (expanding from `false` to `true` or from a narrower to a broader mode). Privilege reductions are material (new seal) but do not require reauthorization.
 
 #### View Mode Ordering (narrow to broad)
 
@@ -512,7 +512,7 @@ All functions return `Result<T, E>`. No exceptions are thrown.
 ## Open Questions Resolved
 
 **Q: How should content type allowlist updates be surfaced?** (PRD Open Questions)
-**A:** Adding or removing content types from the effective allowlist is a material change that triggers a new attestation. The `resolveEffectiveAllowlist` function recomputes the intersection on every view update. If the result differs from the previous effective list, `isMaterialChange` returns `true`. The attestation's `contentTypes` field reflects the new effective list.
+**A:** Adding or removing content types from the effective allowlist is a material change that triggers a new seal. The `resolveEffectiveAllowlist` function recomputes the intersection on every view update. If the result differs from the previous effective list, `isMaterialChange` returns `true`. The seal's `contentTypes` field reflects the new effective list.
 
 **Q: Should non-material view/grant changes be applied within an existing session?** (PRD Session section)
 **A:** Yes. Non-material changes (e.g., adjusting a thread scope within the same groups, or minor grant tweaks that don't escalate privileges) are applied in-place and emit a `view.updated` or `grant.updated` event. Only escalations require session reauthorization. This is enforced by `requiresReauthorization` returning `false` for non-escalation changes.

--- a/.agents/plans/v0/05-sessions.md
+++ b/.agents/plans/v0/05-sessions.md
@@ -1,6 +1,6 @@
 # 05-sessions
 
-**Package:** `@xmtp-broker/sessions`
+**Package:** `@xmtp/signet-sessions`
 **Spec version:** 0.1.0
 
 ## Overview
@@ -16,19 +16,19 @@ Sessions are scoped to agent + groups, not per-thread. Thread filtering is a vie
 ## Dependencies
 
 **Imports:**
-- `@xmtp-broker/contracts` — `SessionRecord`, `MaterialityCheck`, `SessionManager` (canonical interface definitions)
-- `@xmtp-broker/schemas` — `SessionConfig`, `SessionToken`, `SessionState`, `SessionRevocationReason`, `ViewConfig`, `GrantConfig`, error classes (`AuthError`, `SessionExpiredError`, `ValidationError`, `NotFoundError`, `InternalError`)
+- `@xmtp/signet-contracts` — `SessionRecord`, `MaterialityCheck`, `SessionManager` (canonical interface definitions)
+- `@xmtp/signet-schemas` — `SessionConfig`, `SessionToken`, `SessionState`, `SessionRevocationReason`, `ViewConfig`, `GrantConfig`, error classes (`AuthError`, `SessionExpiredError`, `ValidationError`, `NotFoundError`, `InternalError`)
 - `better-result` — `Result`, `Ok`, `Err`
 
 **Imported by:**
-- `@xmtp-broker/ws` — transport layer creates sessions on harness connect
-- `@xmtp-broker/policy` — policy engine checks session validity before enforcing grants
-- `@xmtp-broker/attestations` — attestation manager reads session key fingerprint
-- `@xmtp-broker/keys` — key manager issues session keys bound to sessions
+- `@xmtp/signet-ws` — transport layer creates sessions on harness connect
+- `@xmtp/signet-policy` — policy engine checks session validity before enforcing grants
+- `@xmtp/signet-seals` — seal manager reads session key fingerprint
+- `@xmtp/signet-keys` — key manager issues session keys bound to sessions
 
 ## Public Interfaces
 
-> **Note:** The following interfaces are canonically defined in `@xmtp-broker/contracts`: `SessionRecord`, `MaterialityCheck`, `SessionManager`. This package implements the `SessionManager` interface from contracts. The `SessionRevocationReason` enum has moved to `@xmtp-broker/schemas`.
+> **Note:** The following interfaces are canonically defined in `@xmtp/signet-contracts`: `SessionRecord`, `MaterialityCheck`, `SessionManager`. This package implements the `SessionManager` interface from contracts. The `SessionRevocationReason` enum has moved to `@xmtp/signet-schemas`.
 
 ### SessionRecord
 
@@ -164,7 +164,7 @@ function createSessionManager(
 
 ## Zod Schemas
 
-Session schemas are defined in `@xmtp-broker/schemas` (see 02-schemas.md):
+Session schemas are defined in `@xmtp/signet-schemas` (see 02-schemas.md):
 - `SessionConfig` — input for creating a session
 - `SessionToken` — the token shape returned to the harness
 - `SessionState` — `"active" | "expired" | "revoked" | "reauthorization-required"`
@@ -220,7 +220,7 @@ The transport layer converts the `SessionRecord` to a `SessionToken` (the harnes
 - Prefix: `ses_`
 - 16 random bytes, hex-encoded
 - Total length: 36 characters (`ses_` + 32 hex chars)
-- Used for internal references, logging, and attestation binding
+- Used for internal references, logging, and seal binding
 
 ### State Machine
 
@@ -298,7 +298,7 @@ renewSession(sessionId)
     +--> Return updated SessionRecord
 ```
 
-Renewal does not produce an attestation (non-material operation).
+Renewal does not produce a seal (non-material operation).
 
 ### Concurrent Sessions
 
@@ -327,9 +327,9 @@ The `sweepExpired()` method checks both TTL expiry and heartbeat timeout in a si
 
 ### Session Key Binding
 
-Each session is bound to exactly one session key, identified by `sessionKeyFingerprint`. The key is issued by `@xmtp-broker/keys` and passed to `createSession`. The fingerprint is:
+Each session is bound to exactly one session key, identified by `sessionKeyFingerprint`. The key is issued by `@xmtp/signet-keys` and passed to `createSession`. The fingerprint is:
 - Stored in the session record
-- Included in any attestation issued during the session
+- Included in any seal issued during the session
 - Used to verify that requests come from the session they claim
 
 Session keys are ephemeral. They cannot perform operational-key or root-key operations. When a session is revoked or expires, the corresponding key material should be zeroized by the key manager.
@@ -399,8 +399,8 @@ All errors are returned as `Result` values. No exceptions thrown.
 **Q: What triggers session reauthorization vs in-place update?** (PRD: Session and view/grant binding)
 **A:** The materiality rules table above defines the exact boundary. The principle: any change that expands what an agent can see (view escalation) or do (grant escalation) is material and requires a new session. Any change that narrows permissions or adjusts non-security-sensitive configuration is non-material and applies in-place. Reply and react grants are non-material because they operate within the existing view scope -- they don't expose new content or create new egress paths.
 
-**Q: Should session rotation produce attestations?** (PRD: Attestation noise and materiality)
-**A:** No. Routine session rotation (TTL renewal, reconnection with same policy) is a non-material operation. Only policy changes that cross a materiality boundary produce new attestations. The session manager signals materiality to the attestation manager, which decides whether to publish.
+**Q: Should session rotation produce seals?** (PRD: Seal noise and materiality)
+**A:** No. Routine session rotation (TTL renewal, reconnection with same policy) is a non-material operation. Only policy changes that cross a materiality boundary produce new seals. The session manager signals materiality to the seal manager, which decides whether to publish.
 
 ## Deferred
 

--- a/.agents/plans/v0/06-attestations.md
+++ b/.agents/plans/v0/06-attestations.md
@@ -1,40 +1,40 @@
-# 06-attestations
+# 06-seals
 
-**Package:** `@xmtp-broker/attestations`
+**Package:** `@xmtp/signet-seals`
 **Spec version:** 0.1.0
 
 ## Overview
 
-The attestations package manages the lifecycle of group-visible capability attestations -- signed assertions about what an agent can see and do, published into XMTP groups so every member can inspect them.
+The seals package manages the lifecycle of group-visible capability seals -- signed assertions about what an agent can see and do, published into XMTP groups so every member can inspect them.
 
-Attestations are the public face of the broker's policy plane. When a material change occurs (view mode, grant, egress policy, agent addition or revocation), the broker creates a new attestation, signs it with the agent's inbox key, and publishes it as a structured XMTP content type message into the group. Each attestation chains to its predecessor, giving clients a complete, verifiable history of permission changes.
+Attestations are the public face of the broker's policy plane. When a material change occurs (view mode, grant, egress policy, agent addition or revocation), the broker creates a new seal, signs it with the agent's inbox key, and publishes it as a structured XMTP content type message into the group. Each seal chains to its predecessor, giving clients a complete, verifiable history of permission changes.
 
-The package is responsible for four concerns: deciding _when_ a new attestation is needed (materiality), _building_ the attestation payload (creation), _signing_ it (cryptographic binding), and _publishing_ it to the group (delivery). It does not own the XMTP client (that is `@xmtp-broker/core`) or the policy evaluation (that is `@xmtp-broker/policy`). It consumes their outputs and produces the public artifact.
+The package is responsible for four concerns: deciding _when_ a new seal is needed (materiality), _building_ the seal payload (creation), _signing_ it (cryptographic binding), and _publishing_ it to the group (delivery). It does not own the XMTP client (that is `@xmtp/signet-core`) or the policy evaluation (that is `@xmtp/signet-policy`). It consumes their outputs and produces the public artifact.
 
 ## Dependencies
 
 **Imports:**
-- `@xmtp-broker/contracts` -- `AttestationSigner`, `AttestationPublisher`, `SignedAttestation`, `AttestationManager`, `MessageProvenanceMetadata`, `SignedAttestationEnvelope`, `SignedRevocationEnvelope`, `PolicyDelta` (canonical interface definitions)
-- `@xmtp-broker/schemas` -- `AttestationSchema`, `RevocationAttestation`, `RevocationReason`, `ViewMode`, `GrantConfig`, `ViewConfig`, `ContentTypeId`, `AttestationError`, `InternalError`, `ValidationError`
-- `@xmtp-broker/policy` -- `isMaterialChange` (policy engine is the canonical owner of materiality logic)
-- `@xmtp-broker/core` -- XMTP client interface for sending messages to groups
-- `@xmtp-broker/keys` -- signing interface for producing signatures with agent inbox keys
+- `@xmtp/signet-contracts` -- `AttestationSigner`, `AttestationPublisher`, `SignedAttestation`, `SealManager`, `MessageProvenanceMetadata`, `SignedAttestationEnvelope`, `SignedRevocationEnvelope`, `PolicyDelta` (canonical interface definitions)
+- `@xmtp/signet-schemas` -- `SealSchema`, `RevocationAttestation`, `RevocationReason`, `ViewMode`, `GrantConfig`, `ViewConfig`, `ContentTypeId`, `AttestationError`, `InternalError`, `ValidationError`
+- `@xmtp/signet-policy` -- `isMaterialChange` (policy engine is the canonical owner of materiality logic)
+- `@xmtp/signet-core` -- XMTP client interface for sending messages to groups
+- `@xmtp/signet-keys` -- signing interface for producing signatures with agent inbox keys
 - `better-result` -- `Result` type
 - `zod` -- runtime validation
 
 **Imported by:**
-- `@xmtp-broker/sessions` -- reads current attestation ID for message provenance
-- `@xmtp-broker/ws` -- relays attestation events to harnesses
+- `@xmtp/signet-sessions` -- reads current seal ID for message provenance
+- `@xmtp/signet-ws` -- relays seal events to harnesses
 
 ## Public Interfaces
 
-> **Note:** The following interfaces are canonically defined in `@xmtp-broker/contracts`: `AttestationSigner`, `AttestationPublisher`, `SignedAttestation`, `AttestationManager`, `MessageProvenanceMetadata`, `SignedAttestationEnvelope`, `SignedRevocationEnvelope`. This package implements the `AttestationManager` interface from contracts. The local `MaterialFields` type has been unified with `PolicyDelta` from contracts -- use `PolicyDelta` as the canonical type. Materiality logic (`isMaterialChange`) is imported from `@xmtp-broker/policy`, not defined here.
+> **Note:** The following interfaces are canonically defined in `@xmtp/signet-contracts`: `AttestationSigner`, `AttestationPublisher`, `SignedAttestation`, `SealManager`, `MessageProvenanceMetadata`, `SignedAttestationEnvelope`, `SignedRevocationEnvelope`. This package implements the `SealManager` interface from contracts. The local `MaterialFields` type has been unified with `PolicyDelta` from contracts -- use `PolicyDelta` as the canonical type. Materiality logic (`isMaterialChange`) is imported from `@xmtp/signet-policy`, not defined here.
 
-### Attestation ID Generation
+### Seal ID Generation
 
 ```typescript
 /**
- * Generates a random attestation ID. Random (not deterministic) because
+ * Generates a random seal ID. Random (not deterministic) because
  * the same logical change applied at different times is a different
  * attestation (different timestamps, potentially different session key).
  *
@@ -43,21 +43,21 @@ The package is responsible for four concerns: deciding _when_ a new attestation 
 function generateAttestationId(): string;
 ```
 
-Rationale for random over deterministic: two attestations with identical policy fields but different `issuedAt` / `expiresAt` are distinct events. Deterministic IDs would require including timestamps in the hash input, which is equivalent to random for collision purposes but adds unnecessary complexity.
+Rationale for random over deterministic: two seals with identical policy fields but different `issuedAt` / `expiresAt` are distinct events. Deterministic IDs would require including timestamps in the hash input, which is equivalent to random for collision purposes but adds unnecessary complexity.
 
 ### Materiality Check
 
-> **Note:** The `MaterialFields` type below has been unified with `PolicyDelta` from `@xmtp-broker/contracts`. Use `PolicyDelta` as the canonical type. The `isMaterialChange` function is imported from `@xmtp-broker/policy` (the canonical owner of materiality logic) rather than defined locally in this package.
+> **Note:** The `MaterialFields` type below has been unified with `PolicyDelta` from `@xmtp/signet-contracts`. Use `PolicyDelta` as the canonical type. The `isMaterialChange` function is imported from `@xmtp/signet-policy` (the canonical owner of materiality logic) rather than defined locally in this package.
 
 ```typescript
-// Imported from @xmtp-broker/policy:
+// Imported from @xmtp/signet-policy:
 // function isMaterialChange(deltas: readonly PolicyDelta[]): boolean;
 //
-// Imported from @xmtp-broker/contracts:
+// Imported from @xmtp/signet-contracts:
 // interface PolicyDelta { field: string; oldValue: unknown; newValue: unknown; }
 ```
 
-### Attestation Builder
+### Seal Builder
 
 ```typescript
 interface AttestationInput {
@@ -92,7 +92,7 @@ interface AttestationBuildResult {
 }
 
 /**
- * Builds an attestation from input fields, linking to the previous
+ * Builds a seal from input fields, linking to the previous
  * attestation if one exists. Validates the result against AttestationSchema.
  */
 function buildAttestation(
@@ -121,7 +121,7 @@ function grantConfigToOps(grant: GrantConfig): readonly string[];
 function grantConfigToToolScopes(grant: GrantConfig): readonly string[];
 ```
 
-### Attestation Signing
+### Seal Signing
 
 ```typescript
 interface SignedAttestation {
@@ -133,7 +133,7 @@ interface SignedAttestation {
 
 interface AttestationSigner {
   /**
-   * Signs the canonical serialization of an attestation using the
+   * Signs the canonical serialization of a seal using the
    * agent's inbox key (held by the broker).
    */
   sign(
@@ -142,15 +142,15 @@ interface AttestationSigner {
 }
 ```
 
-### Attestation Publishing
+### Seal Publishing
 
 ```typescript
 interface AttestationPublisher {
   /**
-   * Publishes a signed attestation to the group as a custom content
+   * Publishes a signed seal to the group as a custom content
    * type message. All group members can read and verify it.
    *
-   * Returns the XMTP message ID of the published attestation.
+   * Returns the XMTP message ID of the published seal.
    */
   publish(
     signed: SignedAttestation,
@@ -158,20 +158,20 @@ interface AttestationPublisher {
 }
 ```
 
-### Attestation Manager
+### Seal Manager
 
 ```typescript
-interface AttestationManagerDeps {
+interface SealManagerDeps {
   readonly signer: AttestationSigner;
   readonly publisher: AttestationPublisher;
 }
 
-interface AttestationManager {
+interface SealManager {
   /**
-   * Creates, signs, and publishes a new attestation if the change is
-   * material, or if no previous attestation exists for this agent+group.
+   * Creates, signs, and publishes a new seal if the change is
+   * material, or if no previous seal exists for this agent+group.
    *
-   * For non-material changes, returns the current attestation unchanged.
+   * For non-material changes, returns the current seal unchanged.
    */
   attestIfMaterial(
     input: AttestationInput,
@@ -179,7 +179,7 @@ interface AttestationManager {
   ): Promise<Result<SignedAttestation, AttestationError | InternalError>>;
 
   /**
-   * Creates and publishes a revocation attestation. Final -- no un-revoke.
+   * Creates and publishes a revocation seal. Final -- no un-revoke.
    */
   revoke(
     agentInboxId: string,
@@ -189,15 +189,15 @@ interface AttestationManager {
   ): Promise<Result<SignedAttestation, AttestationError | InternalError>>;
 
   /**
-   * Renews an attestation that is approaching expiry without any
-   * material changes. Same fields, new timestamps + attestation ID.
+   * Renews a seal that is approaching expiry without any
+   * material changes. Same fields, new timestamps + seal ID.
    */
   renew(
     currentAttestation: Attestation,
   ): Promise<Result<SignedAttestation, AttestationError | InternalError>>;
 
   /**
-   * Returns the current attestation ID for an agent in a group,
+   * Returns the current seal ID for an agent in a group,
    * or null if no attestation has been published yet.
    */
   currentAttestationId(
@@ -206,20 +206,20 @@ interface AttestationManager {
   ): string | null;
 }
 
-function createAttestationManager(
-  deps: AttestationManagerDeps,
-): AttestationManager;
+function createSealManager(
+  deps: SealManagerDeps,
+): SealManager;
 ```
 
 ## Zod Schemas
 
-All attestation and revocation schemas are defined in `@xmtp-broker/schemas` (see 02-schemas.md). This package adds:
+All attestation and revocation schemas are defined in `@xmtp/signet-schemas` (see 02-schemas.md). This package adds:
 
 ### Content Type Definition
 
 ```typescript
 /**
- * Custom XMTP content type for attestations.
+ * Custom XMTP content type for seals.
  * Follows the authority/type:version convention.
  */
 const ATTESTATION_CONTENT_TYPE_ID = "xmtp.org/agentAttestation:1.0" as const;
@@ -241,7 +241,7 @@ const SignedAttestationEnvelope = z.object({
     .describe("Signature algorithm"),
   signerKeyRef: z.string()
     .describe("Reference to the signing key (agent inbox key fingerprint)"),
-}).describe("Signed attestation envelope for XMTP group publishing");
+}).describe("Signed seal envelope for XMTP group publishing");
 
 type SignedAttestationEnvelope = z.infer<typeof SignedAttestationEnvelope>;
 ```
@@ -253,7 +253,7 @@ const SignedRevocationEnvelope = z.object({
   contentType: z.literal(REVOCATION_CONTENT_TYPE_ID)
     .describe("Content type discriminator"),
   payload: RevocationAttestation
-    .describe("The revocation attestation"),
+    .describe("The revocation seal"),
   signature: z.string()
     .describe("Base64-encoded signature over canonical payload bytes"),
   signatureAlgorithm: z.literal("Ed25519")
@@ -269,18 +269,18 @@ type SignedRevocationEnvelope = z.infer<typeof SignedRevocationEnvelope>;
 
 ```typescript
 /**
- * Produces the canonical byte representation of an attestation for
+ * Produces the canonical byte representation of a seal for
  * signing. Uses deterministic JSON serialization (sorted keys, no
  * whitespace) encoded as UTF-8.
  */
 function canonicalize(attestation: Attestation): Uint8Array;
 ```
 
-Deterministic JSON (sorted keys, no whitespace) ensures the same attestation always produces the same bytes regardless of field insertion order. This is critical for signature verification by clients.
+Deterministic JSON (sorted keys, no whitespace) ensures the same seal always produces the same bytes regardless of field insertion order. This is critical for signature verification by clients.
 
 ## Behaviors
 
-### Attestation Lifecycle
+### Seal Lifecycle
 
 ```
                     ┌─────────────┐
@@ -301,7 +301,7 @@ Deterministic JSON (sorted keys, no whitespace) ensures the same attestation alw
      └────────────┘  └────┬────┘
                           │
                     ┌─────▼──────┐
-                    │   Active   │ (new attestation, chains to previous)
+                    │   Active   │ (new seal, chains to previous)
                     └─────┬──────┘
                           │ revoke
                           ▼
@@ -310,28 +310,28 @@ Deterministic JSON (sorted keys, no whitespace) ensures the same attestation alw
                     └─────────────┘
 ```
 
-### Attestation Creation Flow
+### Seal Creation Flow
 
 1. Caller (policy engine) detects a state change and calls `attestIfMaterial()`.
-2. Manager extracts `MaterialFields` from the input and compares against the previous attestation (if any).
-3. If no previous attestation exists, creation is always triggered.
-4. If a previous attestation exists and the change is not material, the current attestation is returned unchanged.
+2. Manager extracts `MaterialFields` from the input and compares against the previous seal (if any).
+3. If no previous seal exists, creation is always triggered.
+4. If a previous seal exists and the change is not material, the current seal is returned unchanged.
 5. If material, `buildAttestation()` constructs the payload with:
-   - New `attestationId` via `generateAttestationId()`
-   - `previousAttestationId` pointing to the prior attestation
+   - New `sealId` via `generateAttestationId()`
+   - `previousSealId` pointing to the prior seal
    - `issuedAt` set to `new Date().toISOString()`
    - `expiresAt` set to `issuedAt + ttlSeconds` (default: 86400 = 24 hours)
    - `grantedOps` derived from `grantConfigToOps(grant)`
    - `toolScopes` derived from `grantConfigToToolScopes(grant)`
    - `issuer` set to the broker's signing identity
-6. The payload is validated against `AttestationSchema`.
+6. The payload is validated against `SealSchema`.
 7. `signer.sign()` canonicalizes and signs the payload.
 8. `publisher.publish()` sends it to the group as the custom content type.
-9. Manager stores the attestation ID as the current attestation for this agent+group.
+9. Manager stores the seal ID as the current seal for this agent+group.
 
-### Attestation Chaining
+### Seal Chaining
 
-Each attestation links to its predecessor via `previousAttestationId`:
+Each attestation links to its predecessor via `previousSealId`:
 
 ```
 att_initial (previousAttestationId: null)
@@ -381,16 +381,16 @@ Clients reconstruct the full history by walking the chain backward from the most
 
 - Attestations carry `expiresAt`, defaulting to 24 hours from `issuedAt`.
 - The broker schedules renewal before expiry (e.g., at 75% of TTL).
-- Renewal creates a new attestation with identical material fields, new timestamps, and a new `attestationId` chaining to the previous one.
-- If the broker is offline when renewal is due, the attestation expires. Clients show a staleness badge. The broker creates a fresh attestation upon restart.
+- Renewal creates a new seal with identical material fields, new timestamps, and a new `sealId` chaining to the previous one.
+- If the broker is offline when renewal is due, the seal expires. Clients show a staleness badge. The broker creates a fresh seal upon restart.
 
 ### Revocation Flow
 
 1. Owner or system (heartbeat timeout, admin removal) triggers revocation.
 2. Manager calls `revoke()` with the reason.
 3. A `RevocationAttestation` is built with:
-   - New `attestationId`
-   - `previousAttestationId` pointing to the last active attestation
+   - New `sealId`
+   - `previousSealId` pointing to the last active attestation
    - `reason` from the `RevocationReason` enum
    - `revokedAt` set to current time
    - `issuer` set to broker's signing identity
@@ -400,7 +400,7 @@ Clients reconstruct the full history by walking the chain backward from the most
 
 ### Message Provenance
 
-Agent-authored messages reference the current `attestationId` via message metadata. The transport layer (WebSocket/MCP) attaches the attestation reference when forwarding agent messages to `@xmtp-broker/core` for sending.
+Agent-authored messages reference the current `sealId` via message metadata. The transport layer (WebSocket/MCP) attaches the seal reference when forwarding agent messages to `@xmtp/signet-core` for sending.
 
 ```typescript
 interface MessageProvenanceMetadata {
@@ -410,29 +410,29 @@ interface MessageProvenanceMetadata {
 ```
 
 Clients receiving a message can:
-1. Look up the referenced attestation in the group's attestation history.
-2. Compare the attestation's `expiresAt` against the current time.
-3. If expired, render a staleness note (e.g., "produced under expired attestation").
+1. Look up the referenced attestation in the group's seal history.
+2. Compare the seal's `expiresAt` against the current time.
+3. If expired, render a staleness note (e.g., "produced under expired seal").
 4. If the referenced attestation differs from the current one, render a delta note.
 
 ### Client Verification
 
-Clients verify attestation signatures using this flow:
+Clients verify seal signatures using this flow:
 
 1. Parse the `SignedAttestationEnvelope` from the XMTP message.
 2. Extract the `payload` and `signature`.
 3. Canonicalize the payload using the same deterministic JSON algorithm.
 4. Look up the agent's inbox key from XMTP identity (the `agentInboxId` field).
 5. Verify the Ed25519 signature over the canonical bytes using the inbox key.
-6. Check `expiresAt` -- if past, show staleness badge but still render the attestation.
-7. Validate `previousAttestationId` chains to the last known attestation for continuity.
+6. Check `expiresAt` -- if past, show staleness badge but still render the seal.
+7. Validate `previousSealId` chains to the last known attestation for continuity.
 
 ## Error Cases
 
 | Error | Category | When |
 |-------|----------|------|
-| `AttestationError` | validation | Payload fails `AttestationSchema` validation |
-| `AttestationError` | validation | `previousAttestationId` references unknown attestation |
+| `AttestationError` | validation | Payload fails `SealSchema` validation |
+| `AttestationError` | validation | `previousSealId` references unknown attestation |
 | `AttestationError` | validation | Attempted attestation for revoked agent+group |
 | `InternalError` | internal | Signing fails (key unavailable or corrupted) |
 | `InternalError` | internal | Publishing fails (XMTP send error) |
@@ -442,24 +442,24 @@ The `attestIfMaterial` handler returns `Result`, never throws. Transport-level e
 
 ## Open Questions Resolved
 
-**Q: How should clients render stale or expired attestations?** (PRD Open Questions)
-**A:** Clients show a staleness badge after `expiresAt` passes. Messages still render normally with a note like "produced under expired attestation." The attestation content remains visible -- staleness indicates the broker hasn't refreshed, not that the attestation is invalid. Rationale: hiding history punishes the user; flagging currency lets them decide how much to trust it.
+**Q: How should clients render stale or expired seals?** (PRD Open Questions)
+**A:** Clients show a staleness badge after `expiresAt` passes. Messages still render normally with a note like "produced under expired seal." The seal content remains visible -- staleness indicates the broker hasn't refreshed, not that the seal is invalid. Rationale: hiding history punishes the user; flagging currency lets them decide how much to trust it.
 
 **Q: How much policy should be in-group versus off-chain broker config?** (PRD Open Questions)
-**A:** Attestations (the public summary of permissions) are published in-group. Full policy configuration (view definitions, grant details, egress config, tool scopes) lives off-chain in the broker's local config. The attestation is a projection of the policy state, not a replica. Rationale: keeps group message history clean while ensuring transparency for the fields that matter to group members.
+**A:** Attestations (the public summary of permissions) are published in-group. Full policy configuration (view definitions, grant details, egress config, tool scopes) lives off-chain in the broker's local config. The seal is a projection of the policy state, not a replica. Rationale: keeps group message history clean while ensuring transparency for the fields that matter to group members.
 
-**Q: What is the exact minimum viable attestation schema?** (PRD Open Questions, resolved in 02-schemas)
+**Q: What is the exact minimum viable seal schema?** (PRD Open Questions, resolved in 02-schemas)
 **A:** Full 24-field schema from day one. All fields present; optional fields use `null`. Confirmed and adopted by this spec.
 
 **Q: How should content type allowlist updates be surfaced?** (PRD Open Questions, resolved in 02-schemas)
-**A:** Adding or removing content types from the allowlist is a material change that triggers a new attestation. The `contentTypes` array in the attestation reflects the current effective list. Confirmed and adopted by this spec.
+**A:** Adding or removing content types from the allowlist is a material change that triggers a new seal. The `contentTypes` array in the seal reflects the current effective list. Confirmed and adopted by this spec.
 
 ## Deferred
 
 - **Owner co-signing.** v1 uses broker-only signing with the agent's inbox key. Optional owner co-signing for high-stakes changes (e.g., upgrading to `full` visibility) is a future enhancement.
-- **Attestation backfill protocol.** Clients can scan group history for attestation messages. A dedicated backfill request/response protocol is deferred to Phase 2.
-- **Custom content type codec registration with XMTP SDK.** The content type IDs are defined; registering them as formal codecs with the SDK's codec registry is an integration concern handled in `@xmtp-broker/core`.
-- **Attestation storage/indexing.** The manager tracks current attestation IDs in memory. Persistent attestation storage for querying history is deferred -- group message history serves as the durable store.
+- **Attestation backfill protocol.** Clients can scan group history for seal messages. A dedicated backfill request/response protocol is deferred to Phase 2.
+- **Custom content type codec registration with XMTP SDK.** The content type IDs are defined; registering them as formal codecs with the SDK's codec registry is an integration concern handled in `@xmtp/signet-core`.
+- **Attestation storage/indexing.** The manager tracks current seal IDs in memory. Persistent attestation storage for querying history is deferred -- group message history serves as the durable store.
 - **Signature algorithm agility.** v1 uses Ed25519 only. Algorithm negotiation is deferred.
 - **Runtime attestation (TEE) integration.** Trust tier is set to `source-verified` maximum in v1. TEE-backed runtime attestation is Phase 2.
 - **Multi-verifier aggregation.** v1 supports one `verifierStatementRef`. Multiple verifier references are deferred.
@@ -469,7 +469,7 @@ The `attestIfMaterial` handler returns `Result`, never throws. Transport-level e
 ### What to Test
 
 1. **Materiality detection** -- `isMaterialChange` correctly identifies material vs non-material changes across all field combinations.
-2. **Attestation building** -- `buildAttestation` produces valid `AttestationSchema`-conformant payloads with correct chaining.
+2. **Attestation building** -- `buildAttestation` produces valid `SealSchema`-conformant payloads with correct chaining.
 3. **Grant-to-ops mapping** -- `grantConfigToOps` and `grantConfigToToolScopes` produce correct string arrays for all grant configurations.
 4. **Canonical serialization** -- `canonicalize` is deterministic: same input always produces same bytes regardless of object key order.
 5. **Signing** -- `AttestationSigner.sign` produces verifiable signatures.
@@ -494,7 +494,7 @@ const curr2 = extractMaterialFields(attestationWithKeyB);
 const result2 = isMaterialChange(prev2, curr2);
 expect(result2.value.material).toBe(false);
 
-// Chaining: first attestation has null previous
+// Chaining: first seal has null previous
 const first = buildAttestation(input, null);
 expect(first.value.attestation.previousAttestationId).toBeNull();
 
@@ -533,8 +533,8 @@ function createTestPublisher(): AttestationPublisher & {
   readonly published: readonly SignedAttestation[];
 };
 
-/** Creates a fully configured AttestationManager with test deps. */
-function createTestAttestationManager(): AttestationManager & {
+/** Creates a fully configured SealManager with test deps. */
+function createTestSealManager(): SealManager & {
   readonly signer: ReturnType<typeof createTestSigner>;
   readonly publisher: ReturnType<typeof createTestPublisher>;
 };
@@ -557,7 +557,7 @@ packages/attestations/
                                 # SignedAttestationEnvelope, SignedRevocationEnvelope
     signer.ts                   # AttestationSigner interface
     publisher.ts                # AttestationPublisher interface
-    manager.ts                  # AttestationManager, createAttestationManager()
+    manager.ts                  # SealManager, createSealManager()
     provenance.ts               # MessageProvenanceMetadata
     __tests__/
       attestation-id.test.ts

--- a/.agents/plans/v0/07-key-management.md
+++ b/.agents/plans/v0/07-key-management.md
@@ -1,34 +1,34 @@
 # 07-key-management
 
-**Package:** `@xmtp-broker/keys`
+**Package:** `@xmtp/signet-keys`
 **Spec version:** 0.1.0
 
 ## Overview
 
-The key management package implements the three-tier key hierarchy that underpins the broker's security model. It provides hardware-backed signing through macOS Secure Enclave, encrypted secret storage (vault), and the `SignerProvider` interface consumed by `@xmtp-broker/core`.
+The key management package implements the three-tier key hierarchy that underpins the broker's security model. It provides hardware-backed signing through macOS Secure Enclave, encrypted secret storage (vault), and the `SignerProvider` interface consumed by `@xmtp/signet-core`.
 
 The fundamental design principle: the broker can **invoke** signing operations without being able to **extract** the signing key. The Secure Enclave generates and holds the root key -- it is non-exportable by hardware design. Operational keys and session keys are derived from root-protected material, each with progressively weaker access policies that enable autonomous broker operation for routine tasks while gating privilege escalation behind biometric authentication.
 
 The package bridges two cryptographic worlds. The Secure Enclave supports P-256 (secp256r1) exclusively. XMTP uses Ed25519 for inbox identity signatures. The bridge strategy: the enclave-backed P-256 root key protects an encrypted vault containing the Ed25519 operational key material. The enclave key never signs XMTP messages directly -- it authorizes access to the software keys that do. This gives us hardware-backed access control without fighting the enclave's algorithm constraints.
 
-On platforms without Secure Enclave (Intel Macs, Linux), the package degrades to software key storage with Keychain or file-based encryption, and the attestation `trustTier` reflects the actual security posture.
+On platforms without Secure Enclave (Intel Macs, Linux), the package degrades to software key storage with Keychain or file-based encryption, and the seal `trustTier` reflects the actual security posture.
 
 ## Dependencies
 
 **Imports:**
-- `@xmtp-broker/contracts` -- `SignerProvider`, `AttestationSigner` (canonical interface definitions)
-- `@xmtp-broker/schemas` -- `TrustTier`, error classes (`InternalError`, `ValidationError`, `AuthError`, `NotFoundError`)
+- `@xmtp/signet-contracts` -- `SignerProvider`, `AttestationSigner` (canonical interface definitions)
+- `@xmtp/signet-schemas` -- `TrustTier`, error classes (`InternalError`, `ValidationError`, `AuthError`, `NotFoundError`)
 - `better-result` -- `Result` type
 - `zod` -- config validation
 
 **Imported by:**
-- `@xmtp-broker/core` -- consumes `SignerProvider` for XMTP client creation
-- `@xmtp-broker/sessions` -- requests session key issuance
-- `@xmtp-broker/attestations` -- consumes `AttestationSigner` for signing attestations
+- `@xmtp/signet-core` -- consumes `SignerProvider` for XMTP client creation
+- `@xmtp/signet-sessions` -- requests session key issuance
+- `@xmtp/signet-seals` -- consumes `SealStamper` for signing seals
 
 ## Public Interfaces
 
-> **Note:** The `SignerProvider` and `AttestationSigner` interfaces are canonically defined in `@xmtp-broker/contracts`. This package implements both. The duplicate `SignerProvider` definition previously in this spec now references the contracts package as the source of truth.
+> **Note:** The `SignerProvider` and `SealStamper` interfaces are canonically defined in `@xmtp/signet-contracts`. This package implements both. The duplicate `SignerProvider` definition previously in this spec now references the contracts package as the source of truth.
 
 ### Configuration
 
@@ -109,10 +109,10 @@ interface SessionKey {
 
 ### SignerProvider (consumed by broker-core)
 
-> Canonical definition: `@xmtp-broker/contracts`. This package implements it via `KeyManager.toSignerProvider()`.
+> Canonical definition: `@xmtp/signet-contracts`. This package implements it via `KeyManager.toSignerProvider()`.
 
 ```typescript
-// Imported from @xmtp-broker/contracts:
+// Imported from @xmtp/signet-contracts:
 // interface SignerProvider {
 //   getSigner(identityId: string): Promise<Result<Signer, InternalError>>;
 //   getDbEncryptionKey(identityId: string): Promise<Result<Uint8Array, InternalError>>;
@@ -215,11 +215,11 @@ function createKeyManager(
 ): Promise<Result<KeyManager, InternalError>>;
 ```
 
-### AttestationSigner Adapter
+### SealSigner Adapter
 
 ```typescript
 import type { AttestationSigner, SignedAttestation } from
-  "@xmtp-broker/contracts";
+  "@xmtp/signet-contracts";
 
 /** Creates an AttestationSigner backed by the key manager. */
 function createAttestationSigner(
@@ -230,7 +230,7 @@ function createAttestationSigner(
 
 ## Zod Schemas
 
-Key management config schemas are defined above (`KeyManagerConfigSchema`, `KeyPolicySchema`). The `TrustTier` schema is imported from `@xmtp-broker/schemas`.
+Key management config schemas are defined above (`KeyManagerConfigSchema`, `KeyPolicySchema`). The `TrustTier` schema is imported from `@xmtp/signet-schemas`.
 
 Runtime key records (`RootKeyHandle`, `OperationalKey`, `SessionKey`) are plain TypeScript interfaces, not Zod schemas, because they are internal to the runtime tier.
 
@@ -334,7 +334,7 @@ XMTP Signer (Ed25519 signatures)
 | Operation | Why |
 |-----------|-----|
 | Message signing | Routine, high-frequency |
-| Attestation publishing | Routine, tied to session lifecycle |
+| Seal publishing | Routine, tied to session lifecycle |
 | Session key issuance | Bounded by existing grants |
 | Heartbeat signing | Background liveness |
 
@@ -404,7 +404,7 @@ New Machine
     +--> Broker performs XMTP installation rotation
     |    (inbox persists, signing key material rotates)
     |
-    +--> Broker publishes updated attestation
+    +--> Broker publishes updated seal
     |
     +--> Old machine's root key is abandoned (non-exportable,
     |    hardware-bound, automatically inaccessible)
@@ -432,12 +432,12 @@ rotateOperationalKey(identityId)
     |
     +--> New sessions use the new operational key
     |
-    +--> Trigger attestation update (material change)
+    +--> Trigger seal update (material change)
 ```
 
 ### Per-Group Identity Key Management
 
-Each group identity (from `@xmtp-broker/core` per-group mode) gets:
+Each group identity (from `@xmtp/signet-core` per-group mode) gets:
 - Its own Ed25519 operational key stored in the vault as `op-key:<identityId>`
 - Its own database encryption key stored as `db-key:<identityId>`
 - Both protected by the single root key
@@ -501,7 +501,7 @@ detectPlatform()
     |
     +--> Set trustTier based on platform
     |
-    +--> Attestation includes actual platform in metadata
+    +--> Seal includes actual platform in metadata
 ```
 
 All three paths implement the same `KeyManager` interface. The `SignerProvider` returned by `toSignerProvider()` behaves identically regardless of platform. The difference is only in the security guarantees, reflected in `trustTier` and logged at startup.
@@ -560,7 +560,7 @@ The Swift subprocess has a 30-second timeout. If biometric is pending, the OS co
 **A:** Each group identity gets its own Ed25519 operational key and database encryption key, all stored in the vault under the single root key. The root key is the authority for all group identities. Creating a new group identity requires root key authorization (biometric). This scales linearly with group count but keeps the trust anchor singular.
 
 **Q: What happens on platforms without Secure Enclave?** (PRD: "degrade gracefully with clear labeling")
-**A:** The `KeyManager` interface is platform-agnostic. On Intel Macs, Keychain with software keys. On Linux, passphrase-encrypted file storage. The `trustTier` in attestations reflects the actual security posture (`source-verified` vs `unverified`). The broker logs a warning at startup.
+**A:** The `KeyManager` interface is platform-agnostic. On Intel Macs, Keychain with software keys. On Linux, passphrase-encrypted file storage. The `trustTier` in seals reflects the actual security posture (`source-verified` vs `unverified`). The broker logs a warning at startup.
 
 ## Deferred
 
@@ -582,10 +582,10 @@ The Swift subprocess has a 30-second timeout. If biometric is pending, the OS co
 4. **SignerProvider contract** -- `getSigner()` returns a valid XMTP `Signer`. `getDbEncryptionKey()` returns 32 bytes.
 5. **Vault CRUD** -- Set, get, delete, list secrets. Verify encrypted-at-rest (read raw file, confirm not plaintext).
 6. **Biometric gating** -- Operations that require root key return `AuthError` when biometric is unavailable/cancelled (mocked).
-7. **Key rotation** -- New key replaces old, attestation trigger signaled, existing sessions unaffected.
+7. **Key rotation** -- New key replaces old, seal trigger signaled, existing sessions unaffected.
 8. **Platform degradation** -- Software fallback produces correct `trustTier` and logs warnings.
 9. **Subprocess error handling** -- Timeout, crash, invalid JSON all produce `InternalError`.
-10. **AttestationSigner adapter** -- Produces valid `SignedAttestation` with correct `signerKeyRef`.
+10. **AttestationSigner adapter** -- Produces valid `SignedSeal` with correct `signerKeyRef`.
 
 ### How to Test
 

--- a/.agents/plans/v0/08-websocket-transport.md
+++ b/.agents/plans/v0/08-websocket-transport.md
@@ -1,25 +1,25 @@
 # 08-websocket-transport
 
-**Package:** `@xmtp-broker/ws`
+**Package:** `@xmtp/signet-ws`
 **Spec version:** 0.1.0
 
 ## Overview
 
-The WebSocket transport is the Phase 1 harness-facing interface for xmtp-broker. It translates the transport-agnostic handler contract into a persistent, bidirectional connection between agent harnesses and the broker. A harness connects, authenticates with a session token, and then receives a filtered event stream and sends scoped requests over a single WebSocket connection.
+The WebSocket transport is the Phase 1 harness-facing interface for xmtp-signet. It translates the transport-agnostic handler contract into a persistent, bidirectional connection between agent harnesses and the broker. A harness connects, authenticates with a session token, and then receives a filtered event stream and sends scoped requests over a single WebSocket connection.
 
-The transport is a thin adapter. It owns connection lifecycle, wire protocol framing, auth handshake, sequence numbering, backpressure, and reconnection support. It does not own policy decisions, session state, or XMTP client operations -- those are delegated to the runtime tier packages (`@xmtp-broker/sessions`, `@xmtp-broker/policy`, `@xmtp-broker/core`) via their handler interfaces.
+The transport is a thin adapter. It owns connection lifecycle, wire protocol framing, auth handshake, sequence numbering, backpressure, and reconnection support. It does not own policy decisions, session state, or XMTP client operations -- those are delegated to the runtime tier packages (`@xmtp/signet-sessions`, `@xmtp/signet-policy`, `@xmtp/signet-core`) via their handler interfaces.
 
 Built on `Bun.serve()` native WebSocket support, the transport uses per-connection state via `ws.data` typing, a connection registry for event broadcasting, and structured JSON frames with a `type` discriminator. No binary frames in v0. No HTTP-level auth -- authentication happens in-band as the first frame after upgrade.
 
 ## Dependencies
 
 **Imports:**
-- `@xmtp-broker/contracts` -- `BrokerCore`, `CoreContext`, `SessionManager`, `SessionRecord`, `AttestationManager`, `RawEvent`, `RevealStateStore` (canonical interface definitions; this package consumes these interfaces, does not implement them)
-- `@xmtp-broker/schemas` -- `BrokerEvent`, `HarnessRequest`, `RequestResponse`, `SessionToken`, `ViewConfig`, `GrantConfig`, error classes (`AuthError`, `SessionExpiredError`, `ValidationError`)
-- `@xmtp-broker/sessions` -- `SessionManager` implementation
-- `@xmtp-broker/policy` -- `projectMessage`, grant validation functions, `RevealStateStore` implementation
-- `@xmtp-broker/core` -- `BrokerCore` implementation
-- `@xmtp-broker/attestations` -- `AttestationManager` implementation
+- `@xmtp/signet-contracts` -- `SignetCore`, `CoreContext`, `SessionManager`, `SessionRecord`, `SealManager`, `RawEvent`, `RevealStateStore` (canonical interface definitions; this package consumes these interfaces, does not implement them)
+- `@xmtp/signet-schemas` -- `BrokerEvent`, `HarnessRequest`, `RequestResponse`, `SessionToken`, `ViewConfig`, `GrantConfig`, error classes (`AuthError`, `SessionExpiredError`, `ValidationError`)
+- `@xmtp/signet-sessions` -- `SessionManager` implementation
+- `@xmtp/signet-policy` -- `projectMessage`, grant validation functions, `RevealStateStore` implementation
+- `@xmtp/signet-core` -- `SignetCore` implementation
+- `@xmtp/signet-seals` -- `SealManager` implementation
 - `better-result` -- `Result`, `ok`, `err`
 - `zod` -- frame validation at the wire boundary
 
@@ -152,9 +152,9 @@ Broker-to-harness responses use the `RequestResponse` shape from 02-schemas, dis
 
 ```typescript
 interface WsServerDeps {
-  readonly core: BrokerCore;
+  readonly core: SignetCore;
   readonly sessionManager: SessionManager;
-  readonly attestationManager: AttestationManager;
+  readonly attestationManager: SealManager;
 }
 
 interface WsServer {
@@ -181,7 +181,7 @@ function createWsServer(
 
 ## Zod Schemas
 
-All event and request schemas are imported from `@xmtp-broker/schemas` (see 02-schemas.md). This package adds:
+All event and request schemas are imported from `@xmtp/signet-schemas` (see 02-schemas.md). This package adds:
 
 - `WsServerConfigSchema` -- server configuration
 - `AuthFrame` -- harness auth handshake
@@ -254,7 +254,7 @@ All event and request schemas are imported from `@xmtp-broker/schemas` (see 02-s
    - Sends `AuthenticatedFrame` with session info, view, and grant.
    - If `lastSeenSeq` is non-null, replays buffered events (see Reconnection).
    - Starts heartbeat timer.
-   - Subscribes to `BrokerCore` raw events for this session's view scope.
+   - Subscribes to `SignetCore` raw events for this session's view scope.
 6. On failure:
    - Sends `AuthErrorFrame` with the error code and message.
    - Closes the WebSocket with code 4001 (auth failed).
@@ -278,14 +278,14 @@ Request timeout: if the handler does not respond within 30 seconds, the broker s
 
 ### Event Broadcasting
 
-When the `BrokerCore` emits a `RawEvent`:
+When the `SignetCore` emits a `RawEvent`:
 
 1. The transport routes it through `projectMessage()` for each active connection's view config.
 2. If the projection result is `emit`, the transport wraps the `MessageEvent` in a `SequencedFrame`.
 3. The frame is serialized to JSON and sent on the connection.
 4. The frame is appended to the connection's replay buffer.
 
-Non-message events (`session.expired`, `heartbeat`, `attestation.updated`, etc.) are sent directly to relevant connections without projection.
+Non-message events (`session.expired`, `heartbeat`, `seal.updated`, etc.) are sent directly to relevant connections without projection.
 
 ### Sequence Numbers
 
@@ -498,7 +498,7 @@ Protocol errors (malformed frames, unknown types) send a `RequestResponse` with 
 
 ### How to Test
 
-**Unit tests**: Mock the `BrokerCore`, `SessionManager`, and `AttestationManager`. Test frame parsing, sequence numbering, replay buffer, backpressure logic, and connection state transitions in isolation.
+**Unit tests**: Mock the `SignetCore`, `SessionManager`, and `SealManager`. Test frame parsing, sequence numbering, replay buffer, backpressure logic, and connection state transitions in isolation.
 
 **Integration tests**: Start a real `WsServer` on a random port, connect with a WebSocket client, and exercise the full auth -> request -> response -> disconnect flow. Use mock runtime deps.
 
@@ -559,9 +559,9 @@ function createTestWsServer(
 ): { server: WsServer; mocks: WsTestMocks; port: number };
 
 interface WsTestMocks {
-  core: BrokerCore;
+  core: SignetCore;
   sessionManager: SessionManager;
-  attestationManager: AttestationManager;
+  attestationManager: SealManager;
   emitRawEvent: (event: RawEvent) => void;
 }
 

--- a/.agents/plans/v0/09-verifier.md
+++ b/.agents/plans/v0/09-verifier.md
@@ -1,23 +1,23 @@
 # 09-verifier
 
-**Package:** `@xmtp-broker/verifier`
+**Package:** `@xmtp/signet-verifier`
 **Spec version:** 0.1.0
 
 ## Overview
 
-The verifier is a standalone service that checks broker claims and issues signed verification statements. It exists to answer a single question: "Is this broker what it claims to be?" The answer takes the form of a cryptographically signed statement that brokers can reference in their group-visible attestations via the `verifierStatementRef` field.
+The verifier is a standalone service that checks broker claims and issues signed verification statements. It exists to answer a single question: "Is this broker what it claims to be?" The answer takes the form of a cryptographically signed statement that brokers can reference in their group-visible seals via the `verifierStatementRef` field.
 
 The verifier is itself an XMTP inbox. All verification happens over XMTP DMs -- there is no HTTP API, no privileged endpoint, no central authority. A broker (or any group member) opens a DM with the verifier, sends a verification request, and receives a signed verification statement in response. This design means the protocol surface is identical whether the verifier is the reference deployment, a community-run instance, or a self-hosted container. The decentralization path is baked in from day one.
 
-At v0 launch, the verifier supports only the **source-verified** trust tier: checking source code availability, build provenance (SLSA/Sigstore), release signing, and attestation chain validity. Runtime attestation (TEE) verification is deferred to Phase 2.
+At v0 launch, the verifier supports only the **source-verified** trust tier: checking source code availability, build provenance (SLSA/Sigstore), release signing, and seal chain validity. Runtime attestation (TEE) verification is deferred to Phase 2.
 
-The verifier publishes its own attestation about its identity and capabilities so that clients can decide which verifier issuers they trust. Multiple independent verifiers can coexist -- no single verifier has authority over the ecosystem.
+The verifier publishes its own seal about its identity and capabilities so that clients can decide which verifier issuers they trust. Multiple independent verifiers can coexist -- no single verifier has authority over the ecosystem.
 
 ## Dependencies
 
 **Imports:**
-- `@xmtp-broker/contracts` -- `SignedAttestationEnvelope`, `SignedRevocationEnvelope` (consumed for parsing attestations during verification)
-- `@xmtp-broker/schemas` -- `AttestationSchema`, `TrustTier`, `ValidationError`, `InternalError`, `TimeoutError`
+- `@xmtp/signet-contracts` -- `SignedAttestationEnvelope`, `SignedRevocationEnvelope` (consumed for parsing attestations during verification)
+- `@xmtp/signet-schemas` -- `SealSchema`, `TrustTier`, `ValidationError`, `InternalError`, `TimeoutError`
 - `@xmtp/node-sdk` -- XMTP client for DM-based communication
 - `better-result` -- `Result` type
 - `zod` -- runtime validation
@@ -53,7 +53,7 @@ const VerificationRequestSchema = z.object({
   groupId: z.string().nullable()
     .describe("Group context for verification, null for broker-wide"),
   attestation: AttestationSchema.nullable()
-    .describe("Attestation to verify, null if only checking provenance"),
+    .describe("Seal to verify, null if only checking provenance"),
   artifactDigest: z.string()
     .describe("SHA-256 digest of the broker artifact (hex-encoded)"),
   buildProvenanceBundle: z.string().nullable()
@@ -161,7 +161,7 @@ const VerifierSelfAttestation = z.object({
   sourceRepoUrl: z.string().url()
     .describe("URL of the verifier's source code"),
   issuedAt: z.string().datetime()
-    .describe("When this self-attestation was created"),
+    .describe("When this self-sealing was created"),
   signature: z.string()
     .describe("Base64-encoded self-signature"),
 }).describe("Self-attestation published by the verifier");
@@ -192,7 +192,7 @@ interface VerifierService {
     senderInboxId: string,
   ): Promise<Result<VerificationStatement, ValidationError | InternalError | TimeoutError>>;
 
-  /** Get the verifier's self-attestation. */
+  /** Get the verifier's self-sealing. */
   selfAttestation(): VerifierSelfAttestation;
 }
 
@@ -218,7 +218,7 @@ interface CheckHandler {
 
 ## Zod Schemas
 
-All schemas are defined inline above. The verifier package owns these schemas directly rather than placing them in `@xmtp-broker/schemas`, because the verifier is a standalone service that other broker packages do not import. The content type IDs (`verificationRequest:1.0`, `verificationStatement:1.0`) follow the same `xmtp.org/type:version` convention used by attestations.
+All schemas are defined inline above. The verifier package owns these schemas directly rather than placing them in `@xmtp/signet-schemas`, because the verifier is a standalone service that other broker packages do not import. The content type IDs (`verificationRequest:1.0`, `verificationStatement:1.0`) follow the same `xmtp.org/type:version` convention used by attestations.
 
 ## Behaviors
 
@@ -258,9 +258,9 @@ Requester                    Verifier
    - `source_available` -- HTTP HEAD/GET against `sourceRepoUrl`, expect 200
    - `build_provenance` -- If `buildProvenanceBundle` is non-null, parse and verify SLSA provenance or Sigstore bundle
    - `release_signing` -- If `releaseTag` is non-null, check GitHub release for signing signatures
-   - `attestation_signature` -- If `attestation` is non-null, verify the Ed25519 signature against the agent's inbox key
-   - `attestation_chain` -- If `attestation` is non-null, verify `previousAttestationId` chain has no gaps
-   - `schema_compliance` -- If `attestation` is non-null, validate against `AttestationSchema`
+   - `attestation_signature` -- If `seal` is non-null, verify the Ed25519 signature against the agent's inbox key
+   - `attestation_chain` -- If `seal` is non-null, verify `previousSealId` chain has no gaps
+   - `schema_compliance` -- If `seal` is non-null, validate against `SealSchema`
 5. Determine overall verdict:
    - `verified` -- all applicable checks pass
    - `partial` -- some checks pass, some skip, none fail
@@ -328,20 +328,20 @@ Skip: request.attestation is null
 Evidence: { signerKeyRef, signatureValid }
 ```
 
-Canonicalizes the attestation payload using deterministic JSON (same algorithm as `@xmtp-broker/attestations`), then verifies the Ed25519 signature. The agent's public key is resolved via XMTP identity lookup using the `agentInboxId`.
+Canonicalizes the seal payload using deterministic JSON (same algorithm as `@xmtp/signet-seals`), then verifies the Ed25519 signature. The agent's public key is resolved via XMTP identity lookup using the `agentInboxId`.
 
 ### Check: attestation_chain
 
 ```
 Check ID: "attestation_chain"
 Input: request.attestation, request.groupId
-Pass: previousAttestationId is null (initial) or references a known prior attestation
-Fail: Chain has gaps or references unknown attestation IDs
+Pass: previousAttestationId is null (initial) or references a known prior seal
+Fail: Chain has gaps or references unknown seal IDs
 Skip: request.attestation is null
 Evidence: { chainLength, previousId, chainValid }
 ```
 
-v0 performs a structural check only: verifies that `previousAttestationId` is either null (for the first attestation) or a well-formed attestation ID. Full chain walk (fetching prior attestations from group history) is deferred -- the verifier cannot access group message history in v0 since it may not be a group member.
+v0 performs a structural check only: verifies that `previousSealId` is either null (for the first seal) or a well-formed seal ID. Full chain walk (fetching prior seals from group history) is deferred -- the verifier cannot access group message history in v0 since it may not be a group member.
 
 ### Check: schema_compliance
 
@@ -356,7 +356,7 @@ Evidence: { errors (if any) }
 
 ### Canonical Statement Serialization
 
-The verification statement is signed over its canonical representation. The serialization algorithm is identical to the one used for attestations:
+The verification statement is signed over its canonical representation. The serialization algorithm is identical to the one used for seals:
 
 1. Remove the `signature` and `signatureAlgorithm` fields from the statement.
 2. Serialize remaining fields as deterministic JSON (sorted keys, no whitespace).
@@ -393,7 +393,7 @@ Rate limit violations are not errors in the handler sense -- they produce a `rej
 ## Open Questions Resolved
 
 **Q: Which verification classes should the reference verifier support at launch?** (PRD Open Questions)
-**A:** Source-verified only. The verifier checks: source availability, build provenance (SLSA/Sigstore bundle structure and signatures), release signing (GitHub attestations), attestation signature validity, attestation chain structure, and schema compliance. Runtime attestation (TEE) is deferred to Phase 2. Rationale: source-verified provides meaningful trust signals without requiring TEE infrastructure. It ships something useful fast and establishes the verifier-over-XMTP protocol pattern that runtime attestation will later extend.
+**A:** Source-verified only. The verifier checks: source availability, build provenance (SLSA/Sigstore bundle structure and signatures), release signing (GitHub attestations), attestation signature validity, seal chain structure, and schema compliance. Runtime attestation (TEE) is deferred to Phase 2. Rationale: source-verified provides meaningful trust signals without requiring TEE infrastructure. It ships something useful fast and establishes the verifier-over-XMTP protocol pattern that runtime attestation will later extend.
 
 **Q: Should the verifier use HTTP or XMTP for communication?** (Implicit from PRD)
 **A:** XMTP DMs only. No HTTP API. The verifier is an XMTP inbox that processes DMs. This ensures: (1) the protocol surface is uniform regardless of who runs the verifier, (2) the decentralization path requires no infrastructure changes, (3) any XMTP participant can interact with any verifier using the same tools they use for messaging. The tradeoff is that the verifier requires a persistent XMTP client connection, which rules out purely stateless deployments (like bare Cloudflare Workers).
@@ -403,7 +403,7 @@ Rate limit violations are not errors in the handler sense -- they produce a `rej
 - **Runtime attestation (TEE) verification.** Phase 2. Requires defining TEE-agnostic attestation evidence formats and integrating with platform-specific verification APIs (AWS Nitro, etc.).
 - **Reproducible build verification.** Checking that an artifact reproduces bit-for-bit from source requires running builds, which is out of scope for a lightweight verifier. Deferred until the broker project has reproducible build infrastructure.
 - **Rekor transparency log queries.** v0 verifies Sigstore bundle structure and signatures offline. Querying the Rekor transparency log for inclusion proofs adds network dependency and complexity. Stretch goal for v0, required for v1.
-- **Full attestation chain walk.** The verifier cannot access group message history to walk the full attestation chain. v0 checks structural validity only. A future version may accept the chain as input or join the group temporarily.
+- **Full seal chain walk.** The verifier cannot access group message history to walk the full seal chain. v0 checks structural validity only. A future version may accept the chain as input or join the group temporarily.
 - **Multi-statement aggregation.** v0 supports one verifier statement per attestation (`verifierStatementRef` is a single string). Supporting references to multiple independent verifier statements is deferred.
 - **Verifier discovery protocol.** How brokers find verifiers. v0 assumes the verifier inbox ID is configured manually. A discovery mechanism (e.g., well-known XMTP group, ENS records) is future work.
 - **Statement revocation.** Verifier statements expire but cannot be actively revoked in v0. If a verifier discovers a previously-verified broker is compromised, it can only refuse new verifications. Active revocation broadcast is deferred.
@@ -511,7 +511,7 @@ packages/verifier/
       request.ts                # VerificationRequestSchema
       statement.ts              # VerificationStatementSchema, VerificationVerdict
       check.ts                  # VerificationCheck, CheckVerdict
-      self-attestation.ts       # VerifierSelfAttestation, VerifierCapabilities
+      self-sealing.ts       # VerifierSelfAttestation, VerifierCapabilities
     checks/
       handler.ts                # CheckHandler interface
       source-available.ts       # source_available check
@@ -540,4 +540,4 @@ packages/verifier/
       fixtures.ts               # Test utilities
 ```
 
-Each source file targets under 150 LOC. The `checks/` directory isolates each verification check for independent testing and future extensibility. The `schemas/` directory keeps verifier-specific schemas separate from the shared `@xmtp-broker/schemas` package.
+Each source file targets under 150 LOC. The `checks/` directory isolates each verification check for independent testing and future extensibility. The `schemas/` directory keeps verifier-specific schemas separate from the shared `@xmtp/signet-schemas` package.

--- a/.agents/plans/v0/10-action-registry.md
+++ b/.agents/plans/v0/10-action-registry.md
@@ -1,17 +1,17 @@
 # 10-action-registry
 
-**Package:** `@xmtp-broker/contracts` (ActionSpec, HandlerContext extensions), `@xmtp-broker/schemas` (ActionResult envelope)
+**Package:** `@xmtp/signet-contracts` (ActionSpec, HandlerContext extensions), `@xmtp/signet-schemas` (ActionResult envelope)
 **Spec version:** 0.1.0
 
 ## Overview
 
-The action registry introduces the "define once, expose everywhere" pattern to xmtp-broker. An `ActionSpec` bundles a handler function with its Zod input schema and per-surface metadata (CLI, MCP) into a single registration unit. Transport adapters consume ActionSpecs to mechanically wire domain logic into their protocol -- no per-transport handler code needed.
+The action registry introduces the "define once, expose everywhere" pattern to xmtp-signet. An `ActionSpec` bundles a handler function with its Zod input schema and per-surface metadata (CLI, MCP) into a single registration unit. Transport adapters consume ActionSpecs to mechanically wire domain logic into their protocol -- no per-transport handler code needed.
 
 This spec adds three things:
 
-1. **`ActionSpec<TInput, TOutput, TError>`** -- the bundling type that connects a handler to its schemas and surface metadata. Lives in `@xmtp-broker/contracts` alongside the existing `Handler` type it references.
+1. **`ActionSpec<TInput, TOutput, TError>`** -- the bundling type that connects a handler to its schemas and surface metadata. Lives in `@xmtp/signet-contracts` alongside the existing `Handler` type it references.
 
-2. **`ActionResult<T>`** -- the universal output envelope that all transports render from. Defined as a Zod schema in `@xmtp-broker/schemas` so it can be validated at boundaries and used for type inference.
+2. **`ActionResult<T>`** -- the universal output envelope that all transports render from. Defined as a Zod schema in `@xmtp/signet-schemas` so it can be validated at boundaries and used for type inference.
 
 3. **Extended `HandlerContext`** -- adds `requestId`, `signal`, and optional `adminAuth`/`sessionId` to the existing `CoreContext`-based `HandlerContext`. These fields are needed by all handlers regardless of transport.
 
@@ -22,11 +22,11 @@ The ActionSpec type is deliberately minimal. It does not prescribe how transport
 ## Dependencies
 
 **Imports:**
-- `@xmtp-broker/schemas` -- `BrokerError`, `ErrorCategory`, Zod (for ActionResult schema)
+- `@xmtp/signet-schemas` -- `SignetError`, `ErrorCategory`, Zod (for ActionResult schema)
 - `better-result` -- `Result` (in Handler signature)
 
 **Imported by:**
-- All runtime packages that define handlers (`core`, `sessions`, `policy`, `attestations`)
+- All runtime packages that define handlers (`core`, `sessions`, `policy`, `seals`)
 - All transport packages (`ws`, `mcp`, future CLI)
 
 ## Public Interfaces
@@ -42,7 +42,7 @@ The ActionSpec type is deliberately minimal. It does not prescribe how transport
 interface ActionSpec<
   TInput,
   TOutput,
-  TError extends BrokerError = BrokerError,
+  TError extends SignetError = SignetError,
 > {
   /** Unique action identifier. Convention: `{domain}.{verb}` (e.g., `session.list`). */
   readonly id: string;
@@ -272,19 +272,19 @@ interface ActionRegistry {
    * Register an ActionSpec. Throws if an action with the same id
    * is already registered (fail-fast for duplicate registrations).
    */
-  register(spec: ActionSpec<unknown, unknown, BrokerError>): void;
+  register(spec: ActionSpec<unknown, unknown, SignetError>): void;
 
   /** Look up an ActionSpec by id. Returns undefined if not found. */
-  lookup(id: string): ActionSpec<unknown, unknown, BrokerError> | undefined;
+  lookup(id: string): ActionSpec<unknown, unknown, SignetError> | undefined;
 
   /** List all registered ActionSpecs. */
-  list(): readonly ActionSpec<unknown, unknown, BrokerError>[];
+  list(): readonly ActionSpec<unknown, unknown, SignetError>[];
 
   /**
    * List ActionSpecs that have a specific surface.
    * Convenience for transport adapters.
    */
-  listForSurface(surface: "cli" | "mcp"): readonly ActionSpec<unknown, unknown, BrokerError>[];
+  listForSurface(surface: "cli" | "mcp"): readonly ActionSpec<unknown, unknown, SignetError>[];
 
   /** Number of registered actions. */
   readonly size: number;
@@ -305,13 +305,13 @@ function createActionRegistry(): ActionRegistry;
  * Called by transport adapters after handler execution.
  */
 function toActionResult<T>(
-  result: Result<T, BrokerError>,
+  result: Result<T, SignetError>,
   meta: ActionResultMeta,
   pagination?: Pagination,
 ): ActionResult<T>;
 ```
 
-This function is the bridge between the handler world (returns `Result<T, BrokerError>`) and the transport world (renders `ActionResult<T>`). It extracts `_tag`, `category`, `message`, and `context` from the error case and wraps the success case with `ok: true`.
+This function is the bridge between the handler world (returns `Result<T, SignetError>`) and the transport world (renders `ActionResult<T>`). It extracts `_tag`, `category`, `message`, and `context` from the error case and wraps the success case with `ok: true`.
 
 ## Zod Schemas
 
@@ -319,13 +319,13 @@ All Zod schemas are defined inline in the Public Interfaces section above. Summa
 
 | Schema | Package | File |
 |--------|---------|------|
-| `ActionResultMetaSchema` | `@xmtp-broker/schemas` | `src/result/action-result.ts` |
-| `ActionErrorSchema` | `@xmtp-broker/schemas` | `src/result/action-result.ts` |
-| `PaginationSchema` | `@xmtp-broker/schemas` | `src/result/action-result.ts` |
-| `ActionResultSchema` (factory) | `@xmtp-broker/schemas` | `src/result/action-result.ts` |
-| `ActionErrorResultSchema` | `@xmtp-broker/schemas` | `src/result/action-result.ts` |
+| `ActionResultMetaSchema` | `@xmtp/signet-schemas` | `src/result/action-result.ts` |
+| `ActionErrorSchema` | `@xmtp/signet-schemas` | `src/result/action-result.ts` |
+| `PaginationSchema` | `@xmtp/signet-schemas` | `src/result/action-result.ts` |
+| `ActionResultSchema` (factory) | `@xmtp/signet-schemas` | `src/result/action-result.ts` |
+| `ActionErrorResultSchema` | `@xmtp/signet-schemas` | `src/result/action-result.ts` |
 
-The `ActionSpec`, `CliSurface`, `McpSurface`, and registry types are plain TypeScript interfaces in `@xmtp-broker/contracts`. They are not Zod schemas because they are internal compile-time contracts, not wire formats validated at boundaries.
+The `ActionSpec`, `CliSurface`, `McpSurface`, and registry types are plain TypeScript interfaces in `@xmtp/signet-contracts`. They are not Zod schemas because they are internal compile-time contracts, not wire formats validated at boundaries.
 
 ## Behaviors
 
@@ -373,7 +373,7 @@ Transport adapter         Zod schema              Handler              toActionR
       │                       │                      │                       │
       │  handler(validatedInput, ctx)                │                       │
       │─────────────────────────────────────────────►│                       │
-      │  Result<T, BrokerError>                      │                       │
+      │  Result<T, SignetError>                      │                       │
       │◄─────────────────────────────────────────────│                       │
       │                                              │                       │
       │  toActionResult(result, meta, pagination?)                           │
@@ -398,7 +398,7 @@ Action IDs use `{domain}.{verb}` format:
 | `session` | `session.list`, `session.issue`, `session.revoke`, `session.inspect` |
 | `message` | `message.send`, `message.list` |
 | `group` | `group.list`, `group.info` |
-| `attestation` | `attestation.current`, `attestation.refresh`, `attestation.revoke` |
+| `seal` | `seal.current`, `seal.refresh`, `seal.revoke` |
 | `broker` | `broker.status`, `broker.start`, `broker.stop` |
 | `key` | `key.list`, `key.rotate` |
 
@@ -464,7 +464,7 @@ Calling `register()` with an action ID that already exists throws immediately. T
 
 | Scenario | Error | Category |
 |----------|-------|----------|
-| Duplicate action ID registration | Throws `Error` (programming bug, not `BrokerError`) | -- |
+| Duplicate action ID registration | Throws `Error` (programming bug, not `SignetError`) | -- |
 | Input fails Zod validation | `ValidationError` | validation |
 | Handler returns `err()` | Error propagated through `toActionResult` | varies |
 | Handler throws (bug) | Caught by transport, wrapped as `InternalError` | internal |
@@ -476,7 +476,7 @@ Note: the registry itself has no error cases beyond the duplicate check. All oth
 ## Open Questions Resolved
 
 **Q: Where does ActionSpec live -- contracts or a new package?**
-**A:** In `@xmtp-broker/contracts`. ActionSpec is a cross-package interface (runtime packages implement it, transport packages consume it). That is exactly what the contracts package is for. Adding a new package for a single type + a registry function is overengineering.
+**A:** In `@xmtp/signet-contracts`. ActionSpec is a cross-package interface (runtime packages implement it, transport packages consume it). That is exactly what the contracts package is for. Adding a new package for a single type + a registry function is overengineering.
 
 **Q: Should the registry be async?**
 **A:** No. The registry is an in-memory Map. Registration happens synchronously during broker initialization before any transport starts listening. There is no persistence, no I/O, no reason for async.
@@ -567,7 +567,7 @@ expect(parsed.success).toBe(true);
 function createTestActionSpec(
   id: string,
   surfaces?: { cli?: CliSurface; mcp?: McpSurface },
-): ActionSpec<unknown, unknown, BrokerError>;
+): ActionSpec<unknown, unknown, SignetError>;
 
 /** Create test HandlerContext with defaults. */
 function createTestHandlerContext(

--- a/.agents/plans/v0/11-sdk-integration.md
+++ b/.agents/plans/v0/11-sdk-integration.md
@@ -1,6 +1,6 @@
 # 11-sdk-integration
 
-**Package:** `@xmtp-broker/core`
+**Package:** `@xmtp/signet-core`
 **Spec version:** 0.1.0
 
 ## Overview
@@ -21,14 +21,14 @@ The integration lives in a new `packages/core/src/sdk/` directory to keep SDK-co
 
 **Imports:**
 - `@xmtp/node-sdk` -- `Client`, `Signer`, `Conversations`, `Group`, `DecodedMessage`, `GroupPermissionsOptions` (production SDK)
-- `@xmtp-broker/schemas` -- `BrokerError`, `InternalError`, `NotFoundError`, `TimeoutError`
-- `@xmtp-broker/contracts` -- `SignerProvider` (for type reference only)
+- `@xmtp/signet-schemas` -- `SignetError`, `InternalError`, `NotFoundError`, `TimeoutError`
+- `@xmtp/signet-contracts` -- `SignerProvider` (for type reference only)
 - `better-result` -- `Result`, `Result.ok`, `Result.err`
 - `bun:sqlite` -- `Database` (for identity store extension)
 
 **Imported by:**
-- `@xmtp-broker/core` internal -- `broker-core.ts` passes `SdkClientFactory` as the production factory
-- Nothing external -- this is an internal implementation detail of `@xmtp-broker/core`
+- `@xmtp/signet-core` internal -- `broker-core.ts` passes `SdkClientFactory` as the production factory
+- Nothing external -- this is an internal implementation detail of `@xmtp/signet-core`
 
 ## Public Interfaces
 
@@ -118,8 +118,8 @@ No new interface is needed. The integration simply calls `setInboxId()` after su
 
 When per-group identity is enabled (default-on per spec 03), creating or joining a group is an atomic operation that creates a new identity for that group. The flow is:
 
-1. `BrokerCore` receives a "create group" or "join group" request.
-2. `BrokerCore` calls `ClientRegistry.createClient(groupId)`.
+1. `SignetCore` receives a "create group" or "join group" request.
+2. `SignetCore` calls `ClientRegistry.createClient(groupId)`.
 3. `ClientRegistry` generates a new identity ID and calls `SdkClientFactory.create()` with fresh `XmtpClientCreateOptions` (new `identityId`, new `dbPath`, new `dbEncryptionKey` from the vault).
 4. The factory creates a new `@xmtp/node-sdk` `Client` with its own inbox — this is the identity that joins/creates the group.
 5. `ClientRegistry` registers the new `SdkClient` and maps it to the `groupId`.
@@ -207,7 +207,7 @@ All SDK exceptions are caught and translated to broker error types:
 function wrapSdkCall<T>(
   fn: () => Promise<T>,
   context: string,
-): Promise<Result<T, BrokerError>> {
+): Promise<Result<T, SignetError>> {
   try {
     const result = await fn();
     return Result.ok(result);

--- a/.agents/plans/v0/12-admin-keys.md
+++ b/.agents/plans/v0/12-admin-keys.md
@@ -1,6 +1,6 @@
 # 12-admin-keys
 
-**Package:** `@xmtp-broker/keys`
+**Package:** `@xmtp/signet-keys`
 **Spec version:** 0.1.0
 
 ## Overview
@@ -26,7 +26,7 @@ Admin Key (Ed25519, in vault)  <-- THIS SPEC
 ## Dependencies
 
 **Imports:**
-- `@xmtp-broker/schemas` -- `BrokerError`, `InternalError`, `AuthError`, `ValidationError`, `NotFoundError`
+- `@xmtp/signet-schemas` -- `SignetError`, `InternalError`, `AuthError`, `ValidationError`, `NotFoundError`
 - `better-result` -- `Result`
 - `zod` -- JWT payload validation
 
@@ -36,9 +36,9 @@ Admin Key (Ed25519, in vault)  <-- THIS SPEC
 - `./config.js` -- `KeyManagerConfig` (for data directory)
 
 **Imported by:**
-- `@xmtp-broker/keys` -- `KeyManager` exposes admin key operations alongside inbox key operations
-- Future `@xmtp-broker/daemon` -- validates admin JWTs on the Unix socket
-- Future `@xmtp-broker/cli` -- generates admin JWTs for CLI-to-daemon requests
+- `@xmtp/signet-keys` -- `KeyManager` exposes admin key operations alongside inbox key operations
+- Future `@xmtp/signet-daemon` -- validates admin JWTs on the Unix socket
+- Future `@xmtp/signet-cli` -- generates admin JWTs for CLI-to-daemon requests
 
 ## Public Interfaces
 

--- a/.agents/plans/v0/13-daemon-cli.md
+++ b/.agents/plans/v0/13-daemon-cli.md
@@ -1,37 +1,37 @@
 # 13-daemon-cli
 
-**Package:** `@xmtp-broker/cli`
+**Package:** `@xmtp/signet-cli`
 **Spec version:** 0.1.0
 
 ## Overview
 
-The CLI package is the composition root and primary human interface for the xmtp-broker. It wires all runtime packages into a running daemon process and exposes 8 command groups for operating, administering, and debugging the broker. The CLI is a thin transport adapter over the same handler contract used by WebSocket -- every command maps to a handler that receives typed input and returns `Result<T, E>`.
+The CLI package is the composition root and primary human interface for the xmtp-signet. It wires all runtime packages into a running daemon process and exposes 8 command groups for operating, administering, and debugging the broker. The CLI is a thin transport adapter over the same handler contract used by WebSocket -- every command maps to a handler that receives typed input and returns `Result<T, E>`.
 
 The package serves three distinct roles:
 
 1. **Daemon lifecycle** -- Start, stop, and monitor the broker process. The daemon owns the XMTP client, key hierarchy, session store, policy engine, WebSocket server, and admin socket.
 2. **Admin transport** -- CLI commands connect to the daemon's Unix domain socket, send JSON-RPC 2.0 requests, and display results. This is the admin-facing counterpart to the WebSocket's harness-facing interface.
-3. **Direct mode fallback** -- When no daemon is running, qualifying commands spin up a one-shot XMTP client for development and scripting, bypassing the session/grant/attestation system entirely.
+3. **Direct mode fallback** -- When no daemon is running, qualifying commands spin up a one-shot XMTP client for development and scripting, bypassing the session/grant/seal system entirely.
 
 The binary name is `xmtp-broker`. Built with Commander.js on Bun, it composes cleanly with the broker's Zod schemas for argument validation and the existing error taxonomy for exit code mapping.
 
 ## Dependencies
 
 **Imports:**
-- `@xmtp-broker/contracts` -- `BrokerCore`, `SessionManager`, `AttestationManager`, `CoreContext`, `HandlerContext`, `Handler`, `SignerProvider`, `CoreState`, `GroupInfo`, `SessionRecord`, `RawEvent` (canonical interface definitions)
-- `@xmtp-broker/schemas` -- `SessionConfig`, `SessionToken`, `ViewConfig`, `GrantConfig`, `BrokerEvent`, error classes (`ValidationError`, `AuthError`, `InternalError`, `NotFoundError`, `PermissionError`, `TimeoutError`, `CancelledError`), `ErrorCategory`, `ERROR_CATEGORY_META`
-- `@xmtp-broker/core` -- `BrokerCore` implementation, `BrokerCoreConfig`
-- `@xmtp-broker/policy` -- `PolicyEngine`, view filtering, grant enforcement
-- `@xmtp-broker/sessions` -- `SessionManager` implementation
-- `@xmtp-broker/attestations` -- `AttestationManager` implementation
-- `@xmtp-broker/keys` -- `KeyManager`, `SignerProvider` implementation
-- `@xmtp-broker/ws` -- `WsServer`, `WsServerConfig`
+- `@xmtp/signet-contracts` -- `SignetCore`, `SessionManager`, `SealManager`, `CoreContext`, `HandlerContext`, `Handler`, `SignerProvider`, `CoreState`, `GroupInfo`, `SessionRecord`, `RawEvent` (canonical interface definitions)
+- `@xmtp/signet-schemas` -- `SessionConfig`, `SessionToken`, `ViewConfig`, `GrantConfig`, `BrokerEvent`, error classes (`ValidationError`, `AuthError`, `InternalError`, `NotFoundError`, `PermissionError`, `TimeoutError`, `CancelledError`), `ErrorCategory`, `ERROR_CATEGORY_META`
+- `@xmtp/signet-core` -- `SignetCore` implementation, `SignetCoreConfig`
+- `@xmtp/signet-policy` -- `PolicyEngine`, view filtering, grant enforcement
+- `@xmtp/signet-sessions` -- `SessionManager` implementation
+- `@xmtp/signet-seals` -- `SealManager` implementation
+- `@xmtp/signet-keys` -- `KeyManager`, `SignerProvider` implementation
+- `@xmtp/signet-ws` -- `WsServer`, `WsServerConfig`
 - `commander` -- CLI framework
 - `smol-toml` -- TOML config parsing
 - `better-result` -- `Result`, `ok`, `err`
 - `zod` -- config and argument validation
 
-**Imported by:** Nothing -- this is the top of the dependency graph, alongside `@xmtp-broker/ws`.
+**Imported by:** Nothing -- this is the top of the dependency graph, alongside `@xmtp/signet-ws`.
 
 ## Public Interfaces
 
@@ -130,9 +130,9 @@ On macOS, `$XDG_RUNTIME_DIR` defaults to `$TMPDIR` if unset.
 ```typescript
 /** The fully wired broker runtime returned by the composition root. */
 interface BrokerRuntime {
-  readonly core: BrokerCore;
+  readonly core: SignetCore;
   readonly sessionManager: SessionManager;
-  readonly attestationManager: AttestationManager;
+  readonly attestationManager: SealManager;
   readonly keyManager: KeyManager;
   readonly policyEngine: PolicyEngine;
   readonly wsServer: WsServer;
@@ -141,10 +141,10 @@ interface BrokerRuntime {
   readonly paths: ResolvedPaths;
 
   /** Start all services in dependency order. */
-  start(): Promise<Result<void, BrokerError>>;
+  start(): Promise<Result<void, SignetError>>;
 
   /** Graceful shutdown in reverse dependency order. */
-  shutdown(): Promise<Result<void, BrokerError>>;
+  shutdown(): Promise<Result<void, SignetError>>;
 
   /** Current lifecycle state. */
   readonly state: DaemonState;
@@ -204,10 +204,10 @@ interface AdminClient {
   request<T>(
     method: string,
     params?: Record<string, unknown>,
-  ): Promise<Result<T, BrokerError>>;
+  ): Promise<Result<T, SignetError>>;
 
   /** Check if the daemon is reachable. */
-  ping(): Promise<Result<DaemonStatus, BrokerError>>;
+  ping(): Promise<Result<DaemonStatus, SignetError>>;
 
   /** Close the connection. */
   close(): void;
@@ -326,7 +326,7 @@ interface AdminDispatcher {
     method: string,
     params: Record<string, unknown>,
     ctx: HandlerContext,
-  ): Promise<Result<unknown, BrokerError>>;
+  ): Promise<Result<unknown, SignetError>>;
 }
 ```
 
@@ -351,10 +351,10 @@ JSON-RPC methods use dot-delimited names matching the CLI command structure:
 | `grant list` | `grant.list` |
 | `grant inspect <id>` | `grant.inspect` |
 | `grant revoke <id>` | `grant.revoke` |
-| `attestation list` | `attestation.list` |
-| `attestation inspect <id>` | `attestation.inspect` |
-| `attestation verify <id>` | `attestation.verify` |
-| `attestation revoke <id>` | `attestation.revoke` |
+| `seal list` | `seal.list` |
+| `seal inspect <id>` | `seal.inspect` |
+| `seal verify <id>` | `seal.verify` |
+| `seal revoke <id>` | `seal.revoke` |
 | `message send <group> <text>` | `message.send` |
 | `message list <group>` | `message.list` |
 | `message stream <group>` | `message.stream` |
@@ -379,14 +379,14 @@ interface OutputOptions {
 
 /** Format a Result for CLI output. */
 function formatResult<T>(
-  result: Result<T, BrokerError>,
+  result: Result<T, SignetError>,
   options: OutputOptions,
   formatter: (value: T) => string,
 ): string;
 
-/** Format a BrokerError for CLI output. */
+/** Format a SignetError for CLI output. */
 function formatError(
-  error: BrokerError,
+  error: SignetError,
   options: OutputOptions,
 ): string;
 
@@ -394,7 +394,7 @@ function formatError(
 function exitCodeFromCategory(category: ErrorCategory): number;
 ```
 
-The `exitCodeFromCategory` function reads from `ERROR_CATEGORY_META` in `@xmtp-broker/schemas`, which maps categories to exit codes. This is the single source of truth -- the CLI does not maintain its own exit code table.
+The `exitCodeFromCategory` function reads from `ERROR_CATEGORY_META` in `@xmtp/signet-schemas`, which maps categories to exit codes. This is the single source of truth -- the CLI does not maintain its own exit code table.
 
 ### Direct Mode Client
 
@@ -411,7 +411,7 @@ type DirectModeConfig = z.infer<typeof DirectModeConfigSchema>;
 /** Create a one-shot XMTP client for direct mode. */
 function createDirectClient(
   config: DirectModeConfig,
-): Promise<Result<DirectClient, BrokerError>>;
+): Promise<Result<DirectClient, SignetError>>;
 
 interface DirectClient {
   /** The underlying XMTP client (raw access, no policy). */
@@ -428,7 +428,7 @@ This means Secure Enclave integration (spec 07) is a hard dependency for the CLI
 
 ## Zod Schemas
 
-All new schemas are defined above. This package imports existing schemas from `@xmtp-broker/schemas` (error taxonomy, session types, view/grant configs) and `@xmtp-broker/contracts` (service interfaces).
+All new schemas are defined above. This package imports existing schemas from `@xmtp/signet-schemas` (error taxonomy, session types, view/grant configs) and `@xmtp/signet-contracts` (service interfaces).
 
 Schemas defined in this package:
 
@@ -474,8 +474,8 @@ Schemas defined in this package:
 1. Key manager -- detect platform, load or create root key
 2. Broker core -- create XMTP client(s), sync groups
 3. Session manager -- initialize session store
-4. Attestation manager -- bind to key manager and core
-5. Policy engine -- wire to session and attestation managers
+4. Seal manager -- bind to key manager and core
+5. Policy engine -- wire to session and seal managers
 6. WebSocket server -- begin accepting harness connections
 7. Admin server -- open Unix domain socket
 8. Write PID file
@@ -723,7 +723,7 @@ xmtp-broker identity export-public
 
 **`info`**: Daemon mode. Displays inbox ID, installation ID, identity mode, key fingerprints, platform capability, and trust tier.
 
-**`rotate-keys`**: Daemon mode, admin auth required. Triggers operational key rotation through the key manager. May prompt for biometric. Publishes updated attestations.
+**`rotate-keys`**: Daemon mode, admin auth required. Triggers operational key rotation through the key manager. May prompt for biometric. Publishes updated seals.
 
 **`export-public`**: Daemon mode. Exports public key material (operational key public key, root key public key, fingerprints) in a format suitable for verification.
 
@@ -776,7 +776,7 @@ All grant commands require the daemon and admin auth.
 
 **`revoke <id>`**: Revokes a specific grant, which triggers session reauthorization (material change).
 
-#### `attestation` -- Attestation Lifecycle
+#### `seal` -- Seal Lifecycle
 
 ```
 xmtp-broker attestation list [--group <groupId>] [--agent <inboxId>]
@@ -785,15 +785,15 @@ xmtp-broker attestation verify <id>
 xmtp-broker attestation revoke <id>
 ```
 
-All attestation commands require the daemon. `verify` and `inspect` have limited direct mode support if given raw attestation data via stdin.
+All seal commands require the daemon. `verify` and `inspect` have limited direct mode support if given raw seal data via stdin.
 
-**`list`**: Lists attestations filtered by group or agent. Displays: attestation ID, group, agent, trust tier, issued, expires.
+**`list`**: Lists seals filtered by group or agent. Displays: seal ID, group, agent, trust tier, issued, expires.
 
-**`inspect <id>`**: Shows full attestation content including the signed envelope, verification chain, view/grant summary, and provenance metadata.
+**`inspect <id>`**: Shows full seal content including the signed envelope, verification chain, view/grant summary, and provenance metadata.
 
-**`verify <id>`**: Runs the 6-check verification pipeline from spec 09 against a specific attestation. Displays pass/fail for each check and an overall result.
+**`verify <id>`**: Runs the 6-check verification pipeline from spec 09 against a specific seal. Displays pass/fail for each check and an overall result.
 
-**`revoke <id>`**: Revokes an attestation and publishes a revocation message to the group.
+**`revoke <id>`**: Revokes a seal and publishes a revocation message to the group.
 
 #### `message` -- Message Operations
 
@@ -902,7 +902,7 @@ Commands that require the daemon:
 | `identity info/rotate-keys/export-public` | Requires key manager |
 | `session *` | Sessions are a daemon concept |
 | `grant *` | Grants are a daemon concept |
-| `attestation *` | Attestation manager is daemon-internal |
+| `seal *` | Seal manager is daemon-internal |
 | `admin *` | Admin operations by definition |
 
 ### Composition Root
@@ -912,7 +912,7 @@ The `createBrokerRuntime` function is the application's composition root. It wir
 ```typescript
 async function createBrokerRuntime(
   config: CliConfig,
-): Promise<Result<BrokerRuntime, BrokerError>> {
+): Promise<Result<BrokerRuntime, SignetError>> {
   // 1. Resolve paths
   const paths = resolvePaths(config);
 
@@ -935,7 +935,7 @@ async function createBrokerRuntime(
   };
 
   // 5. Create broker core
-  const core = createBrokerCore({
+  const core = createSignetCore({
     dataDir: paths.dataDir,
     env: config.broker.env,
     identityMode: config.broker.identityMode,
@@ -948,9 +948,9 @@ async function createBrokerRuntime(
     maxConcurrentPerAgent: config.sessions.maxConcurrentPerAgent,
   });
 
-  // 7. Create attestation signer and manager
+  // 7. Create seal signer and manager
   const attestationSigner = createAttestationSigner(keyManager, coreContext.brokerId);
-  const attestationManager = createAttestationManager({
+  const attestationManager = createSealManager({
     signer: attestationSigner,
     publisher: core.toAttestationPublisher(),
   });
@@ -1030,7 +1030,7 @@ A second SIGINT/SIGTERM forces immediate exit (matching Unix conventions). The f
 ```typescript
 interface PidFile {
   /** Write PID file. Returns error if a live process holds it. */
-  acquire(pidPath: string): Result<void, BrokerError>;
+  acquire(pidPath: string): Result<void, SignetError>;
 
   /** Remove PID file. */
   release(pidPath: string): void;
@@ -1158,7 +1158,7 @@ function resolveOutputOptions(cmd: Command): OutputOptions;
 
 /** Handle a Result: format and print on success, print error and exit on failure. */
 function handleResult<T>(
-  result: Result<T, BrokerError>,
+  result: Result<T, SignetError>,
   options: OutputOptions,
   formatter: (value: T) => string,
 ): void;
@@ -1215,7 +1215,7 @@ Operations that trigger audit entries:
 | `session.issue` | Yes |
 | `session.revoke` | Yes |
 | `grant.revoke` | Yes |
-| `attestation.revoke` | Yes |
+| `seal.revoke` | Yes |
 | `identity.rotateKeys` | Yes |
 | `broker.start` | Yes |
 | `broker.stop` | Yes |
@@ -1233,7 +1233,7 @@ Operations that trigger audit entries:
 | Admin socket connection refused | `InternalError` | 8 | internal |
 | Admin auth failed (bad admin key) | `AuthError` | 9 | auth |
 | Session not found | `NotFoundError` | 2 | not_found |
-| Attestation not found | `NotFoundError` | 2 | not_found |
+| Seal not found | `NotFoundError` | 2 | not_found |
 | Group not found | `NotFoundError` | 2 | not_found |
 | Operation requires daemon (direct mode unsupported) | `ValidationError` | 1 | validation |
 | Direct mode vault not found or inaccessible | `AuthError` | 9 | auth |
@@ -1244,7 +1244,7 @@ Operations that trigger audit entries:
 | PID file locked by live process | `ValidationError` | 1 | validation |
 | Permission denied on socket/PID file | `PermissionError` | 4 | permission |
 
-Exit codes are derived from `ERROR_CATEGORY_META` in `@xmtp-broker/schemas/errors/category.ts`. The CLI calls `exitCodeFromCategory(error.category)` -- no separate exit code table.
+Exit codes are derived from `ERROR_CATEGORY_META` in `@xmtp/signet-schemas/errors/category.ts`. The CLI calls `exitCodeFromCategory(error.category)` -- no separate exit code table.
 
 ## Open Questions Resolved
 
@@ -1310,7 +1310,7 @@ Exit codes are derived from `ERROR_CATEGORY_META` in `@xmtp-broker/schemas/error
 
 **Unit tests**: Test config loading, path resolution, output formatting, PID file management, JSON-RPC framing, audit log, and action registry in isolation. Mock the file system and admin socket where needed.
 
-**Integration tests**: Start a real admin server on a temporary Unix socket, connect with the admin client, and exercise the full request/response flow. Use mock runtime deps (mock `BrokerCore`, `SessionManager`, etc.) to focus on the transport layer.
+**Integration tests**: Start a real admin server on a temporary Unix socket, connect with the admin client, and exercise the full request/response flow. Use mock runtime deps (mock `SignetCore`, `SessionManager`, etc.) to focus on the transport layer.
 
 **CLI integration tests**: Invoke the `xmtp-broker` binary as a subprocess, feed it arguments, and assert on stdout, stderr, and exit codes. These tests exercise the full Commander pipeline and output formatting.
 
@@ -1437,9 +1437,9 @@ function createTestCliConfig(
 function createMockRuntime(): {
   runtime: BrokerRuntime;
   mocks: {
-    core: BrokerCore;
+    core: SignetCore;
     sessionManager: SessionManager;
-    attestationManager: AttestationManager;
+    attestationManager: SealManager;
     keyManager: KeyManager;
   };
 };
@@ -1547,7 +1547,7 @@ Each source file targets under 200 LOC. The largest files will be the command mo
 
 ```jsonc
 {
-  "name": "@xmtp-broker/cli",
+  "name": "@xmtp/signet-cli",
   "version": "0.0.0",
   "private": true,
   "type": "module",
@@ -1568,14 +1568,14 @@ Each source file targets under 200 LOC. The largest files will be the command mo
     "start": "bun run bin/xmtp-broker.ts"
   },
   "dependencies": {
-    "@xmtp-broker/contracts": "workspace:*",
-    "@xmtp-broker/schemas": "workspace:*",
-    "@xmtp-broker/core": "workspace:*",
-    "@xmtp-broker/policy": "workspace:*",
-    "@xmtp-broker/sessions": "workspace:*",
-    "@xmtp-broker/attestations": "workspace:*",
-    "@xmtp-broker/keys": "workspace:*",
-    "@xmtp-broker/ws": "workspace:*",
+    "@xmtp/signet-contracts": "workspace:*",
+    "@xmtp/signet-schemas": "workspace:*",
+    "@xmtp/signet-core": "workspace:*",
+    "@xmtp/signet-policy": "workspace:*",
+    "@xmtp/signet-sessions": "workspace:*",
+    "@xmtp/signet-seals": "workspace:*",
+    "@xmtp/signet-keys": "workspace:*",
+    "@xmtp/signet-ws": "workspace:*",
     "better-result": "catalog:",
     "commander": "14.0.3",
     "smol-toml": "1.6.0",

--- a/.agents/plans/v0/14-mcp-transport.md
+++ b/.agents/plans/v0/14-mcp-transport.md
@@ -1,13 +1,13 @@
 # 14-mcp-transport
 
-**Package:** `@xmtp-broker/mcp`
+**Package:** `@xmtp/signet-mcp`
 **Spec version:** 0.1.0
 
 ## Overview
 
 The MCP transport exposes broker ActionSpecs as MCP tools, enabling AI agents (Claude Code, Cursor, etc.) to interact with the broker through the Model Context Protocol. It is the second transport surface after WebSocket, and -- like WebSocket -- it is **harness-facing**. MCP callers operate as agent sessions with scoped views and grants, not as broker administrators.
 
-An AI agent using MCP tools is acting as a participant in XMTP conversations: sending messages, listing conversations, creating groups, managing its identity. It is NOT acting as the broker administrator. Admin operations (daemon lifecycle, session/grant management, key rotation, attestation management, audit) remain locked down in the CLI with admin key JWT auth.
+An AI agent using MCP tools is acting as a participant in XMTP conversations: sending messages, listing conversations, creating groups, managing its identity. It is NOT acting as the broker administrator. Admin operations (daemon lifecycle, session/grant management, key rotation, seal management, audit) remain locked down in the CLI with admin key JWT auth.
 
 The transport is a thin adapter. It reads ActionSpecs from the registry, converts Zod input schemas to JSON Schema via `zodToJsonSchema()`, registers them as MCP tools, and translates handler Results into MCP content blocks. All domain logic remains in the handlers. The MCP package contains no business logic.
 
@@ -21,10 +21,10 @@ Built on `@modelcontextprotocol/sdk`, the official MCP SDK. The SDK handles prot
 ## Dependencies
 
 **Imports:**
-- `@xmtp-broker/contracts` -- `ActionSpec`, `ActionRegistry`, `HandlerContext`, `Handler`
-- `@xmtp-broker/schemas` -- `ActionResultMetaSchema`, `ActionErrorSchema`, `BrokerError`, `ValidationError`, `SessionToken`, `ViewConfig`, `GrantConfig`, error category metadata
-- `@xmtp-broker/sessions` -- `SessionManager` (token validation, session lookup)
-- `@xmtp-broker/policy` -- `projectMessage`, grant validation functions
+- `@xmtp/signet-contracts` -- `ActionSpec`, `ActionRegistry`, `HandlerContext`, `Handler`
+- `@xmtp/signet-schemas` -- `ActionResultMetaSchema`, `ActionErrorSchema`, `SignetError`, `ValidationError`, `SessionToken`, `ViewConfig`, `GrantConfig`, error category metadata
+- `@xmtp/signet-sessions` -- `SessionManager` (token validation, session lookup)
+- `@xmtp/signet-policy` -- `projectMessage`, grant validation functions
 - `@modelcontextprotocol/sdk` -- `Server`, `StdioServerTransport`, `CallToolRequestSchema`, `ListToolsRequestSchema`
 - `better-result` -- `Result`, `ok`, `err`
 - `zod` -- runtime validation
@@ -119,7 +119,7 @@ interface McpToolRegistration {
 }
 
 function actionSpecToMcpTool(
-  spec: ActionSpec<unknown, unknown, BrokerError>,
+  spec: ActionSpec<unknown, unknown, SignetError>,
 ): McpToolRegistration;
 ```
 
@@ -136,7 +136,7 @@ function actionSpecToMcpTool(
 
 ## Zod Schemas
 
-This package adds only `McpServerConfigSchema` (defined above). All other schemas are imported from `@xmtp-broker/schemas` (ActionResult envelope) and `@xmtp-broker/contracts` (ActionSpec types).
+This package adds only `McpServerConfigSchema` (defined above). All other schemas are imported from `@xmtp/signet-schemas` (ActionResult envelope) and `@xmtp/signet-contracts` (ActionSpec types).
 
 ## Behaviors
 
@@ -248,9 +248,9 @@ Only harness-facing actions are exposed through MCP. The curating mechanism is t
 | `key.rotate` | Key management -- admin only |
 | `key.import` | Key management -- admin only |
 | `key.export` | Key management -- admin only |
-| `attestation.current` | Attestation management -- admin only |
-| `attestation.refresh` | Attestation management -- admin only |
-| `attestation.revoke` | Attestation management -- admin only |
+| `seal.current` | Seal management -- admin only |
+| `seal.refresh` | Seal management -- admin only |
+| `seal.revoke` | Seal management -- admin only |
 | `identity.delete` | Destructive identity operation -- admin only |
 | `identity.export` | Key material exposure -- admin only |
 
@@ -282,7 +282,7 @@ MCP Client                    MCP Server                  ActionSpec Handler
     │                              │                              │
     │                              │  handler(parsedInput, ctx)   │
     │                              │─────────────────────────────►│
-    │                              │  Result<T, BrokerError>      │
+    │                              │  Result<T, SignetError>      │
     │                              │◄─────────────────────────────│
     │                              │                              │
     │                              │  toActionResult(result, meta)│
@@ -474,7 +474,7 @@ These hints help MCP clients make UI decisions (e.g., requiring confirmation for
 ## Open Questions Resolved
 
 **Q: Should MCP callers authenticate as admin or as a session?**
-**A:** As a session. MCP callers are agent participants in conversations, not broker administrators. The session token provides the same scoped access as WebSocket -- view-filtered reads, grant-checked writes. Admin operations (daemon lifecycle, session management, key rotation, attestation management) stay in the CLI with admin key JWT auth. This is consistent with the Convos approach where agents interact with the messaging layer, not the infrastructure layer.
+**A:** As a session. MCP callers are agent participants in conversations, not broker administrators. The session token provides the same scoped access as WebSocket -- view-filtered reads, grant-checked writes. Admin operations (daemon lifecycle, session management, key rotation, seal management) stay in the CLI with admin key JWT auth. This is consistent with the Convos approach where agents interact with the messaging layer, not the infrastructure layer.
 
 **Q: Where does the session token come from?**
 **A:** From the MCP server configuration, provided by the MCP client at process launch. In stdio mode, the MCP client (Claude Code, Cursor) passes the token via its config block, typically as an environment variable (`XMTP_BROKER_SESSION_TOKEN`). The token is validated at startup and the session record is cached. Each tool call performs a lightweight liveness check (expiry + revocation via `sessionManager.isActive()`). The admin obtains the session token via the CLI (`broker session:issue`) and configures the MCP client with it.
@@ -697,7 +697,7 @@ Each source file targets under 150 LOC. The `server.ts` orchestrates but delegat
 
 ```jsonc
 {
-  "name": "@xmtp-broker/mcp",
+  "name": "@xmtp/signet-mcp",
   "version": "0.0.0",
   "private": true,
   "type": "module",
@@ -717,10 +717,10 @@ Each source file targets under 150 LOC. The `server.ts` orchestrates but delegat
     "test": "bun test"
   },
   "dependencies": {
-    "@xmtp-broker/contracts": "workspace:*",
-    "@xmtp-broker/schemas": "workspace:*",
-    "@xmtp-broker/sessions": "workspace:*",
-    "@xmtp-broker/policy": "workspace:*",
+    "@xmtp/signet-contracts": "workspace:*",
+    "@xmtp/signet-schemas": "workspace:*",
+    "@xmtp/signet-sessions": "workspace:*",
+    "@xmtp/signet-policy": "workspace:*",
     "@modelcontextprotocol/sdk": "1.27.1",
     "better-result": "catalog:",
     "zod": "catalog:",

--- a/.agents/plans/v0/15-handler-sdk.md
+++ b/.agents/plans/v0/15-handler-sdk.md
@@ -1,6 +1,6 @@
 # 15-handler-sdk
 
-**Package:** `@xmtp-broker/handler`
+**Package:** `@xmtp/signet-handler`
 **Spec version:** 0.1.0
 
 ## Overview
@@ -9,18 +9,18 @@ The handler SDK is a thin TypeScript client library that harness developers inst
 
 This is a client-side library, not a harness. It abstracts the wire protocol completely -- harness developers never see `AuthFrame`, `SequencedFrame`, or WebSocket close codes. They call `sendMessage()`, iterate over `events`, and check `state`. Framework-specific adapters (Claude Agent SDK, OpenAI Agents, etc.) come later and wrap this package.
 
-The handler SDK runs in the harness process, not in the broker. It depends only on type packages (`@xmtp-broker/schemas`, `@xmtp-broker/contracts`) and `better-result`. It has no XMTP SDK dependency, no policy logic, and no framework opinions. The entire real logic is ~300 LOC -- the rest is types and tests.
+The handler SDK runs in the harness process, not in the broker. It depends only on type packages (`@xmtp/signet-schemas`, `@xmtp/signet-contracts`) and `better-result`. It has no XMTP SDK dependency, no policy logic, and no framework opinions. The entire real logic is ~300 LOC -- the rest is types and tests.
 
 ## Dependencies
 
 **Imports:**
-- `@xmtp-broker/schemas` -- `BrokerEvent`, `BrokerError`, `ValidationError`, `AuthError`, `SessionExpiredError`, `ViewConfig`, `GrantConfig`, `SessionToken`, `ContentTypeId`, error classes
-- `@xmtp-broker/contracts` -- type-only imports for `HarnessRequest`, `RequestResponse`, `SessionRecord` (wire format types used internally)
+- `@xmtp/signet-schemas` -- `BrokerEvent`, `SignetError`, `ValidationError`, `AuthError`, `SessionExpiredError`, `ViewConfig`, `GrantConfig`, `SessionToken`, `ContentTypeId`, error classes
+- `@xmtp/signet-contracts` -- type-only imports for `HarnessRequest`, `RequestResponse`, `SessionRecord` (wire format types used internally)
 - `better-result` -- `Result`, `ok`, `err`
 - `zod` -- frame validation at the wire boundary (incoming broker frames)
 
 **Does NOT import:**
-- `@xmtp-broker/core`, `@xmtp-broker/policy`, `@xmtp-broker/sessions`, `@xmtp-broker/keys` -- no runtime broker packages
+- `@xmtp/signet-core`, `@xmtp/signet-policy`, `@xmtp/signet-sessions`, `@xmtp/signet-keys` -- no runtime broker packages
 - `@xmtp/node-sdk` -- talks to the broker, not to XMTP directly
 - `Bun.serve()` -- this is a client, not a server
 
@@ -61,10 +61,10 @@ type BrokerHandlerConfig = z.infer<typeof BrokerHandlerConfigSchema>;
 ```typescript
 interface BrokerHandler {
   /** Open the WebSocket connection and authenticate. */
-  connect(): Promise<Result<void, BrokerError>>;
+  connect(): Promise<Result<void, SignetError>>;
 
   /** Close the connection gracefully. Completes in-flight requests. */
-  disconnect(): Promise<Result<void, BrokerError>>;
+  disconnect(): Promise<Result<void, SignetError>>;
 
   /** Typed async iterable of broker events, filtered by the session's view. */
   readonly events: AsyncIterable<BrokerEvent>;
@@ -73,22 +73,22 @@ interface BrokerHandler {
   sendMessage(
     groupId: string,
     content: MessageContent,
-  ): Promise<Result<MessageSent, BrokerError>>;
+  ): Promise<Result<MessageSent, SignetError>>;
 
   /** Send a reaction to a message. */
   sendReaction(
     groupId: string,
     messageId: string,
     reaction: string,
-  ): Promise<Result<ReactionSent, BrokerError>>;
+  ): Promise<Result<ReactionSent, SignetError>>;
 
   /** List conversations visible to this session. */
-  listConversations(): Promise<Result<Conversation[], BrokerError>>;
+  listConversations(): Promise<Result<Conversation[], SignetError>>;
 
   /** Get detailed info about a conversation. */
   getConversationInfo(
     groupId: string,
-  ): Promise<Result<ConversationInfo, BrokerError>>;
+  ): Promise<Result<ConversationInfo, SignetError>>;
 
   /** Current session info (view, grant, expiry). */
   readonly session: SessionInfo | null;
@@ -124,7 +124,7 @@ type StateChangeCallback = (
   previousState: HandlerState,
 ) => void;
 
-type ErrorCallback = (error: BrokerError) => void;
+type ErrorCallback = (error: SignetError) => void;
 ```
 
 ### Session Info
@@ -183,7 +183,7 @@ interface ConversationInfo {
 
 ## Zod Schemas
 
-This package adds only `BrokerHandlerConfigSchema` (defined above) and internal frame validation schemas. All event and request types are imported from `@xmtp-broker/schemas`.
+This package adds only `BrokerHandlerConfigSchema` (defined above) and internal frame validation schemas. All event and request types are imported from `@xmtp/signet-schemas`.
 
 ### Internal Frame Schemas (not exported)
 
@@ -334,7 +334,7 @@ Each request method:
 // Internal request tracking
 interface PendingRequest {
   readonly requestId: string;
-  readonly resolve: (result: Result<unknown, BrokerError>) => void;
+  readonly resolve: (result: Result<unknown, SignetError>) => void;
   readonly timer: Timer;
 }
 ```
@@ -430,7 +430,7 @@ The handler tracks `lastSeenSeq` -- the highest sequence number received from th
 **A:** Three signals: (1) a `session.expired` event on the event stream (the broker sends this before closing), (2) transition to `disconnected` or `closed` state (observable via `onStateChange`), and (3) an error via `onError`. The harness can listen on whichever channel is most natural for its architecture.
 
 **Q: Should request methods throw or return Results?**
-**A:** Return `Result<T, BrokerError>`. Consistent with the broker's internal handler contract and the project's "Result types, not exceptions" principle. Harness developers pattern-match on `result.ok` / `result.error` rather than try/catch.
+**A:** Return `Result<T, SignetError>`. Consistent with the broker's internal handler contract and the project's "Result types, not exceptions" principle. Harness developers pattern-match on `result.ok` / `result.error` rather than try/catch.
 
 **Q: Should the handler validate outbound requests?**
 **A:** No. The handler sends requests to the broker and the broker validates them against the session's grant and view. Client-side validation would duplicate logic and drift from the broker's truth. The handler does minimal structural validation (e.g., non-empty groupId) but defers policy decisions to the broker.
@@ -611,7 +611,7 @@ expect(result.error.category).toBe("validation");
 const { handler, server, sendBackpressure } = createTestHandler();
 await handler.connect();
 
-const errors: BrokerError[] = [];
+const errors: SignetError[] = [];
 handler.onError((e) => errors.push(e));
 
 sendBackpressure({ buffered: 200, limit: 256 });
@@ -692,7 +692,7 @@ Each source file targets under 150 LOC. The `handler.ts` orchestrates but delega
 
 ```jsonc
 {
-  "name": "@xmtp-broker/handler",
+  "name": "@xmtp/signet-handler",
   "version": "0.0.0",
   "private": true,
   "type": "module",
@@ -709,8 +709,8 @@ Each source file targets under 150 LOC. The `handler.ts` orchestrates but delega
     "test": "bun test"
   },
   "dependencies": {
-    "@xmtp-broker/contracts": "workspace:*",
-    "@xmtp-broker/schemas": "workspace:*",
+    "@xmtp/signet-contracts": "workspace:*",
+    "@xmtp/signet-schemas": "workspace:*",
     "better-result": "catalog:",
     "zod": "catalog:"
   },

--- a/.agents/plans/v0/EXECUTION-PHASE2B.md
+++ b/.agents/plans/v0/EXECUTION-PHASE2B.md
@@ -36,7 +36,7 @@ branches on top).
 
 ```text
 v0/phase2-docs (current top)
-  └── v0/lazy-core            Step 1: two-phase BrokerCore init
+  └── v0/lazy-core            Step 1: two-phase SignetCore init
        └── v0/session-actions  Step 2: session service + ActionSpecs
             └── v0/admin-auth-helper  Step 3: shared createAuthenticatedClient
                  └── v0/cli-wiring    Step 4: wire CLI commands to AdminClient
@@ -44,7 +44,7 @@ v0/phase2-docs (current top)
                            └── v0/tracer-smoke   Step 6: tracer bullet verification
 ```
 
-## Step 1: Lazy BrokerCore Init
+## Step 1: Lazy SignetCore Init
 
 **Branch:** `v0/lazy-core`
 **Scope:** `packages/contracts/`, `packages/core/`, `packages/cli/`
@@ -66,19 +66,19 @@ export type CoreState =
 ```
 
 **`packages/contracts/src/services.ts`** — Add `initializeLocal()` to
-`BrokerCore`:
+`SignetCore`:
 
 ```typescript
-interface BrokerCore {
+interface SignetCore {
   readonly state: CoreState;
-  initializeLocal(): Promise<Result<void, BrokerError>>;
-  initialize(): Promise<Result<void, BrokerError>>;
-  shutdown(): Promise<Result<void, BrokerError>>;
-  getGroupInfo(groupId: string): Promise<Result<GroupInfo, BrokerError>>;
+  initializeLocal(): Promise<Result<void, SignetError>>;
+  initialize(): Promise<Result<void, SignetError>>;
+  shutdown(): Promise<Result<void, SignetError>>;
+  getGroupInfo(groupId: string): Promise<Result<GroupInfo, SignetError>>;
 }
 ```
 
-**`packages/core/src/broker-core.ts`** — Add `"local"` to `BrokerState` and a
+**`packages/core/src/broker-core.ts`** — Add `"local"` to `SignetState` and a
 real local-only startup path:
 
 - `startLocal()` opens the identity store and sets state to `"local"`.
@@ -86,7 +86,7 @@ real local-only startup path:
 - `stop()` accepts `"local"`, `"running"`, and `"error"`.
 - No XMTP clients are created during `startLocal()`.
 
-**`packages/cli/src/start.ts`** — Update the adapter from `BrokerCoreImpl` to
+**`packages/cli/src/start.ts`** — Update the adapter from `SignetCoreImpl` to
 the contract:
 
 - Map `"local"` -> `"ready-local"`.
@@ -145,18 +145,18 @@ it matches real service behavior:
 
 ```typescript
 interface SessionManager {
-  issue(config: SessionConfig): Promise<Result<IssuedSession, BrokerError>>;
+  issue(config: SessionConfig): Promise<Result<IssuedSession, SignetError>>;
   list(
     agentInboxId?: string,
-  ): Promise<Result<readonly SessionRecord[], BrokerError>>;
-  lookup(sessionId: string): Promise<Result<SessionRecord, BrokerError>>;
-  lookupByToken(token: string): Promise<Result<SessionRecord, BrokerError>>;
+  ): Promise<Result<readonly SessionRecord[], SignetError>>;
+  lookup(sessionId: string): Promise<Result<SessionRecord, SignetError>>;
+  lookupByToken(token: string): Promise<Result<SessionRecord, SignetError>>;
   revoke(
     sessionId: string,
     reason: SessionRevocationReason,
-  ): Promise<Result<void, BrokerError>>;
-  heartbeat(sessionId: string): Promise<Result<void, BrokerError>>;
-  isActive(sessionId: string): Promise<Result<boolean, BrokerError>>;
+  ): Promise<Result<void, SignetError>>;
+  heartbeat(sessionId: string): Promise<Result<void, SignetError>>;
+  isActive(sessionId: string): Promise<Result<boolean, SignetError>>;
 }
 ```
 
@@ -202,7 +202,7 @@ export interface SessionActionDeps {
 
 export function createSessionActions(
   deps: SessionActionDeps,
-): ActionSpec<unknown, unknown, BrokerError>[]
+): ActionSpec<unknown, unknown, SignetError>[]
 ```
 
 Four ActionSpecs for Phase 2B:
@@ -219,12 +219,12 @@ Four ActionSpecs for Phase 2B:
 ```typescript
 export interface BrokerActionDeps {
   readonly status: () => DaemonStatus;
-  readonly shutdown: () => Promise<Result<void, BrokerError>>;
+  readonly shutdown: () => Promise<Result<void, SignetError>>;
 }
 
 export function createBrokerActions(
   deps: BrokerActionDeps,
-): ActionSpec<unknown, unknown, BrokerError>[]
+): ActionSpec<unknown, unknown, SignetError>[]
 ```
 
 Two ActionSpecs:
@@ -324,7 +324,7 @@ export interface AuthenticatedClient {
 
 export async function createAuthenticatedClient(
   options?: AuthenticatedClientOptions,
-): Promise<Result<AuthenticatedClient, BrokerError>>
+): Promise<Result<AuthenticatedClient, SignetError>>
 ```
 
 Sequence:

--- a/.agents/plans/v0/EXECUTION-PHASE2C.md
+++ b/.agents/plans/v0/EXECUTION-PHASE2C.md
@@ -213,7 +213,7 @@ reviewer.
 
 `identity init` creates vault keys (root, operational, admin) but never
 registers with the XMTP network. The `IdentityStore` has records with
-`inboxId: null`. `BrokerCoreImpl.start()` iterates these identities and
+`inboxId: null`. `SignetCoreImpl.start()` iterates these identities and
 calls `SdkClientFactory.create()`, but that call needs a signer derived from
 the identity's key material — and that derivation path isn't wired from the
 CLI.
@@ -254,14 +254,14 @@ CLI.
 
 ```typescript
 import { Result } from "better-result";
-import type { BrokerError } from "@xmtp-broker/schemas";
-import { InternalError } from "@xmtp-broker/schemas";
+import type { SignetError } from "@xmtp/signet-schemas";
+import { InternalError } from "@xmtp/signet-schemas";
 import type { SqliteIdentityStore } from "./identity-store.js";
 import type {
   XmtpClientFactory,
   SignerProviderLike,
 } from "./xmtp-client-factory.js";
-import type { BrokerCoreConfig, XmtpEnv } from "./config.js";
+import type { SignetCoreConfig, XmtpEnv } from "./config.js";
 
 export type SignerProviderFactory = (identityId: string) => SignerProviderLike;
 
@@ -269,7 +269,7 @@ export interface IdentityRegistrationDeps {
   readonly identityStore: SqliteIdentityStore;
   readonly clientFactory: XmtpClientFactory;
   readonly signerProviderFactory: SignerProviderFactory;
-  readonly config: Pick<BrokerCoreConfig, "dataDir" | "env" | "appVersion">;
+  readonly config: Pick<SignetCoreConfig, "dataDir" | "env" | "appVersion">;
 }
 
 export interface RegisterIdentityInput {
@@ -298,7 +298,7 @@ export interface RegisteredIdentity {
 export async function registerIdentity(
   deps: IdentityRegistrationDeps,
   input: RegisterIdentityInput,
-): Promise<Result<RegisteredIdentity, BrokerError>> {
+): Promise<Result<RegisteredIdentity, SignetError>> {
   // 1. Create identity record (inboxId starts null)
   const createResult = await deps.identityStore.create(
     input.groupId ?? null,
@@ -418,10 +418,10 @@ how `start.ts` constructs deps for the daemon:
 // 7. Register XMTP identity (skip for --env local)
 const env = options.env ?? config.broker?.env ?? "dev";
 if (env !== "local") {
-  const { createSdkClientFactory } = await import("@xmtp-broker/core");
-  const { createSignerProvider } = await import("@xmtp-broker/keys");
+  const { createSdkClientFactory } = await import("@xmtp/signet-core");
+  const { createSignerProvider } = await import("@xmtp/signet-keys");
   const { registerIdentity, SqliteIdentityStore } = await import(
-    "@xmtp-broker/core"
+    "@xmtp/signet-core"
   );
 
   const identityStore = new SqliteIdentityStore(
@@ -508,7 +508,7 @@ cmd
     }
 
     const paths = resolvePaths(configResult.value);
-    const { SqliteIdentityStore } = await import("@xmtp-broker/core");
+    const { SqliteIdentityStore } = await import("@xmtp/signet-core");
     const store = new SqliteIdentityStore(
       `${paths.dataDir}/identities.db`,
     );
@@ -575,7 +575,7 @@ deps that `start.ts` would use in the daemon:
 | `KeyManager` | `createKeyManager(config)` | Already created at step 3 |
 | `SignerProviderFactory` | `createSignerProvider(keyManagerRef, id)` | `createSignerProvider(km, id)` |
 | `XmtpClientFactory` | `createSdkClientFactory()` | `createSdkClientFactory()` |
-| `SqliteIdentityStore` | Owned by `BrokerCoreImpl` | Created directly with `identities.db` path |
+| `SqliteIdentityStore` | Owned by `SignetCoreImpl` | Created directly with `identities.db` path |
 
 The key manager (`km`) is already alive at the point where registration
 happens, so the signer provider factory can be constructed inline.
@@ -596,8 +596,8 @@ a different inbox ID. `identity list` shows both.
 
 **Implementer prompt context:**
 - Read `packages/cli/src/runtime.ts` lines 250-323 for `BrokerRuntime.start()`
-- Read `packages/cli/src/start.ts` lines 130-163 for the `BrokerCore` adapter
-- Read `packages/core/src/broker-core.ts` lines 105-238 for `BrokerCoreImpl.start()`
+- Read `packages/cli/src/start.ts` lines 130-163 for the `SignetCore` adapter
+- Read `packages/core/src/broker-core.ts` lines 105-238 for `SignetCoreImpl.start()`
 - Read `packages/cli/src/daemon/status.ts` for `DaemonStatus` schema
 - The key change is adding `core.initialize()` call after `core.initializeLocal()` in `runtime.ts`
 - Graceful degradation: network failure logs a warning, daemon continues in local mode
@@ -605,7 +605,7 @@ a different inbox ID. `identity list` shows both.
 ### Problem
 
 `broker start` calls `core.initializeLocal()` and stops there. The
-`core.initialize()` method (which maps to `BrokerCoreImpl.start()`) that
+`core.initialize()` method (which maps to `SignetCoreImpl.start()`) that
 hydrates real XMTP clients is never called. This was correct for Phase 2B
 (local mode only), but now that identities are registered, the daemon needs
 to connect to the network.
@@ -623,19 +623,19 @@ to connect to the network.
 // 6. Log startup event
 ```
 
-The `BrokerCore` contract (from `@xmtp-broker/contracts`) has both
+The `SignetCore` contract (from `@xmtp/signet-contracts`) has both
 `initializeLocal()` and `initialize()`. The adapter in `start.ts` maps
-these to `BrokerCoreImpl.startLocal()` and `BrokerCoreImpl.start()`.
+these to `SignetCoreImpl.startLocal()` and `SignetCoreImpl.start()`.
 
 **`packages/cli/src/start.ts`** — The adapter (lines 130-163):
 
 ```typescript
-// BrokerCore adapter wrapping BrokerCoreImpl:
+// SignetCore adapter wrapping SignetCoreImpl:
 async initializeLocal() { return impl.startLocal(); },
 async initialize() { return impl.start(); },
 ```
 
-`BrokerCoreImpl.start()` (lines 105-238 in `broker-core.ts`) already does
+`SignetCoreImpl.start()` (lines 105-238 in `broker-core.ts`) already does
 everything needed: iterates stored identities, creates SDK clients, syncs,
 starts streams, transitions to `"running"`.
 
@@ -673,7 +673,7 @@ if (config.broker.env !== "local") {
 // 3. Start WebSocket server (proceeds regardless of core state)
 ```
 
-The `BrokerCoreImpl.start()` method already handles the "no identities"
+The `SignetCoreImpl.start()` method already handles the "no identities"
 case gracefully — it loops over `identityStore.list()` and if the list is
 empty, it starts the heartbeat and transitions to `"running"` with zero
 clients. This is fine; the daemon is ready to accept identities later.
@@ -701,9 +701,9 @@ async status(): Promise<DaemonStatus> {
 }
 ```
 
-> **Implementation note:** The `BrokerCore` contract doesn't expose identity
+> **Implementation note:** The `SignetCore` contract doesn't expose identity
 > count or inbox IDs yet. Either add `listIdentities()` to the contract, or
-> expose it through the `BrokerCoreImpl` adapter in `start.ts`. The adapter
+> expose it through the `SignetCoreImpl` adapter in `start.ts`. The adapter
 > pattern from `start.ts` (lines 130-163) is the right place to add this.
 
 **`packages/cli/src/__tests__/network-startup.test.ts`** — Tests:
@@ -735,7 +735,7 @@ inbox IDs. Without identities, daemon stays in local mode.
 - Read `packages/core/src/sdk/sdk-client.ts` for how to implement `createGroup` with `wrapSdkCall`
 - Read `packages/cli/src/runtime.ts` for where to register new ActionSpecs
 - Node.js SDK uses `client.conversations.createGroup(inboxIds: string[], opts?)` — plain strings, NOT typed identifiers
-- `BrokerCoreImpl.#registry` is private — add a public accessor or `getManagedClient(id)` method
+- `SignetCoreImpl.#registry` is private — add a public accessor or `getManagedClient(id)` method
 
 ### Problem
 
@@ -759,8 +759,8 @@ wrapping the SDK. All methods use the `wrapSdkCall()` helper.
 ```typescript
 export function createSessionActions(
   deps: SessionActionDeps,
-): ActionSpec<unknown, unknown, BrokerError>[] {
-  const issue: ActionSpec<SessionConfigType, unknown, BrokerError> = {
+): ActionSpec<unknown, unknown, SignetError>[] {
+  const issue: ActionSpec<SessionConfigType, unknown, SignetError> = {
     id: "session.issue",
     input: SessionConfig,          // Zod schema
     handler: async (input) => deps.sessionManager.issue(input),
@@ -801,7 +801,7 @@ const result = await resolvedDeps.withDaemonClient(
 createGroup(
   memberInboxIds: readonly string[],
   options?: { name?: string },
-): Promise<Result<XmtpGroupInfo, BrokerError>>;
+): Promise<Result<XmtpGroupInfo, SignetError>>;
 ```
 
 **`packages/core/src/sdk/sdk-client.ts`** — Implement `createGroup`:
@@ -810,7 +810,7 @@ createGroup(
 async createGroup(
   memberInboxIds: readonly string[],
   options?: { name?: string },
-): Promise<Result<XmtpGroupInfo, BrokerError>> {
+): Promise<Result<XmtpGroupInfo, SignetError>> {
   return wrapSdkCall(async () => {
     // Node.js SDK uses plain inbox ID strings, NOT typed identifier objects.
     // createGroupWithIdentifiers() does NOT exist in the Node SDK —
@@ -844,13 +844,13 @@ conversation operations:
 ```typescript
 import { z } from "zod";
 import { Result } from "better-result";
-import type { ActionSpec } from "@xmtp-broker/contracts";
-import type { BrokerError } from "@xmtp-broker/schemas";
-import { NotFoundError } from "@xmtp-broker/schemas";
-import type { BrokerCoreImpl } from "./broker-core.js";
+import type { ActionSpec } from "@xmtp/signet-contracts";
+import type { SignetError } from "@xmtp/signet-schemas";
+import { NotFoundError } from "@xmtp/signet-schemas";
+import type { SignetCoreImpl } from "./broker-core.js";
 
 export interface ConversationActionDeps {
-  readonly core: BrokerCoreImpl;
+  readonly core: SignetCoreImpl;
 }
 
 const CreateGroupInput = z.object({
@@ -868,16 +868,16 @@ const GroupInfoInput = z.object({
 });
 
 function widenActionSpec<TInput, TOutput>(
-  spec: ActionSpec<TInput, TOutput, BrokerError>,
-): ActionSpec<unknown, unknown, BrokerError> {
-  return spec as ActionSpec<unknown, unknown, BrokerError>;
+  spec: ActionSpec<TInput, TOutput, SignetError>,
+): ActionSpec<unknown, unknown, SignetError> {
+  return spec as ActionSpec<unknown, unknown, SignetError>;
 }
 
 export function createConversationActions(
   deps: ConversationActionDeps,
-): ActionSpec<unknown, unknown, BrokerError>[] {
+): ActionSpec<unknown, unknown, SignetError>[] {
 
-  const create: ActionSpec<z.infer<typeof CreateGroupInput>, unknown, BrokerError> = {
+  const create: ActionSpec<z.infer<typeof CreateGroupInput>, unknown, SignetError> = {
     id: "conversation.create",
     input: CreateGroupInput,
     handler: async (input) => {
@@ -917,7 +917,7 @@ export function createConversationActions(
     mcp: { toolName: "broker/conversation/create", description: "Create a group conversation", readOnly: false },
   };
 
-  const list: ActionSpec<z.infer<typeof ListGroupsInput>, unknown, BrokerError> = {
+  const list: ActionSpec<z.infer<typeof ListGroupsInput>, unknown, SignetError> = {
     id: "conversation.list",
     input: ListGroupsInput,
     handler: async (input) => {
@@ -936,7 +936,7 @@ export function createConversationActions(
     mcp: { toolName: "broker/conversation/list", description: "List group conversations", readOnly: true },
   };
 
-  const info: ActionSpec<z.infer<typeof GroupInfoInput>, unknown, BrokerError> = {
+  const info: ActionSpec<z.infer<typeof GroupInfoInput>, unknown, SignetError> = {
     id: "conversation.info",
     input: GroupInfoInput,
     handler: async (input) => {
@@ -952,7 +952,7 @@ export function createConversationActions(
 
 > **Implementation note:** `deps.core.registry` is currently private
 > (`#registry`). Either add a public accessor or expose a
-> `getManagedClient(identityId)` method on `BrokerCoreImpl`. The `context`
+> `getManagedClient(identityId)` method on `SignetCoreImpl`. The `context`
 > property is already public and may be sufficient for some operations.
 
 **`packages/cli/src/commands/conversation.ts`** — Wire CLI commands following
@@ -961,7 +961,7 @@ the session command pattern:
 ```typescript
 import { Command } from "commander";
 import { Result } from "better-result";
-import type { BrokerError } from "@xmtp-broker/schemas";
+import type { SignetError } from "@xmtp/signet-schemas";
 import { exitCodeFromCategory } from "../output/exit-codes.js";
 import { formatOutput } from "../output/formatter.js";
 import {
@@ -1031,20 +1031,20 @@ export function createConversationCommands(
 
 ```typescript
 // After session actions registration:
-import { createConversationActions } from "@xmtp-broker/core";
+import { createConversationActions } from "@xmtp/signet-core";
 
 for (const spec of createConversationActions({ core: coreImpl })) {
   registry.register(spec);
 }
 ```
 
-> **Note:** This requires `coreImpl` (the `BrokerCoreImpl` instance) rather
-> than the `BrokerCore` contract adapter. The adapter in `start.ts` creates
-> `BrokerCoreImpl` internally (line 124). Either expose it, or pass the impl
+> **Note:** This requires `coreImpl` (the `SignetCoreImpl` instance) rather
+> than the `SignetCore` contract adapter. The adapter in `start.ts` creates
+> `SignetCoreImpl` internally (line 124). Either expose it, or pass the impl
 > into the runtime as a separate dependency.
 
 **`packages/core/src/__tests__/conversation-actions.test.ts`** — Tests using
-mocked `BrokerCoreImpl` with mock `XmtpClient`:
+mocked `SignetCoreImpl` with mock `XmtpClient`:
 
 - Create group with members → returns groupId and member count
 - Create group with empty members → succeeds (creator-only group)
@@ -1129,7 +1129,7 @@ export interface ConvosInvite {
 
 export function parseConvosInviteUrl(
   url: string,
-): Result<ConvosInvite, BrokerError>
+): Result<ConvosInvite, SignetError>
 ```
 
 **`packages/core/src/convos/join.ts`** — New file. Join protocol:
@@ -1139,7 +1139,7 @@ export interface JoinConversationDeps {
   readonly identityStore: SqliteIdentityStore;
   readonly clientFactory: XmtpClientFactory;
   readonly signerProviderFactory: SignerProviderFactory;
-  readonly config: Pick<BrokerCoreConfig, "dataDir" | "env" | "appVersion">;
+  readonly config: Pick<SignetCoreConfig, "dataDir" | "env" | "appVersion">;
 }
 
 export interface JoinResult {
@@ -1163,7 +1163,7 @@ export async function joinConversation(
   deps: JoinConversationDeps,
   inviteUrl: string,
   options?: { label?: string; timeoutMs?: number },
-): Promise<Result<JoinResult, BrokerError>>
+): Promise<Result<JoinResult, SignetError>>
 ```
 
 **`packages/cli/src/commands/conversation.ts`** — Add `conversation join`:
@@ -1238,7 +1238,7 @@ export interface GenerateInviteInput {
 
 export function generateConvosInviteUrl(
   input: GenerateInviteInput,
-): Result<string, BrokerError>
+): Result<string, SignetError>
 ```
 
 **`packages/cli/src/invite/qr.ts`** — Terminal QR renderer (already planned):
@@ -1848,10 +1848,10 @@ gt submit --stack --no-interactive
   `SqliteIdentityStore`, `SdkClientFactory`, and `SignerProviderFactory`
   directly (same pattern as `start.ts` but without the daemon lifecycle).
   The key manager is already alive at that point.
-- **`BrokerCoreImpl` private fields.** The conversation actions need access to
+- **`SignetCoreImpl` private fields.** The conversation actions need access to
   `#registry` and `identityStore`. The `identityStore` is already public
   (line 80). The registry needs a public accessor or a
-  `getManagedClient(identityId)` method added to `BrokerCoreImpl`.
+  `getManagedClient(identityId)` method added to `SignetCoreImpl`.
 - **Empty group creation.** We use the XMTP-JS pattern of adding members at
   creation time (simpler). The Convos pattern of empty genesis + invite flow
   is more complex and deferred.

--- a/.agents/plans/v0/EXECUTION.md
+++ b/.agents/plans/v0/EXECUTION.md
@@ -157,7 +157,7 @@ The main conversation thread:
 - New directory: `packages/core/src/sdk/` with `factory.ts`, `client.ts`, `signer.ts`, `error-mapping.ts`, `type-mapping.ts`
 - Pin `@xmtp/node-sdk` to exactly `6.0.0`
 - The `createXmtpSigner` adapter wraps Result-returning methods into exception-throwing ones
-- Per-group identity orchestration: BrokerCore → ClientRegistry → SdkClientFactory (see spec 11 §Per-Group Identity Orchestration)
+- Per-group identity orchestration: SignetCore → ClientRegistry → SdkClientFactory (see spec 11 §Per-Group Identity Orchestration)
 
 **Commit convention:** `feat(core): wire @xmtp/node-sdk via SdkClientFactory and SdkClient`
 
@@ -208,7 +208,7 @@ The main conversation thread:
 **Implementer prompt context:**
 - Read spec 13 §Overview, §Dependencies, §Public Interfaces (config schemas only), §Zod Schemas, §File Layout
 - Read `cli-broker-interaction.md` design doc for background
-- Create `packages/cli/package.json` with `commander@14.0.3`, `smol-toml@1.6.0`, all `@xmtp-broker/*` workspace deps
+- Create `packages/cli/package.json` with `commander@14.0.3`, `smol-toml@1.6.0`, all `@xmtp/signet-*` workspace deps
 - Create `tsconfig.json`, `src/index.ts` (Commander program shell with no commands yet)
 - Create `src/config/schema.ts` — `CliConfigSchema`, `AdminServerConfigSchema`, `ResolvedPaths`
 - Create `src/config/loader.ts` — TOML loading, env var overrides, path resolution (XDG)
@@ -283,7 +283,7 @@ The main conversation thread:
 **Estimated size:** ~400 LOC
 
 **Implementer prompt context:**
-- Read spec 13 §Behaviors for each command group: broker, identity, session, grant, attestation, message, conversation, admin
+- Read spec 13 §Behaviors for each command group: broker, identity, session, grant, seal, message, conversation, admin
 - Create one file per group in `src/commands/`: `broker.ts`, `identity.ts`, `session.ts`, `grant.ts`, `attestation.ts`, `message.ts`, `conversation.ts`, `admin.ts`
 - Each command file: define Commander subcommand, parse args, validate with Zod, route through AdminClient (daemon mode)
 - Create `src/output/formatter.ts` — table/JSON/text output formatting, `--json` flag handling
@@ -334,7 +334,7 @@ The main conversation thread:
 
 **Implementer prompt context:**
 - Read spec 13 §Public Interfaces (BrokerRuntime), §Behaviors (Startup Sequence detail)
-- Create `src/runtime.ts` — `createBrokerRuntime(config)` that instantiates and wires: KeyManager, BrokerCore, SessionManager, PolicyEngine, AttestationManager, WsServer, AdminServer
+- Create `src/runtime.ts` — `createBrokerRuntime(config)` that instantiates and wires: KeyManager, SignetCore, SessionManager, PolicyEngine, SealManager, WsServer, AdminServer
 - Create `src/audit/log.ts` — `AuditLog`, append-only JSONL at `$XDG_STATE_HOME/xmtp-broker/audit.jsonl`
 - Wire runtime into `broker start` command (already defined in step 4d, now gets its implementation)
 - Tests: runtime creation with mocked deps, audit log append/read, startup sequence ordering
@@ -393,7 +393,7 @@ The main conversation thread:
 - Read spec 08 for the WebSocket protocol being wrapped
 - Read specs 02, 02b for event/request types
 - New package: `packages/handler/`
-- Dependencies: `@xmtp-broker/schemas`, `@xmtp-broker/contracts`, `better-result`, `zod`
+- Dependencies: `@xmtp/signet-schemas`, `@xmtp/signet-contracts`, `better-result`, `zod`
 - NO runtime broker packages (core, policy, sessions, keys)
 - `createBrokerHandler(config)` → `BrokerHandler`
 - Typed async iterable event stream

--- a/.agents/plans/v0/PLAN.md
+++ b/.agents/plans/v0/PLAN.md
@@ -1,4 +1,4 @@
-# xmtp-broker v0 Architecture Plan
+# xmtp-signet v0 Architecture Plan
 
 **Version:** 0.2.0
 **Status:** Draft
@@ -7,7 +7,7 @@
 
 ## One-Line Summary
 
-A brokered agent architecture where the broker is the real XMTP client, agents consume filtered views through scoped grants, and group-visible attestations make permissions inspectable.
+A brokered agent architecture where the broker is the real XMTP client, agents consume filtered views through scoped grants, and group-visible seals make permissions inspectable.
 
 ## Architecture Overview
 
@@ -62,15 +62,15 @@ These decisions resolve PRD open questions and establish constraints for all spe
 
 | Decision | Resolution | Rationale |
 |----------|-----------|-----------|
-| Min attestation schema | Full schema from PRD day one; optional fields use `null` not omission | Prevents schema drift; clients always know the shape |
-| Stale attestation rendering | Clients show staleness badge after `expiresAt`; messages still render with "produced under expired attestation" note | Don't hide history, but flag currency |
+| Min seal schema | Full schema from PRD day one; optional fields use `null` not omission | Prevents schema drift; clients always know the shape |
+| Stale seal rendering | Clients show staleness badge after `expiresAt`; messages still render with "produced under expired seal" note | Don't hide history, but flag currency |
 | Reveal history UX | Out of scope for v0 specs (client concern) | Broker provides the data; UX is per-client |
 | Per-thread session scoping | Sessions scope to agent+groups, not individual threads; thread filtering is a view concern | Simpler session model; threads are view config |
-| In-group vs off-chain policy | Attestations in-group; full policy config off-chain in broker | Keeps groups clean; attestation is the public summary |
+| In-group vs off-chain policy | Seals in-group; full policy config off-chain in broker | Keeps groups clean; seal is the public summary |
 | Recovery for hosted deployments | Deferred to post-v0; v0 focuses on local broker | Hosted adds TEE complexity; local Secure Enclave is Phase 1 |
 | Verification classes at launch | Source-verified only; runtime-attested is Phase 2 | Ship something useful fast |
 | Default heartbeat interval | 30 seconds; configurable per-agent | Balances liveness visibility with noise |
-| Content type allowlist updates | Material change → new attestation; broker logs the delta | Consistent with materiality rules |
+| Content type allowlist updates | Material change → new seal; broker logs the delta | Consistent with materiality rules |
 | Per-group identity | Default-on, configurable; each group gets a unique identity key | Strongest isolation; matches convos-node-sdk pattern |
 | Mono-package vs monorepo | Monorepo with Bun workspaces from day one | Clean dependency boundaries between tiers |
 | Foundation tier split | `schemas` = data shapes (Zod schemas, enums, error taxonomy); `contracts` = cross-package interfaces (service/provider contracts, event types). `contracts` imports from `schemas` only. | 22 interfaces defined in runtime specs belong in Foundation. Separating shapes from contracts keeps `schemas` zero-dep beyond Zod and gives runtime packages a stable interface layer. |
@@ -94,41 +94,41 @@ These decisions resolve PRD open questions and establish constraints for all spe
 | Spec | Package | Purpose |
 |------|---------|---------|
 | [01-repo-scaffolding](01-repo-scaffolding.md) | (workspace root) | Build tooling, config, conventions |
-| [02-schemas](02-schemas.md) | `@xmtp-broker/schemas` | Zod schemas, inferred types, error taxonomy, enums |
-| [02b-contracts](02b-contracts.md) | `@xmtp-broker/contracts` | Cross-package interfaces, provider contracts, event types |
-| [10-action-registry](10-action-registry.md) | `@xmtp-broker/contracts` + `@xmtp-broker/schemas` | ActionSpec, ActionResult envelope, extended HandlerContext |
+| [02-schemas](02-schemas.md) | `@xmtp/signet-schemas` | Zod schemas, inferred types, error taxonomy, enums |
+| [02b-contracts](02b-contracts.md) | `@xmtp/signet-contracts` | Cross-package interfaces, provider contracts, event types |
+| [10-action-registry](10-action-registry.md) | `@xmtp/signet-contracts` + `@xmtp/signet-schemas` | ActionSpec, ActionResult envelope, extended HandlerContext |
 
 ### Runtime Tier (depends on Foundation)
 
 | Spec | Package | Purpose |
 |------|---------|---------|
-| [03-broker-core](03-broker-core.md) | `@xmtp-broker/core` | XMTP client lifecycle, raw plane, per-group identity |
-| [04-policy-engine](04-policy-engine.md) | `@xmtp-broker/policy` | View filtering, grant enforcement, reveal state |
-| [05-sessions](05-sessions.md) | `@xmtp-broker/sessions` | Session issuance, binding, lifecycle |
-| [06-attestations](06-attestations.md) | `@xmtp-broker/attestations` | Attestation lifecycle, signing, publishing |
-| [07-key-management](07-key-management.md) | `@xmtp-broker/keys` | Secure Enclave, derived key hierarchy |
-| [11-sdk-integration](11-sdk-integration.md) | `@xmtp-broker/core` | Wire `@xmtp/node-sdk` into production client factory |
-| [12-admin-keys](12-admin-keys.md) | `@xmtp-broker/keys` | Admin key pair, JWT auth |
+| [03-broker-core](03-broker-core.md) | `@xmtp/signet-core` | XMTP client lifecycle, raw plane, per-group identity |
+| [04-policy-engine](04-policy-engine.md) | `@xmtp/signet-policy` | View filtering, grant enforcement, reveal state |
+| [05-sessions](05-sessions.md) | `@xmtp/signet-sessions` | Session issuance, binding, lifecycle |
+| [06-seals](06-attestations.md) | `@xmtp/signet-seals` | Seal lifecycle, signing, publishing |
+| [07-key-management](07-key-management.md) | `@xmtp/signet-keys` | Secure Enclave, derived key hierarchy |
+| [11-sdk-integration](11-sdk-integration.md) | `@xmtp/signet-core` | Wire `@xmtp/node-sdk` into production client factory |
+| [12-admin-keys](12-admin-keys.md) | `@xmtp/signet-keys` | Admin key pair, JWT auth |
 
 ### Transport Tier (depends on Runtime)
 
 | Spec | Package | Purpose |
 |------|---------|---------|
-| [08-websocket-transport](08-websocket-transport.md) | `@xmtp-broker/ws` | Phase 1 harness-facing interface |
-| [13-daemon-cli](13-daemon-cli.md) | `@xmtp-broker/cli` | Daemon lifecycle, CLI commands, admin socket, direct mode |
-| [14-mcp-transport](14-mcp-transport.md) | `@xmtp-broker/mcp` | MCP tools via `@modelcontextprotocol/sdk` |
+| [08-websocket-transport](08-websocket-transport.md) | `@xmtp/signet-ws` | Phase 1 harness-facing interface |
+| [13-daemon-cli](13-daemon-cli.md) | `@xmtp/signet-cli` | Daemon lifecycle, CLI commands, admin socket, direct mode |
+| [14-mcp-transport](14-mcp-transport.md) | `@xmtp/signet-mcp` | MCP tools via `@modelcontextprotocol/sdk` |
 
 ### Client Tier (depends on Transport)
 
 | Spec | Package | Purpose |
 |------|---------|---------|
-| [15-handler-sdk](15-handler-sdk.md) | `@xmtp-broker/handler` | TypeScript client for harness developers to connect agents to broker |
+| [15-handler-sdk](15-handler-sdk.md) | `@xmtp/signet-handler` | TypeScript client for harness developers to connect agents to broker |
 
 ### External Services
 
 | Spec | Package | Purpose |
 |------|---------|---------|
-| [09-verifier](09-verifier.md) | `@xmtp-broker/verifier` | Reference verification service |
+| [09-verifier](09-verifier.md) | `@xmtp/signet-verifier` | Reference verification service |
 
 ## Dependency Graph
 
@@ -165,19 +165,19 @@ These decisions resolve PRD open questions and establish constraints for all spe
 Notes:
 - `02b-contracts` imports from `02-schemas` only; defines cross-package interfaces
 - `10-action-registry` extends both `contracts` (ActionSpec type) and `schemas` (ActionResult envelope)
-- `07-key-mgmt` is Runtime tier (used by core, sessions, attestations for signing)
-- `08-ws-transport` is the orchestrator connecting core, policy, sessions, and attestations
+- `07-key-mgmt` is Runtime tier (used by core, sessions, seals for signing)
+- `08-ws-transport` is the orchestrator connecting core, policy, sessions, and seals
 - `09-verifier` depends only on schemas (standalone service)
 - `11-sdk-integration` extends `core` with production `@xmtp/node-sdk` wiring
 - `12-admin-keys` extends `keys` with admin key pair and JWT auth
 - `13-daemon-cli` is the composition root wiring all packages into a running process
 - `14-mcp-transport` exposes ActionSpecs as MCP tools
-- `04-policy` owns the canonical materiality logic; `06-attestations` imports from it
+- `04-policy` owns the canonical materiality logic; `06-seals` imports from it
 - Dependencies flow downward only within tiers
 
 ## Package Scope Convention
 
-All internal packages use the `@xmtp-broker/` scope. This is a workspace-internal scope, not published to npm. It provides clean import paths and prevents accidental external dependency.
+All internal packages use the `@xmtp/signet-` scope. This is a workspace-internal scope, not published to npm. It provides clean import paths and prevents accidental external dependency.
 
 ## Spec Template
 
@@ -199,7 +199,7 @@ Every spec doc follows this structure:
 **Phase 1 (specs 01-09):**
 - Local broker on macOS with Secure Enclave
 - WebSocket transport
-- Core view/grant/attestation model
+- Core view/grant/seal model
 - Per-group identity (default-on)
 - Reference verifier (source-verified tier)
 - Single-owner governance
@@ -211,7 +211,7 @@ Every spec doc follows this structure:
 - Admin key system (separate from inbox keys, JWT auth)
 - Daemon lifecycle, CLI with 8 command groups, Unix socket admin
 - MCP transport (harness-facing, session-scoped) for Claude Code / LLM tool integration
-- Handler SDK (`@xmtp-broker/handler`) — TypeScript client for harness developers
+- Handler SDK (`@xmtp/signet-handler`) — TypeScript client for harness developers
 
 **Deferred (not in v0 specs):**
 - Hosted/managed broker deployment

--- a/.agents/plans/v0/REMAINING-WORK.md
+++ b/.agents/plans/v0/REMAINING-WORK.md
@@ -4,7 +4,7 @@
 **Updated:** 2026-03-17
 **Context:** Phase 2C (Convos interop, conversation management, devnet connectivity) is complete across 38 stacked PRs. This document tracks what remains before the signet is feature-complete for Phase 1 (PRD) and ready for Phase 2 delivery to external developers.
 
-**Note:** The XMTP Signet rename is now complete in the live code and public runtime surface. This document reflects the current `signet` naming. Historical planning notes may still use `broker` or `attestation` terminology where they describe earlier design phases.
+**Note:** The XMTP Signet rename is now complete in the live code and public runtime surface. This document reflects the current `signet` naming. Historical planning notes may still use `broker` or `seal` terminology where they describe earlier design phases.
 
 ## Current State
 
@@ -94,7 +94,7 @@ Items the PRD scopes to Phase 1 that are not yet complete.
 
 ### P2-7: Historical Docs Terminology Cleanup
 
-**What:** Update historical plans, skills, and notes that still say `broker` / `attestation` where they now refer to `signet` / `seal`.
+**What:** Update historical plans, skills, and notes that still say `broker` / `seal` where they now refer to `signet` / `seal`.
 
 **Why:** The live code and public runtime surface are renamed, but hidden docs under `.agents/`, `.claude/`, and `.trail/` still contain older terminology. This is not a runtime blocker, but it does create friction for future agent and contributor onboarding.
 

--- a/.agents/plans/v0/SPEC.md
+++ b/.agents/plans/v0/SPEC.md
@@ -1,4 +1,4 @@
-# XMTP Agent Broker PRD
+# XMTP Agent Signet PRD
 
 **Version:** 0.2.1
 **Status:** Draft
@@ -6,15 +6,15 @@
 
 ## Summary
 
-This document proposes an **agent broker** architecture for XMTP-based applications and agents.
+This document proposes an **agent signet** architecture for XMTP-based applications and agents.
 
 The core idea is simple:
 
-- A **broker** is the real XMTP client.
-- The broker owns the raw XMTP signer, installation continuity, local encrypted database, and message sync.
+- A **signet** is the real XMTP client.
+- The signet owns the raw XMTP signer, installation continuity, local encrypted database, and message sync.
 - An **agent harness** never touches the raw XMTP client directly.
 - Instead, the harness connects to the broker over a controlled interface and receives a filtered **view** of one or more conversations and a scoped **grant** of allowed actions.
-- The permissions and scope of the view and grant are represented by group-visible **attestations**.
+- The permissions and scope of the view and grant are represented by group-visible **seals**.
 
 This model is designed to support agents in XMTP and Convos without pretending that a standard group member can somehow be cryptographically blind to ordinary group messages. It creates a practical, harness-agnostic security boundary that works with local brokers, self-hosted brokers, and managed broker deployments.
 
@@ -63,7 +63,7 @@ The current state:
 
 This proposal does not solve trust by decree. It moves us from **opaque trust** to **inspectable trust**.
 
-Concretely, that means a brokered agent can publish signed, group-visible attestations describing its current permissions, hosting mode, and scope, and agent-authored messages can reference the attestation they were produced under.
+Concretely, that means a brokered agent can publish signed, group-visible seals describing its current permissions, hosting mode, and scope, and agent-authored messages can reference the seal they were produced under.
 
 That still does not prove the operator is honest. But it gives the group something cryptographic and inspectable to verify, which is strictly better than the current state where agents can make claims and nobody can tell what is actually behind them.
 
@@ -80,7 +80,7 @@ In this model:
 - The broker is the real XMTP participant runtime.
 - The agent consumes a derived and policy-filtered interface.
 - Permissions are enforced at the broker boundary.
-- Group-visible attestation messages communicate the current capability state of an agent.
+- Group-visible seal messages communicate the current capability state of an agent.
 - The same conceptual model works across local, self-hosted, and managed deployments.
 
 ### What we are not proposing
@@ -149,7 +149,7 @@ Responsibilities:
 - Sync, receive, and store the real conversation state.
 - Enforce policy for views, grants, and message projection.
 - Issue sessions to agent harnesses.
-- Publish group-visible capability attestations.
+- Publish group-visible capability seals.
 - Manage per-agent isolation when serving multiple agents.
 
 The term “broker” is preferred over “gateway” to avoid confusion with XMTP Gateway Service and other gateway terminology in the ecosystem.
@@ -161,12 +161,12 @@ Each agent has its own XMTP inbox. The broker holds the signer for that inbox an
 This means:
 
 - The group sees each agent as a distinct participant with its own inbox identity.
-- Attestations are about a specific agent, not about the broker as a whole.
+- Seals are about a specific agent, not about the broker as a whole.
 - One broker can manage multiple agent inboxes, each joining different groups independently.
 - There is no “ventriloquist” problem where one broker identity speaks as multiple agents.
 - The broker is infrastructure, not a participant. It does not appear in group membership.
 
-When a single broker serves multiple agents in the same group, each agent has its own inbox, its own attestation, its own view, and its own grant. The broker maintains strict isolation between agents internally — Agent A’s view must not leak into Agent B’s derived state.
+When a single broker serves multiple agents in the same group, each agent has its own inbox, its own seal, its own view, and its own grant. The broker maintains strict isolation between agents internally — Agent A’s view must not leak into Agent B’s derived state.
 
 ### View
 
@@ -246,13 +246,13 @@ Suggested initial view modes as convenience labels:
 
 A view mode is only a convenience label. The underlying view object (including the content type allowlist) and grant object should remain explicit and authoritative.
 
-### Attestation
+### Seal
 
-An **attestation** is a signed assertion about an agent’s current permissions, scope, and operating posture.
+A **seal** is a signed assertion about an agent’s current permissions, scope, and operating posture.
 
-Attestations are meant to be visible to the group and updated whenever permissions change materially.
+Seals are meant to be visible to the group and updated whenever permissions change materially.
 
-Attestations establish shared understanding of:
+Seals establish shared understanding of:
 
 - Who owns the agent.
 - Which inbox the agent uses.
@@ -263,11 +263,11 @@ Attestations establish shared understanding of:
 - The hosting mode and trust posture.
 - What changed since the previous state.
 
-#### Attestation noise and materiality
+#### Seal noise and materiality
 
-Not every internal state change should produce a group-visible attestation. The system should distinguish **material changes** from **routine operations**.
+Not every internal state change should produce a group-visible seal. The system should distinguish **material changes** from **routine operations**.
 
-Material changes that produce group-visible attestations:
+Material changes that produce group-visible seals:
 
 - View mode or scope changes.
 - Grant additions or removals.
@@ -370,7 +370,7 @@ It includes:
 - Grant definitions (action permissions).
 - Reveal state.
 - Group policy state.
-- Attestations.
+- Seals.
 - Revocations.
 
 #### Derived plane
@@ -410,7 +410,7 @@ The system should define one capability model and multiple connection adapters, 
 
 When an agent sends conversation content to an external LLM provider, the privacy story changes fundamentally. This is arguably the single most consequential thing a group member would want to know about an agent.
 
-Egress and inference posture must be declared as structured, first-class fields in the attestation — not buried in a generic policy blob.
+Egress and inference posture must be declared as structured, first-class fields in the seal — not buried in a generic policy blob.
 
 ### Required egress fields
 
@@ -419,11 +419,11 @@ Egress and inference posture must be declared as structured, first-class fields 
 - `contentEgressScope` — What content leaves the broker boundary: `full-messages` | `summaries-only` | `tool-calls-only` | `none`
 - `retentionAtProvider` — `none` | `session` | `persistent` | `unknown`
 
-These fields are **required** in every attestation. If the value cannot be determined, the field must be set to `unknown` rather than omitted. Silent omission is not allowed. Every attestation takes an explicit position, even if that position is “I don’t know.”
+These fields are **required** in every seal. If the value cannot be determined, the field must be set to `unknown` rather than omitted. Silent omission is not allowed. Every seal takes an explicit position, even if that position is “I don’t know.”
 
 ### Envelope declaration
 
-For agent frameworks that dynamically switch inference providers (such as OpenClaw), the attestation should declare the **envelope** of possible providers, not the instantaneous state. If the agent may route to Anthropic, OpenAI, or a local model depending on the query, the attestation declares all three and sets `inferenceMode` to `hybrid`.
+For agent frameworks that dynamically switch inference providers (such as OpenClaw), the seal should declare the **envelope** of possible providers, not the instantaneous state. If the agent may route to Anthropic, OpenAI, or a local model depending on the query, the seal declares all three and sets `inferenceMode` to `hybrid`.
 
 Overstating the envelope is acceptable. Understating it is not.
 
@@ -431,25 +431,25 @@ Overstating the envelope is acceptable. Understating it is not.
 
 In v1, these fields are self-reported by the broker. An unverified broker claiming `inferenceMode: local` gets treated with the same skepticism as any other unverified claim. A source-verified or runtime-attested broker making that claim is more credible. The schema does not solve trust — it gives trust something structured to attach to.
 
-## Attestation Model
+## Seal Model
 
-### Why attestations matter
+### Why seals matter
 
-Attestations make agent posture legible to the conversation itself.
+Seals make agent posture legible to the conversation itself.
 
-Without attestations, permissions live only in the owner’s client or broker config. That is not enough for a multi-party environment.
+Without seals, permissions live only in the owner’s client or broker config. That is not enough for a multi-party environment.
 
-### Attestation signing in v1
+### Seal signing in v1
 
-In v1, the broker signs attestations using the agent’s inbox key (which the broker holds). The attestation includes the `ownerInboxId` field, which creates a social accountability link — the group can see who is responsible for the agent — even though the owner is not cryptographically co-signing every update.
+In v1, the broker signs seals using the agent’s inbox key (which the broker holds). The seal includes the `ownerInboxId` field, which creates a social accountability link — the group can see who is responsible for the agent — even though the owner is not cryptographically co-signing every update.
 
-Clients verify the signature against the agent’s inbox, confirming the attestation came from the entity that controls that agent.
+Clients verify the signature against the agent’s inbox, confirming the seal came from the entity that controls that agent.
 
-In future versions, optional owner co-signing could be added for high-stakes permission changes (such as upgrading from `reveal-only` to `full` visibility), while keeping routine attestations broker-signed only.
+In future versions, optional owner co-signing could be added for high-stakes permission changes (such as upgrading from `reveal-only` to `full` visibility), while keeping routine seals broker-signed only.
 
-### Attestation lifecycle
+### Seal lifecycle
 
-An attestation should be published when a material change occurs:
+A seal should be published when a material change occurs:
 
 - An agent is added.
 - Permissions are first granted.
@@ -459,10 +459,10 @@ An attestation should be published when a material change occurs:
 - The ownership or hosting mode changes.
 - A verifier statement is updated.
 
-### Suggested attestation fields
+### Suggested seal fields
 
-- `attestationId`
-- `previousAttestationId`
+- `sealId`
+- `previousSealId`
 - `agentInboxId`
 - `ownerInboxId`
 - `groupId`
@@ -489,7 +489,7 @@ An attestation should be published when a material change occurs:
 
 ### Message provenance
 
-Agent-authored messages should reference the attestation under which they were produced.
+Agent-authored messages should reference the seal under which they were produced.
 
 This gives clients the ability to render:
 
@@ -497,15 +497,15 @@ This gives clients the ability to render:
 - Whether a message was generated under different permissions than the current state.
 - Whether permissions changed mid-conversation.
 
-### Trust model for attestations
+### Trust model for seals
 
-The system should not rely on self-attestation from the agent alone.
+The system should not rely on self-sealing from the agent alone.
 
 The more trustworthy path is:
 
-- The broker signs the attestation with the agent’s inbox key.
-- The attestation is posted into the group.
-- Agent messages reference the current attestation.
+- The broker signs the seal with the agent’s inbox key.
+- The seal is posted into the group.
+- Agent messages reference the current seal.
 - Clients compare references over time.
 - Verifier statements (when available) add external validation.
 
@@ -533,7 +533,7 @@ Runtime attestation gets you to: “this live hosted broker is likely running th
 
 The design should be **TEE-agnostic and verifier-agnostic** — AWS Nitro today, other attested runtimes tomorrow, or purely source/build-verified self-hosting for users who do not want enclave dependencies.
 
-### Layer 4: Capability Attestation
+### Layer 4: Capability Seal
 
 What gets posted into the group. Describes what this broker claims the agent can do right now. This is the app/XIP layer — the view, the grant, the hosting mode, the egress posture.
 
@@ -560,7 +560,7 @@ The trust chain maps to three practical tiers that clients can render:
 - Hosted runtime proves measurement via remote attestation.
 - Secrets are released only to approved measurements.
 
-The group-visible attestation includes a `trustTier` field reflecting the highest tier the broker can currently demonstrate.
+The group-visible seal includes a `trustTier` field reflecting the highest tier the broker can currently demonstrate.
 
 ## Broker Verification
 
@@ -582,7 +582,7 @@ The verifier identity is just an XMTP inbox. The verification statement is a sig
 1. Broker sends a verification request containing: broker inbox identity, challenge nonce, artifact digest, build provenance bundle, optional runtime attestation evidence, requested verification class.
 1. Verifier checks policy and evidence.
 1. Verifier replies over XMTP with a signed verification statement.
-1. Broker references that statement in its group-visible capability attestation via the `verifierStatementRef` field.
+1. Broker references that statement in its group-visible capability seal via the `verifierStatementRef` field.
 1. Clients validate: the verifier issuer, the signature, expiry, evidence class, and whether subsequent agent messages still point to a current statement.
 
 ### Multiple issuers
@@ -650,7 +650,7 @@ The broker-mediated model adds a mandatory dependency: if the broker goes down, 
 
 ### Heartbeat and staleness
 
-The attestation includes a `heartbeatInterval` field indicating the expected liveness cadence. Clients should render an “agent unreachable” or “last active N minutes ago” indicator when the interval is exceeded. This does not require noisy group-visible messages — it can be inferred from session keepalives or lightweight structured signals.
+The seal includes a `heartbeatInterval` field indicating the expected liveness cadence. Clients should render an “agent unreachable” or “last active N minutes ago” indicator when the interval is exceeded. This does not require noisy group-visible messages — it can be inferred from session keepalives or lightweight structured signals.
 
 ### Broker recovery: inbound messages
 
@@ -670,22 +670,22 @@ Revocation should be **immediate, visible, and fail-closed**. If there is any am
 
 ### Normal revocation
 
-The owner instructs the broker to revoke the agent. The broker immediately terminates the agent’s session, posts a revocation attestation to the group, and stops projecting any view to that agent.
+The owner instructs the broker to revoke the agent. The broker immediately terminates the agent’s session, posts a revocation seal to the group, and stops projecting any view to that agent.
 
 ### Owner loses access
 
 If the owner’s device is lost or the owner leaves the group, two safety valves apply:
 
-- **Mandatory expiration:** Attestations must have an `expiresAt` field. A broker with no owner contact eventually stops being authorized.
+- **Mandatory expiration:** Seals must have an `expiresAt` field. A broker with no owner contact eventually stops being authorized.
 - **Group admin override:** Group admins can remove the agent’s inbox from the group at the XMTP group permissions level, which effectively kills access regardless of what the broker thinks.
 
 ### Session expiry without rotation
 
-If a session expires and the harness does not re-authenticate, the broker automatically stops projecting the view. No silent continuation on stale credentials. The broker posts a session-expired attestation so the group knows the agent is no longer active under valid authorization.
+If a session expires and the harness does not re-authenticate, the broker automatically stops projecting the view. No silent continuation on stale credentials. The broker posts a session-expired seal so the group knows the agent is no longer active under valid authorization.
 
 ### In-flight messages during revocation
 
-If the agent has a message in transit when revocation hits, the broker drops it. A message that arrives at the broker after the revocation attestation was posted should never reach the group. Better to lose a message than to have an agent act after its permissions were pulled.
+If the agent has a message in transit when revocation hits, the broker drops it. A message that arrives at the broker after the revocation seal was posted should never reach the group. Better to lose a message than to have an agent act after its permissions were pulled.
 
 ## Threat Model
 
@@ -707,15 +707,15 @@ Mitigation includes hardware-backed key storage (Secure Enclave, TPM), standard 
 
 ### Compromised broker host (self-hosted / managed)
 
-What they gain: full raw message access for all agents the broker manages, all signer material, and the ability to forge attestations. The hosted environment is the real client boundary, and compromise of it is equivalent to owning every agent on that broker.
+What they gain: full raw message access for all agents the broker manages, all signer material, and the ability to forge seals. The hosted environment is the real client boundary, and compromise of it is equivalent to owning every agent on that broker.
 
-Mitigations: short-lived sessions limit exposure window, mandatory attestation expiry forces periodic renewal, runtime attestation (Tier 3) can detect environment tampering, and the broker’s attestation history creates a forensic trail.
+Mitigations: short-lived sessions limit exposure window, mandatory seal expiry forces periodic renewal, runtime attestation (Tier 3) can detect environment tampering, and the broker’s seal history creates a forensic trail.
 
 ### Malicious operator (managed deployment)
 
-What they gain: the same access as a compromised host, but with the added ability to operate covertly over time. A malicious managed broker operator can silently exfiltrate messages, forge attestations, and impersonate agents.
+What they gain: the same access as a compromised host, but with the added ability to operate covertly over time. A malicious managed broker operator can silently exfiltrate messages, forge seals, and impersonate agents.
 
-Mitigations: the `hostingMode` field in attestations discloses managed deployment, allowing clients to render appropriate trust indicators. Runtime attestation (Tier 3) with TEE-backed key release is the strongest counter. Verifier statements from independent issuers provide a cross-check. But fundamentally, a managed broker requires trust in the operator — the system should be honest about that.
+Mitigations: the `hostingMode` field in seals discloses managed deployment, allowing clients to render appropriate trust indicators. Runtime attestation (Tier 3) with TEE-backed key release is the strongest counter. Verifier statements from independent issuers provide a cross-check. But fundamentally, a managed broker requires trust in the operator — the system should be honest about that.
 
 ### Network adversary
 
@@ -736,13 +736,13 @@ That owner can:
 
 ### Group visibility
 
-Even in the owner-driven model, the resulting permissions are visible to the group via attestations. Group members can inspect what an agent can see and do at any time.
+Even in the owner-driven model, the resulting permissions are visible to the group via seals. Group members can inspect what an agent can see and do at any time.
 
 ### Power asymmetry in v1
 
-The v1 model creates a known power asymmetry. If Alice adds an agent with `full` visibility, Bob can see that via the attestation, but he has no direct mechanism to override or restrict the agent’s permissions — his recourse is limited to leaving the group or asking Alice to change the configuration.
+The v1 model creates a known power asymmetry. If Alice adds an agent with `full` visibility, Bob can see that via the seal, but he has no direct mechanism to override or restrict the agent’s permissions — his recourse is limited to leaving the group or asking Alice to change the configuration.
 
-This is an accepted limitation of v1. The attestation model makes the situation transparent, which is a meaningful improvement over the current state where Bob has no visibility at all.
+This is an accepted limitation of v1. The seal model makes the situation transparent, which is a meaningful improvement over the current state where Bob has no visibility at all.
 
 ### Future group governance
 
@@ -767,7 +767,7 @@ Possible Convos additions:
 - Trust tier indicators.
 - Permission editing UI.
 - Reveal toggles on messages and threads.
-- Timeline cards for attestation changes (material changes only).
+- Timeline cards for seal changes (material changes only).
 - Agent ownership labeling.
 - Hosting mode labeling.
 - Inference and egress disclosure (e.g. “processes locally” or “sends to Anthropic, session only”).
@@ -868,7 +868,7 @@ All deployment modes share:
 
 - The same broker protocol.
 - The same view and grant model.
-- The same attestation model.
+- The same seal model.
 - The same client UX semantics.
 
 They do not share the same trust boundary.
@@ -887,7 +887,7 @@ Recommended outputs:
 
 - Broker protocol spec.
 - View, grant, and session spec.
-- Attestation schema.
+- Seal schema.
 - Reference verifier implementation (deployable to Cloudflare Workers or Railway).
 - Broker reference implementations.
 - One-click deployment templates.
@@ -910,7 +910,7 @@ Recommended outputs:
 
 - Cloudflare handles control-plane tasks.
 - A stateful raw broker runs elsewhere.
-- Good fit for global session management, fanout, and attestation coordination.
+- Good fit for global session management, fanout, and seal coordination.
 
 ### Platform considerations
 
@@ -933,7 +933,7 @@ A one-click deployment experience should:
 - Generate broker secrets inside the target environment.
 - Avoid showing long-lived secrets back to the user in plaintext when possible.
 - Support user-controlled recovery and rotation.
-- Publish broker identity and attestation fingerprints.
+- Publish broker identity and seal fingerprints.
 - Make the hosting mode visible to the client.
 
 ### Honest security posture for hosted deployment
@@ -972,7 +972,7 @@ Suggested event types:
 - `session.started`
 - `session.expired`
 - `session.reauthorization_required`
-- `attestation.updated`
+- `seal.updated`
 - `view.updated`
 - `grant.updated`
 - `message.visible`
@@ -1008,7 +1008,7 @@ That is true whether the broker is local or hosted.
 - A malicious host or operator may still exfiltrate data in hosted environments.
 - An agent can still remember or infer content it has already seen.
 - Egress to an LLM provider weakens privacy relative to pure client-to-client messaging.
-- Attestation fields beyond the trust chain are self-reported in v1.
+- Seal fields beyond the trust chain are self-reported in v1.
 
 ### Hard requirements
 
@@ -1019,7 +1019,7 @@ That is true whether the broker is local or hosted.
 - Privilege escalation requires root key authorization (biometric or equivalent).
 - Clear session expiration and rotation.
 - Clear revocation flow with fail-closed behavior.
-- Mandatory `expiresAt` on all attestations.
+- Mandatory `expiresAt` on all seals.
 
 ## Key Management and Hardware Binding
 
@@ -1051,7 +1051,7 @@ The broker should maintain a three-tier derived key hierarchy:
 
 - Derived from the root key.
 - Protected by `passcode` or `open` policy depending on deployment mode.
-- Used for: routine message signing, attestation publishing, session issuance, and day-to-day broker operations.
+- Used for: routine message signing, seal publishing, session issuance, and day-to-day broker operations.
 - Does not require biometric authentication per operation, allowing the broker to function autonomously for routine tasks.
 
 #### Session keys
@@ -1064,7 +1064,7 @@ The broker should maintain a three-tier derived key hierarchy:
 
 ### Privilege escalation and biometric gating
 
-Routine broker operations — sending messages, publishing routine attestations, managing sessions — should flow through the operational key without requiring per-operation authentication. This allows agents to function autonomously within their granted permissions.
+Routine broker operations — sending messages, publishing routine seals, managing sessions — should flow through the operational key without requiring per-operation authentication. This allows agents to function autonomously within their granted permissions.
 
 Operations that cross a privilege threshold should require root key authorization, which means biometric (or equivalent) authentication:
 
@@ -1114,7 +1114,7 @@ For hosted brokers, the Secure Enclave is not available. The equivalent pattern 
 - Key release conditioned on runtime attestation measurements.
 - The architectural boundary is the same — the broker can use the key but never see it — just implemented with different hardware.
 
-The attestation’s `trustTier` and `hostingMode` fields should reflect whether hardware-backed key storage is in use.
+The seal’s `trustTier` and `hostingMode` fields should reflect whether hardware-backed key storage is in use.
 
 ## Key Rotation
 
@@ -1127,35 +1127,35 @@ Secure Enclave keys are non-exportable and device-bound by hardware design. Movi
 1. Authenticate on the new machine (biometric enrollment).
 1. The broker creates new enclave-backed keys on the new hardware.
 1. The broker performs an XMTP installation rotation — the agent’s inbox identity persists, but the signing key material rotates.
-1. The broker publishes an updated attestation reflecting the new key material and any updated verifier statements.
+1. The broker publishes an updated seal reflecting the new key material and any updated verifier statements.
 1. The old machine’s keys are revoked.
 
 This is cleaner than a “recovery key” approach because it avoids ever having exportable root material. There are no seed phrases or recovery keys to secure, leak, or lose. The agent’s identity continuity is maintained through XMTP’s installation management, not through key portability.
 
 ### Periodic rotation
 
-Even without a machine change, operational keys should support periodic rotation as a security hygiene measure. The broker should be able to rotate operational keys without disrupting active sessions — new sessions use the new key, existing sessions continue until their natural expiry, and the attestation is updated to reflect the rotation.
+Even without a machine change, operational keys should support periodic rotation as a security hygiene measure. The broker should be able to rotate operational keys without disrupting active sessions — new sessions use the new key, existing sessions continue until their natural expiry, and the seal is updated to reflect the rotation.
 
-### Rotation attestation
+### Rotation seal
 
-Any key rotation event is a material change and should produce a group-visible attestation update. The group should be able to see that key material changed, when it changed, and that the new material chains back to a valid root.
+Any key rotation event is a material change and should produce a group-visible seal update. The group should be able to see that key material changed, when it changed, and that the new material chains back to a valid root.
 
 ## Candidate XIP Directions
 
 This proposal is intentionally app-layer first, but several pieces are candidates for future XIPs.
 
-### Capability Attestation XIP (recommended first)
+### Capability Seal XIP (recommended first)
 
-Standardize a portable, signed attestation format for agent capabilities.
+Standardize a portable, signed seal format for agent capabilities.
 
 Potential scope:
 
-- Required attestation fields (including structured egress/inference fields).
+- Required seal fields (including structured egress/inference fields).
 - View and grant semantics.
 - Update semantics and materiality thresholds.
 - Revocation semantics.
 - Ownership and issuer model.
-- Attestation references in agent-authored messages.
+- Seal references in agent-authored messages.
 
 This is recommended as the first XIP because it is the foundation everything else references.
 
@@ -1169,13 +1169,13 @@ Potential scope:
 - Verification statement format.
 - Issuer / expiry / revocation semantics.
 - Standard verification classes (self-asserted, source-verified, build-provenance-verified, runtime-attested).
-- Standard way for attestations to reference verifier statements.
+- Standard way for seals to reference verifier statements.
 
 ### Agent Message Provenance XIP
 
 Standardize how agent-authored messages indicate:
 
-- Which attestation they were produced under.
+- Which seal they were produced under.
 - Whether the agent was acting with full, reveal-only, or other view modes.
 - Whether tool use or external actions were involved.
 
@@ -1255,14 +1255,14 @@ Convos can add flavor to this model without waiting for protocol-level changes.
 - Attach to local broker.
 - Attach to self-hosted broker.
 - Inspect active session details.
-- Inspect attestation history.
+- Inspect seal history.
 - Export broker fingerprints and configuration.
 
 ## Rollout Strategy
 
 ### Phase 1
 
-- Define broker, view, grant, attestation, and session concepts.
+- Define broker, view, grant, seal, and session concepts.
 - Ship local broker reference implementation with Secure Enclave-backed key management.
 - Implement derived key hierarchy (root → operational → session).
 - Ship open source reference verifier (Cloudflare Workers / Railway).
@@ -1276,10 +1276,10 @@ Convos can add flavor to this model without waiting for protocol-level changes.
 - Add self-hosted deployment templates.
 - Add MCP and SDK adapters.
 - Add permission editing UX.
-- Add attestation timeline UX (material changes only).
+- Add seal timeline UX (material changes only).
 - Add action confirmations and richer tool scopes.
 - Verifier-over-XMTP flow operational.
-- Draft Capability Attestation XIP based on implementation learnings.
+- Draft Capability Seal XIP based on implementation learnings.
 
 ### Phase 3
 
@@ -1293,8 +1293,8 @@ Convos can add flavor to this model without waiting for protocol-level changes.
 
 ## Open Questions
 
-- What is the exact minimum viable attestation schema?
-- How should clients render stale or expired attestations?
+- What is the exact minimum viable seal schema?
+- How should clients render stale or expired seals?
 - How should reveal history be represented in UX?
 - Should session issuance be tied to explicit per-thread scopes by default?
 - How much policy should be in-group versus off-chain broker config?
@@ -1331,7 +1331,7 @@ The proposal is successful if it achieves the following:
 - Users misunderstand the difference between local and hosted modes.
 - The view and grant model feels too complex.
 - Too much UX ceremony discourages agent usage.
-- Attestations become noisy despite the materiality threshold.
+- Seals become noisy despite the materiality threshold.
 - Group members feel powerless under the v1 owner-only governance model.
 
 ### Mitigations
@@ -1355,13 +1355,13 @@ Start with:
 - Derived key hierarchy with biometric-gated privilege escalation.
 - WebSocket as the primary live interface.
 - Structured view and grant model.
-- Group-visible capability attestations with structured egress disclosure.
+- Group-visible capability seals with structured egress disclosure.
 - An open source reference verifier deployable to Cloudflare Workers or Railway.
 - Convos as a rich UX proving ground.
 - Self-hosted templates for Fly and Railway.
 - A Cloudflare-friendly hybrid control-plane design.
 
-Use implementation learnings to identify which parts should become formal XIPs, starting with Capability Attestation.
+Use implementation learnings to identify which parts should become formal XIPs, starting with Capability Seal.
 
 ## Appendix: Crisp Framing
 
@@ -1370,10 +1370,10 @@ The simplest way to explain the proposal is:
 - The **broker** is the real XMTP client.
 - The **view** is what the agent is allowed to see.
 - The **grant** is what the agent is allowed to do.
-- The **attestation** is what the group is told about that view and grant.
+- The **seal** is what the group is told about that view and grant.
 - The **session** is how the harness connects to it.
 - The **verifier** is how the group can check whether the broker is what it claims.
 
 Or more simply:
 
-**The group trusts the attestation. The broker enforces the view and grant. The agent never touches the raw client. The verifier keeps the broker honest.**
+**The group trusts the seal. The broker enforces the view and grant. The agent never touches the raw client. The verifier keeps the broker honest.**

--- a/.agents/plans/v0/phase1-integration-tests.md
+++ b/.agents/plans/v0/phase1-integration-tests.md
@@ -10,7 +10,7 @@ These tests wire up real Phase 1 package implementations with **mocked XMTP** (n
 
 ```
 Real code:
-  schemas, contracts, policy, sessions, attestations, keys, ws
+  schemas, contracts, policy, sessions, seals, keys, ws
 
 Mocked:
   XmtpClient (no real XMTP network)
@@ -25,7 +25,7 @@ End-to-end flow with all packages wired together:
 
 1. Create a `KeyManager` (software-vault mode)
 2. Initialize identity (root key → operational key)
-3. Create a `BrokerCore` with mock `XmtpClientFactory`
+3. Create a `SignetCore` with mock `XmtpClientFactory`
 4. Initialize the broker (creates XMTP client)
 5. Create a `SessionManager`
 6. Issue a session with a view (full mode) and grant (send + react)
@@ -49,16 +49,16 @@ Verify view filtering and grant checking across packages:
 - **Grant enforcement:** Send allowed → succeeds. Send denied → `PermissionError`. React allowed → succeeds. Group management denied → `PermissionError`.
 - **Material change detection:** View mode change → triggers `session.reauthorization_required`. Grant expansion → triggers reauth. Session rotation within same scope → silent.
 
-### 3. Attestation Lifecycle (`attestation-lifecycle.test.ts`)
+### 3. Seal Lifecycle (`attestation-lifecycle.test.ts`)
 
-Full attestation flow through real packages:
+Full seal flow through real packages:
 
-- Issue attestation for agent in group → signed with operational key
-- Verify attestation signature with public key
-- Verify attestation chain: first attestation has `previousAttestationId: null`
-- Refresh attestation → new attestation chains to previous
-- Revoke attestation → signed revocation envelope
-- Query current attestation → returns latest
+- Issue seal for agent in group → signed with operational key
+- Verify seal signature with public key
+- Verify seal chain: first seal has `previousAttestationId: null`
+- Refresh seal → new seal chains to previous
+- Revoke seal → signed revocation envelope
+- Query current seal → returns latest
 - Query after revocation → returns null
 
 ### 4. Session Lifecycle (`session-lifecycle.test.ts`)
@@ -105,9 +105,9 @@ Transport-level behaviors with real WsServer:
 
 Verify that implementations match their contract interfaces:
 
-- `BrokerCore` implementation satisfies `BrokerCore` interface from contracts
+- `SignetCore` implementation satisfies `SignetCore` interface from contracts
 - `SessionManager` implementation satisfies `SessionManager` interface
-- `AttestationManager` implementation satisfies `AttestationManager` interface
+- `SealManager` implementation satisfies `SealManager` interface
 - `SignerProvider` implementation satisfies `SignerProvider` interface
 - `AttestationSigner` implementation satisfies `AttestationSigner` interface
 - All error types from schemas are constructable and have correct categories


### PR DESCRIPTION
## Summary
- Mechanical terminology update across 33 historical planning documents
- `BrokerCore` → `SignetCore`, `BrokerError` → `SignetError`, `AttestationManager` → `SealManager`, etc.
- `@xmtp-broker/*` → `@xmtp/signet-*` package scope
- Preserves historical context: code blocks, file paths, and external attestation concepts left unchanged

## Test plan
- [x] No code changes — docs only
- [x] Full monorepo build/typecheck/test/lint green (no regressions)

In-collaboration-with: [Claude Code](https://claude.com/claude-code)