### PR TITLE
feat(keys): Secure Enclave dispatch in root key initialization and signing

### DIFF
--- a/packages/keys/src/__tests__/key-manager.test.ts
+++ b/packages/keys/src/__tests__/key-manager.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createKeyManager, type KeyManager } from "../key-manager.js";
+import { detectPlatform } from "../platform.js";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -26,12 +27,17 @@ describe("KeyManager", () => {
   });
 
   describe("initialize", () => {
-    test("detects platform as software-vault for v0", () => {
-      expect(manager.platform).toBe("software-vault");
+    test("detects platform matching detectPlatform()", () => {
+      const expected = detectPlatform();
+      expect(manager.platform).toBe(expected);
     });
 
-    test("maps software-vault to unverified trust tier", () => {
-      expect(manager.trustTier).toBe("unverified");
+    test("trust tier matches platform", () => {
+      if (manager.platform === "secure-enclave") {
+        expect(manager.trustTier).toBe("source-verified");
+      } else {
+        expect(manager.trustTier).toBe("unverified");
+      }
     });
 
     test("creates a root key handle on initialization", async () => {
@@ -40,7 +46,7 @@ describe("KeyManager", () => {
       if (Result.isError(result)) throw new Error("init failed");
       expect(result.value.keyRef).toBeDefined();
       expect(result.value.publicKey).toBeDefined();
-      expect(result.value.platform).toBe("software-vault");
+      expect(result.value.platform).toBe(detectPlatform());
     });
 
     test("returns existing root key on re-initialization", async () => {

--- a/packages/keys/src/__tests__/platform.test.ts
+++ b/packages/keys/src/__tests__/platform.test.ts
@@ -1,5 +1,13 @@
-import { describe, test, expect } from "bun:test";
-import { detectPlatform, platformToTrustTier } from "../platform.js";
+import { describe, test, expect, afterEach } from "bun:test";
+import {
+  detectPlatform,
+  platformToTrustTier,
+  resetPlatformCache,
+} from "../platform.js";
+
+afterEach(() => {
+  resetPlatformCache();
+});
 
 describe("detectPlatform", () => {
   test("returns a valid PlatformCapability", () => {
@@ -13,10 +21,39 @@ describe("detectPlatform", () => {
     expect(valid).toContain(platform);
   });
 
-  test("returns software-vault for v0", () => {
-    // v0 always returns software-vault since no Swift bridge
+  test("returns secure-enclave on macOS with signer binary available", () => {
+    // On a macOS dev machine with the signer built, this returns secure-enclave.
+    // On CI/Linux, it returns software-vault. Both are correct.
+    const platform = detectPlatform();
+    if (process.platform === "darwin") {
+      // May be either depending on whether signer binary is built
+      expect(["secure-enclave", "software-vault"]).toContain(platform);
+    } else {
+      expect(platform).toBe("software-vault");
+    }
+  });
+
+  test("caches the result across calls", () => {
+    const first = detectPlatform();
+    const second = detectPlatform();
+    expect(first).toBe(second);
+  });
+
+  test("returns software-vault when signer is not available", () => {
+    // Force no signer by setting env to nonexistent path and resetting cache
+    const orig = process.env["SIGNET_SIGNER_PATH"];
+    process.env["SIGNET_SIGNER_PATH"] = "/nonexistent/signet-signer";
+    resetPlatformCache();
+
     const platform = detectPlatform();
     expect(platform).toBe("software-vault");
+
+    // Restore
+    if (orig === undefined) {
+      delete process.env["SIGNET_SIGNER_PATH"];
+    } else {
+      process.env["SIGNET_SIGNER_PATH"] = orig;
+    }
   });
 });
 

--- a/packages/keys/src/__tests__/root-key-se.test.ts
+++ b/packages/keys/src/__tests__/root-key-se.test.ts
@@ -1,0 +1,138 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Result } from "better-result";
+import { mkdtempSync, rmSync, writeFileSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createVault, type Vault } from "../vault.js";
+import { initializeRootKey, signWithRootKey } from "../root-key.js";
+
+/**
+ * Tests for root key SE dispatch path.
+ * Uses SIGNET_SIGNER_PATH env var + mock scripts to test the full
+ * subprocess path without actual Secure Enclave hardware.
+ */
+
+const MOCK_KEY_REF = "dGVzdC1rZXktcmVm";
+const MOCK_PUBLIC_KEY = "04" + "ab".repeat(32) + "cd".repeat(32);
+const MOCK_SIGNATURE =
+  "3046022100" + "aa".repeat(32) + "022100" + "bb".repeat(32);
+
+function createMockSignerScript(tmpDir: string): string {
+  const scriptPath = join(tmpDir, "mock-signet-signer");
+  // Return different JSON based on subcommand
+  const script = `#!/usr/bin/env bash
+case "$1" in
+  "create")
+    echo '{"keyRef":"${MOCK_KEY_REF}","publicKey":"${MOCK_PUBLIC_KEY}","policy":"open"}'
+    ;;
+  "sign")
+    echo '{"signature":"${MOCK_SIGNATURE}"}'
+    ;;
+  "info")
+    echo '{"available":true,"chip":"Mock M2","macOS":"15.0"}'
+    ;;
+  "delete")
+    ;;
+  *)
+    echo '{}' ;;
+esac
+exit 0
+`;
+  writeFileSync(scriptPath, script);
+  chmodSync(scriptPath, 0o755);
+  return scriptPath;
+}
+
+describe("root-key SE dispatch", () => {
+  let dataDir: string;
+  let vault: Vault;
+  let originalSignerPath: string | undefined;
+
+  beforeEach(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), "rootkey-se-test-"));
+    const result = await createVault(dataDir);
+    if (Result.isError(result)) throw new Error("vault setup failed");
+    vault = result.value;
+
+    // Set SIGNET_SIGNER_PATH to mock script
+    originalSignerPath = process.env["SIGNET_SIGNER_PATH"];
+    const mockPath = createMockSignerScript(dataDir);
+    process.env["SIGNET_SIGNER_PATH"] = mockPath;
+  });
+
+  afterEach(() => {
+    vault.close();
+    rmSync(dataDir, { recursive: true, force: true });
+    // Restore env
+    if (originalSignerPath === undefined) {
+      delete process.env["SIGNET_SIGNER_PATH"];
+    } else {
+      process.env["SIGNET_SIGNER_PATH"] = originalSignerPath;
+    }
+  });
+
+  test("SE platform creates key via subprocess and stores handle", async () => {
+    const result = await initializeRootKey(vault, "open", "secure-enclave");
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result))
+      throw new Error(`init failed: ${result.error.message}`);
+
+    expect(result.value.platform).toBe("secure-enclave");
+    expect(result.value.keyRef).toBe(MOCK_KEY_REF);
+    expect(result.value.publicKey).toBe(MOCK_PUBLIC_KEY);
+  });
+
+  test("SE platform does NOT store private material in vault", async () => {
+    await initializeRootKey(vault, "open", "secure-enclave");
+
+    const names = vault.list();
+    expect(names).toContain("root-key-ref");
+    // No private key stored — SE keys never leave the enclave
+    expect(names).not.toContain("root-key:private");
+  });
+
+  test("SE handle loads from vault on re-init", async () => {
+    const r1 = await initializeRootKey(vault, "open", "secure-enclave");
+    if (Result.isError(r1)) throw new Error("first init failed");
+
+    const r2 = await initializeRootKey(vault, "open", "secure-enclave");
+    expect(Result.isOk(r2)).toBe(true);
+    if (Result.isError(r2)) throw new Error("re-init failed");
+
+    expect(r2.value.keyRef).toBe(r1.value.keyRef);
+    expect(r2.value.platform).toBe("secure-enclave");
+  });
+
+  test("signWithRootKey dispatches to SE when handle has secure-enclave platform", async () => {
+    await initializeRootKey(vault, "open", "secure-enclave");
+
+    const data = new Uint8Array([1, 2, 3]);
+    const result = await signWithRootKey(vault, data);
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result))
+      throw new Error(`sign failed: ${result.error.message}`);
+
+    expect(result.value.byteLength).toBeGreaterThan(0);
+  });
+
+  test("software platform uses existing software path (unchanged)", async () => {
+    const result = await initializeRootKey(vault, "open", "software-vault");
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result)) throw new Error("init failed");
+
+    expect(result.value.platform).toBe("software-vault");
+
+    // Signing should work via software path
+    const sig = await signWithRootKey(vault, new Uint8Array([1, 2, 3]));
+    expect(Result.isOk(sig)).toBe(true);
+  });
+
+  test("SE init fails gracefully when signer binary not found", async () => {
+    process.env["SIGNET_SIGNER_PATH"] = "/nonexistent/path/signet-signer";
+
+    const result = await initializeRootKey(vault, "open", "secure-enclave");
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isOk(result)) throw new Error("expected error");
+    expect(result.error.message).toContain("signet-signer binary not found");
+  });
+});

--- a/packages/keys/src/index.ts
+++ b/packages/keys/src/index.ts
@@ -14,7 +14,26 @@ export type {
 export type { RootKeyHandle, OperationalKey, SessionKey } from "./types.js";
 
 // Platform detection
-export { detectPlatform, platformToTrustTier } from "./platform.js";
+export {
+  detectPlatform,
+  platformToTrustTier,
+  resetPlatformCache,
+} from "./platform.js";
+
+// Secure Enclave bridge
+export {
+  findSignerBinary,
+  seCreate,
+  seSign,
+  seInfo,
+  seDelete,
+} from "./se-bridge.js";
+export type {
+  SeCreateResponse,
+  SeSignResponse,
+  SeSystemInfoResponse,
+  SeKeyInfoResponse,
+} from "./se-protocol.js";
 
 // Key manager
 export { createKeyManager } from "./key-manager.js";

--- a/packages/keys/src/platform.ts
+++ b/packages/keys/src/platform.ts
@@ -1,14 +1,53 @@
 import type { TrustTier } from "@xmtp/signet-schemas";
 import type { PlatformCapability } from "./config.js";
+import { findSignerBinary } from "./se-bridge.js";
+
+/** Cached platform detection result. */
+let cachedPlatform: PlatformCapability | null = null;
 
 /**
  * Detect the current platform's key storage capability.
- * v0: always returns "software-vault" since the Swift CLI bridge is not yet implemented.
+ * On macOS with signet-signer binary available and SE reported as available,
+ * returns "secure-enclave". Otherwise falls back to "software-vault".
+ *
+ * Result is cached — platform doesn't change during runtime.
  */
 export function detectPlatform(): PlatformCapability {
-  // v0: software fallback only.
-  // Future: check for Secure Enclave via signet-signer subprocess.
+  if (cachedPlatform !== null) return cachedPlatform;
+
+  cachedPlatform = detectPlatformUncached();
+  return cachedPlatform;
+}
+
+function detectPlatformUncached(): PlatformCapability {
+  if (process.platform !== "darwin") return "software-vault";
+
+  const signerPath = findSignerBinary();
+  if (!signerPath) return "software-vault";
+
+  // Synchronous check with 5-second timeout to avoid hanging on broken signer
+  try {
+    const result = Bun.spawnSync(
+      [signerPath, "info", "--system", "--format", "json"],
+      { stdout: "pipe", stderr: "pipe", timeout: 5_000 },
+    );
+
+    if (result.exitCode !== 0) return "software-vault";
+
+    const stdout = new TextDecoder().decode(result.stdout);
+    const parsed = JSON.parse(stdout) as { available?: boolean };
+
+    if (parsed.available === true) return "secure-enclave";
+  } catch {
+    // Any failure falls through to software-vault
+  }
+
   return "software-vault";
+}
+
+/** Reset cached platform (for testing). */
+export function resetPlatformCache(): void {
+  cachedPlatform = null;
 }
 
 /** Map platform capability to the corresponding trust tier. */

--- a/packages/keys/src/root-key.ts
+++ b/packages/keys/src/root-key.ts
@@ -13,6 +13,7 @@ import {
   signP256,
   toHex,
 } from "./crypto-keys.js";
+import { seCreate, seSign, findSignerBinary } from "./se-bridge.js";
 
 const RootKeyHandleSchema = z.object({
   keyRef: z.string(),
@@ -30,8 +31,7 @@ export type RootKeyResult = RootKeyHandle;
 
 /**
  * Initialize or load the root key.
- * v0: software P-256 key stored in the vault.
- * Future: Secure Enclave via Swift subprocess.
+ * Dispatches to Secure Enclave or software vault based on platform.
  */
 export async function initializeRootKey(
   vault: Vault,
@@ -67,14 +67,64 @@ export async function initializeRootKey(
     }
   }
 
-  // Generate new root key
+  // Dispatch to platform-specific initialization
+  if (platform === "secure-enclave") {
+    return initializeRootKeySE(vault, policy);
+  }
+
+  return initializeRootKeySoftware(vault, policy, platform);
+}
+
+/** Initialize root key via Secure Enclave subprocess. */
+async function initializeRootKeySE(
+  vault: Vault,
+  policy: KeyPolicy,
+): Promise<Result<RootKeyResult, InternalError>> {
+  const signerPath = findSignerBinary();
+  if (!signerPath) {
+    return Result.err(
+      InternalError.create(
+        "signet-signer binary not found — cannot create SE key",
+      ),
+    );
+  }
+
+  const label = `signet-root-${Date.now()}`;
+  const createResult = await seCreate(label, policy, signerPath);
+  if (Result.isError(createResult)) return createResult;
+
+  const { keyRef, publicKey } = createResult.value;
+
+  const handle: RootKeyHandle = {
+    keyRef,
+    publicKey,
+    policy,
+    platform: "secure-enclave",
+    createdAt: new Date().toISOString(),
+  };
+
+  // Store handle metadata in vault (no private material — keyRef is the opaque SE token)
+  const storeResult = await vault.set(
+    ROOT_KEY_REF,
+    new TextEncoder().encode(JSON.stringify(handle)),
+  );
+  if (Result.isError(storeResult)) return storeResult;
+
+  return Result.ok(handle);
+}
+
+/** Initialize root key via software P-256 (existing behavior). */
+async function initializeRootKeySoftware(
+  vault: Vault,
+  policy: KeyPolicy,
+  platform: PlatformCapability,
+): Promise<Result<RootKeyResult, InternalError>> {
   const keyPair = await generateP256KeyPair();
   if (Result.isError(keyPair)) return keyPair;
 
   const pubBytes = await exportPublicKey(keyPair.value.publicKey);
   if (Result.isError(pubBytes)) return pubBytes;
 
-  // Export and store the private key
   const privBytes = await exportPrivateKey(keyPair.value.privateKey);
   if (Result.isError(privBytes)) return privBytes;
 
@@ -93,7 +143,6 @@ export async function initializeRootKey(
     createdAt: new Date().toISOString(),
   };
 
-  // Store root key handle metadata in vault
   const storeResult = await vault.set(
     ROOT_KEY_REF,
     new TextEncoder().encode(JSON.stringify(handle)),
@@ -104,10 +153,77 @@ export async function initializeRootKey(
 }
 
 /**
- * Sign data with the root key. Loads private material from vault on-demand,
- * signs, then lets the CryptoKey be garbage collected.
+ * Sign data with the root key. Dispatches based on the platform stored
+ * in the root key handle metadata.
  */
 export async function signWithRootKey(
+  vault: Vault,
+  data: Uint8Array,
+): Promise<Result<Uint8Array, InternalError>> {
+  // Load handle to determine platform
+  const handleBytes = await vault.get(ROOT_KEY_REF);
+  if (Result.isError(handleBytes)) {
+    return Result.err(
+      InternalError.create("Root key handle not found in vault"),
+    );
+  }
+
+  let handle: RootKeyHandle;
+  try {
+    const parsed = RootKeyHandleSchema.safeParse(
+      JSON.parse(new TextDecoder().decode(handleBytes.value)),
+    );
+    if (!parsed.success) {
+      return Result.err(
+        InternalError.create("Invalid root key handle data", {
+          cause: parsed.error.message,
+        }),
+      );
+    }
+    handle = parsed.data;
+  } catch (e) {
+    return Result.err(
+      InternalError.create("Corrupt root key data", { cause: String(e) }),
+    );
+  }
+
+  if (handle.platform === "secure-enclave") {
+    return signWithRootKeySE(handle.keyRef, data);
+  }
+
+  return signWithRootKeySoftware(vault, data);
+}
+
+/** Sign via Secure Enclave subprocess. */
+async function signWithRootKeySE(
+  keyRef: string,
+  data: Uint8Array,
+): Promise<Result<Uint8Array, InternalError>> {
+  const signerPath = findSignerBinary();
+  if (!signerPath) {
+    return Result.err(
+      InternalError.create(
+        "signet-signer binary not found — cannot sign with SE key",
+      ),
+    );
+  }
+
+  const signResult = await seSign(keyRef, data, signerPath);
+  if (Result.isError(signResult)) return signResult;
+
+  // Convert hex DER signature to raw (r || s) format to match WebCrypto output
+  const hex = signResult.value.signature;
+  const derBytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    derBytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
+  }
+  const bytes = derToRaw(derBytes);
+
+  return Result.ok(bytes);
+}
+
+/** Sign via software key loaded from vault (existing behavior). */
+async function signWithRootKeySoftware(
   vault: Vault,
   data: Uint8Array,
 ): Promise<Result<Uint8Array, InternalError>> {

--- a/packages/keys/src/se-bridge.ts
+++ b/packages/keys/src/se-bridge.ts
@@ -29,10 +29,10 @@ const SUBPROCESS_TIMEOUT_MS = parseInt(
  * 3. signet-signer on $PATH
  */
 export function findSignerBinary(): string | null {
-  // 1. Explicit env override
+  // 1. Explicit env override — if set, use it exclusively (don't fall through)
   const envPath = process.env["SIGNET_SIGNER_PATH"];
-  if (envPath && existsSync(envPath)) {
-    return envPath;
+  if (envPath !== undefined) {
+    return existsSync(envPath) ? envPath : null;
   }
 
   // 2. Local dev build — walk up from this file to repo root

--- a/packages/keys/src/se-protocol.ts
+++ b/packages/keys/src/se-protocol.ts
@@ -1,8 +1,13 @@
 import { z } from "zod";
+import type { KeyPolicy } from "./config.js";
 import { KeyPolicySchema } from "./config.js";
 
 /** Response from `signet-signer create`. */
-export const SeCreateResponseSchema = z.object({
+export const SeCreateResponseSchema: z.ZodObject<{
+  keyRef: z.ZodString;
+  publicKey: z.ZodString;
+  policy: z.ZodEnum<["biometric", "passcode", "open"]>;
+}> = z.object({
   keyRef: z.string().describe("Base64-encoded SE data representation"),
   publicKey: z
     .string()
@@ -10,29 +15,49 @@ export const SeCreateResponseSchema = z.object({
   policy: KeyPolicySchema,
 });
 
-export type SeCreateResponse = z.infer<typeof SeCreateResponseSchema>;
+export type SeCreateResponse = {
+  keyRef: string;
+  publicKey: string;
+  policy: KeyPolicy;
+};
 
 /** Response from `signet-signer sign`. */
-export const SeSignResponseSchema = z.object({
+export const SeSignResponseSchema: z.ZodObject<{
+  signature: z.ZodString;
+}> = z.object({
   signature: z
     .string()
     .describe("Hex-encoded DER signature with low-S normalization"),
 });
 
-export type SeSignResponse = z.infer<typeof SeSignResponseSchema>;
+export type SeSignResponse = {
+  signature: string;
+};
 
 /** Response from `signet-signer info --system`. */
-export const SeSystemInfoResponseSchema = z.object({
+export const SeSystemInfoResponseSchema: z.ZodObject<{
+  available: z.ZodBoolean;
+  chip: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+  macOS: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+}> = z.object({
   available: z.boolean(),
   chip: z.string().nullable().optional(),
   macOS: z.string().nullable().optional(),
 });
 
-export type SeSystemInfoResponse = z.infer<typeof SeSystemInfoResponseSchema>;
+export type SeSystemInfoResponse = {
+  available: boolean;
+  chip?: string | null | undefined;
+  macOS?: string | null | undefined;
+};
 
 /** Response from `signet-signer info --key-ref`. */
-export const SeKeyInfoResponseSchema = z.object({
+export const SeKeyInfoResponseSchema: z.ZodObject<{
+  exists: z.ZodBoolean;
+}> = z.object({
   exists: z.boolean(),
 });
 
-export type SeKeyInfoResponse = z.infer<typeof SeKeyInfoResponseSchema>;
+export type SeKeyInfoResponse = {
+  exists: boolean;
+};


### PR DESCRIPTION
- platform.ts: real detection via signet-signer info --system subprocess
  - Caches result (platform doesn't change at runtime)
  - Falls back to software-vault on non-macOS or missing binary
- root-key.ts: conditional dispatch based on platform
  - SE path: creates key via subprocess, stores opaque keyRef in vault
  - SE path: NO private material stored (keys never leave enclave)
  - Software path: unchanged behavior
  - signWithRootKey reads handle.platform to dispatch
- se-bridge.ts: env var takes priority and is exclusive (no fallthrough)
- Updated tests for platform-aware assertions
- 7 new tests for SE dispatch with mock signer scripts

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)