### PR TITLE
feat(cli): replay historical messages when reveal is granted

### DIFF
--- a/packages/cli/src/__tests__/ws-request-handler.test.ts
+++ b/packages/cli/src/__tests__/ws-request-handler.test.ts
@@ -1,14 +1,20 @@
 import { describe, expect, test } from "bun:test";
 import { Result } from "better-result";
 import type { SessionRecord } from "@xmtp/signet-contracts";
-import type { HarnessRequest, SignetEvent } from "@xmtp/signet-schemas";
+import type {
+  HarnessRequest,
+  RevealEvent,
+  SignetEvent,
+} from "@xmtp/signet-schemas";
 import {
   AuthError,
   NotFoundError,
   PermissionError,
 } from "@xmtp/signet-schemas";
 import { createWsRequestHandler } from "../ws/request-handler.js";
+import type { ReplayMessage } from "../ws/request-handler.js";
 import { createPendingActionStore } from "@xmtp/signet-sessions";
+import { createRevealStateStore } from "@xmtp/signet-policy";
 
 function makeSessionRecord(
   overrides: Partial<SessionRecord> = {},
@@ -420,5 +426,328 @@ describe("createWsRequestHandler", () => {
     if (result.isErr()) {
       expect(result.error).toBeInstanceOf(PermissionError);
     }
+  });
+
+  test("reveal_content replays historical messages as message.revealed events", async () => {
+    const revealStore = createRevealStateStore();
+    const broadcastedEvents: {
+      sessionId: string;
+      event: SignetEvent;
+    }[] = [];
+
+    const messages: readonly ReplayMessage[] = [
+      {
+        messageId: "msg_1",
+        groupId: "g1",
+        senderInboxId: "sender_a",
+        contentType: "xmtp.org/text:1.0",
+        content: { text: "hello" },
+        sentAt: "2024-01-01T00:01:00Z",
+        threadId: "thread_1",
+      },
+      {
+        messageId: "msg_2",
+        groupId: "g1",
+        senderInboxId: "sender_b",
+        contentType: "xmtp.org/text:1.0",
+        content: { text: "world" },
+        sentAt: "2024-01-01T00:02:00Z",
+        threadId: "thread_1",
+      },
+    ];
+
+    const handler = createWsRequestHandler({
+      ensureCoreReady: async () => Result.ok(undefined),
+      sendMessage: async () => Result.ok({ messageId: "unused" }),
+      sessionManager: {
+        heartbeat: async () => Result.ok(undefined),
+        getRevealState: () => Result.ok(revealStore),
+      },
+      broadcast: (sessionId, event) => {
+        broadcastedEvents.push({ sessionId, event });
+      },
+      listMessages: async () => Result.ok(messages),
+    });
+
+    const request: HarnessRequest = {
+      type: "reveal_content",
+      requestId: "req_reveal_1",
+      reveal: {
+        revealId: "rev_1",
+        groupId: "g1",
+        scope: "thread",
+        targetId: "thread_1",
+        requestedBy: "owner_1",
+        expiresAt: null,
+      },
+    };
+
+    const result = await handler(request, makeSessionRecord());
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const grant = result.value as { revealId: string };
+      expect(grant.revealId).toBe("rev_1");
+    }
+
+    // Both messages should be revealed via broadcast
+    expect(broadcastedEvents).toHaveLength(2);
+    for (const entry of broadcastedEvents) {
+      expect(entry.sessionId).toBe("sess_123");
+      expect(entry.event.type).toBe("message.revealed");
+    }
+
+    const first = broadcastedEvents[0]?.event as RevealEvent;
+    expect(first.messageId).toBe("msg_1");
+    expect(first.revealId).toBe("rev_1");
+    expect(first.content).toEqual({ text: "hello" });
+
+    const second = broadcastedEvents[1]?.event as RevealEvent;
+    expect(second.messageId).toBe("msg_2");
+    expect(second.revealId).toBe("rev_1");
+  });
+
+  test("reveal_content skips replay when listMessages is not provided", async () => {
+    const revealStore = createRevealStateStore();
+    const broadcastedEvents: {
+      sessionId: string;
+      event: SignetEvent;
+    }[] = [];
+
+    const handler = createWsRequestHandler({
+      ensureCoreReady: async () => Result.ok(undefined),
+      sendMessage: async () => Result.ok({ messageId: "unused" }),
+      sessionManager: {
+        heartbeat: async () => Result.ok(undefined),
+        getRevealState: () => Result.ok(revealStore),
+      },
+      broadcast: (sessionId, event) => {
+        broadcastedEvents.push({ sessionId, event });
+      },
+    });
+
+    const request: HarnessRequest = {
+      type: "reveal_content",
+      requestId: "req_reveal_2",
+      reveal: {
+        revealId: "rev_2",
+        groupId: "g1",
+        scope: "message",
+        targetId: "msg_1",
+        requestedBy: "owner_1",
+        expiresAt: null,
+      },
+    };
+
+    const result = await handler(request, makeSessionRecord());
+
+    expect(result.isOk()).toBe(true);
+    // No broadcast since listMessages is not wired
+    expect(broadcastedEvents).toHaveLength(0);
+  });
+
+  test("reveal_content filters out replayed messages with disallowed content types", async () => {
+    const revealStore = createRevealStateStore();
+    const broadcastedEvents: {
+      sessionId: string;
+      event: SignetEvent;
+    }[] = [];
+
+    const messages: readonly ReplayMessage[] = [
+      {
+        messageId: "msg_text",
+        groupId: "g1",
+        senderInboxId: "sender_a",
+        contentType: "xmtp.org/text:1.0",
+        content: { text: "allowed" },
+        sentAt: "2024-01-01T00:01:00Z",
+        threadId: null,
+      },
+      {
+        messageId: "msg_reaction",
+        groupId: "g1",
+        senderInboxId: "sender_a",
+        contentType: "xmtp.org/reaction:1.0",
+        content: { emoji: ":+1:" },
+        sentAt: "2024-01-01T00:02:00Z",
+        threadId: null,
+      },
+    ];
+
+    const handler = createWsRequestHandler({
+      ensureCoreReady: async () => Result.ok(undefined),
+      sendMessage: async () => Result.ok({ messageId: "unused" }),
+      sessionManager: {
+        heartbeat: async () => Result.ok(undefined),
+        getRevealState: () => Result.ok(revealStore),
+      },
+      broadcast: (sessionId, event) => {
+        broadcastedEvents.push({ sessionId, event });
+      },
+      listMessages: async () => Result.ok(messages),
+    });
+
+    // Use sender scope to reveal all messages from sender_a.
+    // Session only allows text content type, so reaction should be filtered.
+    const request: HarnessRequest = {
+      type: "reveal_content",
+      requestId: "req_reveal_filter",
+      reveal: {
+        revealId: "rev_filter",
+        groupId: "g1",
+        scope: "sender",
+        targetId: "sender_a",
+        requestedBy: "owner_1",
+        expiresAt: null,
+      },
+    };
+
+    const result = await handler(request, makeSessionRecord());
+
+    expect(result.isOk()).toBe(true);
+    // Only the text message should be broadcast; the reaction is filtered
+    expect(broadcastedEvents).toHaveLength(1);
+    const revealed = broadcastedEvents[0]?.event as RevealEvent;
+    expect(revealed.messageId).toBe("msg_text");
+    expect(revealed.contentType).toBe("xmtp.org/text:1.0");
+  });
+
+  test("reveal_content filters out replayed messages outside thread scope", async () => {
+    const revealStore = createRevealStateStore();
+    const broadcastedEvents: {
+      sessionId: string;
+      event: SignetEvent;
+    }[] = [];
+
+    const messages: readonly ReplayMessage[] = [
+      {
+        messageId: "msg_in_scope",
+        groupId: "g1",
+        senderInboxId: "sender_a",
+        contentType: "xmtp.org/text:1.0",
+        content: { text: "in scope" },
+        sentAt: "2024-01-01T00:01:00Z",
+        threadId: "thread_allowed",
+      },
+      {
+        messageId: "msg_out_scope",
+        groupId: "g1",
+        senderInboxId: "sender_a",
+        contentType: "xmtp.org/text:1.0",
+        content: { text: "out of scope" },
+        sentAt: "2024-01-01T00:02:00Z",
+        threadId: "thread_not_allowed",
+      },
+    ];
+
+    const handler = createWsRequestHandler({
+      ensureCoreReady: async () => Result.ok(undefined),
+      sendMessage: async () => Result.ok({ messageId: "unused" }),
+      sessionManager: {
+        heartbeat: async () => Result.ok(undefined),
+        getRevealState: () => Result.ok(revealStore),
+      },
+      broadcast: (sessionId, event) => {
+        broadcastedEvents.push({ sessionId, event });
+      },
+      listMessages: async () => Result.ok(messages),
+    });
+
+    // Session scoped to a specific thread. Use sender scope to reveal
+    // all messages from sender_a; thread scope filter should drop the
+    // message in thread_not_allowed.
+    const session = makeSessionRecord({
+      view: {
+        mode: "full",
+        threadScopes: [{ groupId: "g1", threadId: "thread_allowed" }],
+        contentTypes: ["xmtp.org/text:1.0"],
+      },
+    });
+
+    const request: HarnessRequest = {
+      type: "reveal_content",
+      requestId: "req_reveal_scope",
+      reveal: {
+        revealId: "rev_scope",
+        groupId: "g1",
+        scope: "sender",
+        targetId: "sender_a",
+        requestedBy: "owner_1",
+        expiresAt: null,
+      },
+    };
+
+    const result = await handler(request, session);
+
+    expect(result.isOk()).toBe(true);
+    // Only in-scope thread message should be broadcast
+    expect(broadcastedEvents).toHaveLength(1);
+    const revealed = broadcastedEvents[0]?.event as RevealEvent;
+    expect(revealed.messageId).toBe("msg_in_scope");
+  });
+
+  test("reveal_content only replays messages matching the reveal scope", async () => {
+    const revealStore = createRevealStateStore();
+    const broadcastedEvents: {
+      sessionId: string;
+      event: SignetEvent;
+    }[] = [];
+
+    const messages: readonly ReplayMessage[] = [
+      {
+        messageId: "msg_target",
+        groupId: "g1",
+        senderInboxId: "sender_a",
+        contentType: "xmtp.org/text:1.0",
+        content: { text: "revealed" },
+        sentAt: "2024-01-01T00:01:00Z",
+        threadId: null,
+      },
+      {
+        messageId: "msg_other",
+        groupId: "g1",
+        senderInboxId: "sender_b",
+        contentType: "xmtp.org/text:1.0",
+        content: { text: "not revealed" },
+        sentAt: "2024-01-01T00:02:00Z",
+        threadId: null,
+      },
+    ];
+
+    const handler = createWsRequestHandler({
+      ensureCoreReady: async () => Result.ok(undefined),
+      sendMessage: async () => Result.ok({ messageId: "unused" }),
+      sessionManager: {
+        heartbeat: async () => Result.ok(undefined),
+        getRevealState: () => Result.ok(revealStore),
+      },
+      broadcast: (sessionId, event) => {
+        broadcastedEvents.push({ sessionId, event });
+      },
+      listMessages: async () => Result.ok(messages),
+    });
+
+    // Reveal only a single message by ID
+    const request: HarnessRequest = {
+      type: "reveal_content",
+      requestId: "req_reveal_3",
+      reveal: {
+        revealId: "rev_3",
+        groupId: "g1",
+        scope: "message",
+        targetId: "msg_target",
+        requestedBy: "owner_1",
+        expiresAt: null,
+      },
+    };
+
+    const result = await handler(request, makeSessionRecord());
+
+    expect(result.isOk()).toBe(true);
+    // Only the targeted message should be revealed
+    expect(broadcastedEvents).toHaveLength(1);
+    const revealed = broadcastedEvents[0]?.event as RevealEvent;
+    expect(revealed.messageId).toBe("msg_target");
+    expect(revealed.revealId).toBe("rev_3");
   });
 });

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -326,6 +326,24 @@ export function createProductionDeps(): SignetRuntimeDeps {
             event as import("@xmtp/signet-schemas").SignetEvent,
           );
         },
