### PR TITLE
feat(signer): Swift Secure Enclave CLI for P-256 key operations

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -35,6 +35,20 @@ for tool in turbo oxlint oxfmt; do
   fi
 done
 
+# Build signet-signer (macOS only, optional)
+if [[ "$(uname)" == "Darwin" ]]; then
+  echo "==> Checking Swift toolchain"
+  if command -v swift >/dev/null 2>&1; then
+    echo "  Swift $(swift --version 2>&1 | head -1)"
+    echo "==> Building signet-signer"
+    (cd signet-signer && swift build -c release --quiet)
+    echo "  Built: signet-signer/.build/release/signet-signer"
+  else
+    echo "  Swift not found — Secure Enclave support unavailable"
+    echo "  Install Xcode Command Line Tools: xcode-select --install"
+  fi
+fi
+
 echo "==> Bootstrap complete"
 echo "Next steps:"
 echo "  bun run format:check"

--- a/signet-signer/.gitignore
+++ b/signet-signer/.gitignore
@@ -1,0 +1,2 @@
+.build/
+.swiftpm/

--- a/signet-signer/Package.resolved
+++ b/signet-signer/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/signet-signer/Package.swift
+++ b/signet-signer/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "signet-signer",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .executable(name: "signet-signer", targets: ["signet-signer"]),
+        .library(name: "SignetCore", targets: ["SignetCore"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "signet-signer",
+            dependencies: [
+                "SignetCore",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]
+        ),
+        .target(
+            name: "SignetCore",
+            dependencies: []
+        ),
+        .testTarget(
+            name: "SignetCoreTests",
+            dependencies: ["SignetCore"]
+        ),
+    ]
+)

--- a/signet-signer/Sources/SignetCore/Models.swift
+++ b/signet-signer/Sources/SignetCore/Models.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Access control policy for Secure Enclave key operations.
+public enum KeyPolicy: String, Codable, CaseIterable, Sendable {
+    case open = "open"
+    case passcode = "passcode"
+    case biometric = "biometric"
+}
+
+// MARK: - Error Types
+
+public enum SignetError: Error, CustomStringConvertible {
+    case seUnavailable
+    case creationFailed(String)
+    case keyMissing(String)
+    case signingFailed(String)
+    case invalidHex(String)
+    case authCancelled
+
+    public var description: String {
+        switch self {
+        case .seUnavailable:
+            return "Secure Enclave is not available on this device"
+        case .creationFailed(let msg):
+            return "key creation failed: \(msg)"
+        case .keyMissing(let msg):
+            return "key not found: \(msg)"
+        case .signingFailed(let msg):
+            return "signing failed: \(msg)"
+        case .invalidHex(let msg):
+            return "invalid hex: \(msg)"
+        case .authCancelled:
+            return "authentication cancelled by user"
+        }
+    }
+
+    public var exitCode: Int32 {
+        switch self {
+        case .seUnavailable: return 1
+        case .creationFailed: return 1
+        case .keyMissing: return 1
+        case .signingFailed: return 1
+        case .invalidHex: return 1
+        case .authCancelled: return 2
+        }
+    }
+}
+
+// MARK: - JSON Response Types
+
+public struct CreateResponse: Codable {
+    public let keyRef: String
+    public let publicKey: String
+    public let policy: String
+    public let label: String
+
+    public init(keyRef: String, publicKey: String, policy: String, label: String) {
+        self.keyRef = keyRef
+        self.publicKey = publicKey
+        self.policy = policy
+        self.label = label
+    }
+}
+
+public struct SignResponse: Codable {
+    public let signature: String
+
+    public init(signature: String) {
+        self.signature = signature
+    }
+}
+
+public struct SystemInfoResponse: Codable {
+    public let available: Bool
+    public let chip: String?
+    public let macOS: String?
+
+    public init(available: Bool, chip: String?, macOS: String?) {
+        self.available = available
+        self.chip = chip
+        self.macOS = macOS
+    }
+}
+
+public struct KeyInfoResponse: Codable {
+    public let exists: Bool
+
+    public init(exists: Bool) {
+        self.exists = exists
+    }
+}

