### PR TITLE
feat(keys): add biometric gate config and middleware

### DIFF
--- a/packages/keys/src/__tests__/biometric-gate.test.ts
+++ b/packages/keys/src/__tests__/biometric-gate.test.ts
@@ -1,0 +1,100 @@
+import { describe, test, expect } from "bun:test";
+import { Result } from "better-result";
+import {
+  createBiometricGate,
+  BiometricGateConfigSchema,
+  type BiometricGateConfig,
+  type GatedOperation,
+} from "../biometric-gate.js";
+
+describe("BiometricGateConfig", () => {
+  test("defaults: rootKeyCreation on, everything else off", () => {
+    const config = BiometricGateConfigSchema.parse({});
+    expect(config.rootKeyCreation).toBe(true);
+    expect(config.operationalKeyRotation).toBe(false);
+    expect(config.viewUpgrade).toBe(false);
+    expect(config.grantEscalation).toBe(false);
+    expect(config.agentCreation).toBe(false);
+  });
+});
+
+describe("createBiometricGate", () => {
+  const allOff: BiometricGateConfig = {
+    rootKeyCreation: false,
+    operationalKeyRotation: false,
+    viewUpgrade: false,
+    grantEscalation: false,
+    agentCreation: false,
+  };
+
+  const allOn: BiometricGateConfig = {
+    rootKeyCreation: true,
+    operationalKeyRotation: true,
+    viewUpgrade: true,
+    grantEscalation: true,
+    agentCreation: true,
+  };
+
+  test("passes through when operation is disabled", async () => {
+    let prompted = false;
+    const gate = createBiometricGate(allOff, async () => {
+      prompted = true;
+      return Result.ok(undefined);
+    });
+
+    const result = await gate("rootKeyCreation");
+    expect(result.isOk()).toBe(true);
+    expect(prompted).toBe(false);
+  });
+
+  test("prompts when operation is enabled", async () => {
+    const prompted: GatedOperation[] = [];
+    const gate = createBiometricGate(allOn, async (op) => {
+      prompted.push(op);
+      return Result.ok(undefined);
+    });
+
+    const result = await gate("operationalKeyRotation");
+    expect(result.isOk()).toBe(true);
+    expect(prompted).toEqual(["operationalKeyRotation"]);
+  });
+
+  test("returns error when prompter returns error", async () => {
+    const gate = createBiometricGate(allOn, async () => {
+      return Result.err({
+        _tag: "CancelledError" as const,
+        code: 1800,
+        category: "cancelled" as const,
+        message: "User cancelled",
+        context: null,
+      });
+    });
+
+    const result = await gate("viewUpgrade");
+    expect(result.isErr()).toBe(true);
+  });
+
+  test("wraps thrown errors as InternalError", async () => {
+    const gate = createBiometricGate(allOn, async () => {
+      throw new Error("SE bridge timeout");
+    });
+
+    const result = await gate("agentCreation");
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.category).toBe("internal");
+    }
+  });
+
+  test("wraps cancel-like thrown errors as CancelledError", async () => {
+    const gate = createBiometricGate(allOn, async () => {
+      throw new Error("User pressed cancel");
+    });
+
+    const result = await gate("rootKeyCreation");
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.category).toBe("cancelled");
+    }
+  });
+});

