### PR TITLE
feat(cli): wire biometric gate config into CLI config schema

### DIFF
--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -1,4 +1,9 @@
 import { z } from "zod";
+import { BiometricGateConfigSchema } from "@xmtp/signet-keys";
+import type {
+  BiometricGateConfig,
+  BiometricGateConfigInput,
+} from "@xmtp/signet-keys";
 
 // -- Admin server config --
 
@@ -90,6 +95,7 @@ export type CliConfig = {
     rootKeyPolicy: "biometric" | "passcode" | "open";
     operationalKeyPolicy: "biometric" | "passcode" | "open";
   };
+  biometricGating: BiometricGateConfig;
   ws: {
     port: number;
     host: string;
@@ -116,6 +122,7 @@ type CliConfigInput = {
         operationalKeyPolicy?: "biometric" | "passcode" | "open" | undefined;
       }
     | undefined;
+  biometricGating?: BiometricGateConfigInput | undefined;
   ws?:
     | {
         port?: number | undefined;
@@ -173,6 +180,7 @@ const CliConfigBaseSchema = z
           .describe("Protection level for operational keys"),
       })
       .default({}),
+    biometricGating: BiometricGateConfigSchema.default({}),
     ws: z
       .object({
         port: z


### PR DESCRIPTION
Add biometricGating section to CliConfig with per-operation toggles.
rootKeyCreation defaults to on, all other operations default to off.
Config propagates through the CLI config schema for runtime wiring.

Closes #71

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)