--- a/signet-signer/Sources/SignetCore/SecureEnclaveManager.swift
+++ b/signet-signer/Sources/SignetCore/SecureEnclaveManager.swift
@@ -1,0 +1,163 @@
+import Foundation
+import CryptoKit
+import Security
+
+public class SecureEnclaveManager {
+
+    public init() {}
+
+    // MARK: - Key Creation
+
+    public func createKey(policy: KeyPolicy) throws -> (dataRepresentation: Data, publicKey: Data) {
+        guard SecureEnclave.isAvailable else {
+            throw SignetError.seUnavailable
+        }
+
+        var flags: SecAccessControlCreateFlags = [.privateKeyUsage]
+        switch policy {
+        case .open:
+            break
+        case .passcode:
+            flags.insert(.devicePasscode)
+        case .biometric:
+            flags.insert(.biometryCurrentSet)
+        }
+
+        var error: Unmanaged<CFError>?
+        guard let accessControl = SecAccessControlCreateWithFlags(
+            nil,
+            kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+            flags,
+            &error
+        ) else {
+            throw SignetError.creationFailed(
+                "failed to create access control: \(error?.takeRetainedValue().localizedDescription ?? "unknown")"
+            )
+        }
+
+        let privateKey: SecureEnclave.P256.Signing.PrivateKey
+        do {
+            privateKey = try SecureEnclave.P256.Signing.PrivateKey(accessControl: accessControl)
+        } catch {
+            if isAuthCancelled(error) {
+                throw SignetError.authCancelled
+            }
+            throw SignetError.creationFailed("SE key generation failed: \(error.localizedDescription)")
+        }
+
+        let dataRep = privateKey.dataRepresentation
+        let publicKeyBytes = Data(privateKey.publicKey.x963Representation)
+
+        return (dataRepresentation: dataRep, publicKey: publicKeyBytes)
+    }
+
+    // MARK: - Key Lookup
+
+    /// Check if a key exists by trying to load it from dataRepresentation.
+    public func lookupKey(_ base64DataRep: String) -> Bool {
+        guard let dataRep = Data(base64Encoded: base64DataRep) else {
+            return false
+        }
+        do {
+            _ = try SecureEnclave.P256.Signing.PrivateKey(dataRepresentation: dataRep)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    // MARK: - Signing
+
+    public func signData(_ data: Data, dataRepresentation: Data) throws -> Data {
+        let privateKey: SecureEnclave.P256.Signing.PrivateKey
+        do {
+            privateKey = try SecureEnclave.P256.Signing.PrivateKey(dataRepresentation: dataRepresentation)
+        } catch {
+            throw SignetError.keyMissing("failed to load SE key: \(error.localizedDescription)")
+        }
+
+        do {
+            if data.count == 32 {
+                // Pre-hashed signing: caller passes a 32-byte digest.
+                // Cast to SHA256Digest to avoid CryptoKit double-hashing.
+                let digest: SHA256Digest = data.withUnsafeBytes { ptr in
+                    ptr.baseAddress!.assumingMemoryBound(to: SHA256Digest.self).pointee
+                }
+                let signature = try privateKey.signature(for: digest)
+                return signature.derRepresentation
+            } else {
+                // Standard ES256: let CryptoKit hash with SHA-256
+                let signature = try privateKey.signature(for: data)
+                return signature.derRepresentation
+            }
+        } catch {
+            if isAuthCancelled(error) {
+                throw SignetError.authCancelled
+            }
+            throw SignetError.signingFailed(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Auth Cancellation Detection
+
+    /// Detect LAContext authentication cancellation across macOS versions.
+    private func isAuthCancelled(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        // LAError code -2 = userCancel
+        if nsError.domain == "com.apple.LocalAuthentication" && nsError.code == -2 {
+            return true
+        }
+        // String fallback for cross-version compatibility
+        let desc = error.localizedDescription.lowercased()
+        return desc.contains("cancel") || desc.contains("user denied")
+    }
+
+    // MARK: - Key Deletion
+
+    /// Best-effort deletion of an SE key.
+    public func deleteKey(_ base64DataRep: String) {
+        guard let dataRep = Data(base64Encoded: base64DataRep) else { return }
+        guard let key = try? SecureEnclave.P256.Signing.PrivateKey(dataRepresentation: dataRep) else { return }
+
+        let publicKeySHA1 = Data(Insecure.SHA1.hash(data: key.publicKey.x963Representation))
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassKey,
+            kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
+            kSecAttrTokenID as String: kSecAttrTokenIDSecureEnclave,
+            kSecAttrApplicationLabel as String: publicKeySHA1 as CFData,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+
+    // MARK: - System Info
+
+    public func isAvailable() -> Bool {
+        SecureEnclave.isAvailable
+    }
+
+    public func getChipName() -> String {
+        var size: Int = 0
+        sysctlbyname("machdep.cpu.brand_string", nil, &size, nil, 0)
+        if size > 0 {
+            var result = [CChar](repeating: 0, count: size)
+            sysctlbyname("machdep.cpu.brand_string", &result, &size, nil, 0)
+            return String(cString: result)
+        }
+        size = 0
+        sysctlbyname("hw.chip", nil, &size, nil, 0)
+        if size > 0 {
+            var result = [CChar](repeating: 0, count: size)
+            sysctlbyname("hw.chip", &result, &size, nil, 0)
+            return String(cString: result)
+        }
+        return "Unknown"
+    }
+
+    public func getMacOSVersion() -> String {
+        let v = ProcessInfo.processInfo.operatingSystemVersion
+        if v.patchVersion != 0 {
+            return "\(v.majorVersion).\(v.minorVersion).\(v.patchVersion)"
+        }
+        return "\(v.majorVersion).\(v.minorVersion)"
+    }
+}

--- a/signet-signer/Sources/SignetCore/SignatureFormatter.swift
+++ b/signet-signer/Sources/SignetCore/SignatureFormatter.swift
@@ -1,0 +1,211 @@
+import Foundation
+
+public struct SignatureFormatter {
+
+    // P-256 curve order
+    public static let curveOrder = dataFromHexLiteral(
+        "FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551"
+    )
+    // curve_order / 2
+    public static let halfOrder = dataFromHexLiteral(
+        "7FFFFFFF800000007FFFFFFFFFFFFFFFDE737D56D38BCF4279DCE5617E3192A8"
+    )
+
+    // MARK: - DER Parsing
+
+    public static func parseDERSignature(_ der: Data) throws -> (r: Data, s: Data) {
+        guard der.count >= 8 else {
+            throw SignetError.invalidHex("DER signature too short")
+        }
+        var offset = 0
+
+        guard der[offset] == 0x30 else {
+            throw SignetError.invalidHex("invalid DER: expected SEQUENCE tag")
+        }
+        offset += 1
+
+        let seqLen = Int(der[offset])
+        offset += 1
+
+        guard offset + seqLen <= der.count else {
+            throw SignetError.invalidHex("invalid DER: sequence length exceeds data")
+        }
+
+        guard der[offset] == 0x02 else {
+            throw SignetError.invalidHex("invalid DER: expected INTEGER tag for r")
+        }
+        offset += 1
+
+        let rLen = Int(der[offset])
+        offset += 1
+
+        guard offset + rLen <= der.count else {
+            throw SignetError.invalidHex("invalid DER: r length exceeds data")
+        }
+
+        var r = Data(der[offset..<(offset + rLen)])
+        offset += rLen
+
+        guard der[offset] == 0x02 else {
+            throw SignetError.invalidHex("invalid DER: expected INTEGER tag for s")
+        }
+        offset += 1
+
+        let sLen = Int(der[offset])
+        offset += 1
+
+        guard offset + sLen <= der.count else {
+            throw SignetError.invalidHex("invalid DER: s length exceeds data")
+        }
+
+        var s = Data(der[offset..<(offset + sLen)])
+
+        // Strip leading zero bytes
+        while r.count > 1 && r[r.startIndex] == 0x00 {
+            r = r.dropFirst()
+        }
+        while s.count > 1 && s[s.startIndex] == 0x00 {
+            s = s.dropFirst()
+        }
+
+        return (r: Data(r), s: Data(s))
+    }
+
+    // MARK: - Low-S Normalization
+
+    public static func applyLowS(s: Data) -> Data {
+        let sPadded = leftPad(s, to: 32)
+        let halfPadded = leftPad(halfOrder, to: 32)
+
+        if compareBigEndian(sPadded, halfPadded) > 0 {
+            let orderPadded = leftPad(curveOrder, to: 32)
+            return subtractBigEndian(orderPadded, sPadded)
+        }
+        return s
+    }
+
+    // MARK: - DER Reconstruction
+
+    public static func reconstructDER(r: Data, s: Data) -> Data {
+        let rDER = encodeInteger(r)
+        let sDER = encodeInteger(s)
+        let seqLen = rDER.count + sDER.count
+        var result = Data()
+        result.append(0x30)
+        result.append(UInt8(seqLen))
+        result.append(rDER)
+        result.append(sDER)
+        return result
+    }
+
+    private static func encodeInteger(_ value: Data) -> Data {
+        var bytes = Data(value)
+        while bytes.count > 1 && bytes[bytes.startIndex] == 0x00 {
+            bytes = Data(bytes.dropFirst())
+        }
+        var result = Data()
+        result.append(0x02)
+        if bytes[bytes.startIndex] & 0x80 != 0 {
+            result.append(UInt8(bytes.count + 1))
+            result.append(0x00)
+        } else {
+            result.append(UInt8(bytes.count))
+        }
+        result.append(bytes)
+        return result
+    }
+
+    // MARK: - Hex Helpers
+
+    public static func formatHex(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    public static func parseHex(_ hex: String) throws -> Data {
+        var cleaned = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if cleaned.isEmpty {
+            throw SignetError.invalidHex("empty input")
+        }
+        if cleaned.hasPrefix("0x") || cleaned.hasPrefix("0X") {
+            cleaned = String(cleaned.dropFirst(2))
+        }
+        if cleaned.isEmpty {
+            throw SignetError.invalidHex("empty hex after prefix")
+        }
+        if cleaned.count % 2 != 0 {
+            throw SignetError.invalidHex("odd-length hex string")
+        }
+        guard cleaned.allSatisfy({ $0.isHexDigit }) else {
+            throw SignetError.invalidHex("contains non-hex characters")
+        }
+        var data = Data()
+        var index = cleaned.startIndex
+        while index < cleaned.endIndex {
+            let nextIndex = cleaned.index(index, offsetBy: 2)
+            let byteString = cleaned[index..<nextIndex]
+            guard let byte = UInt8(byteString, radix: 16) else {
+                throw SignetError.invalidHex("invalid hex byte: \(byteString)")
+            }
+            data.append(byte)
+            index = nextIndex
+        }
+        return data
+    }
+
+    // MARK: - Big-Endian Arithmetic
+
+    public static func compareBigEndian(_ a: Data, _ b: Data) -> Int {
+        let maxLen = max(a.count, b.count)
+        let aPadded = leftPad(a, to: maxLen)
+        let bPadded = leftPad(b, to: maxLen)
+        for i in 0..<maxLen {
+            if aPadded[aPadded.startIndex + i] < bPadded[bPadded.startIndex + i] { return -1 }
+            if aPadded[aPadded.startIndex + i] > bPadded[bPadded.startIndex + i] { return 1 }
+        }
+        return 0
+    }
+
+    public static func subtractBigEndian(_ a: Data, _ b: Data) -> Data {
+        let maxLen = max(a.count, b.count)
+        let aPadded = leftPad(a, to: maxLen)
+        let bPadded = leftPad(b, to: maxLen)
+        var result = [UInt8](repeating: 0, count: maxLen)
+        var borrow: Int = 0
+        for i in stride(from: maxLen - 1, through: 0, by: -1) {
+            let diff = Int(aPadded[aPadded.startIndex + i]) - Int(bPadded[bPadded.startIndex + i]) - borrow
+            if diff < 0 {
+                result[i] = UInt8(diff + 256)
+                borrow = 1
+            } else {
+                result[i] = UInt8(diff)
+                borrow = 0
+            }
+        }
+        var data = Data(result)
+        while data.count > 1 && data[data.startIndex] == 0x00 {
+            data = Data(data.dropFirst())
+        }
+        return data
+    }
+
+    public static func leftPad(_ data: Data, to length: Int) -> Data {
+        if data.count >= length { return data }
+        var padded = Data(repeating: 0, count: length - data.count)
+        padded.append(data)
+        return padded
+    }
+
+    // MARK: - Helper
+
+    private static func dataFromHexLiteral(_ hex: String) -> Data {
+        var data = Data()
+        var index = hex.startIndex
+        while index < hex.endIndex {
+            let nextIndex = hex.index(index, offsetBy: 2)
+            let byteString = hex[index..<nextIndex]
+            data.append(UInt8(byteString, radix: 16)!)
+            index = nextIndex
+        }
+        return data
+    }
+}

--- a/signet-signer/Sources/signet-signer/CreateCommand.swift
+++ b/signet-signer/Sources/signet-signer/CreateCommand.swift
@@ -1,0 +1,50 @@
+import ArgumentParser
+import Foundation
+import SignetCore
+
+struct CreateCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "create",
+        abstract: "Generate a new P-256 signing key in the Secure Enclave"
+    )
+
+    @OptionGroup var globals: GlobalOptions
+
+    @Option(name: .long, help: "Advisory label (echoed in output, not stored in SE)")
+    var label: String
+
+    @Option(name: .long, help: "Access control policy: open, passcode, or biometric")
+    var policy: KeyPolicy
+
+    mutating func run() throws {
+        let manager = SecureEnclaveManager()
+
+        guard manager.isAvailable() else {
+            writeStderr("Secure Enclave is not available on this device")
+            throw ExitCode(1)
+        }
+
+        let result: (dataRepresentation: Data, publicKey: Data)
+        do {
+            result = try manager.createKey(policy: policy)
+        } catch let error as SignetError {
+            if case .authCancelled = error {
+                writeStderr(error.description)
+                throw ExitCode(2)
+            }
+            writeStderr(error.description)
+            throw ExitCode(1)
+        }
+
+        // Label is advisory — CryptoKit SE keys don't carry Keychain labels
+        // without entitlements. The keyRef (dataRepresentation) is the real handle.
+        let output = CreateResponse(
+            keyRef: result.dataRepresentation.base64EncodedString(),
+            publicKey: SignatureFormatter.formatHex(result.publicKey),
+            policy: policy.rawValue,
+            label: label
+        )
+
+        try outputJSON(output)
+    }
+}

--- a/signet-signer/Sources/signet-signer/DeleteCommand.swift
+++ b/signet-signer/Sources/signet-signer/DeleteCommand.swift
@@ -1,0 +1,21 @@
+import ArgumentParser
+import Foundation
+import SignetCore
+
+struct DeleteCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "delete",
+        abstract: "Delete a Secure Enclave key (best-effort)"
+    )
+
+    @OptionGroup var globals: GlobalOptions
+
+    @Option(name: .long, help: "Base64-encoded SE key reference to delete")
+    var keyRef: String
+
+    mutating func run() throws {
+        let manager = SecureEnclaveManager()
+        manager.deleteKey(keyRef)
+        // Exit 0 — deletion is best-effort
+    }
+}

--- a/signet-signer/Sources/signet-signer/InfoCommand.swift
+++ b/signet-signer/Sources/signet-signer/InfoCommand.swift
@@ -1,0 +1,46 @@
+import ArgumentParser
+import Foundation
+import SignetCore
+
+struct InfoCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "info",
+        abstract: "Query system Secure Enclave availability or check if a key exists"
+    )
+
+    @OptionGroup var globals: GlobalOptions
+
+    @Flag(name: .long, help: "Show system SE information")
+    var system: Bool = false
+
+    @Option(name: .long, help: "Base64-encoded SE key reference to check")
+    var keyRef: String?
+
+    mutating func run() throws {
+        if system && keyRef != nil {
+            writeStderr("cannot specify both --system and --key-ref")
+            throw ExitCode(1)
+        }
+
+        if !system && keyRef == nil {
+            writeStderr("specify --system or --key-ref")
+            throw ExitCode(1)
+        }
+
+        let manager = SecureEnclaveManager()
+
+        if system {
+            let output = SystemInfoResponse(
+                available: manager.isAvailable(),
+                chip: manager.getChipName(),
+                macOS: manager.getMacOSVersion()
+            )
+            try outputJSON(output)
+        } else if let ref = keyRef {
+            let output = KeyInfoResponse(
+                exists: manager.lookupKey(ref)
+            )
+            try outputJSON(output)
+        }
+    }
+}

--- a/signet-signer/Sources/signet-signer/SignCommand.swift
+++ b/signet-signer/Sources/signet-signer/SignCommand.swift
@@ -1,0 +1,60 @@
+import ArgumentParser
+import Foundation
+import SignetCore
+
+struct SignCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "sign",
+        abstract: "Sign data with a Secure Enclave key"
+    )
+
+    @OptionGroup var globals: GlobalOptions
+
+    @Option(name: .long, help: "Base64-encoded SE key reference")
+    var keyRef: String
+
+    @Option(name: .long, help: "Hex-encoded data to sign")
+    var data: String
+
+    mutating func run() throws {
+        // Parse key reference
+        guard let dataRep = Data(base64Encoded: keyRef) else {
+            writeStderr("invalid key reference: not valid base64")
+            throw ExitCode(1)
+        }
+
+        // Parse hex data
+        let inputBytes: Data
+        do {
+            inputBytes = try SignatureFormatter.parseHex(data)
+        } catch {
+            writeStderr("invalid hex data: \(error)")
+            throw ExitCode(1)
+        }
+
+        // Sign
+        let manager = SecureEnclaveManager()
+        let derSignature: Data
+        do {
+            derSignature = try manager.signData(inputBytes, dataRepresentation: dataRep)
+        } catch let error as SignetError {
+            if case .authCancelled = error {
+                writeStderr(error.description)
+                throw ExitCode(2)
+            }
+            writeStderr(error.description)
+            throw ExitCode(1)
+        }
+
+        // Parse DER and apply low-S normalization
+        let (r, rawS) = try SignatureFormatter.parseDERSignature(derSignature)
+        let s = SignatureFormatter.applyLowS(s: rawS)
+        let normalizedDER = SignatureFormatter.reconstructDER(r: r, s: s)
+
+        let output = SignResponse(
+            signature: SignatureFormatter.formatHex(normalizedDER)
+        )
+
+        try outputJSON(output)
+    }
+}