--- a/packages/keys/src/biometric-gate.ts
+++ b/packages/keys/src/biometric-gate.ts
@@ -1,0 +1,102 @@
+import { z } from "zod";
+import { Result } from "better-result";
+import { CancelledError, InternalError } from "@xmtp/signet-schemas";
+import type { SignetError } from "@xmtp/signet-schemas";
+
+/** Parsed biometric gate configuration. */
+export type BiometricGateConfig = {
+  rootKeyCreation: boolean;
+  operationalKeyRotation: boolean;
+  viewUpgrade: boolean;
+  grantEscalation: boolean;
+  agentCreation: boolean;
+};
+
+/** Input type with all fields optional for configuration merging. */
+export type BiometricGateConfigInput = {
+  rootKeyCreation?: boolean | undefined;
+  operationalKeyRotation?: boolean | undefined;
+  viewUpgrade?: boolean | undefined;
+  grantEscalation?: boolean | undefined;
+  agentCreation?: boolean | undefined;
+};
+
+/** Per-operation toggles for biometric gating. */
+export const BiometricGateConfigSchema: z.ZodType<
+  BiometricGateConfig,
+  z.ZodTypeDef,
+  BiometricGateConfigInput
+> = z
+  .object({
+    rootKeyCreation: z
+      .boolean()
+      .default(true)
+      .describe("Require biometric for root key creation"),
+    operationalKeyRotation: z
+      .boolean()
+      .default(false)
+      .describe("Require biometric for operational key rotation"),
+    viewUpgrade: z
+      .boolean()
+      .default(false)
+      .describe("Require biometric for upgrading view visibility"),
+    grantEscalation: z
+      .boolean()
+      .default(false)
+      .describe("Require biometric for adding egress grants"),
+    agentCreation: z
+      .boolean()
+      .default(false)
+      .describe("Require biometric for creating new agent inboxes"),
+  })
+  .describe("Per-operation biometric gating configuration");
+
+/** Operations that can be gated by biometric authentication. */
+export type GatedOperation =
+  | "rootKeyCreation"
+  | "operationalKeyRotation"
+  | "viewUpgrade"
+  | "grantEscalation"
+  | "agentCreation";
+
+/** Callback to prompt biometric authentication. Returns Ok if confirmed. */
+export type BiometricPrompter = (
+  operation: GatedOperation,
+) => Promise<Result<void, SignetError>>;
+
+/**
+ * Create a biometric gate that checks config before prompting.
+ *
+ * Returns a function that gates an operation: if the operation is enabled
+ * in config, it calls the prompter. If disabled, it passes through.
+ */
+export function createBiometricGate(
+  config: BiometricGateConfig,
+  prompter: BiometricPrompter,
+): (operation: GatedOperation) => Promise<Result<void, SignetError>> {
+  return async (
+    operation: GatedOperation,
+  ): Promise<Result<void, SignetError>> => {
+    if (!config[operation]) {
+      return Result.ok(undefined);
+    }
+
+    try {
+      return await prompter(operation);
+    } catch (cause) {
+      if (cause instanceof Error && cause.message.includes("cancel")) {
+        return Result.err(
+          CancelledError.create(
+            `Biometric authentication cancelled for ${operation}`,
+          ),
+        );
+      }
+      return Result.err(
+        InternalError.create(
+          `Biometric authentication failed for ${operation}`,
+          { cause: String(cause) },
+        ),
+      );
+    }
+  };
+}

--- a/packages/keys/src/index.ts
+++ b/packages/keys/src/index.ts
@@ -49,6 +49,18 @@ export { createSignerProvider } from "./signer-provider.js";
 // Seal stamper
 export { createSealStamper } from "./seal-stamper.js";
 
+// Biometric gate
+export {
+  createBiometricGate,
+  BiometricGateConfigSchema,
+} from "./biometric-gate.js";
+export type {
+  BiometricGateConfig,
+  BiometricGateConfigInput,
+  GatedOperation,
+  BiometricPrompter,
+} from "./biometric-gate.js";
+
 // Operational key manager
 export { createOperationalKeyManager } from "./operational-key.js";
 export type { OperationalKeyManager } from "./operational-key.js";


### PR DESCRIPTION
Define BiometricGateConfig with per-operation toggles (rootKeyCreation
defaults to on, everything else off). createBiometricGate() returns a
middleware function that checks config and prompts the SE bridge for
biometric confirmation. Handles cancellation and timeout errors.

Closes #71 (partial — config + middleware, wiring follows)

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)