### PR TITLE
feat(sessions): wire session revocation to seal revocation publishing

### DIFF
--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -83,6 +83,10 @@ export function createProductionDeps(): SignetRuntimeDeps {
   let internalSessionManagerRef: InternalSessionManager | null = null;
   // Late-bound WS server ref for session invalidation callbacks
   let globalWsServerRef: WsServer | null = null;
+  // Late-bound seal manager ref for revocation publishing
+  let globalSealManagerRef:
+    | import("@xmtp/signet-contracts").SealManager
+    | null = null;
 
   return {
     async createKeyManager(
@@ -198,6 +202,27 @@ export function createProductionDeps(): SignetRuntimeDeps {
             // the async lookup, so no events leak under stale policy.
             void globalWsServerRef?.invalidateSession(sessionId);
           },
+          onSessionRevoked(session) {
+            // Trigger seal revocation publishing when a session is revoked.
+            // The seal manager publishes a RevocationSeal to the XMTP group.
+            if (!globalSealManagerRef) return;
+            const reason =
+              session.revocationReason === "reauthorization-required"
+                ? "admin-removed"
+                : (session.revocationReason ?? "owner-initiated");
+            void (async () => {
+              const sealResult = await globalSealManagerRef!.current(
+                session.agentInboxId,
+                "", // groupId not available on session — seal lookup by agent
+              );
+              if (sealResult.isOk() && sealResult.value !== null) {
+                await globalSealManagerRef!.revoke(
+                  sealResult.value.seal.sealId,
+                  reason as import("@xmtp/signet-schemas").AgentRevocationReason,
+                );
+              }
+            })();
+          },
         },
       );
       internalSessionManagerRef = internal;
@@ -291,11 +316,13 @@ export function createProductionDeps(): SignetRuntimeDeps {
         );
       };
 
-      return createSealManagerImpl({
+      const sealManager = createSealManagerImpl({
         signer,
         publisher,
         resolveInput,
       });
+      globalSealManagerRef = sealManager;
+      return sealManager;
     },
 
     createWsServer(config: unknown, deps: unknown): WsServer {

--- a/packages/sessions/src/session-manager.ts
+++ b/packages/sessions/src/session-manager.ts
@@ -126,6 +126,8 @@ export interface InternalSessionManager {
 export interface SessionManagerOptions {
   /** Called when a session's policy/state is mutated (for cache invalidation). */
   readonly onSessionMutated?: (sessionId: string) => void;
+  /** Called when a session is revoked. Receives the full record for seal publishing. */
+  readonly onSessionRevoked?: (session: InternalSessionRecord) => void;
 }
 
 /** Create a new session manager with the given configuration. */
@@ -234,11 +236,15 @@ export function createSessionManager(
     reason: SessionRevocationReason,
   ): Result<InternalSessionRecord, InternalError> {
     cleanupRevealState(sessionId);
-    return mutateRecord(sessionId, {
+    const result = mutateRecord(sessionId, {
       state: "revoked",
       revokedAt: now(),
       revocationReason: reason,
     });
+    if (result.isOk()) {
+      options?.onSessionRevoked?.(result.value);
+    }
+    return result;
   }
 
   const manager: InternalSessionManager = {


### PR DESCRIPTION
Add onSessionRevoked callback to SessionManagerOptions. When a session
is revoked, the callback fires with the full record, enabling the
runtime to trigger seal revocation publishing. Wire in start.ts to
look up the current seal and call sealManager.revoke() which publishes
a RevocationSeal to the XMTP group.

Closes #79 (partial — publishing wired, fail-closed follows)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)