### PR TITLE
feat(keys): KeyBackend provider-agnostic interface

### DIFF
--- a/packages/keys/src/__tests__/key-backend.test.ts
+++ b/packages/keys/src/__tests__/key-backend.test.ts
@@ -1,0 +1,226 @@
+import { describe, test, expect } from "bun:test";
+import { Result } from "better-result";
+import { NotFoundError } from "@xmtp/signet-schemas";
+import type {
+  KeyBackend,
+  WalletInfo,
+  AccountInfo,
+  SigningResult,
+  ApiKeyInfo,
+} from "../key-backend.js";
+
+/**
+ * Minimal mock that satisfies the KeyBackend interface.
+ * Every method returns a success Result with stub data.
+ */
+function createMockBackend(provider: "internal" | "ows"): KeyBackend {
+  const wallets: WalletInfo[] = [];
+  const accounts: AccountInfo[] = [];
+
+  return {
+    provider,
+
+    async createWallet(label, _passphrase) {
+      const info: WalletInfo = {
+        id: "w-1",
+        label,
+        provider,
+        accountCount: 0,
+        createdAt: new Date().toISOString(),
+      };
+      wallets.push(info);
+      return Result.ok(info);
+    },
+
+    async deleteWallet(_walletId) {
+      return Result.ok(undefined);
+    },
+
+    async listWallets() {
+      return Result.ok(wallets);
+    },
+
+    async getWallet(walletId) {
+      const wallet = wallets.find((w) => w.id === walletId);
+      if (!wallet) {
+        return Result.err(NotFoundError.create("Wallet", walletId));
+      }
+      return Result.ok(wallet);
+    },
+
+    async deriveAccount(_walletId, chain) {
+      const info: AccountInfo = {
+        index: accounts.length,
+        address: chain === "evm" ? "0xabc" : "ed25519addr",
+        chain,
+        publicKey: "0xdeadbeef",
+      };
+      accounts.push(info);
+      return Result.ok(info);
+    },
+
+    async listAccounts(_walletId) {
+      return Result.ok(accounts);
+    },
+
+    async sign(_walletId, _accountIndex, _data) {
+      const result: SigningResult = {
+        signature: new Uint8Array([1, 2, 3]),
+        publicKey: new Uint8Array([4, 5, 6]),
+        algorithm: "secp256k1",
+      };
+      return Result.ok(result);
+    },
+
+    async getXmtpIdentityKey(_walletId, _accountIndex) {
+      return Result.ok(`0x${"11".repeat(32)}` as `0x${string}`);
+    },
+
+    async createApiKey(_walletId, _credentialId, _passphrase, expiresAt) {
+      const info: ApiKeyInfo = {
+        id: "ak-1",
+        walletId: "w-1",
+        token: "tok_secret",
+        expiresAt,
+      };
+      return Result.ok(info);
+    },
+
+    async revokeApiKey(_keyId) {
+      return Result.ok(undefined);
+    },
+
+    async signWithApiKey(_token, _accountIndex, _data) {
+      const result: SigningResult = {
+        signature: new Uint8Array([7, 8, 9]),
+        publicKey: new Uint8Array([10, 11, 12]),
+        algorithm: "ed25519",
+      };
+      return Result.ok(result);
+    },
+  };
+}
+
+describe("KeyBackend", () => {
+  describe("interface contract", () => {
+    test("internal provider can be instantiated", () => {
+      const backend = createMockBackend("internal");
+      expect(backend.provider).toBe("internal");
+    });
+
+    test("ows provider can be instantiated", () => {
+      const backend = createMockBackend("ows");
+      expect(backend.provider).toBe("ows");
+    });
+  });
+
+  describe("wallet operations", () => {
+    test("createWallet returns WalletInfo on success", async () => {
+      const backend = createMockBackend("internal");
+      const result = await backend.createWallet("My Wallet", "passphrase");
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect(result.value.id).toBe("w-1");
+      expect(result.value.label).toBe("My Wallet");
+      expect(result.value.provider).toBe("internal");
+      expect(result.value.accountCount).toBe(0);
+      expect(typeof result.value.createdAt).toBe("string");
+    });
+
+    test("getWallet returns error for missing wallet", async () => {
+      const backend = createMockBackend("internal");
+      const result = await backend.getWallet("nonexistent");
+      expect(Result.isError(result)).toBe(true);
+    });
+
+    test("listWallets returns readonly array", async () => {
+      const backend = createMockBackend("internal");
+      await backend.createWallet("W1", "pass");
+      const result = await backend.listWallets();
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect(result.value.length).toBe(1);
+    });
+
+    test("deleteWallet returns void on success", async () => {
+      const backend = createMockBackend("internal");
+      const result = await backend.deleteWallet("w-1");
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect(result.value).toBeUndefined();
+    });
+  });
+
+  describe("account derivation", () => {
+    test("deriveAccount returns AccountInfo with correct chain", async () => {
+      const backend = createMockBackend("internal");
+      const result = await backend.deriveAccount("w-1", "evm");
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect(result.value.chain).toBe("evm");
+      expect(result.value.index).toBe(0);
+      expect(typeof result.value.address).toBe("string");
+      expect(typeof result.value.publicKey).toBe("string");
+    });
+
+    test("listAccounts returns readonly array", async () => {
+      const backend = createMockBackend("internal");
+      await backend.deriveAccount("w-1", "ed25519");
+      const result = await backend.listAccounts("w-1");
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect(result.value.length).toBe(1);
+      expect(result.value[0]?.chain).toBe("ed25519");
+    });
+  });
+
+  describe("signing", () => {
+    test("sign returns SigningResult", async () => {
+      const backend = createMockBackend("internal");
+      const data = new Uint8Array([0xff, 0x00]);
+      const result = await backend.sign("w-1", 0, data);
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect(result.value.signature).toBeInstanceOf(Uint8Array);
+      expect(result.value.publicKey).toBeInstanceOf(Uint8Array);
+      expect(result.value.algorithm).toBe("secp256k1");
+    });
+
+    test("signWithApiKey returns SigningResult", async () => {
+      const backend = createMockBackend("internal");
+      const data = new Uint8Array([0x01]);
+      const result = await backend.signWithApiKey("tok_secret", 0, data);
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect(result.value.signature).toBeInstanceOf(Uint8Array);
+      expect(result.value.algorithm).toBe("ed25519");
+    });
+  });
+
+  describe("api key management", () => {
+    test("createApiKey returns ApiKeyInfo", async () => {
+      const backend = createMockBackend("internal");
+      const expires = new Date(Date.now() + 86400000).toISOString();
+      const result = await backend.createApiKey(
+        "w-1",
+        "cred-1",
+        "pass",
+        expires,
+      );
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect(result.value.id).toBe("ak-1");
+      expect(result.value.walletId).toBe("w-1");
+      expect(typeof result.value.token).toBe("string");
+      expect(result.value.expiresAt).toBe(expires);
+    });
+
+    test("revokeApiKey returns void on success", async () => {
+      const backend = createMockBackend("internal");
+      const result = await backend.revokeApiKey("ak-1");
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect(result.value).toBeUndefined();
+    });
+  });
+});

