### PR TITLE
fix(keys): update seal stamper for v1 seal types

### DIFF
--- a/packages/keys/src/__tests__/seal-stamper.test.ts
+++ b/packages/keys/src/__tests__/seal-stamper.test.ts
@@ -77,7 +77,7 @@ describe("SealStamper", () => {
         chatId: "conv_12345678",
         reason: "owner-initiated" as const,
         revokedAt: new Date().toISOString(),
-        issuer: "signet",
+        issuer: "signet-1",
       };
       const result = await signer.signRevocation(revocation);
       expect(Result.isOk(result)).toBe(true);


### PR DESCRIPTION
## Summary

Updates seal-stamper to use SealPayloadType and SealEnvelopeType from
v1 schemas. Signed envelope now uses chain.current + chain.delta
structure with keyId and algorithm fields.

## Closes

Closes #142