### PR TITLE
feat(sessions): add configurable TTL and logging for pending action expiry

### DIFF
--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -100,6 +100,7 @@ export type CliConfig = {
     defaultTtlSeconds: number;
     maxConcurrentPerAgent: number;
     heartbeatIntervalSeconds: number;
+    actionExpirySeconds: number;
   };
   logging: {
     level: "debug" | "info" | "warn" | "error";
@@ -128,6 +129,7 @@ type CliConfigInput = {
         defaultTtlSeconds?: number | undefined;
         maxConcurrentPerAgent?: number | undefined;
         heartbeatIntervalSeconds?: number | undefined;
+        actionExpirySeconds?: number | undefined;
       }
     | undefined;
   logging?:
@@ -207,6 +209,12 @@ const CliConfigBaseSchema = z
           .positive()
           .default(30)
           .describe("Heartbeat interval in seconds"),
+        actionExpirySeconds: z
+          .number()
+          .int()
+          .positive()
+          .default(300)
+          .describe("TTL for pending actions awaiting confirmation (seconds)"),
       })
       .default({}),
     logging: z

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -154,7 +154,11 @@ export async function createSignetRuntime(
   });
 
   const wsServer = deps.createWsServer(
-    { port: config.ws.port, host: config.ws.host },
+    {
+      port: config.ws.port,
+      host: config.ws.host,
+      actionExpirySeconds: config.sessions.actionExpirySeconds,
+    },
     {
       core,
       sessionManager,

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -299,7 +299,11 @@ export function createProductionDeps(): SignetRuntimeDeps {
     },
 
     createWsServer(config: unknown, deps: unknown): WsServer {
-      const cfg = config as { port: number; host: string };
+      const cfg = config as {
+        port: number;
+        host: string;
+        actionExpirySeconds?: number;
+      };
       const d = deps as {
         core: SignetCore;
         sessionManager: import("@xmtp/signet-contracts").SessionManager;
@@ -307,6 +311,7 @@ export function createProductionDeps(): SignetRuntimeDeps {
       };
 
       const pendingActions = createPendingActionStore();
+      const actionExpiryMs = (cfg.actionExpirySeconds ?? 300) * 1000;
 
       // Late-bound broadcast: the WS server isn't created yet when
       // the request handler is wired, so we capture a mutable ref.
@@ -320,6 +325,24 @@ export function createProductionDeps(): SignetRuntimeDeps {
           d.core.sendMessage(groupId, contentType, content),
         sessionManager: d.sessionManager,
         pendingActions,
+        actionExpiryMs,
+        onActionExpired: (action: {
+          actionId: string;
+          sessionId: string;
+          actionType: string;
+          createdAt: string;
+          expiresAt: string;
+        }) => {
+          // eslint-disable-next-line no-console
+          console.info(
+            "[audit] action expired: %s (%s) session=%s created=%s expired=%s",
+            action.actionId,
+            action.actionType,
+            action.sessionId,
+            action.createdAt,
+            action.expiresAt,
+          );
+        },
         broadcast: (sessionId: string, event: unknown) => {
           wsServerRef?.broadcast(
             sessionId,

--- a/packages/cli/src/ws/request-handler.ts
+++ b/packages/cli/src/ws/request-handler.ts
@@ -34,7 +34,7 @@ export interface ReplayMessage {
 }
 
 /** Default expiry for pending actions: 5 minutes. */
-const PENDING_ACTION_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_ACTION_EXPIRY_MS = 5 * 60 * 1000;
 
 /** Dependencies required to route harness requests through the WS transport. */
 export interface HarnessRequestHandlerDeps {
@@ -60,6 +60,16 @@ export interface HarnessRequestHandlerDeps {
       direction?: "ascending" | "descending";
     },
   ) => Promise<Result<readonly ReplayMessage[], SignetError>>;
+  /** Action expiry TTL in milliseconds. Defaults to 5 minutes. */
+  readonly actionExpiryMs?: number;
+  /** Optional callback for logging expired actions. */
+  readonly onActionExpired?: (action: {
+    actionId: string;
+    sessionId: string;
+    actionType: string;
+    createdAt: string;
+    expiresAt: string;
+  }) => void;
 }
 
 /**
@@ -116,7 +126,7 @@ export function createWsRequestHandler(
           },
           createdAt: now.toISOString(),
           expiresAt: new Date(
-            now.getTime() + PENDING_ACTION_TTL_MS,
+            now.getTime() + (deps.actionExpiryMs ?? DEFAULT_ACTION_EXPIRY_MS),
           ).toISOString(),
         });
 
@@ -363,6 +373,13 @@ export function createWsRequestHandler(
       new Date(pending.expiresAt).getTime() < Date.now()
     ) {
       deps.pendingActions.deny(request.actionId);
+      deps.onActionExpired?.({
+        actionId: pending.actionId,
+        sessionId: pending.sessionId,
+        actionType: pending.actionType,
+        createdAt: pending.createdAt,
+        expiresAt: pending.expiresAt,
+      });
       return Result.err(
         PermissionError.create("Pending action has expired", {
           actionId: request.actionId,

--- a/packages/sessions/src/__tests__/pending-actions.test.ts
+++ b/packages/sessions/src/__tests__/pending-actions.test.ts
@@ -58,28 +58,28 @@ describe("createPendingActionStore", () => {
     expect(store.deny("unknown")).toBeNull();
   });
 
-  test("expireStale removes expired actions and returns count", () => {
-    store.add(
-      makeAction({
-        actionId: "act_expired",
-        expiresAt: "2024-01-01T00:04:00Z",
-      }),
-    );
+  test("expireStale removes expired actions and returns them", () => {
+    const expired = makeAction({
+      actionId: "act_expired",
+      expiresAt: "2024-01-01T00:04:00Z",
+    });
+    store.add(expired);
     store.add(
       makeAction({ actionId: "act_valid", expiresAt: "2024-01-01T00:10:00Z" }),
     );
 
     // Now is after act_expired but before act_valid
     const removed = store.expireStale(new Date("2024-01-01T00:05:00Z"));
-    expect(removed).toBe(1);
+    expect(removed).toHaveLength(1);
+    expect(removed[0]!.actionId).toBe("act_expired");
     expect(store.get("act_expired")).toBeNull();
     expect(store.get("act_valid")).not.toBeNull();
   });
 
-  test("expireStale returns 0 when nothing expired", () => {
+  test("expireStale returns empty array when nothing expired", () => {
     store.add(makeAction({ expiresAt: "2024-12-31T23:59:59Z" }));
     const removed = store.expireStale(new Date("2024-01-01T00:00:00Z"));
-    expect(removed).toBe(0);
+    expect(removed).toHaveLength(0);
   });
 
   test("listBySession filters by sessionId", () => {

--- a/packages/sessions/src/pending-actions.ts
+++ b/packages/sessions/src/pending-actions.ts
@@ -29,8 +29,8 @@ export interface PendingActionStore {
   /** Deny an action: removes and returns it, or null if not found. */
   deny(actionId: string): PendingAction | null;
 
-  /** Remove all expired actions. Returns the number removed. */
-  expireStale(now: Date): number;
+  /** Remove all expired actions. Returns the removed actions for logging. */
+  expireStale(now: Date): readonly PendingAction[];
 
   /** List all pending actions for a given session. */
   listBySession(sessionId: string): readonly PendingAction[];
@@ -64,16 +64,16 @@ export function createPendingActionStore(): PendingActionStore {
       return removeAndReturn(actionId);
     },
 
-    expireStale(now: Date): number {
+    expireStale(now: Date): readonly PendingAction[] {
       const nowMs = now.getTime();
-      let removed = 0;
+      const expired: PendingAction[] = [];
       for (const [id, action] of actions) {
         if (new Date(action.expiresAt).getTime() <= nowMs) {
           actions.delete(id);
-          removed++;
+          expired.push(action);
         }
       }
-      return removed;
+      return expired;
     },
 
     listBySession(sessionId: string): readonly PendingAction[] {


### PR DESCRIPTION
Make action expiry TTL configurable via sessions.actionExpirySeconds
(default 300s). expireStale() now returns the expired actions instead
of just a count, enabling audit logging. Wire onActionExpired callback
through the request handler for structured expiry logging.

Closes #78 (partial — outbound action expiry)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)