### PR TITLE
test(cli): Phase 3 comprehensive tracer bullet

### DIFF
--- a/packages/cli/src/__tests__/action-confirm-integration.test.ts
+++ b/packages/cli/src/__tests__/action-confirm-integration.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import type { SessionRecord } from "@xmtp/signet-contracts";
+import type { HarnessRequest, SignetEvent } from "@xmtp/signet-schemas";
+import { createWsRequestHandler } from "../ws/request-handler.js";
+import { createPendingActionStore } from "@xmtp/signet-sessions";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeSessionRecord(
+  overrides: Partial<SessionRecord> = {},
+): SessionRecord {
+  return {
+    sessionId: "sess_action",
+    agentInboxId: "agent_1",
+    sessionKeyFingerprint: "fp_abc",
+    view: {
+      mode: "full",
+      threadScopes: [{ groupId: "g1", threadId: null }],
+      contentTypes: ["xmtp.org/text:1.0"],
+    },
+    grant: {
+      messaging: { send: true, reply: false, react: false, draftOnly: true },
+      groupManagement: {
+        addMembers: false,
+        removeMembers: false,
+        updateMetadata: false,
+        inviteUsers: false,
+      },
+      tools: { scopes: [] },
+      egress: {
+        storeExcerpts: false,
+        useForMemory: false,
+        forwardToProviders: false,
+        quoteRevealed: false,
+        summarize: false,
+      },
+    },
+    state: "active",
+    issuedAt: "2024-01-01T00:00:00Z",
+    expiresAt: "2024-01-02T00:00:00Z",
+    lastHeartbeat: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Integration: draftOnly session -> queue -> confirm/deny cycle
+// ---------------------------------------------------------------------------
+
+describe("action confirmation integration", () => {
+  test("draftOnly session queues action and broadcasts confirmation event", async () => {
+    const broadcastedEvents: { sessionId: string; event: SignetEvent }[] = [];
+    const pendingActions = createPendingActionStore();
+
+    const handler = createWsRequestHandler({
+      ensureCoreReady: async () => Result.ok(undefined),
+      sendMessage: async () => Result.ok({ messageId: "msg_1" }),
+      sessionManager: {
+        heartbeat: async () => Result.ok(undefined),
+      },
+      pendingActions,
+      broadcast: (sessionId, event) => {
+        broadcastedEvents.push({ sessionId, event });
+      },
+    });
+
+    const session = makeSessionRecord();
+    const request: HarnessRequest = {
+      type: "send_message",
+      requestId: "req_draft_1",
+      groupId: "g1",
+      contentType: "xmtp.org/text:1.0",
+      content: { text: "draft message" },
+    };
+
+    const result = await handler(request, session);
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    const data = result.value as { pending: boolean; actionId: string };
+    expect(data.pending).toBe(true);
+    expect(typeof data.actionId).toBe("string");
+
+    // Verify stored
+    const stored = pendingActions.get(data.actionId);
+    expect(stored).not.toBeNull();
+    expect(stored?.actionType).toBe("send_message");
+
+    // Verify broadcast
+    expect(broadcastedEvents).toHaveLength(1);
+    expect(broadcastedEvents[0]?.event.type).toBe(
+      "action.confirmation_required",
+    );
+  });
+
+  test("confirm executes the queued action", async () => {
+    const sendCalls: string[] = [];
+    const pendingActions = createPendingActionStore();
+
+    const handler = createWsRequestHandler({
+      ensureCoreReady: async () => Result.ok(undefined),
+      sendMessage: async (groupId, contentType) => {
+        sendCalls.push(`send:${groupId}:${contentType}`);
+        return Result.ok({ messageId: "msg_confirmed" });
+      },
+      sessionManager: {
+        heartbeat: async () => Result.ok(undefined),
+      },
+      pendingActions,
+      broadcast: () => {},
+    });
+
+    // Pre-populate a pending action
+    pendingActions.add({
+      actionId: "act_e2e_confirm",
+      sessionId: "sess_action",
+      actionType: "send_message",
+      payload: {
+        groupId: "g1",
+        contentType: "xmtp.org/text:1.0",
+        content: { text: "hello" },
+      },
+      createdAt: "2024-01-01T00:00:00Z",
+      expiresAt: "2099-01-01T00:05:00Z",
+    });
+
+    const request: HarnessRequest = {
+      type: "confirm_action",
+      requestId: "req_e2e_confirm",
+      actionId: "act_e2e_confirm",
+      confirmed: true,
+    };
+
+    const result = await handler(request, makeSessionRecord());
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({ messageId: "msg_confirmed" });
+    }
+    expect(sendCalls).toEqual(["send:g1:xmtp.org/text:1.0"]);
+    expect(pendingActions.get("act_e2e_confirm")).toBeNull();
+  });
+
+  test("deny discards the queued action without sending", async () => {
+    const sendCalls: string[] = [];
+    const pendingActions = createPendingActionStore();
+
+    const handler = createWsRequestHandler({
+      ensureCoreReady: async () => Result.ok(undefined),
+      sendMessage: async () => {
+        sendCalls.push("send");
+        return Result.ok({ messageId: "unused" });
+      },
+      sessionManager: {
+        heartbeat: async () => Result.ok(undefined),
+      },
+      pendingActions,
+      broadcast: () => {},
+    });
+
+    pendingActions.add({
+      actionId: "act_e2e_deny",
+      sessionId: "sess_action",
+      actionType: "send_message",
+      payload: {
+        groupId: "g1",
+        contentType: "xmtp.org/text:1.0",
+        content: { text: "nope" },
+      },
+      createdAt: "2024-01-01T00:00:00Z",
+      expiresAt: "2099-01-01T00:05:00Z",
+    });
+
+    const request: HarnessRequest = {
+      type: "confirm_action",
+      requestId: "req_e2e_deny",
+      actionId: "act_e2e_deny",
+      confirmed: false,
+    };
+
+    const result = await handler(request, makeSessionRecord());
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({
+        denied: true,
+        actionId: "act_e2e_deny",
+      });
+    }
+    expect(sendCalls).toEqual([]);
+    expect(pendingActions.get("act_e2e_deny")).toBeNull();
+  });
+});

