### PR TITLE
feat(sessions): add heartbeat staleness check and request handler guard

### DIFF
--- a/packages/cli/src/ws/request-handler.ts
+++ b/packages/cli/src/ws/request-handler.ts
@@ -465,6 +465,30 @@ export function createWsRequestHandler(
     request: HarnessRequest,
     session: SessionRecord,
   ): Promise<Result<unknown, SignetError>> => {
+    // Guard: reject non-heartbeat requests when the session's heartbeat
+    // is stale. This enforces liveness — the harness must maintain its
+    // heartbeat cadence to keep sending requests.
+    if (
+      request.type !== "heartbeat" &&
+      deps.internalSessionManager &&
+      typeof deps.internalSessionManager.isHeartbeatStale === "function"
+    ) {
+      try {
+        const staleResult = deps.internalSessionManager.isHeartbeatStale(
+          session.sessionId,
+        );
+        if (staleResult.isOk() && staleResult.value) {
+          return Result.err(
+            AuthError.create(
+              "Session heartbeat is stale — send a heartbeat before making requests",
+            ),
+          );
+        }
+      } catch {
+        // Staleness check failed — proceed rather than blocking the request
+      }
+    }
+
     switch (request.type) {
       case "send_message":
         return handleSendMessage(request, session);

--- a/packages/sessions/src/__tests__/heartbeat-staleness.test.ts
+++ b/packages/sessions/src/__tests__/heartbeat-staleness.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { createSessionManager } from "../session-manager.js";
+import type { InternalSessionManager } from "../session-manager.js";
+import { createTestSessionConfig } from "./fixtures.js";
+
+let manager: InternalSessionManager;
+
+beforeEach(() => {
+  manager = createSessionManager({
+    heartbeatGracePeriod: 2,
+  });
+});
+
+describe("isHeartbeatStale", () => {
+  test("returns false for freshly created session", async () => {
+    const created = await manager.createSession(
+      createTestSessionConfig({ heartbeatInterval: 5 }),
+      "fp_1",
+    );
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+
+    const result = manager.isHeartbeatStale(created.value.sessionId);
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    expect(result.value).toBe(false);
+  });
+
+  test("returns true when heartbeat exceeds interval + grace period", async () => {
+    const created = await manager.createSession(
+      createTestSessionConfig({ heartbeatInterval: 0.1 }),
+      "fp_1",
+    );
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+
+    // Wait for heartbeat interval + grace period to elapse
+    await new Promise((resolve) => setTimeout(resolve, 2200));
+
+    const result = manager.isHeartbeatStale(created.value.sessionId);
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    expect(result.value).toBe(true);
+  });
+
+  test("returns false after recording a fresh heartbeat", async () => {
+    const created = await manager.createSession(
+      createTestSessionConfig({ heartbeatInterval: 0.1 }),
+      "fp_1",
+    );
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+
+    // Wait a bit, then record heartbeat
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    manager.recordHeartbeat(created.value.sessionId);
+
+    const result = manager.isHeartbeatStale(created.value.sessionId);
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    expect(result.value).toBe(false);
+  });
+
+  test("returns NotFoundError for unknown session", () => {
+    const result = manager.isHeartbeatStale("unknown");
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/packages/sessions/src/session-manager.ts
+++ b/packages/sessions/src/session-manager.ts
@@ -118,6 +118,8 @@ export interface InternalSessionManager {
     state: InternalSessionRecord["state"],
   ): Result<InternalSessionRecord, NotFoundError>;
   sweepExpired(): readonly InternalSessionRecord[];
+  /** Check if a session's heartbeat has exceeded interval + grace period. */
+  isHeartbeatStale(sessionId: string): Result<boolean, NotFoundError>;
 }
 
 /** Hooks for session-manager side effects. */
@@ -480,6 +482,22 @@ export function createSessionManager(
         newGrant,
       );
       return Result.ok(result);
+    },
+
+    isHeartbeatStale(sessionId: string): Result<boolean, NotFoundError> {
+      const record = byId.get(sessionId);
+      if (!record) {
+        return Result.err(NotFoundError.create("Session", sessionId));
+      }
+      if (record.state !== "active") {
+        return Result.ok(false);
+      }
+      const lastHb = new Date(record.lastHeartbeat).getTime();
+      const deadline =
+        lastHb +
+        record.heartbeatInterval * 1000 +
+        config.heartbeatGracePeriod * 1000;
+      return Result.ok(Date.now() >= deadline);
     },
 
     sweepExpired() {


### PR DESCRIPTION
Add isHeartbeatStale() to InternalSessionManager that computes whether
a session's heartbeat has exceeded interval + grace period. Wire a
pre-request guard in the WS handler that rejects non-heartbeat requests
when the session is stale, enforcing harness liveness.

Closes #77 (partial — staleness enforcement, liveness signal follows)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)