--- a/signet-signer/Sources/signet-signer/main.swift
+++ b/signet-signer/Sources/signet-signer/main.swift
@@ -1,0 +1,55 @@
+import ArgumentParser
+import Foundation
+import SignetCore
+
+extension KeyPolicy: ExpressibleByArgument {}
+
+struct SignetSigner: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "signet-signer",
+        abstract: "P-256 key operations via Apple Secure Enclave",
+        version: "0.1.0",
+        subcommands: [
+            CreateCommand.self,
+            SignCommand.self,
+            InfoCommand.self,
+            DeleteCommand.self,
+        ]
+    )
+}
+
+// MARK: - Global Options
+
+struct GlobalOptions: ParsableArguments {
+    @Option(name: .long, help: "Output format: json")
+    var format: String = "json"
+}
+
+// MARK: - Output Helpers
+
+func makeEncoder() -> JSONEncoder {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    return encoder
+}
+
+func writeStdout(_ string: String) {
+    if let data = string.data(using: .utf8) {
+        FileHandle.standardOutput.write(data)
+    }
+}
+
+func writeStderr(_ string: String) {
+    if let data = "error: \(string)\n".data(using: .utf8) {
+        FileHandle.standardError.write(data)
+    }
+}
+
+func outputJSON<T: Encodable>(_ value: T) throws {
+    let encoder = makeEncoder()
+    let data = try encoder.encode(value)
+    FileHandle.standardOutput.write(data)
+    writeStdout("\n")
+}
+
+SignetSigner.main()