--- a/packages/cli/src/__tests__/http-api-integration.test.ts
+++ b/packages/cli/src/__tests__/http-api-integration.test.ts
@@ -1,0 +1,139 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { Result } from "better-result";
+import type { AdminDispatcher } from "../admin/dispatcher.js";
+import {
+  createHttpServer,
+  type HttpServer,
+  type HttpServerDeps,
+} from "../http/server.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeDispatcher(overrides?: Partial<AdminDispatcher>): AdminDispatcher {
+  return {
+    dispatch:
+      overrides?.dispatch ??
+      (async () => ({
+        ok: true as const,
+        data: { status: "ok" },
+        meta: {
+          requestId: "req-1",
+          timestamp: new Date().toISOString(),
+          durationMs: 1,
+        },
+      })),
+    hasMethod: overrides?.hasMethod ?? (() => true),
+  };
+}
+
+function makeDeps(overrides?: Partial<HttpServerDeps>): HttpServerDeps {
+  return {
+    dispatcher: overrides?.dispatcher ?? makeDispatcher(),
+    sessionManager:
+      overrides?.sessionManager ?? ({} as HttpServerDeps["sessionManager"]),
+    verifyAdminJwt:
+      overrides?.verifyAdminJwt ?? (async () => Result.ok(undefined)),
+    status: overrides?.status ?? (() => ({ state: "running", pid: 1 })),
+  };
+}
+
+function randomPort(): number {
+  return 10_000 + Math.floor(Math.random() * 50_000);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+let server: HttpServer | undefined;
+
+afterEach(async () => {
+  if (server !== undefined && server.state === "listening") {
+    await server.stop();
+  }
+  server = undefined;
+});
+
+describe("HTTP API integration", () => {
+  test("health endpoint returns 200 with ok: true", async () => {
+    const deps = makeDeps({
+      status: () => ({ state: "running", pid: 42 }),
+    });
+    const port = randomPort();
+    server = createHttpServer({ port, host: "127.0.0.1" }, deps);
+    await server.start();
+
+    const res = await fetch(`http://127.0.0.1:${port}/v1/health`);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.state).toBe("running");
+  });
+
+  test("admin endpoint with valid auth dispatches and returns result", async () => {
+    const dispatcher = makeDispatcher({
+      dispatch: async () => ({
+        ok: true as const,
+        data: { activeSessions: 3 },
+        meta: {
+          requestId: "req-admin",
+          timestamp: new Date().toISOString(),
+          durationMs: 2,
+        },
+      }),
+    });
+    const deps = makeDeps({ dispatcher });
+    const port = randomPort();
+    server = createHttpServer({ port, host: "127.0.0.1" }, deps);
+    await server.start();
+
+    const res = await fetch(`http://127.0.0.1:${port}/v1/admin/broker.status`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer valid-admin-jwt",
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data).toEqual({ activeSessions: 3 });
+  });
+
+  test("unauthenticated admin request returns 401", async () => {
+    const deps = makeDeps();
+    const port = randomPort();
+    server = createHttpServer({ port, host: "127.0.0.1" }, deps);
+    await server.start();
+
+    const res = await fetch(`http://127.0.0.1:${port}/v1/admin/broker.status`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.category).toBe("auth");
+  });
+
+  test("unknown route returns 404", async () => {
+    const deps = makeDeps();
+    const port = randomPort();
+    server = createHttpServer({ port, host: "127.0.0.1" }, deps);
+    await server.start();
+
+    const res = await fetch(`http://127.0.0.1:${port}/v1/nonexistent`);
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.category).toBe("not_found");
+  });
+});

