### PR TITLE
feat(policy): implement scope guard for credential-based enforcement

### DIFF
--- a/packages/policy/src/__tests__/scope-guard.test.ts
+++ b/packages/policy/src/__tests__/scope-guard.test.ts
@@ -1,0 +1,91 @@
+import { describe, test, expect } from "bun:test";
+import { Result } from "better-result";
+import { NotFoundError } from "@xmtp/signet-schemas";
+import type { ScopeSetType, SignetError } from "@xmtp/signet-schemas";
+import { createScopeGuard } from "../scope-guard.js";
+import type { CredentialScopeLookup } from "../scope-guard.js";
+
+function makeLookup(scopes: ScopeSetType): CredentialScopeLookup {
+  return async () => Result.ok(scopes);
+}
+
+function makeFailingLookup(error: SignetError): CredentialScopeLookup {
+  return async () => Result.err(error);
+}
+
+describe("createScopeGuard", () => {
+  describe("check", () => {
+    test("returns true for a scope in allow and not in deny", async () => {
+      const guard = createScopeGuard(
+        makeLookup({ allow: ["send", "read-messages"], deny: [] }),
+      );
+      const result = await guard.check("send", "cred-1");
+      expect(result.isOk()).toBe(true);
+      expect(result.value).toBe(true);
+    });
+
+    test("returns false for a scope in both allow and deny (deny wins)", async () => {
+      const guard = createScopeGuard(
+        makeLookup({ allow: ["send", "read-messages"], deny: ["send"] }),
+      );
+      const result = await guard.check("send", "cred-1");
+      expect(result.isOk()).toBe(true);
+      expect(result.value).toBe(false);
+    });
+
+    test("returns false for a scope not in allow", async () => {
+      const guard = createScopeGuard(
+        makeLookup({ allow: ["read-messages"], deny: [] }),
+      );
+      const result = await guard.check("send", "cred-1");
+      expect(result.isOk()).toBe(true);
+      expect(result.value).toBe(false);
+    });
+
+    test("returns false when allow and deny are both empty", async () => {
+      const guard = createScopeGuard(makeLookup({ allow: [], deny: [] }));
+      const result = await guard.check("send", "cred-1");
+      expect(result.isOk()).toBe(true);
+      expect(result.value).toBe(false);
+    });
+
+    test("propagates lookup error", async () => {
+      const error = NotFoundError.create("credential", "cred-bad");
+      const guard = createScopeGuard(makeFailingLookup(error));
+      const result = await guard.check("send", "cred-bad");
+      expect(result.isErr()).toBe(true);
+      expect(result.error).toBe(error);
+    });
+
+    test("passes credentialId to the lookup function", async () => {
+      const lookupIds: string[] = [];
+      const guard = createScopeGuard(async (credentialId) => {
+        lookupIds.push(credentialId);
+        return Result.ok({ allow: ["send"], deny: [] });
+      });
+      await guard.check("send", "cred-42");
+      expect(lookupIds).toEqual(["cred-42"]);
+    });
+  });
+
+  describe("effectiveScopes", () => {
+    test("returns the scope set from the lookup", async () => {
+      const scopes: ScopeSetType = {
+        allow: ["send", "read-messages"],
+        deny: ["react"],
+      };
+      const guard = createScopeGuard(makeLookup(scopes));
+      const result = await guard.effectiveScopes("cred-1");
+      expect(result.isOk()).toBe(true);
+      expect(result.value).toEqual(scopes);
+    });
+
+    test("propagates lookup error", async () => {
+      const error = NotFoundError.create("credential", "cred-bad");
+      const guard = createScopeGuard(makeFailingLookup(error));
+      const result = await guard.effectiveScopes("cred-bad");
+      expect(result.isErr()).toBe(true);
+      expect(result.error).toBe(error);
+    });
+  });
+});

--- a/packages/policy/src/index.ts
+++ b/packages/policy/src/index.ts
@@ -35,3 +35,7 @@ export type {
 
 // Materiality classifier
 export { isMaterialChange, requiresReauthorization } from "./materiality.js";
+
+// Scope guard
+export { createScopeGuard } from "./scope-guard.js";
+export type { CredentialScopeLookup } from "./scope-guard.js";

--- a/packages/policy/src/scope-guard.ts
+++ b/packages/policy/src/scope-guard.ts
@@ -1,0 +1,53 @@
+import { Result } from "better-result";
+import type {
+  PermissionScopeType,
+  ScopeSetType,
+  SignetError,
+} from "@xmtp/signet-schemas";
+import { resolveScopeSet } from "@xmtp/signet-schemas";
+import type { ScopeGuard } from "@xmtp/signet-contracts";
+
+/**
+ * Callback to look up a credential's scope set by ID.
+ *
+ * Implementations typically query the credential store and return
+ * the credential's {@link ScopeSetType}. Return an error result
+ * (e.g. {@link NotFoundError}) when the credential does not exist.
+ */
+export type CredentialScopeLookup = (
+  credentialId: string,
+) => Promise<Result<ScopeSetType, SignetError>>;
+
+/**
+ * Create a {@link ScopeGuard} that resolves scopes via a credential lookup.
+ *
+ * The returned guard delegates scope resolution to
+ * {@link resolveScopeSet}, which applies deny-wins semantics:
+ * a scope is effective only if it appears in `allow` and does
+ * NOT appear in `deny`.
+ *
+ * @param lookup - Async function that retrieves a credential's scope set.
+ * @returns A {@link ScopeGuard} backed by the provided lookup.
+ */
+export function createScopeGuard(lookup: CredentialScopeLookup): ScopeGuard {
+  return {
+    async check(
+      scope: PermissionScopeType,
+      credentialId: string,
+    ): Promise<Result<boolean, SignetError>> {
+      const scopesResult = await lookup(credentialId);
+      if (scopesResult.isErr()) {
+        return scopesResult;
+      }
+
+      const resolved = resolveScopeSet(scopesResult.value);
+      return Result.ok(resolved.has(scope));
+    },
+
+    async effectiveScopes(
+      credentialId: string,
+    ): Promise<Result<ScopeSetType, SignetError>> {
+      return lookup(credentialId);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

ScopeGuard resolves scopes via credential lookup callback, checks
individual scope access with deny-wins semantics. 98 tests pass.

## Closes

Closes #156