--- a/signet-signer/Tests/SignetCoreTests/SignatureFormatterTests.swift
+++ b/signet-signer/Tests/SignetCoreTests/SignatureFormatterTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import SignetCore
+
+final class SignatureFormatterTests: XCTestCase {
+
+    // MARK: - Hex Parsing
+
+    func testParseHexValid() throws {
+        let data = try SignatureFormatter.parseHex("deadbeef")
+        XCTAssertEqual(data, Data([0xde, 0xad, 0xbe, 0xef]))
+    }
+
+    func testParseHexWithPrefix() throws {
+        let data = try SignatureFormatter.parseHex("0xCAFE")
+        XCTAssertEqual(data, Data([0xca, 0xfe]))
+    }
+
+    func testParseHexEmptyThrows() {
+        XCTAssertThrowsError(try SignatureFormatter.parseHex(""))
+    }
+
+    func testParseHexOddLengthThrows() {
+        XCTAssertThrowsError(try SignatureFormatter.parseHex("abc"))
+    }
+
+    func testParseHexInvalidCharsThrows() {
+        XCTAssertThrowsError(try SignatureFormatter.parseHex("zzzz"))
+    }
+
+    // MARK: - Hex Formatting
+
+    func testFormatHex() {
+        let data = Data([0xde, 0xad, 0xbe, 0xef])
+        XCTAssertEqual(SignatureFormatter.formatHex(data), "deadbeef")
+    }
+
+    // MARK: - DER Parsing
+
+    func testParseDERSignature() throws {
+        // A minimal valid DER ECDSA signature
+        // SEQUENCE { INTEGER(r=0x01), INTEGER(s=0x02) }
+        let der = Data([0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x02])
+        let (r, s) = try SignatureFormatter.parseDERSignature(der)
+        XCTAssertEqual(r, Data([0x01]))
+        XCTAssertEqual(s, Data([0x02]))
+    }
+
+    func testParseDERStripsLeadingZeros() throws {
+        // r has leading 0x00 (positive sign byte), s has leading 0x00
+        let der = Data([0x30, 0x08, 0x02, 0x02, 0x00, 0x80, 0x02, 0x02, 0x00, 0xFF])
+        let (r, s) = try SignatureFormatter.parseDERSignature(der)
+        XCTAssertEqual(r, Data([0x80]))
+        XCTAssertEqual(s, Data([0xFF]))
+    }
+
+    func testParseDERTooShortThrows() {
+        let der = Data([0x30, 0x01])
+        XCTAssertThrowsError(try SignatureFormatter.parseDERSignature(der))
+    }
+
+    // MARK: - Low-S Normalization
+
+    func testLowSAlreadyLow() {
+        // s = 1 (well below half order)
+        let s = Data([0x01])
+        let result = SignatureFormatter.applyLowS(s: s)
+        XCTAssertEqual(result, s)
+    }
+
+    func testLowSNormalizesHighS() {
+        // s = curveOrder - 1 (which is > halfOrder, so should be normalized to 2)
+        let highS = SignatureFormatter.subtractBigEndian(
+            SignatureFormatter.curveOrder,
+            Data([0x01])
+        )
+        let result = SignatureFormatter.applyLowS(s: highS)
+        // curveOrder - highS = curveOrder - (curveOrder - 1) = 1
+        XCTAssertEqual(result, Data([0x01]))
+    }
+
+    func testLowSHalfOrderIsLow() {
+        // s = halfOrder exactly — should remain unchanged (not greater than)
+        let result = SignatureFormatter.applyLowS(s: SignatureFormatter.halfOrder)
+        XCTAssertEqual(result, SignatureFormatter.halfOrder)
+    }
+
+    // MARK: - DER Round-Trip
+
+    func testDERRoundTrip() throws {
+        let r = Data([0x80, 0x01, 0x02])
+        let s = Data([0x7F, 0x03, 0x04])
+        let der = SignatureFormatter.reconstructDER(r: r, s: s)
+        let (parsedR, parsedS) = try SignatureFormatter.parseDERSignature(der)
+        XCTAssertEqual(parsedR, r)
+        XCTAssertEqual(parsedS, s)
+    }
+
+    func testDERReconstructionAddsSignByte() throws {
+        // r with high bit set needs 0x00 prefix in DER
+        let r = Data([0xFF])
+        let s = Data([0x01])
+        let der = SignatureFormatter.reconstructDER(r: r, s: s)
+        // Should be: 30 06 02 02 00 FF 02 01 01
+        XCTAssertEqual(der[0], 0x30) // SEQUENCE
+        XCTAssertEqual(der[2], 0x02) // INTEGER tag
+        XCTAssertEqual(der[3], 0x02) // length 2 (0x00 + 0xFF)
+        XCTAssertEqual(der[4], 0x00) // sign byte
+        XCTAssertEqual(der[5], 0xFF) // value
+    }
+
+    // MARK: - Big-Endian Arithmetic
+
+    func testCompareBigEndianEqual() {
+        let a = Data([0x01, 0x02])
+        XCTAssertEqual(SignatureFormatter.compareBigEndian(a, a), 0)
+    }
+
+    func testCompareBigEndianLessThan() {
+        let a = Data([0x01])
+        let b = Data([0x02])
+        XCTAssertEqual(SignatureFormatter.compareBigEndian(a, b), -1)
+    }
+
+    func testCompareBigEndianGreaterThan() {
+        let a = Data([0xFF])
+        let b = Data([0x01])
+        XCTAssertEqual(SignatureFormatter.compareBigEndian(a, b), 1)
+    }
+
+    func testSubtractBigEndian() {
+        let a = Data([0x10])
+        let b = Data([0x01])
+        let result = SignatureFormatter.subtractBigEndian(a, b)
+        XCTAssertEqual(result, Data([0x0F]))
+    }
+
+    func testLeftPad() {
+        let data = Data([0x01])
+        let padded = SignatureFormatter.leftPad(data, to: 4)
+        XCTAssertEqual(padded, Data([0x00, 0x00, 0x00, 0x01]))
+    }
+}


### PR DESCRIPTION
Minimal signet-signer Swift binary for hardware-bound key management:
- 4 subcommands: create, sign, info, delete
- P-256 Secure Enclave key creation with open/passcode/biometric policies
- Pre-hashed signing with low-S normalization (mandatory for P-256)
- DER parsing/reconstruction for signature formatting
- JSON output to stdout, errors to stderr
- 19 unit tests for SignatureFormatter (hex, DER, low-S, arithmetic)
- Bootstrap script updated with optional Swift build on macOS

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)