### PR TITLE
feat(cli): fail-closed session check before sending messages

### DIFF
--- a/packages/cli/src/__tests__/ws-request-handler.test.ts
+++ b/packages/cli/src/__tests__/ws-request-handler.test.ts
@@ -67,6 +67,7 @@ describe("createWsRequestHandler", () => {
       },
       sessionManager: {
         heartbeat: async () => Result.ok(undefined),
+        lookup: async () => Result.ok(makeSessionRecord()),
       },
     });
 

--- a/packages/cli/src/ws/request-handler.ts
+++ b/packages/cli/src/ws/request-handler.ts
@@ -168,6 +168,25 @@ export function createWsRequestHandler(
       return readyResult;
     }
 
+    // Fail-closed: re-check session state after core readiness.
+    // The session may have been revoked during the ensureCoreReady() await.
+    const freshResult = await deps.sessionManager.lookup(session.sessionId);
+    if (freshResult.isErr()) {
+      return freshResult;
+    }
+    if (freshResult.value.state !== "active") {
+      return Result.err(
+        AuthError.create(
+          `Session is ${freshResult.value.state} — cannot send messages`,
+        ),
+      );
+    }
+
+    const readyResult = await deps.ensureCoreReady();
+    if (readyResult.isErr()) {
+      return readyResult;
+    }
+
     const sendResult = await deps.sendMessage(
       request.groupId,
       request.contentType,


### PR DESCRIPTION
Re-check session state via lookup before executing sendMessage. If the
session has been revoked between auth and request processing, the send
is rejected with AuthError. This prevents in-flight messages from
being delivered after revocation.

Closes #79

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)