### PR TITLE
feat(seals): add liveness content type and group-visible signal emission

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -22,6 +22,7 @@ export type SignetCoreConfig = {
   env: XmtpEnv;
   identityMode: IdentityMode;
   heartbeatIntervalMs: number;
+  livenessIntervalMs: number;
   syncTimeoutMs: number;
   appVersion: string;
 };
@@ -32,6 +33,7 @@ type SignetCoreConfigInput = {
   env?: XmtpEnv | undefined;
   identityMode?: IdentityMode | undefined;
   heartbeatIntervalMs?: number | undefined;
+  livenessIntervalMs?: number | undefined;
   syncTimeoutMs?: number | undefined;
   appVersion?: string | undefined;
 };
@@ -54,6 +56,12 @@ export const SignetCoreConfigSchema: z.ZodType<
       .positive()
       .default(30_000)
       .describe("Heartbeat emission interval in milliseconds"),
+    livenessIntervalMs: z
+      .number()
+      .int()
+      .positive()
+      .default(60_000)
+      .describe("Liveness signal publication interval in milliseconds"),
     syncTimeoutMs: z
       .number()
       .int()

--- a/packages/core/src/raw-events.ts
+++ b/packages/core/src/raw-events.ts
@@ -55,6 +55,13 @@ export interface RawHeartbeatEvent {
   readonly timestamp: string;
 }
 
+/** Liveness signal to be published to XMTP groups. */
+export interface RawLivenessEvent {
+  readonly type: "raw.liveness";
+  readonly timestamp: string;
+  readonly heartbeatIntervalSeconds: number;
+}
+
 /** Union of all raw events emitted by the core. */
 export type CoreRawEvent =
   | RawMessageEvent
@@ -62,7 +69,8 @@ export type CoreRawEvent =
   | RawGroupUpdatedEvent
   | RawCoreStartedEvent
   | RawCoreStoppedEvent
-  | RawHeartbeatEvent;
+  | RawHeartbeatEvent
+  | RawLivenessEvent;
 
 /** Handler function for raw events. */
 export type RawEventHandler = (event: CoreRawEvent) => void;

--- a/packages/core/src/signet-core.ts
+++ b/packages/core/src/signet-core.ts
@@ -49,6 +49,7 @@ export class SignetCoreImpl {
   readonly #identityStore: SqliteIdentityStore;
   readonly #context: SignetCoreContext;
   #heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  #livenessTimer: ReturnType<typeof setInterval> | null = null;
   #streams: Array<{ abort: () => void }> = [];
 
   constructor(
@@ -376,12 +377,28 @@ export class SignetCoreImpl {
         timestamp: new Date().toISOString(),
       });
     }, this.#config.heartbeatIntervalMs);
+
+    // Liveness signal: published at a separate (typically slower) cadence
+    // so group members can detect agent availability.
+    this.#livenessTimer = setInterval(() => {
+      this.#emitter.emit({
+        type: "raw.liveness",
+        timestamp: new Date().toISOString(),
+        heartbeatIntervalSeconds: Math.round(
+          this.#config.livenessIntervalMs / 1000,
+        ),
+      });
+    }, this.#config.livenessIntervalMs);
   }
 
   #stopHeartbeat(): void {
     if (this.#heartbeatTimer !== null) {
       clearInterval(this.#heartbeatTimer);
       this.#heartbeatTimer = null;
+    }
+    if (this.#livenessTimer !== null) {
+      clearInterval(this.#livenessTimer);
+      this.#livenessTimer = null;
     }
   }
 }

--- a/packages/integration/src/fixtures/test-runtime.ts
+++ b/packages/integration/src/fixtures/test-runtime.ts
@@ -154,6 +154,7 @@ export async function createTestRuntime(options?: TestRuntimeOptions): Promise<{
       env: "dev",
       identityMode: "per-group",
       heartbeatIntervalMs: 60_000, // long to avoid noise in tests
+      livenessIntervalMs: 120_000,
       syncTimeoutMs: 5_000,
       appVersion: "test/0.1.0",
     },

