### PR TITLE
cleanup: remove summary-only view mode

### DIFF
--- a/.agents/docs/init/xmtp-signet.md
+++ b/.agents/docs/init/xmtp-signet.md
@@ -242,7 +242,6 @@ Suggested initial view modes as convenience labels:
 - `thread-only`
 - `redacted`
 - `reveal-only`
-- `summary-only`
 
 A view mode is only a convenience label. The underlying view object (including the content type allowlist) and grant object should remain explicit and authoritative.
 

--- a/.agents/notes/outfitter-patterns/schema-first-architecture.md
+++ b/.agents/notes/outfitter-patterns/schema-first-architecture.md
@@ -88,7 +88,7 @@ const AttestationSchema = z.object({
   agentInboxId: z.string(),
   ownerInboxId: z.string(),
   groupId: z.string(),
-  viewMode: z.enum(["full", "thread-only", "redacted", "reveal-only", "summary-only"]),
+  viewMode: z.enum(["full", "thread-only", "redacted", "reveal-only"]),
   contentTypes: z.array(z.string()),
   grantedOps: z.array(z.string()),
   inferenceMode: z.enum(["local", "external", "hybrid", "unknown"]),

--- a/.agents/plans/v0/02-schemas.md
+++ b/.agents/plans/v0/02-schemas.md
@@ -114,7 +114,6 @@ const ViewMode = z.enum([
   "thread-only",
   "redacted",
   "reveal-only",
-  "summary-only",
 ]).describe("Visibility mode for the agent's view of conversations");
 
 type ViewMode = z.infer<typeof ViewMode>;

--- a/.agents/plans/v0/04-policy-engine.md
+++ b/.agents/plans/v0/04-policy-engine.md
@@ -307,11 +307,8 @@ Determines `MessageVisibility` based on view mode and reveal state:
 | `thread-only`  | `visible`*         | `visible`          |
 | `redacted`     | `redacted`         | `revealed`         |
 | `reveal-only`  | `hidden`           | `revealed`         |
-| `summary-only` | `redacted`**       | `revealed`         |
 
 \* `thread-only` messages already passed the scope filter, so they are visible.
-
-\** `summary-only` uses `redacted` visibility with summarized content in stage 4.
 
 If visibility resolves to `hidden` and no reveal grant covers the message, the pipeline returns `DROP`.
 
@@ -322,8 +319,6 @@ Transforms content based on resolved visibility:
 - `visible` / `historical` / `revealed`: content passes through unchanged.
 - `redacted`: content is replaced with `null`. The `contentType` and metadata (sender, timestamp) are preserved.
 - `hidden`: unreachable (dropped in stage 3).
-
-**`summary-only` mode is Phase 2 behavior.** The mode exists in the schema for forward compatibility, but in v0 the broker returns a `ValidationError` if a harness attempts to create a session or update a view with `mode: "summary-only"`. This prevents harnesses from relying on placeholder behavior that will change semantically in Phase 2.
 
 ### Grant Validation Pipeline
 
@@ -485,7 +480,7 @@ The `requiresReauthorization` function checks a stricter subset: only privilege 
 #### View Mode Ordering (narrow to broad)
 
 ```
-reveal-only < summary-only < redacted < thread-only < full
+reveal-only < redacted < thread-only < full
 ```
 
 A mode change is an escalation if the new mode is broader than the old mode in this ordering.
@@ -505,7 +500,6 @@ A mode change is an escalation if the new mode is broader than the old mode in t
 | Empty effective content type allowlist | `ValidationError` | validation |
 | Reveal requested by non-owner | `PermissionError` | permission |
 | Content type not in effective allowlist (send) | `ValidationError` | validation |
-| View mode set to `summary-only` in v0 | `ValidationError` | validation |
 
 All functions return `Result<T, E>`. No exceptions are thrown.
 
@@ -517,12 +511,7 @@ All functions return `Result<T, E>`. No exceptions are thrown.
 **Q: Should non-material view/grant changes be applied within an existing session?** (PRD Session section)
 **A:** Yes. Non-material changes (e.g., adjusting a thread scope within the same groups, or minor grant tweaks that don't escalate privileges) are applied in-place and emit a `view.updated` or `grant.updated` event. Only escalations require session reauthorization. This is enforced by `requiresReauthorization` returning `false` for non-escalation changes.
 
-**Q: How does summary-only mode work in v0?** (PRD View Modes)
-**A:** In v0, `summary-only` is kept in the schema for forward compatibility but is not usable. If a harness attempts to create a session or update a view with `mode: "summary-only"`, the broker returns a `ValidationError`. Actual summarization (LLM-generated summaries) is deferred to Phase 2. The schema includes the value so the wire format is stable across versions.
-
 ## Deferred
-
-- **LLM-powered summarization**: `summary-only` mode emits placeholders. Actual summary generation requires an inference pipeline, deferred to Phase 2.
 - **Tool parameter constraint validation**: v0 checks that the `toolId` is allowed and that `parameters` is non-null if constrained. Deep parameter validation (e.g., "this integer must be < 100") is deferred.
 - **Group governance beyond owner**: v0 only allows the owner to grant reveals and modify policy. Multi-member governance (approval thresholds, admin caps) is deferred.
 - **Reveal history API**: The engine tracks active reveals but does not expose a history of past reveals. Forensic history is deferred.
@@ -577,7 +566,7 @@ All functions return `Result<T, E>`. No exceptions are thrown.
 24. **Grant escalation**: `send: false -> true` is material + reauth.
 25. **Grant reduction**: `send: true -> false` is material, no reauth.
 26. **Session rotation**: same view+grant -> not material.
-27. **Mode ordering**: verify `reveal-only < summary-only < redacted < thread-only < full`.
+27. **Mode ordering**: verify `reveal-only < redacted < thread-only < full`.
 
 ### Test Utilities
 

--- a/.agents/plans/v0/05-sessions.md
+++ b/.agents/plans/v0/05-sessions.md
@@ -251,7 +251,7 @@ The broker determines whether a policy change is material by comparing the old a
 
 | Field | Material when... |
 |-------|-----------------|
-| `view.mode` | Escalation toward more access: `redacted` -> any, `summary-only` -> `thread-only`/`full`, `reveal-only` -> `full`, `thread-only` -> `full` |
+| `view.mode` | Escalation toward more access: `redacted` -> any, `reveal-only` -> `full`, `thread-only` -> `full` |
 | `grant.messaging.send` | `false` -> `true` |
 | `grant.messaging.draftOnly` | `true` -> `false` (removes guardrail) |
 | `grant.groupManagement.*` | Any `false` -> `true` |

--- a/.agents/plans/v0/PLAN.md
+++ b/.agents/plans/v0/PLAN.md
@@ -74,7 +74,6 @@ These decisions resolve PRD open questions and establish constraints for all spe
 | Per-group identity | Default-on, configurable; each group gets a unique identity key | Strongest isolation; matches convos-node-sdk pattern |
 | Mono-package vs monorepo | Monorepo with Bun workspaces from day one | Clean dependency boundaries between tiers |
 | Foundation tier split | `schemas` = data shapes (Zod schemas, enums, error taxonomy); `contracts` = cross-package interfaces (service/provider contracts, event types). `contracts` imports from `schemas` only. | 22 interfaces defined in runtime specs belong in Foundation. Separating shapes from contracts keeps `schemas` zero-dep beyond Zod and gives runtime packages a stable interface layer. |
-| `summary-only` view mode | Schema defined in v0; implementation deferred to Phase 2 | Schema completeness now; summarization logic is non-trivial and not needed for initial transport |
 | CLI framework | Commander.js | Lightweight, Bun-compatible, composes well with Zod for argument validation |
 | Config format | TOML at `~/.config/xmtp-broker/config.toml` with `smol-toml` parser | XDG conventions; `smol-toml` is zero-dep, spec-compliant |
 | Admin auth | Admin key JWT only; peer credentials deferred to post-v0 | Cross-platform; no native FFI in v0 |

--- a/.agents/plans/v0/SPEC.md
+++ b/.agents/plans/v0/SPEC.md
@@ -242,7 +242,6 @@ Suggested initial view modes as convenience labels:
 - `thread-only`
 - `redacted`
 - `reveal-only`
-- `summary-only`
 
 A view mode is only a convenience label. The underlying view object (including the content type allowlist) and grant object should remain explicit and authoritative.
 

--- a/.claude/skills/xmtp-signet-use/SKILL.md
+++ b/.claude/skills/xmtp-signet-use/SKILL.md
@@ -60,7 +60,6 @@ to control:
 | `thread-only` | Messages within specific threads only |
 | `redacted` | Messages with sensitive content removed |
 | `reveal-only` | Only messages explicitly revealed to the agent |
-| `summary-only` | Broker-generated summaries, not raw messages |
 
 **Default-deny for content types.** If a content type isn't in the allowlist,
 the signet holds it and the agent never sees it. When new content types are
@@ -161,19 +160,10 @@ error. The harness cannot bypass this.
 | Only respond when explicitly asked | `reveal-only` |
 | Work within a specific thread | `thread-only` |
 | See content with PII stripped | `redacted` |
-| Get conversation summaries | `summary-only` |
 
 ### Choosing grants
 
-Start with the minimum. A summarization agent might need:
-
-```
-view:  summary-only
-grant: messaging.send (to post summaries)
-       egress.summarize (to use content for summaries)
-```
-
-A moderation agent might need:
+Start with the minimum. A moderation agent might need:
 
 ```
 view:  full

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -41,7 +41,6 @@ Content types not in the allowlist are held at the signet and never forwarded. T
 | `thread-only` | Messages within specific threads (uses `threadId` derived from Reply content type's `referenceId`) |
 | `redacted`    | Messages with sensitive content removed        |
 | `reveal-only` | Only messages explicitly revealed to the agent |
-| `summary-only` | Signet-generated summaries (defined in schema, reserved — not implemented in v0) |
 
 A view mode is a convenience label. The underlying view object (including content type allowlist) and grant remain explicit and authoritative.
 

--- a/packages/policy/src/__tests__/materiality.test.ts
+++ b/packages/policy/src/__tests__/materiality.test.ts
@@ -173,21 +173,21 @@ describe("requiresReauthorization", () => {
     expect(requiresReauthorization([delta])).toBe(true);
   });
 
-  test("mode ordering: reveal-only < summary-only < redacted < thread-only < full", () => {
-    // reveal-only -> summary-only is escalation
+  test("mode ordering: reveal-only < redacted < thread-only < full", () => {
+    // reveal-only -> redacted is escalation
     const d1: PolicyDelta = {
       ...emptyDelta(),
       viewChanges: [
-        { field: "view.mode", from: "reveal-only", to: "summary-only" },
+        { field: "view.mode", from: "reveal-only", to: "redacted" },
       ],
     };
     expect(requiresReauthorization([d1])).toBe(true);
 
-    // summary-only -> redacted is escalation
+    // redacted -> thread-only is escalation
     const d2: PolicyDelta = {
       ...emptyDelta(),
       viewChanges: [
-        { field: "view.mode", from: "summary-only", to: "redacted" },
+        { field: "view.mode", from: "redacted", to: "thread-only" },
       ],
     };
     expect(requiresReauthorization([d2])).toBe(true);

--- a/packages/policy/src/__tests__/validate-view-mode.test.ts
+++ b/packages/policy/src/__tests__/validate-view-mode.test.ts
@@ -3,15 +3,6 @@ import { validateViewMode } from "../allowlist.js";
 import { Result } from "better-result";
 
 describe("validateViewMode", () => {
-  test("rejects summary-only with ValidationError", () => {
-    const result = validateViewMode("summary-only");
-    expect(Result.isError(result)).toBe(true);
-    if (Result.isError(result)) {
-      expect(result.error._tag).toBe("ValidationError");
-      expect(result.error.context.field).toBe("viewMode");
-    }
-  });
-
   test("accepts full mode", () => {
     const result = validateViewMode("full");
     expect(Result.isOk(result)).toBe(true);

--- a/packages/policy/src/__tests__/visibility-resolver.test.ts
+++ b/packages/policy/src/__tests__/visibility-resolver.test.ts
@@ -27,12 +27,4 @@ describe("resolveVisibility", () => {
   test("reveal-only mode returns revealed with active reveal", () => {
     expect(resolveVisibility("reveal-only", true)).toBe("revealed");
   });
-
-  test("summary-only mode returns redacted without reveal", () => {
-    expect(resolveVisibility("summary-only", false)).toBe("redacted");
-  });
-
-  test("summary-only mode returns revealed with active reveal", () => {
-    expect(resolveVisibility("summary-only", true)).toBe("revealed");
-  });
 });

--- a/packages/policy/src/allowlist.ts
+++ b/packages/policy/src/allowlist.ts
@@ -8,20 +8,10 @@ import type { SignetContentTypeConfig } from "./types.js";
 
 /**
  * Validates that a view mode is supported in the current version.
- * Rejects `summary-only` which is not implemented in v0.
  */
 export function validateViewMode(
-  mode: ViewMode,
+  _mode: ViewMode,
 ): Result<void, ValidationError> {
-  if (mode === "summary-only") {
-    return Result.err(
-      ValidationError.create(
-        "viewMode",
-        "summary-only mode is not supported in v0",
-        { value: mode },
-      ),
-    );
-  }
   return Result.ok(undefined);
 }
 

--- a/packages/policy/src/materiality.ts
+++ b/packages/policy/src/materiality.ts
@@ -14,10 +14,9 @@ const MATERIAL_FIELD_PREFIXES = [
 /** View mode ordering from narrow to broad. */
 const VIEW_MODE_ORDER: Record<string, number> = {
   "reveal-only": 0,
-  "summary-only": 1,
-  redacted: 2,
-  "thread-only": 3,
-  full: 4,
+  redacted: 1,
+  "thread-only": 2,
+  full: 3,
 };
 
 /** Fields where false -> true is a privilege escalation. */

--- a/packages/policy/src/pipeline/visibility-resolver.ts
+++ b/packages/policy/src/pipeline/visibility-resolver.ts
@@ -10,7 +10,6 @@ import type { MessageVisibility, ViewMode } from "@xmtp/signet-schemas";
  * | thread-only    | visible            | visible            |
  * | redacted       | redacted           | revealed           |
  * | reveal-only    | hidden             | revealed           |
- * | summary-only   | redacted           | revealed           |
  */
 export function resolveVisibility(
   mode: ViewMode,
@@ -24,7 +23,5 @@ export function resolveVisibility(
       return isRevealed ? "revealed" : "redacted";
     case "reveal-only":
       return isRevealed ? "revealed" : "hidden";
-    case "summary-only":
-      return isRevealed ? "revealed" : "redacted";
   }
 }

--- a/packages/schemas/src/__tests__/view.test.ts
+++ b/packages/schemas/src/__tests__/view.test.ts
@@ -8,13 +8,7 @@ import {
 
 describe("ViewMode", () => {
   it("accepts all valid view modes", () => {
-    for (const mode of [
-      "full",
-      "thread-only",
-      "redacted",
-      "reveal-only",
-      "summary-only",
-    ]) {
+    for (const mode of ["full", "thread-only", "redacted", "reveal-only"]) {
       expect(ViewMode.safeParse(mode).success).toBe(true);
     }
   });

--- a/packages/schemas/src/reveal.ts
+++ b/packages/schemas/src/reveal.ts
@@ -28,7 +28,9 @@ export const RevealRequest: z.ZodType<RevealRequest> = z
     scope: RevealScope.describe("What granularity to reveal"),
     targetId: z
       .string()
-      .describe("ID of the message, thread, content type, or sender"),
+      .describe(
+        "Target identifier: message ID, thread ID, content type, sender inbox ID, or 'startISO|endISO' for time-window scope",
+      ),
     requestedBy: z
       .string()
       .describe("Inbox ID of the member requesting the reveal"),

--- a/packages/schemas/src/view.ts
+++ b/packages/schemas/src/view.ts
@@ -3,9 +3,9 @@ import { ContentTypeId } from "./content-types.js";
 
 /** Zod schema for an agent session's projected conversation view mode. */
 export const ViewMode: z.ZodEnum<
-  ["full", "thread-only", "redacted", "reveal-only", "summary-only"]
+  ["full", "thread-only", "redacted", "reveal-only"]
 > = z
-  .enum(["full", "thread-only", "redacted", "reveal-only", "summary-only"])
+  .enum(["full", "thread-only", "redacted", "reveal-only"])
   .describe("Visibility mode for the agent's view of conversations");
 
 /** Visibility mode for an agent session's projected conversation view. */

--- a/packages/sessions/src/__tests__/materiality.test.ts
+++ b/packages/sessions/src/__tests__/materiality.test.ts
@@ -20,20 +20,6 @@ describe("checkMateriality", () => {
       expect(result.isMaterial).toBe(true);
     });
 
-    test("summary-only -> full is material", () => {
-      const oldView: ViewConfig = { ...baseView, mode: "summary-only" };
-      const newView: ViewConfig = { ...baseView, mode: "full" };
-      const result = checkMateriality(oldView, baseGrant, newView, baseGrant);
-      expect(result.isMaterial).toBe(true);
-    });
-
-    test("summary-only -> thread-only is material", () => {
-      const oldView: ViewConfig = { ...baseView, mode: "summary-only" };
-      const newView: ViewConfig = { ...baseView, mode: "thread-only" };
-      const result = checkMateriality(oldView, baseGrant, newView, baseGrant);
-      expect(result.isMaterial).toBe(true);
-    });
-
     test("reveal-only -> full is material", () => {
       const oldView: ViewConfig = { ...baseView, mode: "reveal-only" };
       const newView: ViewConfig = { ...baseView, mode: "full" };

--- a/packages/sessions/src/materiality.ts
+++ b/packages/sessions/src/materiality.ts
@@ -21,10 +21,9 @@ export interface DetailedMaterialityCheck extends MaterialityCheck {
  */
 const VIEW_MODE_LEVEL: Record<ViewMode, number> = {
   "reveal-only": 0,
-  "summary-only": 1,
-  redacted: 2,
-  "thread-only": 3,
-  full: 4,
+  redacted: 1,
+  "thread-only": 2,
+  full: 3,
 };
 
 /** Check whether a policy change is material. */


### PR DESCRIPTION
## Summary

Intentional breaking schema change: removes `summary-only` from the `ViewMode` enum entirely. The mode was never implemented and won't be — summarization is content generation, not filtering, and belongs in the harness or a dedicated agent.

### Changes
- `ViewMode` enum: removed `summary-only`
- Policy materiality ordering: removed from mode hierarchy
- Visibility resolver: removed switch case
- Allowlist validation: removed rejection logic (mode no longer parseable)
- All tests updated to exclude `summary-only`
- Planning docs, agent skills, and notes cleaned of all references

### Migration
This is a **breaking change** for any persisted data with `mode: "summary-only"`. No backward compatibility path — the mode was never issued in production.

## Test plan
- [x] All view mode tests pass without summary-only
- [x] Zero `summary-only` references in codebase (`rg` confirms)
- [x] Full monorepo build + typecheck + test green

Closes #89

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)