### PR TITLE
feat(keys): add auto-rotation for operational keys

### DIFF
--- a/packages/keys/src/__tests__/auto-rotation.test.ts
+++ b/packages/keys/src/__tests__/auto-rotation.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createKeyManager, type KeyManager } from "../key-manager.js";
+
+let tmpDir: string;
+let manager: KeyManager | null = null;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "key-rotation-test-"));
+});
+
+afterEach(() => {
+  manager?.close();
+  manager = null;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("auto-rotation", () => {
+  test("startAutoRotation is a no-op when interval is 0", async () => {
+    const result = await createKeyManager({
+      dataDir: tmpDir,
+      rotationIntervalSeconds: 0,
+    });
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    manager = result.value;
+
+    // Should not throw
+    manager.startAutoRotation();
+    manager.stopAutoRotation();
+  });
+
+  test("rotateOperationalKey creates new key material", async () => {
+    const result = await createKeyManager({
+      dataDir: tmpDir,
+      rotationIntervalSeconds: 86400,
+    });
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    manager = result.value;
+
+    await manager.initialize();
+    const createResult = await manager.createOperationalKey("id-1", null);
+    expect(createResult.isOk()).toBe(true);
+    if (!createResult.isOk()) return;
+    const original = createResult.value;
+
+    const rotateResult = await manager.rotateOperationalKey("id-1");
+    expect(rotateResult.isOk()).toBe(true);
+    if (!rotateResult.isOk()) return;
+    const rotated = rotateResult.value;
+
+    expect(rotated.keyId).not.toBe(original.keyId);
+    expect(rotated.fingerprint).not.toBe(original.fingerprint);
+    expect(rotated.identityId).toBe(original.identityId);
+    expect(rotated.rotatedAt).toBeTruthy();
+  });
+
+  test("close stops auto-rotation timer", async () => {
+    const result = await createKeyManager({
+      dataDir: tmpDir,
+      rotationIntervalSeconds: 1,
+    });
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    manager = result.value;
+
+    manager.startAutoRotation();
+    // Close should clean up the timer without errors
+    manager.close();
+    manager = null;
+  });
+});

--- a/packages/keys/src/config.ts
+++ b/packages/keys/src/config.ts
@@ -24,6 +24,8 @@ export type KeyManagerConfig = {
   rootKeyPolicy: KeyPolicy;
   operationalKeyPolicy: KeyPolicy;
   sessionKeyTtlSeconds: number;
+  /** Auto-rotation interval in seconds. 0 disables auto-rotation. */
+  rotationIntervalSeconds: number;
 };
 
 /** Input to KeyManagerConfigSchema (fields with defaults are optional). */
@@ -32,6 +34,7 @@ type KeyManagerConfigInput = {
   rootKeyPolicy?: KeyPolicy | undefined;
   operationalKeyPolicy?: KeyPolicy | undefined;
   sessionKeyTtlSeconds?: number | undefined;
+  rotationIntervalSeconds?: number | undefined;
 };
 
 /** Zod schema for parsed key manager configuration. */
@@ -54,5 +57,13 @@ export const KeyManagerConfigSchema: z.ZodType<
       .positive()
       .default(3600)
       .describe("Default TTL for session keys"),
+    rotationIntervalSeconds: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(86400)
+      .describe(
+        "Auto-rotation interval for operational keys (seconds). 0 disables.",
+      ),
   })
   .describe("Key manager configuration");

--- a/packages/keys/src/key-manager.ts
+++ b/packages/keys/src/key-manager.ts
@@ -97,6 +97,12 @@ export interface KeyManager {
 
   vaultList(): readonly string[];
 
+  /** Start periodic auto-rotation of operational keys. No-op if interval is 0. */
+  startAutoRotation(): void;
+
+  /** Stop the auto-rotation timer. */
+  stopAutoRotation(): void;
+
   close(): void;
 }
 
@@ -129,6 +135,7 @@ export async function createKeyManager(
   const adminKeys: AdminKeyManager = createAdminKeyManager(vault);
 
   let rootKeyHandle: RootKeyHandle | null = null;
+  let rotationTimer: ReturnType<typeof setInterval> | null = null;
 
   const manager: KeyManager = {
     get platform(): PlatformCapability {
@@ -284,7 +291,38 @@ export async function createKeyManager(
       return vault.list();
     },
 
+    startAutoRotation(): void {
+      if (config.rotationIntervalSeconds <= 0) return;
+      if (rotationTimer !== null) return; // already running
+
+      const intervalMs = config.rotationIntervalSeconds * 1000;
+      rotationTimer = setInterval(() => {
+        void (async () => {
+          const keys = opKeys.list();
+          for (const key of keys) {
+            const result = await opKeys.rotate(key.identityId);
+            if (Result.isError(result)) {
+              // eslint-disable-next-line no-console
+              console.warn(
+                "[keys] auto-rotation failed for %s: %s",
+                key.identityId,
+                result.error.message,
+              );
+            }
+          }
+        })();
+      }, intervalMs);
+    },
+
+    stopAutoRotation(): void {
+      if (rotationTimer !== null) {
+        clearInterval(rotationTimer);
+        rotationTimer = null;
+      }
+    },
+
     close(): void {
+      manager.stopAutoRotation();
       vault.close();
     },
   };


### PR DESCRIPTION
Add rotationIntervalSeconds to KeyManagerConfig (default 24h, 0 to
disable). KeyManager gains startAutoRotation()/stopAutoRotation()
methods. The timer rotates all operational keys at the configured
interval. Existing sessions drain naturally — new seals use the
rotated key. close() stops the timer automatically.

Closes #72 (partial — auto-rotation, CLI command follows)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)