+        listMessages: async (
+          groupId: string,
+          options?: {
+            limit?: number;
+            before?: string;
+            after?: string;
+            direction?: "ascending" | "descending";
+          },
+        ) => {
+          if (!coreImplRef) {
+            return Result.err(
+              InternalError.create(
+                "Core not initialized -- cannot list messages",
+              ),
+            );
+          }
+          return coreImplRef.context.listMessages(groupId, options);
+        },
       };
       // Only add internalSessionManager when available (exactOptionalPropertyTypes)
       if (internalSessionManagerRef) {

--- a/packages/cli/src/ws/request-handler.ts
+++ b/packages/cli/src/ws/request-handler.ts
@@ -16,10 +16,22 @@ import type {
   RevealGrant,
 } from "@xmtp/signet-schemas";
 import type { SessionManager, SessionRecord } from "@xmtp/signet-contracts";
-import { validateSendMessage } from "@xmtp/signet-policy";
+import { validateSendMessage, projectMessage } from "@xmtp/signet-policy";
+import type { RawMessage } from "@xmtp/signet-policy";
 import type { RequestHandler } from "@xmtp/signet-ws";
 import type { InternalSessionManager } from "@xmtp/signet-sessions";
 import type { PendingActionStore } from "@xmtp/signet-sessions";
+
+/** Minimal message shape needed for reveal replay. */
+export interface ReplayMessage {
+  readonly messageId: string;
+  readonly groupId: string;
+  readonly senderInboxId: string;
+  readonly contentType: string;
+  readonly content: unknown;
+  readonly sentAt: string;
+  readonly threadId: string | null;
+}
 
 /** Default expiry for pending actions: 5 minutes. */
 const PENDING_ACTION_TTL_MS = 5 * 60 * 1000;
@@ -39,6 +51,15 @@ export interface HarnessRequestHandlerDeps {
   readonly internalSessionManager?: InternalSessionManager;
   readonly pendingActions?: PendingActionStore;
   readonly broadcast?: (sessionId: string, event: SignetEvent) => void;
+  readonly listMessages?: (
+    groupId: string,
+    options?: {
+      limit?: number;
+      before?: string;
+      after?: string;
+      direction?: "ascending" | "descending";
+    },
+  ) => Promise<Result<readonly ReplayMessage[], SignetError>>;
 }
 
 /**
@@ -211,10 +232,53 @@ export function createWsRequestHandler(
 
     store.grant(grant, reveal);
 
-    // TODO: Replay affected historical messages through the projection pipeline
-    // and emit message.revealed events. Currently the grant is stored but
-    // already-hidden content is not re-delivered — future messages will use the
-    // reveal state, but historical content requires a replay mechanism.
+    // Replay historical messages through the projection pipeline
+    if (deps.listMessages && deps.broadcast) {
+      const messagesResult = await deps.listMessages(reveal.groupId);
+      if (messagesResult.isOk()) {
+        const allowlist = new Set(session.view.contentTypes);
+        for (const msg of messagesResult.value) {
+          const isRevealed = store.isRevealed(
+            msg.messageId,
+            msg.groupId,
+            msg.threadId,
+            msg.senderInboxId,
+            msg.contentType,
+            msg.sentAt,
+          );
+          if (!isRevealed) continue;
+
+          // Run through the view projection pipeline to enforce
+          // scope and content-type filters before emitting.
+          const rawMessage: RawMessage = {
+            messageId: msg.messageId,
+            groupId: msg.groupId,
+            senderInboxId: msg.senderInboxId,
+            contentType: msg.contentType,
+            content: msg.content,
+            sentAt: msg.sentAt,
+            sealId: null,
+            threadId: msg.threadId,
+          };
+          const projection = projectMessage(
+            rawMessage,
+            session.view,
+            allowlist,
+            true,
+          );
+          if (projection.action === "emit") {
+            deps.broadcast(session.sessionId, {
+              type: "message.revealed",
+              messageId: msg.messageId,
+              groupId: msg.groupId,
+              contentType: msg.contentType,
+              content: projection.event.content,
+              revealId: grant.revealId,
+            });
+          }
+        }
+      }
+    }
 
     return Result.ok(grant);
   }


### PR DESCRIPTION
## Summary

Closes #67 (part 2). When a reveal grant is stored, replays historical messages through the projection pipeline and broadcasts `message.revealed` events for matching messages.

- **`listMessages` optional dep** on `HarnessRequestHandlerDeps`: accepts a group ID and query options, returns replay messages
- **Replay logic** in `handleRevealContent`: after `store.grant()`, fetches historical messages, checks each against the reveal state store, and broadcasts revealed messages to the session
- **`ReplayMessage` type**: minimal message shape defined locally to avoid coupling to core types
- Removes the stale TODO about replay in `request-handler.ts`

The `listMessages` dep is intentionally optional — wiring from `start.ts` will happen when `SignetCore` exposes the method.

## Test plan

- [x] Replays historical messages as `message.revealed` events (thread-scoped reveal)
- [x] Skips replay when `listMessages` dep is not provided
- [x] Only replays messages matching the reveal scope (message-scoped)
- [x] `bun run check` green

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)