--- a/packages/cli/src/__tests__/reveal-mode.test.ts
+++ b/packages/cli/src/__tests__/reveal-mode.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from "bun:test";
+import type { SessionRecord } from "@xmtp/signet-contracts";
+import type { MessageEvent } from "@xmtp/signet-schemas";
+import { createRevealStateStore } from "@xmtp/signet-policy";
+import {
+  createEventProjector,
+  type EventProjectorDeps,
+} from "../ws/event-projector.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeSessionRecord(
+  overrides: Partial<SessionRecord> = {},
+): SessionRecord {
+  return {
+    sessionId: "sess_reveal",
+    agentInboxId: "agent_1",
+    sessionKeyFingerprint: "fp_abc",
+    view: {
+      mode: "full",
+      threadScopes: [{ groupId: "g1", threadId: null }],
+      contentTypes: ["xmtp.org/text:1.0"],
+    },
+    grant: {
+      messaging: { send: true, reply: false, react: false, draftOnly: false },
+      groupManagement: {
+        addMembers: false,
+        removeMembers: false,
+        updateMetadata: false,
+        inviteUsers: false,
+      },
+      tools: { scopes: [] },
+      egress: {
+        storeExcerpts: false,
+        useForMemory: false,
+        forwardToProviders: false,
+        quoteRevealed: false,
+        summarize: false,
+      },
+    },
+    state: "active",
+    issuedAt: "2024-01-01T00:00:00Z",
+    expiresAt: "2024-01-02T00:00:00Z",
+    lastHeartbeat: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeMessageEvent(overrides: Partial<MessageEvent> = {}): MessageEvent {
+  return {
+    type: "message.visible",
+    messageId: "msg_1",
+    groupId: "g1",
+    senderInboxId: "sender_1",
+    contentType: "xmtp.org/text:1.0",
+    content: "Hello world",
+    visibility: "visible",
+    sentAt: "2024-01-01T00:00:00Z",
+    sealId: null,
+    threadId: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests -- integration of event projector + reveal state store
+// ---------------------------------------------------------------------------
+
+describe("reveal mode integration", () => {
+  test("reveal-only mode drops unrevealed messages", () => {
+    const store = createRevealStateStore();
+    const deps: EventProjectorDeps = {
+      getRevealState: () => store,
+    };
+    const projector = createEventProjector(deps);
+    const session = makeSessionRecord({
+      view: {
+        mode: "reveal-only",
+        threadScopes: [{ groupId: "g1", threadId: null }],
+        contentTypes: ["xmtp.org/text:1.0"],
+      },
+    });
+    const event = makeMessageEvent();
+
+    const result = projector(event, session);
+
+    expect(result).toBeNull();
+  });
+
+  test("reveal-only mode passes revealed messages", () => {
+    const store = createRevealStateStore();
+    // Grant a reveal for the sender
+    store.grant(
+      { revealId: "rev_1", sessionId: "sess_reveal", expiresAt: null },
+      { groupId: "g1", scope: "sender", targetId: "sender_1" },
+    );
+
+    const deps: EventProjectorDeps = {
+      getRevealState: () => store,
+    };
+    const projector = createEventProjector(deps);
+    const session = makeSessionRecord({
+      view: {
+        mode: "reveal-only",
+        threadScopes: [{ groupId: "g1", threadId: null }],
+        contentTypes: ["xmtp.org/text:1.0"],
+      },
+    });
+    const event = makeMessageEvent();
+
+    const result = projector(event, session);
+
+    expect(result).not.toBeNull();
+    const msg = result as MessageEvent;
+    expect(msg.visibility).toBe("revealed");
+    expect(msg.content).toBe("Hello world");
+  });
+
+  test("redacted mode passes with null content when not revealed", () => {
+    const store = createRevealStateStore();
+    const deps: EventProjectorDeps = {
+      getRevealState: () => store,
+    };
+    const projector = createEventProjector(deps);
+    const session = makeSessionRecord({
+      view: {
+        mode: "redacted",
+        threadScopes: [{ groupId: "g1", threadId: null }],
+        contentTypes: ["xmtp.org/text:1.0"],
+      },
+    });
+    const event = makeMessageEvent();
+
+    const result = projector(event, session);
+
+    expect(result).not.toBeNull();
+    const msg = result as MessageEvent;
+    expect(msg.visibility).toBe("redacted");
+    expect(msg.content).toBeNull();
+  });
+
+  test("full mode passes events unchanged", () => {
+    const deps: EventProjectorDeps = {
+      getRevealState: () => null,
+    };
+    const projector = createEventProjector(deps);
+    const session = makeSessionRecord({
+      view: {
+        mode: "full",
+        threadScopes: [{ groupId: "g1", threadId: null }],
+        contentTypes: ["xmtp.org/text:1.0"],
+      },
+    });
+    const event = makeMessageEvent();
+
+    const result = projector(event, session);
+
+    expect(result).not.toBeNull();
+    expect(result).toEqual(event);
+  });
+
+  test("reveal grant/revoke cycle: grant passes, new store drops", () => {
+    // Phase 1: grant a reveal -> message passes
+    const store1 = createRevealStateStore();
+    store1.grant(
+      { revealId: "rev_2", sessionId: "sess_reveal", expiresAt: null },
+      { groupId: "g1", scope: "sender", targetId: "sender_1" },
+    );
+
+    const deps1: EventProjectorDeps = {
+      getRevealState: () => store1,
+    };
+    const projector1 = createEventProjector(deps1);
+    const session = makeSessionRecord({
+      view: {
+        mode: "reveal-only",
+        threadScopes: [{ groupId: "g1", threadId: null }],
+        contentTypes: ["xmtp.org/text:1.0"],
+      },
+    });
+    const event = makeMessageEvent();
+
+    const revealed = projector1(event, session);
+    expect(revealed).not.toBeNull();
+    expect((revealed as MessageEvent).visibility).toBe("revealed");
+
+    // Phase 2: new store with no grants -> message is dropped
+    const store2 = createRevealStateStore();
+    const deps2: EventProjectorDeps = {
+      getRevealState: () => store2,
+    };
+    const projector2 = createEventProjector(deps2);
+
+    const dropped = projector2(event, session);
+    expect(dropped).toBeNull();
+  });
+});

--- a/packages/seals/src/__tests__/seal-wiring.test.ts
+++ b/packages/seals/src/__tests__/seal-wiring.test.ts
@@ -1,0 +1,170 @@
+import { describe, test, expect } from "bun:test";
+import { Result } from "better-result";
+import type { Seal, RevocationSeal } from "@xmtp/signet-schemas";
+import { createSealStamper, type SigningKeyHandle } from "../stamper.js";
+import { createSealPublisher, type PublisherDeps } from "../publisher.js";
+import { SEAL_CONTENT_TYPE_ID } from "../content-type.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async function createTestKeyHandle(): Promise<SigningKeyHandle> {
+  const keyPair = await crypto.subtle.generateKey({ name: "Ed25519" }, true, [
+    "sign",
+    "verify",
+  ]);
+
+  const raw = await crypto.subtle.exportKey("raw", keyPair.publicKey);
+  const hex = Array.from(new Uint8Array(raw))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+
+  return {
+    fingerprint: () => hex.slice(0, 16),
+    async sign(data: Uint8Array): Promise<Uint8Array> {
+      const sig = await crypto.subtle.sign(
+        { name: "Ed25519" },
+        keyPair.privateKey,
+        data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength),
+      );
+      return new Uint8Array(sig);
+    },
+  };
+}
+
+function makeSeal(overrides?: Partial<Seal>): Seal {
+  return {
+    sealId: "seal-wire-1",
+    previousSealId: null,
+    agentInboxId: "agent-inbox-1",
+    ownerInboxId: "owner-inbox-1",
+    groupId: "group-1",
+    threadScope: null,
+    viewMode: "full",
+    contentTypes: ["xmtp.org/text:1.0"],
+    grantedOps: ["send", "reply"],
+    toolScopes: [],
+    inferenceMode: "local",
+    inferenceProviders: [],
+    contentEgressScope: "none",
+    retentionAtProvider: "none",
+    hostingMode: "local",
+    trustTier: "unverified",
+    buildProvenanceRef: null,
+    verifierStatementRef: null,
+    sessionKeyFingerprint: null,
+    policyHash: "sha256:abc123",
+    heartbeatInterval: 30,
+    issuedAt: "2025-01-01T00:00:00.000Z",
+    expiresAt: "2025-01-02T00:00:00.000Z",
+    revocationRules: {
+      maxTtlSeconds: 86400,
+      requireHeartbeat: true,
+      ownerCanRevoke: true,
+      adminCanRemove: true,
+    },
+    issuer: "signet-1",
+    ...overrides,
+  };
+}
+
+function makeRevocation(overrides?: Partial<RevocationSeal>): RevocationSeal {
+  return {
+    sealId: "revoke-wire-1",
+    previousSealId: "seal-wire-1",
+    agentInboxId: "agent-inbox-1",
+    groupId: "group-1",
+    reason: "owner-initiated",
+    revokedAt: "2025-01-01T12:00:00.000Z",
+    issuer: "signet-1",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests: stamper + publisher wired together
+// ---------------------------------------------------------------------------
+
+describe("seal wiring: stamper + publisher", () => {
+  test("stamper signs seal and publisher sends with correct content type", async () => {
+    const keyHandle = await createTestKeyHandle();
+    const stamper = createSealStamper({ signingKey: keyHandle });
+
+    const sentMessages: Array<{
+      groupId: string;
+      contentType: string;
+      content: unknown;
+    }> = [];
+
+    const publisherDeps: PublisherDeps = {
+      async sendMessage(groupId, contentType, content) {
+        sentMessages.push({ groupId, contentType, content });
+        return Result.ok({ messageId: "msg-seal-1" });
+      },
+    };
+    const publisher = createSealPublisher(publisherDeps);
+
+    // Stamp the seal
+    const seal = makeSeal();
+    const stampResult = await stamper.sign(seal);
+    expect(Result.isOk(stampResult)).toBe(true);
+    if (!Result.isOk(stampResult)) return;
+
+    // Publish the envelope
+    const publishResult = await publisher.publish("group-1", stampResult.value);
+    expect(Result.isOk(publishResult)).toBe(true);
+
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0]!.contentType).toBe(SEAL_CONTENT_TYPE_ID);
+    expect(sentMessages[0]!.groupId).toBe("group-1");
+
+    // Verify the published content round-trips
+    const parsed = JSON.parse(sentMessages[0]!.content as string);
+    expect(parsed.seal.sealId).toBe("seal-wire-1");
+    expect(parsed.signatureAlgorithm).toBe("Ed25519");
+    expect(parsed.signerKeyRef).toBe(keyHandle.fingerprint());
+  });
+
+  test("end-to-end seal flow uses xmtp.org/agentSeal:1.0 content type", async () => {
+    const keyHandle = await createTestKeyHandle();
+    const stamper = createSealStamper({ signingKey: keyHandle });
+
+    let capturedContentType = "";
+    const publisher = createSealPublisher({
+      async sendMessage(_groupId, contentType, _content) {
+        capturedContentType = contentType;
+        return Result.ok({ messageId: "msg-e2e-1" });
+      },
+    });
+
+    const stampResult = await stamper.sign(makeSeal());
+    expect(Result.isOk(stampResult)).toBe(true);
+    if (!Result.isOk(stampResult)) return;
+
+    await publisher.publish("group-1", stampResult.value);
+
+    expect(capturedContentType).toBe("xmtp.org/agentSeal:1.0");
+  });
+
+  test("revocation flow uses xmtp.org/agentRevocation:1.0 content type", async () => {
+    const keyHandle = await createTestKeyHandle();
+    const stamper = createSealStamper({ signingKey: keyHandle });
+
+    let capturedContentType = "";
+    const publisher = createSealPublisher({
+      async sendMessage(_groupId, contentType, _content) {
+        capturedContentType = contentType;
+        return Result.ok({ messageId: "msg-rev-1" });
+      },
+    });
+
+    const revResult = await stamper.signRevocation(makeRevocation());
+    expect(Result.isOk(revResult)).toBe(true);
+    if (!Result.isOk(revResult)) return;
+
+    await publisher.publishRevocation("group-1", revResult.value);
+
+    expect(capturedContentType).toBe("xmtp.org/agentRevocation:1.0");
+  });
+});

--- a/packages/sessions/src/__tests__/session-update-integration.test.ts
+++ b/packages/sessions/src/__tests__/session-update-integration.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import type { SessionManager } from "@xmtp/signet-contracts";
+import { createSessionManager } from "../session-manager.js";
+import { createSessionService } from "../service.js";
+import { createUpdateActions } from "../update-actions.js";
+import type { UpdateActionDeps } from "../update-actions.js";
+import type { InternalSessionManager } from "../session-manager.js";
+import { createTestSessionConfig, createTestView } from "./fixtures.js";
+
+// ---------------------------------------------------------------------------
+// Integration: session update with materiality enforcement
+// ---------------------------------------------------------------------------
+
+let manager: InternalSessionManager;
+let sessionService: SessionManager;
+let deps: UpdateActionDeps;
+let sessionId: string;
+
+beforeEach(async () => {
+  manager = createSessionManager({
+    defaultTtlSeconds: 60,
+    maxConcurrentPerAgent: 3,
+    renewalWindowSeconds: 10,
+    heartbeatGracePeriod: 3,
+  });
+
+  sessionService = createSessionService({
+    manager,
+    keyManager: {
+      async issueSessionKey(sid) {
+        return Result.ok({ fingerprint: `fp_${sid}` });
+      },
+    },
+  });
+
+  deps = { sessionManager: sessionService, internalManager: manager };
+
+  // Issue a session with mode: "full" and wide scope
+  const config = createTestSessionConfig({
+    view: {
+      mode: "full",
+      threadScopes: [
+        { groupId: "group-1", threadId: null },
+        { groupId: "group-2", threadId: null },
+      ],
+      contentTypes: ["text", "reaction"],
+    },
+  });
+  const issued = await sessionService.issue(config);
+  expect(issued.isOk()).toBe(true);
+  if (!issued.isOk()) throw new Error("Failed to create session");
+
+  const sessions = await sessionService.list();
+  expect(sessions.isOk()).toBe(true);
+  if (!sessions.isOk()) throw new Error("Failed to list sessions");
+  const session = sessions.value[0];
+  if (!session) throw new Error("No session found");
+  sessionId = session.sessionId;
+});
+
+function stubContext() {
+  return {
+    requestId: "test-req",
+    signal: new AbortController().signal,
+  };
+}
+
+describe("session update integration", () => {
+  test("non-material view narrowing applies immediately", async () => {
+    const actions = createUpdateActions(deps);
+    const updateView = actions.find((a) => a.id === "session.updateView");
+    expect(updateView).toBeDefined();
+    if (!updateView) return;
+
+    // Narrow: remove group-2 from scope (same mode, fewer scopes)
+    const narrowerView = createTestView({
+      mode: "full",
+      threadScopes: [{ groupId: "group-1", threadId: null }],
+      contentTypes: ["text"],
+    });
+
+    const result = await updateView.handler(
+      { sessionId, view: narrowerView },
+      stubContext(),
+    );
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    const output = result.value as {
+      updated: boolean;
+      material: boolean;
+    };
+    expect(output.updated).toBe(true);
+    expect(output.material).toBe(false);
+
+    // Verify the session was actually updated
+    const lookupResult = await sessionService.lookup(sessionId);
+    expect(lookupResult.isOk()).toBe(true);
+    if (!lookupResult.isOk()) return;
+    expect(lookupResult.value.view.threadScopes).toHaveLength(1);
+  });
+
+  test("material mode escalation triggers reauthorization", async () => {
+    // First narrow mode so escalation is detectable
+    const actions = createUpdateActions(deps);
+    const updateView = actions.find((a) => a.id === "session.updateView");
+    expect(updateView).toBeDefined();
+    if (!updateView) return;
+
+    // Narrow to redacted first
+    const narrowed = createTestView({
+      mode: "redacted",
+      threadScopes: [{ groupId: "group-1", threadId: null }],
+      contentTypes: ["text"],
+    });
+    const narrowResult = await updateView.handler(
+      { sessionId, view: narrowed },
+      stubContext(),
+    );
+    expect(narrowResult.isOk()).toBe(true);
+
+    // Now escalate back to full -- this is material
+    const escalated = createTestView({
+      mode: "full",
+      threadScopes: [{ groupId: "group-1", threadId: null }],
+      contentTypes: ["text"],
+    });
+    const result = await updateView.handler(
+      { sessionId, view: escalated },
+      stubContext(),
+    );
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    const output = result.value as {
+      updated: boolean;
+      material: boolean;
+      reason: string | null;
+    };
+    expect(output.updated).toBe(false);
+    expect(output.material).toBe(true);
+    expect(output.reason).toBeTypeOf("string");
+
+    // Session should now be in reauthorization-required state
+    const internal = manager.getSessionById(sessionId);
+    expect(internal.isOk()).toBe(true);
+    if (!internal.isOk()) return;
+    expect(internal.value.state).toBe("reauthorization-required");
+  });
+});


### PR DESCRIPTION
## Summary
- 5 integration test files exercising all Phase 3 features with mocks (no daemon/network required)
- Reveal mode: hidden→revealed→hidden cycle across view modes
- Seal wiring: stamper + publisher end-to-end with correct content types
- Session update: materiality enforcement (non-material applies, material rejects)
- Action confirmation: draftOnly queuing → confirm/deny cycle
- HTTP API: health, admin auth, unauthenticated rejection, 404

## Test plan
- [x] 17 new integration tests across 5 files
- [x] All existing tests unaffected
- [x] Full monorepo build/typecheck/test/lint green

In-collaboration-with: [Claude Code](https://claude.com/claude-code)