### PR TITLE
feat(cli): add signet keys rotate CLI command

### DIFF
--- a/packages/cli/src/actions/signet-actions.ts
+++ b/packages/cli/src/actions/signet-actions.ts
@@ -8,6 +8,7 @@ import type { DaemonStatus } from "../daemon/status.js";
 export interface SignetActionDeps {
   readonly status: () => Promise<DaemonStatus>;
   readonly shutdown: () => Promise<Result<void, SignetError>>;
+  readonly rotateKeys?: () => Promise<Result<{ rotated: number }, SignetError>>;
 }
 
 function widenActionSpec<TInput, TOutput>(
@@ -60,7 +61,7 @@ export function createSignetActions(
     },
   });
 
-  return [
+  const specs: ActionSpec<unknown, unknown, SignetError>[] = [
     widenActionSpec(
       createStatusSpec("signet.status", "signet:status", "signet.status"),
     ),
@@ -68,4 +69,24 @@ export function createSignetActions(
       createStopSpec("signet.stop", "signet:stop", "signet.stop"),
     ),
   ];
+
+  if (deps.rotateKeys) {
+    const rotate = deps.rotateKeys;
+    const rotateSpec: ActionSpec<
+      Record<string, never>,
+      { rotated: number },
+      SignetError
+    > = {
+      id: "keys.rotate",
+      input: z.object({}),
+      handler: async () => rotate(),
+      cli: {
+        command: "keys:rotate",
+        rpcMethod: "keys.rotate",
+      },
+    };
+    specs.push(widenActionSpec(rotateSpec));
+  }
+
+  return specs;
 }

--- a/packages/cli/src/commands/keys.ts
+++ b/packages/cli/src/commands/keys.ts
@@ -1,0 +1,43 @@
+import { Command } from "commander";
+import { Result } from "better-result";
+import { withDaemonClient } from "./admin-rpc.js";
+
+/** Build the `signet keys` command group. */
+export function buildKeysCommand(): Command {
+  const keys = new Command("keys").description("Key management operations");
+
+  keys
+    .command("rotate")
+    .description("Rotate all operational keys immediately")
+    .option("--config <path>", "Path to signet config file")
+    .option("--json", "Output JSON instead of human-readable text")
+    .action(async (options: { config?: string; json?: boolean }) => {
+      const result = await withDaemonClient(options, {}, async (client) => {
+        return client.request("keys.rotate", {});
+      });
+
+      if (Result.isError(result)) {
+        if (options.json) {
+          // eslint-disable-next-line no-console
+          console.log(
+            JSON.stringify({ ok: false, error: result.error.message }),
+          );
+        } else {
+          // eslint-disable-next-line no-console
+          console.error("Key rotation failed:", result.error.message);
+        }
+        process.exit(1);
+      }
+
+      const data = result.value as { rotated: number };
+      if (options.json) {
+        // eslint-disable-next-line no-console
+        console.log(JSON.stringify({ ok: true, ...data }));
+      } else {
+        // eslint-disable-next-line no-console
+        console.log(`Rotated ${data.rotated} operational key(s).`);
+      }
+    });
+
+  return keys;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,6 +14,7 @@ import { createSealCommands } from "./commands/seal.js";
 import { createMessageCommands } from "./commands/message.js";
 import { createConversationCommands } from "./commands/conversation.js";
 import { createAdminCommands } from "./commands/admin.js";
+import { buildKeysCommand } from "./commands/keys.js";
 
 const program: Command = new Command()
   .name("xmtp-signet")
@@ -31,6 +32,7 @@ program.addCommand(createSealCommands());
 program.addCommand(createMessageCommands());
 program.addCommand(createConversationCommands());
 program.addCommand(createAdminCommands());
+program.addCommand(buildKeysCommand());
 
 export { program };
 
@@ -83,6 +85,7 @@ export { createMessageCommands } from "./commands/message.js";
 export { createConversationCommands } from "./commands/conversation.js";
 export type { ConversationCommandDeps } from "./commands/conversation.js";
 export { createAdminCommands } from "./commands/admin.js";
+export { buildKeysCommand } from "./commands/keys.js";
 
 export { exitCodeFromCategory, EXIT_SUCCESS } from "./output/exit-codes.js";
 export type { OutputFormatter, FormatOptions } from "./output/formatter.js";

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -233,6 +233,25 @@ export async function createSignetRuntime(
       }
       return runtimeRef.shutdown();
     },
+    rotateKeys: async () => {
+      const keys = keyManager.listOperationalKeys();
+      let rotated = 0;
+      const errors: string[] = [];
+      for (const key of keys) {
+        const result = await keyManager.rotateOperationalKey(key.identityId);
+        if (result.isOk()) {
+          rotated++;
+        } else {
+          errors.push(`${key.identityId}: ${result.error.message}`);
+        }
+      }
+      if (errors.length > 0 && rotated === 0) {
+        return Result.err(
+          InternalError.create(`All rotations failed: ${errors.join("; ")}`),
+        );
+      }
+      return Result.ok({ rotated, failed: errors.length, errors });
+    },
   })) {
     registry.register(spec);
   }


### PR DESCRIPTION
Register keys.rotate action in the daemon action registry. Add
`signet keys rotate` CLI command that sends RPC to the running daemon
to rotate all operational keys immediately. Supports --json output.

Closes #72

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)