### PR TITLE
feat(core): tag inbound messages as historical during broker recovery

### DIFF
--- a/packages/cli/src/ws/event-projector.ts
+++ b/packages/cli/src/ws/event-projector.ts
@@ -67,6 +67,7 @@ export function createEventProjector(
       sentAt: event.sentAt,
       sealId: event.sealId,
       threadId,
+      isHistorical: event.visibility === "historical",
     };
 
     const effectiveAllowlist = getEffectiveAllowlist(session);

--- a/packages/core/src/signet-core.ts
+++ b/packages/core/src/signet-core.ts
@@ -215,7 +215,8 @@ export class SignetCoreImpl {
         }
         const msgStream = msgStreamResult.value;
         this.#streams.push(msgStream);
-        this.#consumeMessageStream(msgStream.messages);
+        const streamStartedAt = new Date().toISOString();
+        this.#consumeMessageStream(msgStream.messages, streamStartedAt);
 
         const groupStreamResult = await client.streamGroups();
         if (groupStreamResult.isErr()) {
@@ -296,8 +297,18 @@ export class SignetCoreImpl {
   /**
    * Consume messages from a stream and emit raw events.
    * Runs as a fire-and-forget async loop; errors are swallowed.
+   *
+   * Messages with sentAt before the stream start time are tagged as
+   * historical (recovery sync). This lets the harness distinguish
+   * catch-up context from live action triggers.
    */
-  #consumeMessageStream(messages: AsyncIterable<XmtpDecodedMessage>): void {
+  #consumeMessageStream(
+    messages: AsyncIterable<XmtpDecodedMessage>,
+    streamStartedAt?: string,
+  ): void {
+    const cutoffMs = streamStartedAt
+      ? new Date(streamStartedAt).getTime()
+      : Date.now();
     void (async () => {
       try {
         for await (const msg of messages) {
@@ -310,7 +321,7 @@ export class SignetCoreImpl {
             content: msg.content,
             sentAt: msg.sentAt,
             threadId: msg.threadId,
-            isHistorical: false,
+            isHistorical: new Date(msg.sentAt).getTime() < cutoffMs,
           });
         }
       } catch {

--- a/packages/policy/src/__tests__/historical-visibility.test.ts
+++ b/packages/policy/src/__tests__/historical-visibility.test.ts
@@ -1,0 +1,100 @@
+import { describe, test, expect } from "bun:test";
+import { projectMessage } from "../pipeline/project-message.js";
+import type { ContentTypeId, ViewConfig } from "@xmtp/signet-schemas";
+import { createTestRawMessage, createPassthroughView } from "./fixtures.js";
+
+describe("historical message visibility", () => {
+  const baseAllowlist = new Set([
+    "xmtp.org/text:1.0" as ContentTypeId,
+    "xmtp.org/reaction:1.0" as ContentTypeId,
+  ]);
+
+  test("historical message gets visibility 'historical' in full mode", () => {
+    const message = createTestRawMessage({ isHistorical: true });
+    const view = createPassthroughView("group-1");
+    const result = projectMessage(message, view, baseAllowlist, false);
+
+    expect(result.action).toBe("emit");
+    if (result.action === "emit") {
+      expect(result.event.visibility).toBe("historical");
+      expect(result.event.content).toEqual({ text: "hello" });
+    }
+  });
+
+  test("historical message gets visibility 'historical' in thread-only mode", () => {
+    const message = createTestRawMessage({ isHistorical: true });
+    const view: ViewConfig = {
+      mode: "thread-only",
+      threadScopes: [{ groupId: "group-1", threadId: null }],
+      contentTypes: ["xmtp.org/text:1.0" as ContentTypeId],
+    };
+    const result = projectMessage(message, view, baseAllowlist, false);
+
+    expect(result.action).toBe("emit");
+    if (result.action === "emit") {
+      expect(result.event.visibility).toBe("historical");
+    }
+  });
+
+  test("historical message in redacted mode keeps redacted visibility", () => {
+    const message = createTestRawMessage({ isHistorical: true });
+    const view: ViewConfig = {
+      mode: "redacted",
+      threadScopes: [{ groupId: "group-1", threadId: null }],
+      contentTypes: ["xmtp.org/text:1.0" as ContentTypeId],
+    };
+    const result = projectMessage(message, view, baseAllowlist, false);
+
+    expect(result.action).toBe("emit");
+    if (result.action === "emit") {
+      expect(result.event.visibility).toBe("redacted");
+    }
+  });
+
+  test("historical message in reveal-only mode is still dropped without reveal", () => {
+    const message = createTestRawMessage({ isHistorical: true });
+    const view: ViewConfig = {
+      mode: "reveal-only",
+      threadScopes: [{ groupId: "group-1", threadId: null }],
+      contentTypes: ["xmtp.org/text:1.0" as ContentTypeId],
+    };
+    const result = projectMessage(message, view, baseAllowlist, false);
+
+    expect(result.action).toBe("drop");
+  });
+
+  test("non-historical message preserves normal visibility", () => {
+    const message = createTestRawMessage({ isHistorical: false });
+    const view = createPassthroughView("group-1");
+    const result = projectMessage(message, view, baseAllowlist, false);
+
+    expect(result.action).toBe("emit");
+    if (result.action === "emit") {
+      expect(result.event.visibility).toBe("visible");
+    }
+  });
+
+  test("historical flag defaults to false when omitted", () => {
+    const message = createTestRawMessage();
+    const view = createPassthroughView("group-1");
+    const result = projectMessage(message, view, baseAllowlist, false);
+
+    expect(result.action).toBe("emit");
+    if (result.action === "emit") {
+      expect(result.event.visibility).toBe("visible");
+    }
+  });
+
+  test("historical message preserves metadata", () => {
+    const message = createTestRawMessage({ isHistorical: true });
+    const view = createPassthroughView("group-1");
+    const result = projectMessage(message, view, baseAllowlist, false);
+
+    expect(result.action).toBe("emit");
+    if (result.action === "emit") {
+      expect(result.event.senderInboxId).toBe("sender-1");
+      expect(result.event.contentType).toBe("xmtp.org/text:1.0");
+      expect(result.event.sentAt).toBe("2024-01-01T00:00:00Z");
+    }
+  });
+});

--- a/packages/policy/src/pipeline/project-message.ts
+++ b/packages/policy/src/pipeline/project-message.ts
@@ -39,10 +39,20 @@ export function projectMessage(
   }
 
   // Stage 3: Visibility resolver
-  const visibility = resolveVisibility(view.mode, isRevealed);
-  if (visibility === "hidden") {
+  const baseVisibility = resolveVisibility(view.mode, isRevealed);
+  if (baseVisibility === "hidden") {
     return DROP;
   }
+
+  // Stage 3b: Historical override — non-hidden messages during recovery
+  // are tagged as historical so the harness can treat them as context,
+  // not action triggers.
+  const visibility =
+    message.isHistorical === true &&
+    baseVisibility !== "redacted" &&
+    baseVisibility !== "revealed"
+      ? ("historical" as const)
+      : baseVisibility;
 
   // Stage 4: Content projector
   const content = projectContent(

--- a/packages/policy/src/types.ts
+++ b/packages/policy/src/types.ts
@@ -14,6 +14,8 @@ export interface RawMessage {
   readonly sentAt: string;
   readonly threadId: string | null;
   readonly sealId: string | null;
+  /** True if received during broker recovery sync. Defaults to false. */
+  readonly isHistorical?: boolean;
 }
 
 /** Result of projecting a raw message through the view pipeline. */


### PR DESCRIPTION
Wire isHistorical through the projection pipeline so the harness can
distinguish catch-up context from live action triggers. Messages with
sentAt before the stream start time are tagged as historical. The
visibility resolver overrides to "historical" for non-redacted,
non-hidden messages during recovery.

Closes #78 (partial — historical tagging only, action expiry follows)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)