### PR TITLE
docs: add TSDoc coverage to all exported APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,13 @@
   "scripts": {
     "bootstrap": "bash ./scripts/bootstrap.sh",
     "build": "turbo run build",
+    "docs:check": "bun ./scripts/check-doc-coverage.ts",
     "test": "turbo run test",
     "typecheck": "turbo run typecheck",
-    "lint": "turbo run lint",
-    "format:check": "oxfmt --check packages/*/src packages/*/package.json packages/*/tsconfig.json apps scripts package.json tsconfig.base.json turbo.json .lefthook.yml README.md CLAUDE.md",
-    "format:fix": "oxfmt packages/*/src packages/*/package.json packages/*/tsconfig.json apps scripts package.json tsconfig.base.json turbo.json .lefthook.yml README.md CLAUDE.md",
-    "check": "turbo run lint typecheck test"
+    "lint": "turbo run lint && bun run docs:check",
+    "format:check": "oxfmt --check packages/*/src packages/*/package.json packages/*/tsconfig.json apps scripts package.json tsconfig.base.json turbo.json .lefthook.yml README.md CLAUDE.md AGENTS.md",
+    "format:fix": "oxfmt packages/*/src packages/*/package.json packages/*/tsconfig.json apps scripts package.json tsconfig.base.json turbo.json .lefthook.yml README.md CLAUDE.md AGENTS.md",
+    "check": "turbo run lint typecheck test && bun run docs:check"
   },
   "dependencies": {
     "@noble/ciphers": "^2.1.1"

--- a/packages/cli/src/actions/signet-actions.ts
+++ b/packages/cli/src/actions/signet-actions.ts
@@ -4,6 +4,7 @@ import type { ActionSpec } from "@xmtp/signet-contracts";
 import type { SignetError } from "@xmtp/signet-schemas";
 import type { DaemonStatus } from "../daemon/status.js";
 
+/** Dependencies for the daemon-level `signet:*` CLI actions. */
 export interface SignetActionDeps {
   readonly status: () => Promise<DaemonStatus>;
   readonly shutdown: () => Promise<Result<void, SignetError>>;
@@ -15,6 +16,7 @@ function widenActionSpec<TInput, TOutput>(
   return spec as ActionSpec<unknown, unknown, SignetError>;
 }
 
+/** Create CLI actions for daemon status and shutdown. */
 export function createSignetActions(
   deps: SignetActionDeps,
 ): ActionSpec<unknown, unknown, SignetError>[] {

--- a/packages/cli/src/commands/admin-rpc.ts
+++ b/packages/cli/src/commands/admin-rpc.ts
@@ -11,6 +11,9 @@ import {
 
 export type { DaemonCommandContext, DaemonCommandDeps };
 
+/**
+ * Parse a JSON CLI flag value with the shared daemon-command validation path.
+ */
 export function parseJsonInput<T>(
   input: string,
   schema: z.ZodType<T>,
@@ -19,6 +22,10 @@ export function parseJsonInput<T>(
   return parseJsonInputImpl(input, field, schema);
 }
 
+/**
+ * Resolve daemon connection context from command options, then run an RPC body
+ * with an authenticated admin client.
+ */
 export async function withDaemonClient<T>(
   options: { config?: string | undefined },
   deps: Partial<DaemonCommandDeps>,

--- a/packages/cli/src/commands/conversation.ts
+++ b/packages/cli/src/commands/conversation.ts
@@ -7,6 +7,7 @@ import {
   type WithDaemonClient,
 } from "./daemon-client.js";
 
+/** Dependencies for conversation management CLI commands. */
 export interface ConversationCommandDeps {
   readonly withDaemonClient: WithDaemonClient;
   readonly writeStdout: (message: string) => void;

--- a/packages/cli/src/commands/daemon-client.ts
+++ b/packages/cli/src/commands/daemon-client.ts
@@ -13,11 +13,13 @@ import { loadConfig } from "../config/loader.js";
 import { resolvePaths, type ResolvedPaths } from "../config/paths.js";
 import type { CliConfig } from "../config/schema.js";
 
+/** Resolved config and paths for a daemon-scoped CLI command. */
 export interface DaemonCommandContext {
   readonly config: CliConfig;
   readonly paths: ResolvedPaths;
 }
 
+/** Dependencies for commands that connect to the running daemon. */
 export interface DaemonCommandDeps {
   readonly loadConfig: typeof loadConfig;
   readonly resolvePaths: typeof resolvePaths;
@@ -27,10 +29,12 @@ export interface DaemonCommandDeps {
   readonly createAdminClient: (socketPath: string) => AdminClient;
 }
 
+/** Common option bag for commands that can target a config file. */
 export interface DaemonCommandOptions {
   readonly configPath?: string | undefined;
 }
 
+/** Helper for commands that need a transient authenticated admin client. */
 export type WithDaemonClient = <T>(
   options: DaemonCommandOptions,
   run: (
@@ -50,6 +54,7 @@ type RpcKeyManager = Pick<KeyManager, "initialize" | "admin"> & {
   close?: () => void;
 };
 
+/** Build a helper for daemon-backed commands that need an admin client. */
 export function createWithDaemonClient(
   deps: Partial<DaemonCommandDeps> = {},
 ): WithDaemonClient {
@@ -139,6 +144,7 @@ async function runWithKeyManager<T>(
   }
 }
 
+/** Parse inline JSON or `@file` input and validate it against a Zod schema. */
 export async function parseJsonInput<T>(
   value: string,
   field: string,

--- a/packages/cli/src/commands/lifecycle.ts
+++ b/packages/cli/src/commands/lifecycle.ts
@@ -16,6 +16,7 @@ import {
   type WithDaemonClient,
 } from "./daemon-client.js";
 
+/** Dependencies for top-level lifecycle CLI commands. */
 export interface SignetLifecycleCommandDeps {
   readonly loadConfig: typeof loadConfig;
   readonly resolvePaths: typeof resolvePaths;

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -19,6 +19,7 @@ import {
   type WithDaemonClient,
 } from "./daemon-client.js";
 
+/** Dependencies for session management CLI commands. */
 export interface SessionCommandDeps {
   readonly withDaemonClient: WithDaemonClient;
   readonly writeStdout: (message: string) => void;

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -49,6 +49,7 @@ type HttpServerConfigInput =
     }
   | undefined;
 
+/** Schema for the optional HTTP API server configuration block. */
 export const HttpServerConfigSchema: z.ZodType<
   HttpServerConfig,
   z.ZodTypeDef,

--- a/packages/cli/src/direct/client.ts
+++ b/packages/cli/src/direct/client.ts
@@ -19,6 +19,7 @@ type DirectModeConfigInput = {
   dataDir: string;
 };
 
+/** Schema for direct-mode runtime configuration. */
 export const DirectModeConfigSchema: z.ZodType<
   DirectModeConfig,
   z.ZodTypeDef,

--- a/packages/cli/src/http/server.ts
+++ b/packages/cli/src/http/server.ts
@@ -8,11 +8,13 @@ import type { AdminDispatcher } from "../admin/dispatcher.js";
 // Types
 // ---------------------------------------------------------------------------
 
+/** Configuration for the HTTP API server. */
 export interface HttpServerConfig {
   readonly port: number;
   readonly host: string;
 }
 
+/** Dependencies required to serve HTTP admin and status routes. */
 export interface HttpServerDeps {
   readonly dispatcher: AdminDispatcher;
   readonly sessionManager: SessionManager;
@@ -22,6 +24,7 @@ export interface HttpServerDeps {
   readonly status: () => unknown | Promise<unknown>;
 }
 
+/** Minimal lifecycle surface for the HTTP API server. */
 export interface HttpServer {
   start(): Promise<Result<{ port: number }, SignetError>>;
   stop(): Promise<Result<void, SignetError>>;
@@ -87,6 +90,9 @@ function extractBearerToken(req: Request): string | null {
 // Implementation
 // ---------------------------------------------------------------------------
 
+/**
+ * Create the HTTP API server used for admin and health endpoints.
+ */
 export function createHttpServer(
   config: HttpServerConfig,
   deps: HttpServerDeps,

--- a/packages/cli/src/ws/core-upgrade.ts
+++ b/packages/cli/src/ws/core-upgrade.ts
@@ -4,6 +4,9 @@ import type { SignetCore } from "@xmtp/signet-contracts";
 
 type UpgradeableCore = Pick<SignetCore, "state" | "initialize">;
 
+/**
+ * Create a lazy initializer that upgrades the core only when WS traffic needs it.
+ */
 export function createLazyCoreUpgrade(
   core: UpgradeableCore,
 ): () => Promise<Result<void, SignetError>> {

--- a/packages/cli/src/ws/event-projector.ts
+++ b/packages/cli/src/ws/event-projector.ts
@@ -10,6 +10,7 @@ import type { SessionRecord, RevealStateStore } from "@xmtp/signet-contracts";
 import { projectMessage } from "@xmtp/signet-policy";
 import type { RawMessage, ProjectionResult } from "@xmtp/signet-policy";
 
+/** Dependencies used to rehydrate reveal state during WS projection. */
 export interface EventProjectorDeps {
   readonly getRevealState: (sessionId: string) => RevealStateStore | null;
 }

--- a/packages/cli/src/ws/request-handler.ts
+++ b/packages/cli/src/ws/request-handler.ts
@@ -24,6 +24,7 @@ import type { PendingActionStore } from "@xmtp/signet-sessions";
 /** Default expiry for pending actions: 5 minutes. */
 const PENDING_ACTION_TTL_MS = 5 * 60 * 1000;
 
+/** Dependencies required to route harness requests through the WS transport. */
 export interface HarnessRequestHandlerDeps {
   readonly ensureCoreReady: () => Promise<Result<void, SignetError>>;
   readonly sendMessage: (
@@ -40,6 +41,12 @@ export interface HarnessRequestHandlerDeps {
   readonly broadcast?: (sessionId: string, event: SignetEvent) => void;
 }
 
+/**
+ * Create the WS harness request handler.
+ *
+ * The handler stays transport-only: it validates request shape,
+ * delegates to session/core services, and returns typed results.
+ */
 export function createWsRequestHandler(
   deps: HarnessRequestHandlerDeps,
 ): RequestHandler {
@@ -398,5 +405,6 @@ export function createWsRequestHandler(
   };
 }
 
+/** Alias for the WS harness request handler used by older call sites. */
 export const createHarnessRequestHandler: typeof createWsRequestHandler =
   createWsRequestHandler;

--- a/packages/contracts/src/seal-envelope.ts
+++ b/packages/contracts/src/seal-envelope.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { SealSchema, RevocationSeal } from "@xmtp/signet-schemas";
 
-/** Provenance info attached to outbound messages. */
+/** Provenance metadata attached to outbound message seals. */
 export interface MessageProvenanceMetadata {
   readonly sealId: string;
   readonly sessionKeyFingerprint: string;
@@ -34,12 +34,14 @@ const sealEnvelopeShape: SealEnvelopeShape = {
     .describe("Reference to the key that produced the signature"),
 };
 
-/** Signed seal ready for group publication. */
+/** Zod schema for a signed seal ready for group publication. */
 export const SealEnvelope: z.ZodObject<SealEnvelopeShape> = z
   .object(sealEnvelopeShape)
   .describe("Signed seal ready for group publication");
 
+/** Schema alias for a signed seal ready for publication. */
 export const SealEnvelopeSchema: z.ZodObject<SealEnvelopeShape> = SealEnvelope;
+/** Parsed signed seal envelope. */
 export type SealEnvelope = z.infer<typeof SealEnvelopeSchema>;
 
 type SignedRevocationEnvelopeShape = {
@@ -62,10 +64,11 @@ const signedRevocationEnvelopeShape: SignedRevocationEnvelopeShape = {
     .describe("Reference to the key that produced the signature"),
 };
 
-/** Signed revocation ready for group publication. */
+/** Zod schema for a signed revocation ready for group publication. */
 export const SignedRevocationEnvelope: z.ZodObject<SignedRevocationEnvelopeShape> =
   z
     .object(signedRevocationEnvelopeShape)
     .describe("Signed revocation ready for group publication");
 
+/** Parsed signed revocation envelope. */
 export type SignedRevocationEnvelope = z.infer<typeof SignedRevocationEnvelope>;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,15 +1,19 @@
 import { z } from "zod";
 
+/** XMTP network environment that the core should connect to. */
 export const XmtpEnvSchema: z.ZodEnum<["local", "dev", "production"]> = z
   .enum(["local", "dev", "production"])
   .describe("XMTP network environment");
 
+/** XMTP network environment label. */
 export type XmtpEnv = z.infer<typeof XmtpEnvSchema>;
 
+/** Whether each group gets its own identity or shares one. */
 export const IdentityModeSchema: z.ZodEnum<["per-group", "shared"]> = z
   .enum(["per-group", "shared"])
   .describe("Whether each group gets a unique identity or shares one");
 
+/** Identity isolation strategy used by the core. */
 export type IdentityMode = z.infer<typeof IdentityModeSchema>;
 
 /** Parsed signet core configuration (all defaults applied). */
@@ -32,6 +36,7 @@ type SignetCoreConfigInput = {
   appVersion?: string | undefined;
 };
 
+/** Zod schema for parsed signet core configuration. */
 export const SignetCoreConfigSchema: z.ZodType<
   SignetCoreConfig,
   z.ZodTypeDef,

--- a/packages/core/src/conversation-actions.ts
+++ b/packages/core/src/conversation-actions.ts
@@ -14,14 +14,21 @@ import { joinConversation } from "./convos/join.js";
 import { generateConvosInviteUrl } from "./convos/invite-generator.js";
 import type { SignerProviderFactory } from "./identity-registration.js";
 
+/** Dependencies used to build conversation-related action specs. */
 export interface ConversationActionDeps {
+  /** Identity store used to resolve conversation creators and viewers. */
   readonly identityStore: SqliteIdentityStore;
+  /** Lookup for the managed client tied to a signet identity. */
   readonly getManagedClient: (identityId: string) => ManagedClient | undefined;
+  /** Fetch group metadata from XMTP for the provided group id. */
   readonly getGroupInfo: (
     groupId: string,
   ) => Promise<Result<XmtpGroupInfo, SignetError>>;
+  /** Optional XMTP client factory for conversation wiring. */
   readonly clientFactory?: XmtpClientFactory;
+  /** Optional signer provider factory for identity-bound actions. */
   readonly signerProviderFactory?: SignerProviderFactory;
+  /** Optional core config snapshot used by invite/join helpers. */
   readonly config?: Pick<SignetCoreConfig, "dataDir" | "env" | "appVersion">;
 }
 

--- a/packages/integration/src/fixtures/mock-xmtp-client.ts
+++ b/packages/integration/src/fixtures/mock-xmtp-client.ts
@@ -16,11 +16,13 @@ import type {
   GroupStream,
 } from "@xmtp/signet-core";
 
+/** Options for constructing a mock XMTP client. */
 export interface MockXmtpClientOptions {
   readonly inboxId?: string;
   readonly groups?: readonly XmtpGroupInfo[];
 }
 
+/** In-memory XMTP client used by integration tests. */
 export interface MockXmtpClient extends XmtpClient {
   /** Messages sent via sendMessage(). */
   readonly sentMessages: ReadonlyArray<{
@@ -96,11 +98,13 @@ function createControllableStream<T>(): {
   };
 }
 
+/** Stream emitters exposed by the mock client. */
 export interface MockStreams {
   readonly emitMessage: (msg: XmtpDecodedMessage) => void;
   readonly emitGroupEvent: (event: XmtpGroupEvent) => void;
 }
 
+/** Create a controllable in-memory XMTP client. */
 export function createMockXmtpClient(options?: MockXmtpClientOptions): {
   client: MockXmtpClient;
   streams: MockStreams;

--- a/packages/integration/src/fixtures/mock-xmtp-factory.ts
+++ b/packages/integration/src/fixtures/mock-xmtp-factory.ts
@@ -17,11 +17,13 @@ import {
   type MockXmtpClientOptions,
 } from "./mock-xmtp-client.js";
 
+/** Mock XMTP client factory used by integration tests. */
 export interface MockXmtpClientFactory extends XmtpClientFactory {
   /** Access created clients by identity ID. */
   readonly clients: ReadonlyMap<string, MockXmtpClient>;
 }
 
+/** Fan-out emitters for all clients created by the factory. */
 export interface MockFactoryStreams {
   /** Emit a message on all active client streams. */
   readonly emitMessage: (msg: XmtpDecodedMessage) => void;
@@ -29,6 +31,7 @@ export interface MockFactoryStreams {
   readonly emitGroupEvent: (event: XmtpGroupEvent) => void;
 }
 
+/** Create a factory that returns controllable mock XMTP clients. */
 export function createMockXmtpClientFactory(
   defaultOptions?: MockXmtpClientOptions,
 ): {

--- a/packages/integration/src/fixtures/test-runtime.ts
+++ b/packages/integration/src/fixtures/test-runtime.ts
@@ -73,6 +73,7 @@ function createTestPublisher(): SealPublisher & {
   };
 }
 
+/** Fully composed test runtime for integration tests. */
 export interface TestRuntime {
   readonly keyManager: KeyManager;
   readonly signet: SignetCoreImpl;
@@ -89,6 +90,7 @@ export interface TestRuntime {
   readonly groupId: string;
 }
 
+/** Options for constructing the test runtime. */
 export interface TestRuntimeOptions {
   readonly wsConfig?: Partial<WsServerConfig>;
   readonly sessionConfig?: Partial<SessionManagerConfig>;
@@ -97,6 +99,7 @@ export interface TestRuntimeOptions {
   readonly skipStart?: boolean;
 }
 
+/** Create a fully wired in-memory signet runtime for integration tests. */
 export async function createTestRuntime(options?: TestRuntimeOptions): Promise<{
   runtime: TestRuntime;
   streams: {

--- a/packages/integration/src/fixtures/test-ws-client.ts
+++ b/packages/integration/src/fixtures/test-ws-client.ts
@@ -2,6 +2,7 @@
  * WebSocket test client with typed helpers for integration tests.
  */
 
+/** Convenience wrapper around a WebSocket connection in tests. */
 export interface TestWsClient {
   readonly ws: WebSocket;
   /** Wait for the next JSON message. */

--- a/packages/keys/src/config.ts
+++ b/packages/keys/src/config.ts
@@ -1,17 +1,21 @@
 import { z } from "zod";
 
+/** Access policy for a specific key tier. */
 export const KeyPolicySchema: z.ZodEnum<["biometric", "passcode", "open"]> = z
   .enum(["biometric", "passcode", "open"])
   .describe("Access control policy for a key tier");
 
+/** Key policy label. */
 export type KeyPolicy = z.infer<typeof KeyPolicySchema>;
 
+/** Hardware or storage capability detected for the current platform. */
 export const PlatformCapabilitySchema: z.ZodEnum<
   ["secure-enclave", "keychain-software", "tpm", "software-vault"]
 > = z
   .enum(["secure-enclave", "keychain-software", "tpm", "software-vault"])
   .describe("Actual hardware security capability detected");
 
+/** Platform capability label. */
 export type PlatformCapability = z.infer<typeof PlatformCapabilitySchema>;
 
 /** Parsed key manager configuration (all defaults applied). */
@@ -30,6 +34,7 @@ type KeyManagerConfigInput = {
   sessionKeyTtlSeconds?: number | undefined;
 };
 
+/** Zod schema for parsed key manager configuration. */
 export const KeyManagerConfigSchema: z.ZodType<
   KeyManagerConfig,
   z.ZodTypeDef,

--- a/packages/keys/src/key-manager.ts
+++ b/packages/keys/src/key-manager.ts
@@ -24,10 +24,14 @@ import { createAdminKeyManager, type AdminKeyManager } from "./admin-key.js";
 import { initializeRootKey } from "./root-key.js";
 import type { RootKeyHandle, OperationalKey, SessionKey } from "./types.js";
 
+/** High-level key manager facade for all key tiers and vault access. */
 export interface KeyManager {
+  /** Initialize the root key material and any dependent key tiers. */
   initialize(): Promise<Result<RootKeyHandle, InternalError | AuthError>>;
 
+  /** Detected platform capability for key storage and signing. */
   readonly platform: PlatformCapability;
+  /** Trust tier inferred from the detected platform. */
   readonly trustTier: TrustTier;
 
   /** Access admin key operations. */
@@ -96,6 +100,10 @@ export interface KeyManager {
   close(): void;
 }
 
+/**
+ * Create a key manager backed by the configured vault and detected
+ * platform capability.
+ */
 export async function createKeyManager(
   rawConfig: Partial<KeyManagerConfig> & { dataDir: string },
 ): Promise<Result<KeyManager, InternalError>> {

--- a/packages/keys/src/operational-key.ts
+++ b/packages/keys/src/operational-key.ts
@@ -12,22 +12,29 @@ import {
   toHex,
 } from "./crypto-keys.js";
 
+/** Manager for operational keys backed by the vault. */
 export interface OperationalKeyManager {
+  /** Create a new operational key for an identity and optional group. */
   create(
     identityId: string,
     groupId: string | null,
   ): Promise<Result<OperationalKey, InternalError>>;
 
+  /** Look up an operational key by identity. */
   get(identityId: string): Result<OperationalKey, NotFoundError>;
 
+  /** Look up an operational key by group membership. */
   getByGroupId(groupId: string): Result<OperationalKey, NotFoundError>;
 
+  /** Rotate an existing operational key in place. */
   rotate(
     identityId: string,
   ): Promise<Result<OperationalKey, InternalError | NotFoundError>>;
 
+  /** Return all currently known operational keys. */
   list(): readonly OperationalKey[];
 
+  /** Sign bytes using the operational key for an identity. */
   sign(
     identityId: string,
     data: Uint8Array,
@@ -37,6 +44,9 @@ export interface OperationalKeyManager {
 /** Vault key prefix for operational key material. */
 const OP_KEY_PREFIX = "op-key:";
 
+/**
+ * Create an operational key manager backed by the provided vault.
+ */
 export function createOperationalKeyManager(
   vault: Vault,
 ): OperationalKeyManager {

--- a/packages/keys/src/se-protocol.ts
+++ b/packages/keys/src/se-protocol.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { KeyPolicy } from "./config.js";
 import { KeyPolicySchema } from "./config.js";
 
-/** Response from `signet-signer create`. */
+/** Shape of the `signet-signer create` response. */
 export const SeCreateResponseSchema: z.ZodObject<{
   keyRef: z.ZodString;
   publicKey: z.ZodString;
@@ -15,13 +15,14 @@ export const SeCreateResponseSchema: z.ZodObject<{
   policy: KeyPolicySchema,
 });
 
+/** Parsed `signet-signer create` response payload. */
 export type SeCreateResponse = {
   keyRef: string;
   publicKey: string;
   policy: KeyPolicy;
 };
 
-/** Response from `signet-signer sign`. */
+/** Shape of the `signet-signer sign` response. */
 export const SeSignResponseSchema: z.ZodObject<{
   signature: z.ZodString;
 }> = z.object({
@@ -30,11 +31,12 @@ export const SeSignResponseSchema: z.ZodObject<{
     .describe("Hex-encoded DER signature with low-S normalization"),
 });
 
+/** Parsed `signet-signer sign` response payload. */
 export type SeSignResponse = {
   signature: string;
 };
 
-/** Response from `signet-signer info --system`. */
+/** Shape of the `signet-signer info --system` response. */
 export const SeSystemInfoResponseSchema: z.ZodObject<{
   available: z.ZodBoolean;
   chip: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -45,19 +47,21 @@ export const SeSystemInfoResponseSchema: z.ZodObject<{
   macOS: z.string().nullable().optional(),
 });
 
+/** Parsed `signet-signer info --system` response payload. */
 export type SeSystemInfoResponse = {
   available: boolean;
   chip?: string | null | undefined;
   macOS?: string | null | undefined;
 };
 
-/** Response from `signet-signer info --key-ref`. */
+/** Shape of the `signet-signer info --key-ref` response. */
 export const SeKeyInfoResponseSchema: z.ZodObject<{
   exists: z.ZodBoolean;
 }> = z.object({
   exists: z.boolean(),
 });
 
+/** Parsed `signet-signer info --key-ref` response payload. */
 export type SeKeyInfoResponse = {
   exists: boolean;
 };

--- a/packages/keys/src/session-key.ts
+++ b/packages/keys/src/session-key.ts
@@ -18,20 +18,30 @@ interface SessionKeyEntry {
   readonly privateKey: CryptoKey;
 }
 
+/** In-memory manager for issuing, signing with, and revoking session keys. */
 export interface SessionKeyManager {
+  /** Issue a new session key with the provided TTL. */
   issue(
     sessionId: string,
     ttlSeconds: number,
   ): Promise<Result<SessionKey, InternalError>>;
 
+  /** Sign bytes with an active session key. */
   sign(
     keyId: string,
     data: Uint8Array,
   ): Promise<Result<Uint8Array, InternalError | NotFoundError>>;
 
+  /** Revoke a session key immediately. */
   revoke(keyId: string): Result<void, NotFoundError>;
 }
 
+/**
+ * Create an in-memory session key manager.
+ *
+ * Session keys are intentionally ephemeral and live only for the
+ * lifetime of the process.
+ */
 export function createSessionKeyManager(): SessionKeyManager {
   const entries = new Map<string, SessionKeyEntry>();
 

--- a/packages/keys/src/vault.ts
+++ b/packages/keys/src/vault.ts
@@ -91,6 +91,12 @@ async function decrypt(key: CryptoKey, data: Uint8Array): Promise<Uint8Array> {
   return new Uint8Array(plaintext);
 }
 
+/**
+ * Create an encrypted vault backed by bun:sqlite.
+ *
+ * The vault stores encrypted blobs and keeps the encryption key in a
+ * sibling `vault.key` file for file-backed data directories.
+ */
 export async function createVault(
   dataDir: string,
 ): Promise<Result<Vault, InternalError>> {

--- a/packages/schemas/src/content-types.ts
+++ b/packages/schemas/src/content-types.ts
@@ -9,9 +9,10 @@ export const ContentTypeId: z.ZodString = z
   .regex(/^[a-z0-9.-]+\/[a-zA-Z0-9]+:\d+\.\d+$/)
   .describe("XMTP content type identifier (authority/type:version)");
 
+/** Standard XMTP content type identifier string. */
 export type ContentTypeId = z.infer<typeof ContentTypeId>;
 
-/** Standard XMTP content types accepted by default. */
+/** Baseline XMTP content types accepted without extra policy configuration. */
 export const BASELINE_CONTENT_TYPES: readonly [
   "xmtp.org/text:1.0",
   "xmtp.org/reaction:1.0",
@@ -26,18 +27,22 @@ export const BASELINE_CONTENT_TYPES: readonly [
   "xmtp.org/groupUpdated:1.0",
 ] as const;
 
+/** Union of the baseline XMTP content types. */
 export type BaselineContentType = (typeof BASELINE_CONTENT_TYPES)[number];
 
+/** Text payload carried by `xmtp.org/text:1.0`. */
 export type TextPayload = {
   text: string;
 };
 
+/** Zod schema for a plain text XMTP message payload. */
 export const TextPayload: z.ZodType<TextPayload> = z
   .object({
     text: z.string().min(1).describe("Message text content"),
   })
   .describe("Text message payload");
 
+/** Reaction payload carried by `xmtp.org/reaction:1.0`. */
 export type ReactionPayload = {
   reference: string;
   action: "added" | "removed";
@@ -45,6 +50,7 @@ export type ReactionPayload = {
   schema: "unicode" | "shortcode" | "custom";
 };
 
+/** Zod schema for an XMTP reaction payload. */
 export const ReactionPayload: z.ZodType<ReactionPayload> = z
   .object({
     reference: z.string().describe("Message ID being reacted to"),
@@ -58,6 +64,7 @@ export const ReactionPayload: z.ZodType<ReactionPayload> = z
   })
   .describe("Reaction payload");
 
+/** Reply payload carried by `xmtp.org/reply:1.0`. */
 export type ReplyPayload = {
   reference: string;
   content: {
@@ -66,6 +73,7 @@ export type ReplyPayload = {
   };
 };
 
+/** Zod schema for an XMTP reply payload. */
 export const ReplyPayload: z.ZodType<ReplyPayload> = z
   .object({
     reference: z.string().describe("Message ID being replied to"),
@@ -78,12 +86,15 @@ export const ReplyPayload: z.ZodType<ReplyPayload> = z
   })
   .describe("Reply payload");
 
+/** Empty payload carried by `xmtp.org/readReceipt:1.0`. */
 export type ReadReceiptPayload = Record<string, never>;
 
+/** Zod schema for an XMTP read-receipt payload. */
 export const ReadReceiptPayload: z.ZodType<ReadReceiptPayload> = z
   .object({})
   .describe("Read receipt payload (empty body)");
 
+/** Group membership and metadata update payload carried by `xmtp.org/groupUpdated:1.0`. */
 export type GroupUpdatedPayload = {
   initiatedByInboxId: string;
   addedInboxes: string[];
@@ -95,6 +106,7 @@ export type GroupUpdatedPayload = {
   }[];
 };
 
+/** Zod schema for XMTP group membership and metadata update payloads. */
 export const GroupUpdatedPayload: z.ZodType<GroupUpdatedPayload> = z
   .object({
     initiatedByInboxId: z

--- a/packages/schemas/src/errors/auth.ts
+++ b/packages/schemas/src/errors/auth.ts
@@ -1,5 +1,6 @@
 import type { SignetError } from "./base.js";
 
+/** Raised when authentication or authorization fails. */
 export class AuthError extends Error implements SignetError {
   readonly _tag = "AuthError" as const;
   readonly code = 1300;
@@ -18,6 +19,7 @@ export class AuthError extends Error implements SignetError {
   }
 }
 
+/** Raised when a session has expired and can no longer be used. */
 export class SessionExpiredError extends Error implements SignetError {
   readonly _tag = "SessionExpiredError" as const;
   readonly code = 1310;

--- a/packages/schemas/src/errors/base.ts
+++ b/packages/schemas/src/errors/base.ts
@@ -19,6 +19,7 @@ export interface SignetError extends Error {
   readonly context: Record<string, unknown> | null;
 }
 
+/** Union of all signet error implementations. */
 export type AnySignetError =
   | ValidationError
   | NotFoundError

--- a/packages/schemas/src/errors/cancelled.ts
+++ b/packages/schemas/src/errors/cancelled.ts
@@ -1,5 +1,6 @@
 import type { SignetError } from "./base.js";
 
+/** Raised when an operation is cancelled by the user or signal. */
 export class CancelledError extends Error implements SignetError {
   readonly _tag = "CancelledError" as const;
   readonly code = 1600;

--- a/packages/schemas/src/errors/category.ts
+++ b/packages/schemas/src/errors/category.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+/** Cross-transport error categories used for exit/status/JSON-RPC mapping. */
 export const ErrorCategory: z.ZodEnum<
   [
     "validation",
@@ -24,8 +25,10 @@ export const ErrorCategory: z.ZodEnum<
   ])
   .describe("Error category for cross-transport mapping");
 
+/** Cross-transport error categories used for exit/status/JSON-RPC mapping. */
 export type ErrorCategory = z.infer<typeof ErrorCategory>;
 
+/** Transport-specific metadata for an error category. */
 export type ErrorCategoryMeta = {
   readonly exitCode: number;
   readonly statusCode: number;
@@ -33,6 +36,7 @@ export type ErrorCategoryMeta = {
   readonly retryable: boolean;
 };
 
+/** Zod schema for transport metadata attached to each error category. */
 export const ErrorCategoryMetaSchema: z.ZodType<ErrorCategoryMeta> = z
   .object({
     exitCode: z.number().int(),
@@ -95,6 +99,7 @@ export const ERROR_CATEGORY_META: Record<ErrorCategory, ErrorCategoryMeta> = {
   },
 };
 
+/** Look up metadata for a given error category. */
 export function errorCategoryMeta(category: ErrorCategory): ErrorCategoryMeta {
   return ERROR_CATEGORY_META[category];
 }

--- a/packages/schemas/src/errors/internal.ts
+++ b/packages/schemas/src/errors/internal.ts
@@ -1,5 +1,6 @@
 import type { SignetError } from "./base.js";
 
+/** Raised when an unexpected invariant or internal state fails. */
 export class InternalError extends Error implements SignetError {
   readonly _tag = "InternalError" as const;
   readonly code = 1400;

--- a/packages/schemas/src/errors/network.ts
+++ b/packages/schemas/src/errors/network.ts
@@ -1,5 +1,6 @@
 import type { SignetError } from "./base.js";
 
+/** Raised when a network call to a downstream endpoint fails. */
 export class NetworkError extends Error implements SignetError {
   readonly _tag = "NetworkError" as const;
   readonly code = 1700;

--- a/packages/schemas/src/errors/not-found.ts
+++ b/packages/schemas/src/errors/not-found.ts
@@ -1,5 +1,6 @@
 import type { SignetError } from "./base.js";
 
+/** Raised when a requested resource cannot be found. */
 export class NotFoundError extends Error implements SignetError {
   readonly _tag = "NotFoundError" as const;
   readonly code = 1100;

--- a/packages/schemas/src/errors/permission.ts
+++ b/packages/schemas/src/errors/permission.ts
@@ -1,5 +1,6 @@
 import type { SignetError } from "./base.js";
 
+/** Raised when an operation is denied by policy or permissions. */
 export class PermissionError extends Error implements SignetError {
   readonly _tag = "PermissionError" as const;
   readonly code = 1200;
@@ -21,6 +22,7 @@ export class PermissionError extends Error implements SignetError {
   }
 }
 
+/** Raised when a grant does not allow the requested operation. */
 export class GrantDeniedError extends Error implements SignetError {
   readonly _tag = "GrantDeniedError" as const;
   readonly code = 1210;

--- a/packages/schemas/src/errors/timeout.ts
+++ b/packages/schemas/src/errors/timeout.ts
@@ -1,5 +1,6 @@
 import type { SignetError } from "./base.js";
 
+/** Raised when an operation exceeds its configured deadline. */
 export class TimeoutError extends Error implements SignetError {
   readonly _tag = "TimeoutError" as const;
   readonly code = 1500;

--- a/packages/schemas/src/errors/validation.ts
+++ b/packages/schemas/src/errors/validation.ts
@@ -1,5 +1,6 @@
 import type { SignetError } from "./base.js";
 
+/** Validation failure for an invalid request or field value. */
 export class ValidationError extends Error implements SignetError {
   readonly _tag = "ValidationError" as const;
   readonly code = 1000;
@@ -29,6 +30,7 @@ export class ValidationError extends Error implements SignetError {
   }
 }
 
+/** Validation failure for a seal-specific invariant. */
 export class SealError extends Error implements SignetError {
   readonly _tag = "SealError" as const;
   readonly code = 1010;

--- a/packages/schemas/src/events.ts
+++ b/packages/schemas/src/events.ts
@@ -7,14 +7,17 @@ import { ViewConfig } from "./view.js";
 import { GrantConfig } from "./grant.js";
 import { RevocationSeal } from "./revocation.js";
 
+/** Projection modes the signet may use when surfacing a message. */
 export const MessageVisibility: z.ZodEnum<
   ["visible", "historical", "hidden", "revealed", "redacted"]
 > = z
   .enum(["visible", "historical", "hidden", "revealed", "redacted"])
   .describe("How the message is being projected to the agent");
 
+/** Projection mode assigned to a surfaced message event. */
 export type MessageVisibility = z.infer<typeof MessageVisibility>;
 
+/** Event emitted when a message is surfaced to the harness. */
 export type MessageEvent = {
   type: "message.visible";
   messageId: string;
@@ -52,8 +55,10 @@ const _MessageEvent = z
   })
   .describe("A message projected to the agent according to its view");
 
+/** Zod schema for `message.visible` events. */
 export const MessageEvent: z.ZodType<MessageEvent> = _MessageEvent;
 
+/** Event emitted when a seal or revocation is stamped. */
 export type SealStampedEvent = {
   type: "seal.stamped";
   seal: Seal;
@@ -66,8 +71,10 @@ const _SealStampedEvent = z
   })
   .describe("Seal was stamped or updated");
 
+/** Zod schema for `seal.stamped` events. */
 export const SealStampedEvent: z.ZodType<SealStampedEvent> = _SealStampedEvent;
 
+/** Event emitted when a new session is established. */
 export type SessionStartedEvent = {
   type: "session.started";
   session: z.infer<typeof SessionToken>;
@@ -84,9 +91,11 @@ const _SessionStartedEvent = z
   })
   .describe("Session successfully established");
 
+/** Zod schema for `session.started` events. */
 export const SessionStartedEvent: z.ZodType<SessionStartedEvent> =
   _SessionStartedEvent;
 
+/** Event emitted when a session is no longer usable. */
 export type SessionExpiredEvent = {
   type: "session.expired";
   sessionId: string;
@@ -101,9 +110,11 @@ const _SessionExpiredEvent = z
   })
   .describe("Session has expired");
 
+/** Zod schema for `session.expired` events. */
 export const SessionExpiredEvent: z.ZodType<SessionExpiredEvent> =
   _SessionExpiredEvent;
 
+/** Event emitted when a session must be reauthorized after a material change. */
 export type SessionReauthRequiredEvent = {
   type: "session.reauthorization_required";
   sessionId: string;
@@ -120,9 +131,11 @@ const _SessionReauthRequiredEvent = z
   })
   .describe("Session must be reauthorized due to material policy change");
 
+/** Zod schema for `session.reauthorization_required` events. */
 export const SessionReauthRequiredEvent: z.ZodType<SessionReauthRequiredEvent> =
   _SessionReauthRequiredEvent;
 
+/** Liveness event emitted by the signet over active sockets. */
 export type HeartbeatEvent = {
   type: "heartbeat";
   sessionId: string;
@@ -137,8 +150,10 @@ const _HeartbeatEvent = z
   })
   .describe("Liveness signal from the signet");
 
+/** Zod schema for `heartbeat` events. */
 export const HeartbeatEvent: z.ZodType<HeartbeatEvent> = _HeartbeatEvent;
 
+/** Event emitted when previously hidden message content becomes available. */
 export type RevealEvent = {
   type: "message.revealed";
   messageId: string;
@@ -159,8 +174,10 @@ const _RevealEvent = z
   })
   .describe("Previously hidden content revealed to the agent");
 
+/** Zod schema for `message.revealed` events. */
 export const RevealEvent: z.ZodType<RevealEvent> = _RevealEvent;
 
+/** Event emitted when the session view changes in place. */
 export type ViewUpdatedEvent = {
   type: "view.updated";
   view: z.infer<typeof ViewConfig>;
@@ -173,8 +190,10 @@ const _ViewUpdatedEvent = z
   })
   .describe("View configuration changed within the current session");
 
+/** Zod schema for `view.updated` events. */
 export const ViewUpdatedEvent: z.ZodType<ViewUpdatedEvent> = _ViewUpdatedEvent;
 
+/** Event emitted when the session grant changes in place. */
 export type GrantUpdatedEvent = {
   type: "grant.updated";
   grant: z.infer<typeof GrantConfig>;
@@ -187,9 +206,11 @@ const _GrantUpdatedEvent = z
   })
   .describe("Grant configuration changed within the current session");
 
+/** Zod schema for `grant.updated` events. */
 export const GrantUpdatedEvent: z.ZodType<GrantUpdatedEvent> =
   _GrantUpdatedEvent;
 
+/** Event emitted when an agent is revoked by a revocation seal. */
 export type AgentRevokedEvent = {
   type: "agent.revoked";
   revocation: z.infer<typeof RevocationSeal>;
@@ -202,9 +223,11 @@ const _AgentRevokedEvent = z
   })
   .describe("Agent has been revoked from the group");
 
+/** Zod schema for `agent.revoked` events. */
 export const AgentRevokedEvent: z.ZodType<AgentRevokedEvent> =
   _AgentRevokedEvent;
 
+/** Event emitted when owner confirmation is required before an action runs. */
 export type ActionConfirmationEvent = {
   type: "action.confirmation_required";
   actionId: string;
@@ -223,9 +246,11 @@ const _ActionConfirmationEvent = z
   })
   .describe("An action requires owner confirmation before execution");
 
+/** Zod schema for `action.confirmation_required` events. */
 export const ActionConfirmationEvent: z.ZodType<ActionConfirmationEvent> =
   _ActionConfirmationEvent;
 
+/** Event emitted when a recovering client has caught up with replay state. */
 export type SignetRecoveryEvent = {
   type: "signet.recovery.complete";
   caughtUpThrough: string;
@@ -243,9 +268,11 @@ const _SignetRecoveryEvent = z
   })
   .describe("Signet has recovered and resynced");
 
+/** Zod schema for `signet.recovery.complete` events. */
 export const SignetRecoveryEvent: z.ZodType<SignetRecoveryEvent> =
   _SignetRecoveryEvent;
 
+/** Union of all events the signet can emit to a harness session. */
 export type SignetEvent =
   | MessageEvent
   | SealStampedEvent

--- a/packages/schemas/src/grant.ts
+++ b/packages/schemas/src/grant.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+/** Permissions for sending, replying, and reacting in a conversation. */
 export type MessagingGrant = {
   send: boolean;
   reply: boolean;
@@ -7,6 +8,7 @@ export type MessagingGrant = {
   draftOnly: boolean;
 };
 
+/** Zod schema for messaging permissions. */
 export const MessagingGrant: z.ZodType<MessagingGrant> = z
   .object({
     send: z.boolean().describe("Can send messages"),
@@ -18,6 +20,7 @@ export const MessagingGrant: z.ZodType<MessagingGrant> = z
   })
   .describe("Messaging action permissions");
 
+/** Permissions for group membership and metadata management. */
 export type GroupManagementGrant = {
   addMembers: boolean;
   removeMembers: boolean;
@@ -25,6 +28,7 @@ export type GroupManagementGrant = {
   inviteUsers: boolean;
 };
 
+/** Zod schema for group management permissions. */
 export const GroupManagementGrant: z.ZodType<GroupManagementGrant> = z
   .object({
     addMembers: z.boolean().describe("Can add members to the group"),
@@ -34,12 +38,14 @@ export const GroupManagementGrant: z.ZodType<GroupManagementGrant> = z
   })
   .describe("Group management permissions");
 
+/** Permission scope for a single tool invocation surface. */
 export type ToolScope = {
   toolId: string;
   allowed: boolean;
   parameters: Record<string, unknown> | null;
 };
 
+/** Zod schema for a single tool permission scope. */
 export const ToolScope: z.ZodType<ToolScope> = z
   .object({
     toolId: z.string().describe("Identifier for the tool"),
@@ -51,16 +57,19 @@ export const ToolScope: z.ZodType<ToolScope> = z
   })
   .describe("Permission scope for a single tool");
 
+/** Tool-level grant made up of one or more scoped tool permissions. */
 export type ToolGrant = {
   scopes: ToolScope[];
 };
 
+/** Zod schema for tool capability permissions. */
 export const ToolGrant: z.ZodType<ToolGrant> = z
   .object({
     scopes: z.array(ToolScope).describe("Per-tool permission scopes"),
   })
   .describe("Tool capability permissions");
 
+/** Permissions governing what content may leave the signet boundary. */
 export type EgressGrant = {
   storeExcerpts: boolean;
   useForMemory: boolean;
@@ -69,6 +78,7 @@ export type EgressGrant = {
   summarize: boolean;
 };
 
+/** Zod schema for content egress permissions. */
 export const EgressGrant: z.ZodType<EgressGrant> = z
   .object({
     storeExcerpts: z.boolean().describe("Can store message excerpts"),
@@ -83,6 +93,7 @@ export const EgressGrant: z.ZodType<EgressGrant> = z
   })
   .describe("Retention and egress permissions");
 
+/** Complete grant configuration for an agent session. */
 export type GrantConfig = {
   messaging: MessagingGrant;
   groupManagement: GroupManagementGrant;
@@ -90,6 +101,7 @@ export type GrantConfig = {
   egress: EgressGrant;
 };
 
+/** Zod schema for a complete grant configuration. */
 export const GrantConfig: z.ZodType<GrantConfig> = z
   .object({
     messaging: MessagingGrant.describe("Messaging action permissions"),

--- a/packages/schemas/src/requests.ts
+++ b/packages/schemas/src/requests.ts
@@ -3,6 +3,7 @@ import { ContentTypeId } from "./content-types.js";
 import { ViewConfig } from "./view.js";
 import { RevealRequest } from "./reveal.js";
 
+/** Request to send a message to a group. */
 export type SendMessageRequest = {
   type: "send_message";
   requestId: string;
@@ -23,9 +24,11 @@ const _SendMessageRequest = z
   })
   .describe("Send a message to a group");
 
+/** Request to send a message to a group. */
 export const SendMessageRequest: z.ZodType<SendMessageRequest> =
   _SendMessageRequest;
 
+/** Request to add or remove a reaction on a message. */
 export type SendReactionRequest = {
   type: "send_reaction";
   requestId: string;
@@ -46,9 +49,11 @@ const _SendReactionRequest = z
   })
   .describe("React to a message");
 
+/** Request to add or remove a reaction on a message. */
 export const SendReactionRequest: z.ZodType<SendReactionRequest> =
   _SendReactionRequest;
 
+/** Request to send a reply in a thread. */
 export type SendReplyRequest = {
   type: "send_reply";
   requestId: string;
@@ -69,8 +74,10 @@ const _SendReplyRequest = z
   })
   .describe("Reply to a message in a thread");
 
+/** Request to send a reply in a thread. */
 export const SendReplyRequest: z.ZodType<SendReplyRequest> = _SendReplyRequest;
 
+/** Request to update the current session view. */
 export type UpdateViewRequest = {
   type: "update_view";
   requestId: string;
@@ -85,9 +92,11 @@ const _UpdateViewRequest = z
   })
   .describe("Request a view update (signet may reject if material escalation)");
 
+/** Request to update the current session view. */
 export const UpdateViewRequest: z.ZodType<UpdateViewRequest> =
   _UpdateViewRequest;
 
+/** Request to reveal previously hidden content. */
 export type RevealContentRequest = {
   type: "reveal_content";
   requestId: string;
@@ -102,9 +111,11 @@ const _RevealContentRequest = z
   })
   .describe("Request content be revealed to the agent");
 
+/** Request to reveal previously hidden content. */
 export const RevealContentRequest: z.ZodType<RevealContentRequest> =
   _RevealContentRequest;
 
+/** Request to confirm or deny a pending action. */
 export type ConfirmActionRequest = {
   type: "confirm_action";
   requestId: string;
@@ -121,9 +132,11 @@ const _ConfirmActionRequest = z
   })
   .describe("Confirm or deny a pending action");
 
+/** Request to confirm or deny a pending action. */
 export const ConfirmActionRequest: z.ZodType<ConfirmActionRequest> =
   _ConfirmActionRequest;
 
+/** Heartbeat request used to keep a session alive. */
 export type HeartbeatRequest = {
   type: "heartbeat";
   requestId: string;
@@ -138,8 +151,10 @@ const _HeartbeatRequest = z
   })
   .describe("Heartbeat from the harness to keep the session alive");
 
+/** Heartbeat request used to keep a session alive. */
 export const HeartbeatRequest: z.ZodType<HeartbeatRequest> = _HeartbeatRequest;
 
+/** Union of all harness-to-signet requests. */
 export type HarnessRequest =
   | SendMessageRequest
   | SendReactionRequest

--- a/packages/schemas/src/response.ts
+++ b/packages/schemas/src/response.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { ErrorCategory } from "./errors/index.js";
 import { ErrorCategory as ErrorCategorySchema } from "./errors/index.js";
 
+/** Successful response envelope for a harness request. */
 export type RequestSuccess = {
   ok: true;
   requestId: string;
@@ -16,8 +17,10 @@ const _RequestSuccess = z
   })
   .describe("Successful response to a harness request");
 
+/** Successful response envelope for a harness request. */
 export const RequestSuccess: z.ZodType<RequestSuccess> = _RequestSuccess;
 
+/** Failed response envelope for a harness request. */
 export type RequestFailure = {
   ok: false;
   requestId: string;
@@ -47,10 +50,13 @@ const _RequestFailure = z
   })
   .describe("Failed response to a harness request");
 
+/** Failed response envelope for a harness request. */
 export const RequestFailure: z.ZodType<RequestFailure> = _RequestFailure;
 
+/** Discriminated union of harness request responses. */
 export type RequestResponse = RequestSuccess | RequestFailure;
 
+/** Discriminated union of harness request responses. */
 export const RequestResponse: z.ZodType<RequestResponse> = z
   .discriminatedUnion("ok", [_RequestSuccess, _RequestFailure])
   .describe("Response envelope for harness requests");

--- a/packages/schemas/src/reveal.ts
+++ b/packages/schemas/src/reveal.ts
@@ -1,13 +1,16 @@
 import { z } from "zod";
 
+/** Granularity of a reveal operation. */
 export const RevealScope: z.ZodEnum<
   ["message", "thread", "time-window", "content-type", "sender"]
 > = z
   .enum(["message", "thread", "time-window", "content-type", "sender"])
   .describe("Granularity of a reveal operation");
 
+/** Granularity of a reveal operation. */
 export type RevealScope = z.infer<typeof RevealScope>;
 
+/** Request to reveal previously hidden content within a group. */
 export type RevealRequest = {
   revealId: string;
   groupId: string;
@@ -17,6 +20,7 @@ export type RevealRequest = {
   expiresAt: string | null;
 };
 
+/** Zod schema for a reveal request. */
 export const RevealRequest: z.ZodType<RevealRequest> = z
   .object({
     revealId: z.string().describe("Unique reveal request identifier"),
@@ -36,6 +40,7 @@ export const RevealRequest: z.ZodType<RevealRequest> = z
   })
   .describe("Request to reveal content to an agent");
 
+/** Reveal grant that makes previously hidden content visible. */
 export type RevealGrant = {
   revealId: string;
   grantedAt: string;
@@ -43,6 +48,7 @@ export type RevealGrant = {
   expiresAt: string | null;
 };
 
+/** Zod schema for a granted reveal. */
 export const RevealGrant: z.ZodType<RevealGrant> = z
   .object({
     revealId: z.string().describe("Matches the RevealRequest.revealId"),
@@ -56,10 +62,12 @@ export const RevealGrant: z.ZodType<RevealGrant> = z
   })
   .describe("Granted reveal making content visible to the agent");
 
+/** Aggregate reveal state tracked for a session. */
 export type RevealState = {
   activeReveals: RevealGrant[];
 };
 
+/** Zod schema for aggregate reveal state tracked in a session. */
 export const RevealState: z.ZodType<RevealState> = z
   .object({
     activeReveals: z

--- a/packages/schemas/src/revocation.ts
+++ b/packages/schemas/src/revocation.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+/** Reason an agent was revoked from a group. */
 export const AgentRevocationReason: z.ZodEnum<
   [
     "owner-initiated",
@@ -18,8 +19,10 @@ export const AgentRevocationReason: z.ZodEnum<
   ])
   .describe("Why the agent was revoked from a group");
 
+/** Reason an agent was revoked from a group. */
 export type AgentRevocationReason = z.infer<typeof AgentRevocationReason>;
 
+/** Reason a session was revoked. */
 export const SessionRevocationReason: z.ZodEnum<
   [
     "owner-initiated",
@@ -38,8 +41,10 @@ export const SessionRevocationReason: z.ZodEnum<
   ])
   .describe("Why a session was revoked");
 
+/** Reason a session was revoked. */
 export type SessionRevocationReason = z.infer<typeof SessionRevocationReason>;
 
+/** Seal that records revocation of an agent's group membership. */
 export type RevocationSeal = {
   sealId: string;
   previousSealId: string;
@@ -50,6 +55,7 @@ export type RevocationSeal = {
   issuer: string;
 };
 
+/** Zod schema for a revocation seal. */
 export const RevocationSeal: z.ZodType<RevocationSeal> = z
   .object({
     sealId: z.string().describe("ID of this revocation seal"),

--- a/packages/schemas/src/seal.ts
+++ b/packages/schemas/src/seal.ts
@@ -2,14 +2,17 @@ import { z } from "zod";
 import { ContentTypeId } from "./content-types.js";
 import { ViewMode } from "./view.js";
 
+/** Where the agent performs inference. */
 export const InferenceMode: z.ZodEnum<
   ["local", "external", "hybrid", "unknown"]
 > = z
   .enum(["local", "external", "hybrid", "unknown"])
   .describe("How the agent performs inference");
 
+/** Where the agent performs inference. */
 export type InferenceMode = z.infer<typeof InferenceMode>;
 
+/** Which content may leave the signet boundary. */
 export const ContentEgressScope: z.ZodEnum<
   ["full-messages", "summaries-only", "tool-calls-only", "none", "unknown"]
 > = z
@@ -22,22 +25,31 @@ export const ContentEgressScope: z.ZodEnum<
   ])
   .describe("What content leaves the signet boundary");
 
+/** Which content may leave the signet boundary. */
 export type ContentEgressScope = z.infer<typeof ContentEgressScope>;
 
+/** How long the provider retains content. */
+/** Zod schema for provider-side retention scope. */
 export const RetentionAtProvider: z.ZodEnum<
   ["none", "session", "persistent", "unknown"]
 > = z
   .enum(["none", "session", "persistent", "unknown"])
   .describe("How long the inference provider retains content");
 
+/** How long the provider retains content. */
 export type RetentionAtProvider = z.infer<typeof RetentionAtProvider>;
 
+/** Where the signet is hosted. */
+/** Zod schema for how the signet is hosted. */
 export const HostingMode: z.ZodEnum<["local", "self-hosted", "managed"]> = z
   .enum(["local", "self-hosted", "managed"])
   .describe("Where the signet runs");
 
+/** Where the signet is hosted. */
 export type HostingMode = z.infer<typeof HostingMode>;
 
+/** Highest trust tier the signet can demonstrate. */
+/** Zod schema for the highest trust tier demonstrated by a seal. */
 export const TrustTier: z.ZodEnum<
   ["unverified", "source-verified", "reproducibly-verified", "runtime-attested"]
 > = z
@@ -49,8 +61,10 @@ export const TrustTier: z.ZodEnum<
   ])
   .describe("Highest trust tier the signet can demonstrate");
 
+/** Highest trust tier the signet can demonstrate. */
 export type TrustTier = z.infer<typeof TrustTier>;
 
+/** Rules governing how a seal can be revoked. */
 export type RevocationRules = {
   maxTtlSeconds: number;
   requireHeartbeat: boolean;
@@ -58,6 +72,7 @@ export type RevocationRules = {
   adminCanRemove: boolean;
 };
 
+/** Zod schema for seal revocation rules. */
 export const RevocationRules: z.ZodType<RevocationRules> = z
   .object({
     maxTtlSeconds: z
@@ -77,6 +92,7 @@ export const RevocationRules: z.ZodType<RevocationRules> = z
   })
   .describe("Rules governing how this seal can be revoked");
 
+/** Group-visible capability seal for an agent. */
 export type Seal = {
   sealId: string;
   previousSealId: string | null;
@@ -105,6 +121,7 @@ export type Seal = {
   issuer: string;
 };
 
+/** Zod schema for a group-visible capability seal. */
 export const SealSchema: z.ZodType<Seal> = z
   .object({
     sealId: z.string().describe("Unique identifier for this seal"),

--- a/packages/schemas/src/session.ts
+++ b/packages/schemas/src/session.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { ViewConfig } from "./view.js";
 import { GrantConfig } from "./grant.js";
 
+/** Configuration used to issue a new session. */
 export type SessionConfig = {
   agentInboxId: string;
   view: ViewConfig;
@@ -10,6 +11,7 @@ export type SessionConfig = {
   heartbeatInterval?: number | undefined;
 };
 
+/** Zod schema for session issuance input. */
 export const SessionConfig: z.ZodType<SessionConfig> = z
   .object({
     agentInboxId: z.string().describe("Agent this session is for"),
@@ -30,6 +32,7 @@ export const SessionConfig: z.ZodType<SessionConfig> = z
   })
   .describe("Configuration for issuing a new session");
 
+/** Opaque session token returned to the harness. */
 export type SessionToken = {
   sessionId: string;
   agentInboxId: string;
@@ -38,6 +41,7 @@ export type SessionToken = {
   expiresAt: string;
 };
 
+/** Zod schema for the opaque session token returned to the harness. */
 export const SessionToken: z.ZodType<SessionToken> = z
   .object({
     sessionId: z.string().describe("Unique session identifier"),
@@ -50,11 +54,13 @@ export const SessionToken: z.ZodType<SessionToken> = z
   })
   .describe("Opaque session token issued to the harness");
 
+/** Session credentials plus the encoded token string. */
 export type IssuedSession = {
   token: string;
   session: SessionToken;
 };
 
+/** Zod schema for session credentials returned by issuance. */
 export const IssuedSession: z.ZodType<IssuedSession> = z
   .object({
     token: z.string().min(1).describe("Session bearer token"),
@@ -62,10 +68,12 @@ export const IssuedSession: z.ZodType<IssuedSession> = z
   })
   .describe("Issued session credentials returned by session.issue");
 
+/** Lifecycle state for an issued session. */
 export const SessionState: z.ZodEnum<
   ["active", "expired", "revoked", "reauthorization-required"]
 > = z
   .enum(["active", "expired", "revoked", "reauthorization-required"])
   .describe("Current lifecycle state of a session");
 
+/** Lifecycle state for an issued session. */
 export type SessionState = z.infer<typeof SessionState>;

--- a/packages/schemas/src/view.ts
+++ b/packages/schemas/src/view.ts
@@ -1,26 +1,32 @@
 import { z } from "zod";
 import { ContentTypeId } from "./content-types.js";
 
+/** Zod schema for an agent session's projected conversation view mode. */
 export const ViewMode: z.ZodEnum<
   ["full", "thread-only", "redacted", "reveal-only", "summary-only"]
 > = z
   .enum(["full", "thread-only", "redacted", "reveal-only", "summary-only"])
   .describe("Visibility mode for the agent's view of conversations");
 
+/** Visibility mode for an agent session's projected conversation view. */
 export type ViewMode = z.infer<typeof ViewMode>;
 
+/** Allowed content types in a session view. */
 export type ContentTypeAllowlist = string[];
 
+/** Zod schema for the allowlist of visible content types. */
 export const ContentTypeAllowlist: z.ZodType<ContentTypeAllowlist> = z
   .array(ContentTypeId)
   .min(1)
   .describe("Content types the agent is allowed to see");
 
+/** Scope for a single group and optional thread within a view. */
 export type ThreadScope = {
   groupId: string;
   threadId: string | null;
 };
 
+/** Zod schema for a single group/thread scope. */
 export const ThreadScope: z.ZodType<ThreadScope> = z
   .object({
     groupId: z.string().describe("Group the thread belongs to"),
@@ -31,12 +37,14 @@ export const ThreadScope: z.ZodType<ThreadScope> = z
   })
   .describe("Scopes a view to a specific group and optional thread");
 
+/** Complete view configuration for an agent session. */
 export type ViewConfig = {
   mode: ViewMode;
   threadScopes: ThreadScope[];
   contentTypes: ContentTypeAllowlist;
 };
 
+/** Zod schema for a complete agent view configuration. */
 export const ViewConfig: z.ZodType<ViewConfig> = z
   .object({
     mode: ViewMode.describe("Base visibility mode"),

--- a/packages/seals/src/content-type.ts
+++ b/packages/seals/src/content-type.ts
@@ -7,19 +7,14 @@ import {
 import { RevocationSeal } from "@xmtp/signet-schemas";
 import type { RevocationSeal as RevocationSealType } from "@xmtp/signet-schemas";
 
-/**
- * Custom XMTP content type for seals.
- * Follows the authority/type:version convention.
- */
+/** Custom XMTP content type identifier for seal payloads. */
 export const SEAL_CONTENT_TYPE_ID = "xmtp.org/agentSeal:1.0" as const;
 
-/**
- * Custom XMTP content type for revocations.
- * Follows the authority/type:version convention.
- */
+/** Custom XMTP content type identifier for revocation payloads. */
 export const REVOCATION_CONTENT_TYPE_ID =
   "xmtp.org/agentRevocation:1.0" as const;
 
+/** XMTP seal payload with its content type discriminator attached. */
 export type SealMessage = z.infer<typeof SealEnvelopeSchema> & {
   contentType: typeof SEAL_CONTENT_TYPE_ID;
 };
@@ -29,6 +24,7 @@ const _SealMessage = SealEnvelopeSchema.extend({
   contentType: z.literal(SEAL_CONTENT_TYPE_ID),
 }).describe("Seal message with content type discriminator");
 
+/** Zod schema for a seal payload with its content type discriminator. */
 export const SealMessage: z.ZodType<SealMessage> = _SealMessage;
 
 /**
@@ -42,6 +38,7 @@ const SignedRevocationEnvelopeLocal = z.object({
   signerKeyRef: z.string(),
 });
 
+/** XMTP revocation payload with its content type discriminator attached. */
 export type RevocationMessage = {
   revocation: RevocationSealType;
   signature: string;
@@ -55,6 +52,7 @@ const _RevocationMessage = SignedRevocationEnvelopeLocal.extend({
   contentType: z.literal(REVOCATION_CONTENT_TYPE_ID),
 }).describe("Revocation message with content type discriminator");
 
+/** Zod schema for a revocation payload with its content type discriminator. */
 export const RevocationMessage: z.ZodType<RevocationMessage> =
   _RevocationMessage;
 

--- a/packages/sessions/src/actions.ts
+++ b/packages/sessions/src/actions.ts
@@ -8,6 +8,7 @@ import type {
 } from "@xmtp/signet-schemas";
 import { SessionConfig, SessionRevocationReason } from "@xmtp/signet-schemas";
 
+/** Dependencies for session action registration. */
 export interface SessionActionDeps {
   readonly sessionManager: SessionManager;
 }
@@ -19,6 +20,7 @@ function widenActionSpec<TInput, TOutput>(
   return spec as ActionSpec<unknown, unknown, SignetError>;
 }
 
+/** Create CLI and MCP actions for session lifecycle operations. */
 export function createSessionActions(
   deps: SessionActionDeps,
 ): ActionSpec<unknown, unknown, SignetError>[] {

--- a/packages/sessions/src/pending-actions.ts
+++ b/packages/sessions/src/pending-actions.ts
@@ -5,6 +5,7 @@
  * operation. The owner confirms or denies via `confirm_action` requests.
  */
 
+/** A queued action awaiting explicit owner approval. */
 export interface PendingAction {
   readonly actionId: string;
   readonly sessionId: string;
@@ -14,6 +15,7 @@ export interface PendingAction {
   readonly expiresAt: string;
 }
 
+/** Store interface for pending actions. */
 export interface PendingActionStore {
   /** Add a pending action to the store. */
   add(action: PendingAction): void;
@@ -34,6 +36,7 @@ export interface PendingActionStore {
   listBySession(sessionId: string): readonly PendingAction[];
 }
 
+/** Create an in-memory store for pending actions. */
 export function createPendingActionStore(): PendingActionStore {
   const actions = new Map<string, PendingAction>();
 

--- a/packages/sessions/src/reveal-actions.ts
+++ b/packages/sessions/src/reveal-actions.ts
@@ -9,6 +9,7 @@ import type {
 import { RevealScope, PermissionError } from "@xmtp/signet-schemas";
 import type { RevealStateSnapshot } from "@xmtp/signet-contracts";
 
+/** Dependencies for reveal action registration. */
 export interface RevealActionDeps {
   readonly sessionManager: SessionManager;
 }
@@ -37,6 +38,7 @@ function widenActionSpec<TInput, TOutput>(
   return spec as ActionSpec<unknown, unknown, SignetError>;
 }
 
+/** Create CLI and MCP actions for content reveal workflows. */
 export function createRevealActions(
   deps: RevealActionDeps,
 ): ActionSpec<unknown, unknown, SignetError>[] {

--- a/packages/sessions/src/service.ts
+++ b/packages/sessions/src/service.ts
@@ -13,6 +13,7 @@ import type {
   InternalSessionRecord,
 } from "./session-manager.js";
 
+/** Dependencies required by the session service. */
 export interface SessionServiceDeps {
   readonly manager: InternalSessionManager;
   readonly keyManager: {
@@ -51,6 +52,7 @@ function toIssuedSession(record: InternalSessionRecord): IssuedSession {
   };
 }
 
+/** Create the public session service implementation. */
 export function createSessionService(deps: SessionServiceDeps): SessionManager {
   return {
     async issue(config: SessionConfig) {

--- a/packages/sessions/src/session-manager.ts
+++ b/packages/sessions/src/session-manager.ts
@@ -120,6 +120,7 @@ export interface InternalSessionManager {
   sweepExpired(): readonly InternalSessionRecord[];
 }
 
+/** Hooks for session-manager side effects. */
 export interface SessionManagerOptions {
   /** Called when a session's policy/state is mutated (for cache invalidation). */
   readonly onSessionMutated?: (sessionId: string) => void;

--- a/packages/sessions/src/update-actions.ts
+++ b/packages/sessions/src/update-actions.ts
@@ -17,6 +17,7 @@ import type {
 import { AuthError, ViewConfig, GrantConfig } from "@xmtp/signet-schemas";
 import type { InternalSessionManager } from "./session-manager.js";
 
+/** Dependencies for session update actions. */
 export interface UpdateActionDeps {
   readonly sessionManager: SessionManager;
   readonly internalManager: InternalSessionManager;
@@ -35,6 +36,7 @@ function widenActionSpec<TInput, TOutput>(
   return spec as ActionSpec<unknown, unknown, SignetError>;
 }
 
+/** Create CLI and MCP actions for in-place session updates. */
 export function createUpdateActions(
   deps: UpdateActionDeps,
 ): ActionSpec<unknown, unknown, SignetError>[] {

--- a/packages/verifier/src/checks/build-provenance.ts
+++ b/packages/verifier/src/checks/build-provenance.ts
@@ -5,6 +5,7 @@ import type { VerificationRequest } from "../schemas/request.js";
 import type { CheckHandler } from "./handler.js";
 import { findMatchingSubject, parseSigstoreBundle } from "./sigstore-bundle.js";
 
+/** Check ID for build provenance verification. */
 export const BUILD_PROVENANCE_CHECK_ID = "build_provenance" as const;
 
 import type { BuildProvenanceConfig } from "../config.js";

--- a/packages/verifier/src/checks/release-signing.ts
+++ b/packages/verifier/src/checks/release-signing.ts
@@ -4,6 +4,7 @@ import type { VerificationCheck } from "../schemas/check.js";
 import type { VerificationRequest } from "../schemas/request.js";
 import type { CheckHandler } from "./handler.js";
 
+/** Check ID for release signing verification. */
 export const RELEASE_SIGNING_CHECK_ID = "release_signing" as const;
 
 /**

--- a/packages/verifier/src/checks/schema-compliance.ts
+++ b/packages/verifier/src/checks/schema-compliance.ts
@@ -4,6 +4,7 @@ import type { VerificationCheck } from "../schemas/check.js";
 import type { VerificationRequest } from "../schemas/request.js";
 import type { CheckHandler } from "./handler.js";
 
+/** Check ID for schema compliance verification. */
 export const SCHEMA_COMPLIANCE_CHECK_ID = "schema_compliance" as const;
 
 /**

--- a/packages/verifier/src/checks/seal-chain.ts
+++ b/packages/verifier/src/checks/seal-chain.ts
@@ -4,6 +4,7 @@ import type { VerificationCheck } from "../schemas/check.js";
 import type { VerificationRequest } from "../schemas/request.js";
 import type { CheckHandler } from "./handler.js";
 
+/** Check ID for seal chain verification. */
 export const SEAL_CHAIN_CHECK_ID = "seal_chain" as const;
 
 /**

--- a/packages/verifier/src/checks/seal-signature.ts
+++ b/packages/verifier/src/checks/seal-signature.ts
@@ -4,6 +4,7 @@ import type { VerificationCheck } from "../schemas/check.js";
 import type { VerificationRequest } from "../schemas/request.js";
 import type { CheckHandler } from "./handler.js";
 
+/** Check ID for seal signature verification. */
 export const SEAL_SIGNATURE_CHECK_ID = "seal_signature" as const;
 
 /**

--- a/packages/verifier/src/checks/sigstore-bundle.ts
+++ b/packages/verifier/src/checks/sigstore-bundle.ts
@@ -31,6 +31,7 @@ const SigstoreBundleSchema = z.object({
 
 // -- Types (explicit for isolatedDeclarations) --
 
+/** Structural representation of a Sigstore bundle. */
 export type SigstoreBundle = {
   mediaType: string;
   verificationMaterial: {
@@ -44,6 +45,7 @@ export type SigstoreBundle = {
   };
 };
 
+/** Minimal in-toto statement shape accepted by the verifier. */
 export type InTotoStatement = {
   _type: "https://in-toto.io/Statement/v1";
   subject: Array<{ name: string; digest: { sha256: string } }>;
@@ -71,6 +73,7 @@ const InTotoStatementSchema = z.object({
 
 // -- Parsed bundle result --
 
+/** Parsed bundle data returned by `parseSigstoreBundle()`. */
 export type ParsedBundle = {
   bundle: SigstoreBundle;
   statement: InTotoStatement;

--- a/packages/verifier/src/checks/source-available.ts
+++ b/packages/verifier/src/checks/source-available.ts
@@ -4,8 +4,10 @@ import type { VerificationCheck } from "../schemas/check.js";
 import type { VerificationRequest } from "../schemas/request.js";
 import type { CheckHandler } from "./handler.js";
 
+/** Check ID for source availability verification. */
 export const SOURCE_AVAILABLE_CHECK_ID = "source_available" as const;
 
+/** Configuration for the source availability check. */
 export interface SourceAvailableConfig {
   /** Injectable fetch for testing. Defaults to global fetch. */
   readonly fetcher?: typeof fetch;

--- a/packages/verifier/src/config.ts
+++ b/packages/verifier/src/config.ts
@@ -6,7 +6,7 @@ export type BuildProvenanceConfig = {
   expectedIdentityPattern?: string | undefined;
 };
 
-/** Parsed verifier configuration (all defaults applied). */
+/** Parsed verifier configuration with defaults applied. */
 export type VerifierConfig = {
   verifierInboxId: string;
   sourceRepoUrl: string;
@@ -40,10 +40,13 @@ const BuildProvenanceConfigSchema = z
     expectedIdentityPattern: z
       .string()
       .optional()
-      .describe("Prefix match for expected workflow identity (e.g. https://github.com/org/repo/)"),
+      .describe(
+        "Prefix match for expected workflow identity (e.g. https://github.com/org/repo/)",
+      ),
   })
   .describe("Build provenance verification settings");
 
+/** Zod schema for verifier configuration. */
 export const VerifierConfigSchema: z.ZodType<
   VerifierConfig,
   z.ZodTypeDef,
@@ -70,5 +73,7 @@ export const VerifierConfigSchema: z.ZodType<
   ),
 });
 
+/** Default statement lifetime in seconds. */
 export const DEFAULT_STATEMENT_TTL_SECONDS = 86400;
+/** Default per-requester rate limit per hour. */
 export const DEFAULT_MAX_REQUESTS_PER_HOUR = 10;

--- a/packages/verifier/src/content-types.ts
+++ b/packages/verifier/src/content-types.ts
@@ -1,5 +1,7 @@
+/** XMTP content type for verification requests. */
 export const VERIFICATION_REQUEST_CONTENT_TYPE_ID =
   "xmtp.org/verificationRequest:1.0" as const;
 
+/** XMTP content type for verification statements. */
 export const VERIFICATION_STATEMENT_CONTENT_TYPE_ID =
   "xmtp.org/verificationStatement:1.0" as const;

--- a/packages/verifier/src/rate-limiter.ts
+++ b/packages/verifier/src/rate-limiter.ts
@@ -3,6 +3,7 @@
  * Tracks request timestamps per requester and rejects when the
  * count within the window exceeds the configured maximum.
  */
+/** Public rate limiter API used by the verifier service. */
 export interface RateLimiter {
   /** Returns true if the request is allowed, false if rate-limited. */
   check(requesterId: string): boolean;
@@ -10,6 +11,7 @@ export interface RateLimiter {
   reset(): void;
 }
 
+/** Configuration for the in-memory rate limiter. */
 export interface RateLimiterConfig {
   readonly maxRequests: number;
   readonly windowMs: number;
@@ -17,6 +19,7 @@ export interface RateLimiterConfig {
   readonly now?: () => number;
 }
 
+/** Create an in-memory sliding window rate limiter. */
 export function createRateLimiter(config: RateLimiterConfig): RateLimiter {
   const timestamps = new Map<string, number[]>();
   const getNow = config.now ?? Date.now;

--- a/packages/verifier/src/schemas/check.ts
+++ b/packages/verifier/src/schemas/check.ts
@@ -1,11 +1,14 @@
 import { z } from "zod";
 
+/** Verdict for a single verifier check. */
 export const CheckVerdict: z.ZodEnum<["pass", "fail", "skip"]> = z
   .enum(["pass", "fail", "skip"])
   .describe("Outcome of a single verification check");
 
+/** Type alias for a single verifier check verdict. */
 export type CheckVerdict = z.infer<typeof CheckVerdict>;
 
+/** Result payload for one verification check. */
 export type VerificationCheck = {
   checkId: string;
   verdict: CheckVerdict;
@@ -25,5 +28,6 @@ const _VerificationCheck = z
   })
   .describe("Result of a single verification check");
 
+/** Zod schema for a single verification check result. */
 export const VerificationCheck: z.ZodType<VerificationCheck> =
   _VerificationCheck;

--- a/packages/verifier/src/schemas/request.ts
+++ b/packages/verifier/src/schemas/request.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { SealSchema, TrustTier } from "@xmtp/signet-schemas";
 import type { Seal, TrustTier as TrustTierType } from "@xmtp/signet-schemas";
 
+/** Verification request sent to the verifier. */
 export type VerificationRequest = {
   requestId: string;
   agentInboxId: string;
@@ -16,6 +17,7 @@ export type VerificationRequest = {
   challengeNonce: string;
 };
 
+/** Zod schema for a verifier request. */
 export const VerificationRequestSchema: z.ZodType<VerificationRequest> = z
   .object({
     requestId: z.string().describe("Unique request identifier for correlation"),

--- a/packages/verifier/src/schemas/self-seal.ts
+++ b/packages/verifier/src/schemas/self-seal.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { TrustTier } from "@xmtp/signet-schemas";
 import type { TrustTier as TrustTierType } from "@xmtp/signet-schemas";
 
+/** Capabilities advertised by a verifier instance. */
 export type VerifierCapabilities = {
   supportedTiers: TrustTierType[];
   supportedChecks: string[];
@@ -24,9 +25,11 @@ const _VerifierCapabilities = z
   })
   .describe("Capabilities advertised by this verifier");
 
+/** Zod schema for verifier capabilities. */
 export const VerifierCapabilities: z.ZodType<VerifierCapabilities> =
   _VerifierCapabilities;
 
+/** Self-seal document published by a verifier. */
 export type VerifierSelfSeal = {
   verifierInboxId: string;
   capabilities: VerifierCapabilities;
@@ -35,6 +38,7 @@ export type VerifierSelfSeal = {
   signature: string;
 };
 
+/** Zod schema for a verifier self-seal. */
 export const VerifierSelfSealSchema: z.ZodType<VerifierSelfSeal> = z
   .object({
     verifierInboxId: z.string().describe("XMTP inbox ID of this verifier"),

--- a/packages/verifier/src/schemas/statement.ts
+++ b/packages/verifier/src/schemas/statement.ts
@@ -3,14 +3,17 @@ import { TrustTier } from "@xmtp/signet-schemas";
 import type { TrustTier as TrustTierType } from "@xmtp/signet-schemas";
 import { VerificationCheck } from "./check.js";
 
+/** Overall outcome emitted by the verifier. */
 export const VerificationVerdict: z.ZodEnum<
   ["verified", "partial", "rejected"]
 > = z
   .enum(["verified", "partial", "rejected"])
   .describe("Overall verification outcome");
 
+/** Type union for verifier outcomes. */
 export type VerificationVerdict = z.infer<typeof VerificationVerdict>;
 
+/** Signed statement produced by the verifier for a request. */
 export type VerificationStatement = {
   statementId: string;
   requestId: string;
@@ -27,6 +30,7 @@ export type VerificationStatement = {
   signatureAlgorithm: "Ed25519";
 };
 
+/** Zod schema for a verifier statement. */
 export const VerificationStatementSchema: z.ZodType<VerificationStatement> = z
   .object({
     statementId: z.string().describe("Unique statement identifier"),

--- a/packages/verifier/src/service.ts
+++ b/packages/verifier/src/service.ts
@@ -40,6 +40,7 @@ const ALL_CHECK_IDS = [
   "schema_compliance",
 ] as const;
 
+/** Options used to construct the verifier service. */
 export interface VerifierServiceOptions {
   readonly config: VerifierConfig;
   /** Injectable signing function. Signs canonical bytes, returns base64. */
@@ -54,6 +55,7 @@ export interface VerifierServiceOptions {
   readonly rateLimiter?: RateLimiter;
 }
 
+/** Runtime API exposed by the verifier package. */
 export interface VerifierService {
   handleRequest(
     request: VerificationRequest,
@@ -67,6 +69,7 @@ export interface VerifierService {
   selfSeal(): VerifierSelfSeal;
 }
 
+/** Create the verifier service with the configured checks and signer. */
 export function createVerifierService(
   options: VerifierServiceOptions,
 ): VerifierService {

--- a/packages/ws/src/backpressure.ts
+++ b/packages/ws/src/backpressure.ts
@@ -1,3 +1,4 @@
+/** Backpressure state derived from the current per-connection send depth. */
 export type BackpressureState = "ok" | "warning" | "exceeded";
 
 /**

--- a/packages/ws/src/close-codes.ts
+++ b/packages/ws/src/close-codes.ts
@@ -24,4 +24,5 @@ export const WS_CLOSE_CODES = {
   PROTOCOL_ERROR: 4009,
 } as const;
 
+/** Union of all WebSocket close codes used by the signet server. */
 export type WsCloseCode = (typeof WS_CLOSE_CODES)[keyof typeof WS_CLOSE_CODES];

--- a/packages/ws/src/config.ts
+++ b/packages/ws/src/config.ts
@@ -34,6 +34,7 @@ type WsServerConfigInput = {
   rateLimitMaxMessages?: number | null | undefined;
 };
 
+/** Zod schema that parses WebSocket server configuration and applies defaults. */
 export const WsServerConfigSchema: z.ZodType<
   WsServerConfig,
   z.ZodTypeDef,

--- a/packages/ws/src/connection-state.ts
+++ b/packages/ws/src/connection-state.ts
@@ -3,6 +3,7 @@ import { CircularBuffer } from "./replay-buffer.js";
 import { BackpressureTracker } from "./backpressure.js";
 import type { SequencedFrame } from "./frames.js";
 
+/** Lifecycle phases for a websocket connection. */
 export type ConnectionPhase =
   | "authenticating"
   | "active"
@@ -55,6 +56,7 @@ export interface ConnectionData {
 
 let connectionCounter = 0;
 
+/** Create the initial per-connection state attached to `ws.data`. */
 export function createConnectionState(
   softLimit = 64,
   hardLimit = 256,
@@ -78,6 +80,7 @@ export function createConnectionState(
   };
 }
 
+/** Check whether a websocket connection can move between two phases. */
 export function canTransition(
   from: ConnectionPhase,
   to: ConnectionPhase,

--- a/packages/ws/src/frames.ts
+++ b/packages/ws/src/frames.ts
@@ -7,13 +7,14 @@ import {
 } from "@xmtp/signet-schemas";
 import type { SignetEvent as SignetEventType } from "@xmtp/signet-schemas";
 
+/** Inbound authentication frame sent by the harness. */
 export type AuthFrame = {
   type: "auth";
   token: string;
   lastSeenSeq: number | null;
 };
 
-/** Auth frame sent by harness as first message. */
+/** Zod schema for the inbound authentication frame. */
 const _AuthFrame = z
   .object({
     type: z.literal("auth"),
@@ -27,8 +28,10 @@ const _AuthFrame = z
   })
   .describe("Authentication frame from harness");
 
+/** Zod schema for the inbound authentication frame. */
 export const AuthFrame: z.ZodType<AuthFrame> = _AuthFrame;
 
+/** Authenticated confirmation frame returned by the signet. */
 export type AuthenticatedFrame = {
   type: "authenticated";
   connectionId: string;
@@ -38,7 +41,7 @@ export type AuthenticatedFrame = {
   resumedFromSeq: number | null;
 };
 
-/** Authenticated confirmation from signet. */
+/** Zod schema for the authenticated confirmation frame. */
 export const AuthenticatedFrame: z.ZodType<AuthenticatedFrame> = z
   .object({
     type: z.literal("authenticated"),
@@ -55,13 +58,14 @@ export const AuthenticatedFrame: z.ZodType<AuthenticatedFrame> = z
   })
   .describe("Authentication success response from signet");
 
+/** Error frame emitted before the socket closes on auth failure. */
 export type AuthErrorFrame = {
   type: "auth_error";
   code: number;
   message: string;
 };
 
-/** Auth error from signet, sent before close. */
+/** Zod schema for the auth error frame. */
 export const AuthErrorFrame: z.ZodType<AuthErrorFrame> = z
   .object({
     type: z.literal("auth_error"),
@@ -70,13 +74,14 @@ export const AuthErrorFrame: z.ZodType<AuthErrorFrame> = z
   })
   .describe("Authentication failure response from signet");
 
+/** Backpressure warning emitted when the send buffer approaches its limit. */
 export type BackpressureFrame = {
   type: "backpressure";
   buffered: number;
   limit: number;
 };
 
-/** Backpressure warning from signet. */
+/** Zod schema for the backpressure warning frame. */
 export const BackpressureFrame: z.ZodType<BackpressureFrame> = z
   .object({
     type: z.literal("backpressure"),
@@ -85,12 +90,13 @@ export const BackpressureFrame: z.ZodType<BackpressureFrame> = z
   })
   .describe("Backpressure warning from signet");
 
+/** Sequenced event envelope used for replay and recovery. */
 export type SequencedFrame = {
   seq: number;
   event: SignetEventType;
 };
 
-/** Sequenced event envelope for replay support. */
+/** Zod schema for the sequenced event envelope. */
 export const SequencedFrame: z.ZodType<SequencedFrame> = z
   .object({
     seq: z
@@ -105,12 +111,12 @@ export const SequencedFrame: z.ZodType<SequencedFrame> = z
   .describe("Sequenced event envelope for replay support");
 
 /**
- * Discriminated union of all inbound frame types from harness.
- * The auth frame is the only non-request frame; requests use HarnessRequest
- * from schemas.
+ * Discriminated union of all inbound frame types from the harness.
+ * The auth frame is the only non-request frame; requests use HarnessRequest.
  */
 export const InboundFrame: z.ZodType<AuthFrame> = z.discriminatedUnion("type", [
   _AuthFrame,
 ]);
 
+/** Type union for all inbound harness frames. */
 export type InboundFrame = z.infer<typeof InboundFrame>;

--- a/packages/ws/src/server.ts
+++ b/packages/ws/src/server.ts
@@ -32,8 +32,10 @@ import { routeRequest, type RequestHandler } from "./request-router.js";
 import { sequenceEvent } from "./event-broadcaster.js";
 import { WS_CLOSE_CODES } from "./close-codes.js";
 
+/** Lifecycle states for the websocket server. */
 export type WsServerState = "idle" | "listening" | "draining" | "stopped";
 
+/** Dependencies required to run the websocket transport. */
 export interface WsServerDeps {
   readonly core: SignetCore;
   readonly sessionManager: SessionManager;
@@ -47,6 +49,7 @@ export interface WsServerDeps {
   ) => SignetEvent | null;
 }
 
+/** Public lifecycle and broadcast surface for the websocket transport. */
 export interface WsServer {
   start(): Promise<Result<{ port: number }, SignetError>>;
   stop(): Promise<Result<void, SignetError>>;
@@ -62,6 +65,9 @@ export interface WsServer {
   invalidateSession(sessionId: string): Promise<void>;
 }
 
+/**
+ * Create the websocket server that fronts the signet harness transport.
+ */
 export function createWsServer(
   rawConfig: Partial<WsServerConfig>,
   deps: WsServerDeps,

--- a/scripts/check-doc-coverage.ts
+++ b/scripts/check-doc-coverage.ts
@@ -1,0 +1,208 @@
+#!/usr/bin/env bun
+
+import { readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import ts from "typescript";
+
+const ROOT_DIR = process.cwd();
+const PACKAGES_DIR = join(ROOT_DIR, "packages");
+const SKIP_DIRS = new Set(["__tests__", "dist", "node_modules"]);
+
+type PackageStats = {
+  total: number;
+  documented: number;
+};
+
+function walkSourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+
+    if (stat.isDirectory()) {
+      if (SKIP_DIRS.has(entry)) continue;
+      walkSourceFiles(fullPath, acc);
+      continue;
+    }
+
+    if (
+      (fullPath.endsWith(".ts") || fullPath.endsWith(".tsx")) &&
+      !fullPath.endsWith(".d.ts")
+    ) {
+      acc.push(fullPath);
+    }
+  }
+
+  return acc;
+}
+
+function getModifiers(node: ts.Node): readonly ts.ModifierLike[] {
+  return ts.getModifiers?.(node) ?? node.modifiers ?? [];
+}
+
+function isExported(node: ts.Node): boolean {
+  const modifiers = getModifiers(node);
+
+  return modifiers.some(
+    (modifier) =>
+      modifier.kind === ts.SyntaxKind.ExportKeyword ||
+      modifier.kind === ts.SyntaxKind.DefaultKeyword,
+  );
+}
+
+function hasDocComment(node: ts.Node, sourceFile: ts.SourceFile): boolean {
+  const jsDocs = ts.getJSDocCommentsAndTags(node);
+
+  for (const doc of jsDocs) {
+    if (!ts.isJSDoc(doc)) continue;
+
+    const { comment, tags } = doc;
+    if (typeof comment === "string" && comment.trim().length > 0) return true;
+    if (Array.isArray(comment) && comment.length > 0) return true;
+    if (tags !== undefined && tags.length > 0) return true;
+  }
+
+  const commentRanges =
+    ts.getLeadingCommentRanges(sourceFile.getFullText(), node.pos) ?? [];
+
+  return commentRanges.some((range) =>
+    sourceFile.getFullText().slice(range.pos, range.end).startsWith("/**"),
+  );
+}
+
+function getNodeName(
+  node: ts.Node | undefined,
+  sourceFile: ts.SourceFile,
+): string {
+  if (node === undefined) return "default";
+
+  try {
+    return node.getText(sourceFile);
+  } catch {
+    return "default";
+  }
+}
+
+function formatPercent(numerator: number, denominator: number): string {
+  if (denominator === 0) return "100.0";
+  return ((numerator / denominator) * 100).toFixed(1);
+}
+
+function printSummary(
+  byPackage: ReadonlyArray<[string, PackageStats]>,
+  total: number,
+  documented: number,
+): void {
+  console.log(
+    `Exported API doc coverage: ${documented}/${total} (${formatPercent(documented, total)}%)`,
+  );
+
+  for (const [pkg, stats] of byPackage) {
+    console.log(
+      `  ${pkg.padEnd(12)} ${String(stats.documented).padStart(3)}/${String(stats.total).padEnd(3)} ${formatPercent(stats.documented, stats.total).padStart(5)}%`,
+    );
+  }
+}
+
+const sourceFiles = walkSourceFiles(PACKAGES_DIR);
+const program = ts.createProgram(sourceFiles, {
+  target: ts.ScriptTarget.ESNext,
+  module: ts.ModuleKind.ESNext,
+  skipLibCheck: true,
+  allowJs: false,
+});
+
+const byPackage = new Map<string, PackageStats>();
+const undocumented: string[] = [];
+let total = 0;
+let documented = 0;
+
+for (const sourceFile of program.getSourceFiles()) {
+  const relativePath = relative(ROOT_DIR, sourceFile.fileName);
+
+  if (
+    (!sourceFile.fileName.includes("/packages/") &&
+      !sourceFile.fileName.startsWith("packages/")) ||
+    sourceFile.fileName.includes("/node_modules/") ||
+    relativePath.includes("/src/__tests__/")
+  ) {
+    continue;
+  }
+
+  const match = relativePath.match(/^packages\/([^/]+)\//);
+  const packageName = match?.[1] ?? "(unknown)";
+  if (!byPackage.has(packageName)) {
+    byPackage.set(packageName, { total: 0, documented: 0 });
+  }
+
+  const stats = byPackage.get(packageName);
+  if (stats === undefined) {
+    throw new Error(`Missing package stats bucket for ${packageName}`);
+  }
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isVariableStatement(statement) && isExported(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        total += 1;
+        stats.total += 1;
+
+        if (hasDocComment(statement, sourceFile)) {
+          documented += 1;
+          stats.documented += 1;
+          continue;
+        }
+
+        const line =
+          sourceFile.getLineAndCharacterOfPosition(
+            declaration.getStart(sourceFile),
+          ).line + 1;
+
+        undocumented.push(
+          `${relativePath}:${line} variable ${getNodeName(declaration.name, sourceFile)}`,
+        );
+      }
+
+      continue;
+    }
+
+    const isCountableExport =
+      (ts.isFunctionDeclaration(statement) ||
+        ts.isClassDeclaration(statement) ||
+        ts.isInterfaceDeclaration(statement) ||
+        ts.isTypeAliasDeclaration(statement) ||
+        ts.isEnumDeclaration(statement)) &&
+      isExported(statement);
+
+    if (!isCountableExport) continue;
+
+    total += 1;
+    stats.total += 1;
+
+    if (hasDocComment(statement, sourceFile)) {
+      documented += 1;
+      stats.documented += 1;
+      continue;
+    }
+
+    const line =
+      sourceFile.getLineAndCharacterOfPosition(statement.getStart(sourceFile))
+        .line + 1;
+
+    undocumented.push(
+      `${relativePath}:${line} ${ts.SyntaxKind[statement.kind]} ${getNodeName(statement.name, sourceFile)}`,
+    );
+  }
+}
+
+const sortedPackages = [...byPackage.entries()].sort(([a], [b]) =>
+  a.localeCompare(b),
+);
+
+printSummary(sortedPackages, total, documented);
+
+if (undocumented.length > 0) {
+  console.error("\nUndocumented exported declarations:");
+  for (const line of undocumented) {
+    console.error(`  - ${line}`);
+  }
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

Adds JSDoc/TSDoc comments to every exported type, schema, function, and interface across all packages. Introduces a doc coverage enforcement script.

- 75 files changed, ~550 lines of documentation
- **Mechanical only** — no logic changes, no behavior changes
- `scripts/check-doc-coverage.ts` scans all exported symbols for missing TSDoc
- Wired into `bun run lint` and `bun run check` so coverage is enforced in CI

### Packages covered

schemas, contracts, core, keys, sessions, seals, policy, verifier, ws, cli, integration fixtures

## Test plan

- [x] All existing tests pass (no behavior changes)
- [x] `bun run docs:check` passes with zero uncovered exports
- [x] `bun run check` (lint + typecheck + test + docs:check) all green

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)