--- a/packages/keys/src/index.ts
+++ b/packages/keys/src/index.ts
@@ -13,6 +13,16 @@ export type {
 // Types
 export type { RootKeyHandle, OperationalKey, SessionKey } from "./types.js";
 
+// Key backend interface
+export type {
+  KeyBackend,
+  WalletProvider,
+  WalletInfo,
+  AccountInfo,
+  SigningResult,
+  ApiKeyInfo,
+} from "./key-backend.js";
+
 // Platform detection
 export {
   detectPlatform,

--- a/packages/keys/src/key-backend.ts
+++ b/packages/keys/src/key-backend.ts
@@ -1,0 +1,144 @@
+import type { Result } from "better-result";
+import type { SignetError } from "@xmtp/signet-schemas";
+import type { WalletProviderType } from "@xmtp/signet-schemas";
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+/** Identifies the wallet provider backing this key backend. */
+export type WalletProvider = WalletProviderType;
+
+/** Summary information about a managed wallet. */
+export interface WalletInfo {
+  /** Wallet identifier. */
+  readonly id: string;
+  /** Human-readable name. */
+  readonly label: string;
+  /** Which provider manages this wallet. */
+  readonly provider: WalletProvider;
+  /** Number of derived accounts. */
+  readonly accountCount: number;
+  /** ISO 8601 creation timestamp. */
+  readonly createdAt: string;
+}
+
+/** A derived account within a wallet. */
+export interface AccountInfo {
+  /** BIP-44 derivation index. */
+  readonly index: number;
+  /** Derived address (0x-prefixed for EVM, base58 for Ed25519). */
+  readonly address: string;
+  /** Signing curve used by this account. */
+  readonly chain: "evm" | "ed25519";
+  /** Hex-encoded public key. */
+  readonly publicKey: string;
+}
+
+/** Result of a signing operation. */
+export interface SigningResult {
+  /** Raw signature bytes. */
+  readonly signature: Uint8Array;
+  /** Public key of the signer. */
+  readonly publicKey: Uint8Array;
+  /** Algorithm used to produce the signature. */
+  readonly algorithm: "secp256k1" | "ed25519";
+}
+
+/** Metadata for an API key that grants signing access to a wallet. */
+export interface ApiKeyInfo {
+  /** Key identifier (maps to credential ID). */
+  readonly id: string;
+  /** Wallet this key grants access to. */
+  readonly walletId: string;
+  /** Bearer token (shown once at creation, then redacted). */
+  readonly token: string;
+  /** ISO 8601 expiration timestamp. */
+  readonly expiresAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Backend interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Provider-agnostic interface for wallet and key operations.
+ *
+ * Implementations back either the `internal` (signet-managed BIP-39 vault)
+ * or `ows` (external OWS vault) provider. Consumers program against this
+ * interface and never touch raw key material directly.
+ */
+export interface KeyBackend {
+  /** The provider type backing this instance. */
+  readonly provider: WalletProvider;
+
+  // -- Wallet operations ---------------------------------------------------
+
+  /** Create a new wallet with a fresh BIP-39 mnemonic. */
+  createWallet(
+    label: string,
+    passphrase: string,
+  ): Promise<Result<WalletInfo, SignetError>>;
+
+  /** Delete a wallet and all derived key material. */
+  deleteWallet(walletId: string): Promise<Result<void, SignetError>>;
+
+  /** List all wallets managed by this backend. */
+  listWallets(): Promise<Result<readonly WalletInfo[], SignetError>>;
+
+  /** Get wallet info by ID. */
+  getWallet(walletId: string): Promise<Result<WalletInfo, SignetError>>;
+
+  // -- Account derivation --------------------------------------------------
+
+  /** Derive a new account at the next available BIP-44 index. */
+  deriveAccount(
+    walletId: string,
+    chain: "evm" | "ed25519",
+  ): Promise<Result<AccountInfo, SignetError>>;
+
+  /** List derived accounts for a wallet. */
+  listAccounts(
+    walletId: string,
+  ): Promise<Result<readonly AccountInfo[], SignetError>>;
+
+  // -- Signing -------------------------------------------------------------
+
+  /** Sign arbitrary data with a specific account's private key. */
+  sign(
+    walletId: string,
+    accountIndex: number,
+    data: Uint8Array,
+  ): Promise<Result<SigningResult, SignetError>>;
+
+  /**
+   * Return the EVM private key for an existing derived account.
+   *
+   * Used only for XMTP identity registration paths that require a
+   * secp256k1 private key.
+   */
+  getXmtpIdentityKey(
+    walletId: string,
+    accountIndex: number,
+  ): Promise<Result<`0x${string}`, SignetError>>;
+
+  // -- API key (credential token) management -------------------------------
+
+  /** Create an API key that grants signing access to a wallet via HKDF token. */
+  createApiKey(
+    walletId: string,
+    credentialId: string,
+    passphrase: string,
+    expiresAt: string,
+  ): Promise<Result<ApiKeyInfo, SignetError>>;
+
+  /** Revoke an API key, destroying its encrypted mnemonic copy. */
+  revokeApiKey(keyId: string): Promise<Result<void, SignetError>>;
+
+  /** Sign data using an API key token (without exposing the passphrase). */
+  signWithApiKey(
+    token: string,
+    accountIndex: number,
+    data: Uint8Array,
+  ): Promise<Result<SigningResult, SignetError>>;
+}


### PR DESCRIPTION
## Summary

Adds KeyBackend interface with wallet CRUD, BIP-44 account derivation,
signing, and HKDF API key management. Supports internal and ows providers.
Interface only — no implementation yet.

## Closes

Closes #149