--- a/packages/seals/src/__tests__/liveness-content-type.test.ts
+++ b/packages/seals/src/__tests__/liveness-content-type.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from "bun:test";
+import {
+  LIVENESS_CONTENT_TYPE_ID,
+  LivenessMessage,
+  encodeLivenessMessage,
+} from "../content-type.js";
+
+describe("liveness content type", () => {
+  test("LIVENESS_CONTENT_TYPE_ID follows naming convention", () => {
+    expect(LIVENESS_CONTENT_TYPE_ID).toBe("xmtp.org/agentLiveness:1.0");
+  });
+
+  test("encodeLivenessMessage attaches contentType discriminator", () => {
+    const msg = encodeLivenessMessage({
+      agentInboxId: "agent-1",
+      timestamp: "2024-01-01T00:00:00Z",
+      heartbeatIntervalSeconds: 30,
+    });
+
+    expect(msg.contentType).toBe(LIVENESS_CONTENT_TYPE_ID);
+    expect(msg.agentInboxId).toBe("agent-1");
+    expect(msg.timestamp).toBe("2024-01-01T00:00:00Z");
+    expect(msg.heartbeatIntervalSeconds).toBe(30);
+  });
+
+  test("LivenessMessage schema validates correct payload", () => {
+    const result = LivenessMessage.safeParse({
+      agentInboxId: "agent-1",
+      timestamp: "2024-01-01T00:00:00Z",
+      heartbeatIntervalSeconds: 30,
+      contentType: LIVENESS_CONTENT_TYPE_ID,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("LivenessMessage schema rejects invalid timestamp", () => {
+    const result = LivenessMessage.safeParse({
+      agentInboxId: "agent-1",
+      timestamp: "not-a-date",
+      heartbeatIntervalSeconds: 30,
+      contentType: LIVENESS_CONTENT_TYPE_ID,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("LivenessMessage schema rejects wrong content type", () => {
+    const result = LivenessMessage.safeParse({
+      agentInboxId: "agent-1",
+      timestamp: "2024-01-01T00:00:00Z",
+      heartbeatIntervalSeconds: 30,
+      contentType: "xmtp.org/wrong:1.0",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/seals/src/content-type.ts
+++ b/packages/seals/src/content-type.ts
@@ -7,6 +7,9 @@ import {
 import { RevocationSeal } from "@xmtp/signet-schemas";
 import type { RevocationSeal as RevocationSealType } from "@xmtp/signet-schemas";
 
+/** Custom XMTP content type identifier for liveness payloads. */
+export const LIVENESS_CONTENT_TYPE_ID = "xmtp.org/agentLiveness:1.0" as const;
+
 /** Custom XMTP content type identifier for seal payloads. */
 export const SEAL_CONTENT_TYPE_ID = "xmtp.org/agentSeal:1.0" as const;
 
@@ -66,4 +69,36 @@ export function encodeRevocationMessage(
   envelope: SignedRevocationEnvelope,
 ): RevocationMessage {
   return { contentType: REVOCATION_CONTENT_TYPE_ID, ...envelope };
+}
+
+// ---------------------------------------------------------------------------
+// Liveness
+// ---------------------------------------------------------------------------
+
+/** Liveness signal published to XMTP groups for group-visible agent status. */
+export type LivenessMessage = {
+  readonly agentInboxId: string;
+  readonly timestamp: string;
+  readonly heartbeatIntervalSeconds: number;
+  readonly contentType: typeof LIVENESS_CONTENT_TYPE_ID;
+};
+
+/** Schema for a liveness signal with contentType discriminator. */
+const _LivenessMessage = z
+  .object({
+    agentInboxId: z.string(),
+    timestamp: z.string().datetime(),
+    heartbeatIntervalSeconds: z.number().int().positive(),
+    contentType: z.literal(LIVENESS_CONTENT_TYPE_ID),
+  })
+  .describe("Liveness signal with content type discriminator");
+
+/** Zod schema for a liveness signal payload. */
+export const LivenessMessage: z.ZodType<LivenessMessage> = _LivenessMessage;
+
+/** Wraps liveness data with the contentType discriminator field. */
+export function encodeLivenessMessage(
+  data: Omit<LivenessMessage, "contentType">,
+): LivenessMessage {
+  return { contentType: LIVENESS_CONTENT_TYPE_ID, ...data };
 }


### PR DESCRIPTION
Define LIVENESS_CONTENT_TYPE_ID with LivenessMessage schema and encoder.
Add raw.liveness event type and configurable livenessIntervalMs (default
60s) to the core. The core emits liveness events on a separate timer
from heartbeats, allowing group members to detect agent availability.

Closes #77

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)