### PR TITLE
feat(cli): operator and credential commands for xs

### DIFF
--- a/packages/cli/src/__tests__/xs-operator-commands.test.ts
+++ b/packages/cli/src/__tests__/xs-operator-commands.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+import type { Command } from "commander";
+
+/**
+ * Tests for the operator and credential command structures.
+ *
+ * These verify the Commander.js command tree matches the v1 spec:
+ * options, arguments, and descriptions are all wired correctly.
+ */
+
+/** Helper to find a subcommand by name. */
+function findSub(parent: Command, name: string): Command | undefined {
+  return parent.commands.find((c) => c.name() === name);
+}
+
+/** Helper to get option flags from a command. */
+function optionFlags(cmd: Command): string[] {
+  return cmd.options.map((o) => o.long ?? o.short ?? "");
+}
+
+describe("operator commands", () => {
+  // Lazy import so test file can be written before implementation exists
+  async function load() {
+    const { createOperatorCommands } =
+      await import("../commands/xs-operator.js");
+    return createOperatorCommands();
+  }
+
+  test("top-level command is named operator", async () => {
+    const cmd = await load();
+    expect(cmd.name()).toBe("operator");
+  });
+
+  test("has description", async () => {
+    const cmd = await load();
+    expect(cmd.description()).toBeTruthy();
+  });
+
+  test("create subcommand has --label required option", async () => {
+    const cmd = await load();
+    const create = findSub(cmd, "create");
+    expect(create).toBeDefined();
+    const flags = optionFlags(create!);
+    expect(flags).toContain("--label");
+  });
+
+  test("create subcommand has --role, --scope, --provider options", async () => {
+    const cmd = await load();
+    const create = findSub(cmd, "create");
+    expect(create).toBeDefined();
+    const flags = optionFlags(create!);
+    expect(flags).toContain("--role");
+    expect(flags).toContain("--scope");
+    expect(flags).toContain("--provider");
+  });
+
+  test("create subcommand has --json option", async () => {
+    const cmd = await load();
+    const create = findSub(cmd, "create");
+    expect(create).toBeDefined();
+    const flags = optionFlags(create!);
+    expect(flags).toContain("--json");
+  });
+
+  test("list subcommand has --json option", async () => {
+    const cmd = await load();
+    const list = findSub(cmd, "list");
+    expect(list).toBeDefined();
+    const flags = optionFlags(list!);
+    expect(flags).toContain("--json");
+  });
+
+  test("info subcommand accepts an id argument", async () => {
+    const cmd = await load();
+    const info = findSub(cmd, "info");
+    expect(info).toBeDefined();
+    // Commander stores registered args
+    const args = info!.registeredArguments;
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    expect(args[0]?.name()).toBe("id");
+  });
+
+  test("rename subcommand accepts an id argument and --label option", async () => {
+    const cmd = await load();
+    const rename = findSub(cmd, "rename");
+    expect(rename).toBeDefined();
+    const args = rename!.registeredArguments;
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    expect(args[0]?.name()).toBe("id");
+    const flags = optionFlags(rename!);
+    expect(flags).toContain("--label");
+  });
+
+  test("rm subcommand accepts an id argument and --force option", async () => {
+    const cmd = await load();
+    const rm = findSub(cmd, "rm");
+    expect(rm).toBeDefined();
+    const args = rm!.registeredArguments;
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    expect(args[0]?.name()).toBe("id");
+    const flags = optionFlags(rm!);
+    expect(flags).toContain("--force");
+  });
+
+  test("has exactly 5 subcommands", async () => {
+    const cmd = await load();
+    expect(cmd.commands.length).toBe(5);
+    const names = cmd.commands.map((c) => c.name());
+    expect(names).toEqual(
+      expect.arrayContaining(["create", "list", "info", "rename", "rm"]),
+    );
+  });
+});
+
+describe("credential commands", () => {
+  async function load() {
+    const { createCredentialCommands } =
+      await import("../commands/xs-credential.js");
+    return createCredentialCommands();
+  }
+
+  test("top-level command is named cred", async () => {
+    const cmd = await load();
+    expect(cmd.name()).toBe("cred");
+  });
+
+  test("has description", async () => {
+    const cmd = await load();
+    expect(cmd.description()).toBeTruthy();
+  });
+
+  test("issue subcommand has --config, --op, and --chat options", async () => {
+    const cmd = await load();
+    const issue = findSub(cmd, "issue");
+    expect(issue).toBeDefined();
+    const flags = optionFlags(issue!);
+    expect(flags).toContain("--config");
+    expect(flags).toContain("--op");
+    expect(flags).toContain("--chat");
+  });
+
+  test("issue subcommand has --policy, --allow, --deny, --ttl, --json options", async () => {
+    const cmd = await load();
+    const issue = findSub(cmd, "issue");
+    expect(issue).toBeDefined();
+    const flags = optionFlags(issue!);
+    expect(flags).toContain("--policy");
+    expect(flags).toContain("--allow");
+    expect(flags).toContain("--deny");
+    expect(flags).toContain("--ttl");
+    expect(flags).toContain("--json");
+  });
+
+  test("list subcommand has --config, --op, and --json options", async () => {
+    const cmd = await load();
+    const list = findSub(cmd, "list");
+    expect(list).toBeDefined();
+    const flags = optionFlags(list!);
+    expect(flags).toContain("--config");
+    expect(flags).toContain("--op");
+    expect(flags).toContain("--json");
+  });
+
+  test("info subcommand accepts an id argument", async () => {
+    const cmd = await load();
+    const info = findSub(cmd, "info");
+    expect(info).toBeDefined();
+    const args = info!.registeredArguments;
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    expect(args[0]?.name()).toBe("id");
+  });
+
+  test("revoke subcommand accepts an id argument and --config, --force options", async () => {
+    const cmd = await load();
+    const revoke = findSub(cmd, "revoke");
+    expect(revoke).toBeDefined();
+    const args = revoke!.registeredArguments;
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    expect(args[0]?.name()).toBe("id");
+    const flags = optionFlags(revoke!);
+    expect(flags).toContain("--config");
+    expect(flags).toContain("--force");
+    expect(flags).toContain("--json");
+  });
+
+  test("update subcommand accepts an id argument and --config plus scope options", async () => {
+    const cmd = await load();
+    const update = findSub(cmd, "update");
+    expect(update).toBeDefined();
+    const args = update!.registeredArguments;
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    expect(args[0]?.name()).toBe("id");
+    const flags = optionFlags(update!);
+    expect(flags).toContain("--config");
+    expect(flags).toContain("--allow");
+    expect(flags).toContain("--deny");
+    expect(flags).toContain("--policy");
+    expect(flags).toContain("--json");
+  });
+
+  test("issue rejects invalid ttl values", async () => {
+    const { parsePositiveIntegerOption } = await import(
+      "../commands/xs-credential.js"
+    );
+    expect(() => parsePositiveIntegerOption("10s")).toThrow(
+      /positive integer/,
+    );
+    expect(() => parsePositiveIntegerOption("abc")).toThrow(
+      /positive integer/,
+    );
+  });
+
+  test("has exactly 5 subcommands", async () => {
+    const cmd = await load();
+    expect(cmd.commands.length).toBe(5);
+    const names = cmd.commands.map((c) => c.name());
+    expect(names).toEqual(
+      expect.arrayContaining(["issue", "list", "info", "revoke", "update"]),
+    );
+  });
+});

--- a/packages/cli/src/commands/xs-credential.ts
+++ b/packages/cli/src/commands/xs-credential.ts
@@ -1,0 +1,402 @@
+/**
+ * Credential management commands for the `xs cred` subcommand group.
+ *
+ * These are the v1 credential-native CLI surfaces. They speak to the running
+ * daemon over the admin socket and keep the `cred` taxonomy expected by the
+ * cutover CLI while translating into the current runtime RPC methods.
+ *
+ * @module
+ */
+
+import { Command, InvalidArgumentError } from "commander";
+import type {
+  CredentialRecordType,
+  CredentialConfigType,
+  IssuedCredentialType,
+  ScopeSetType,
+  SignetError,
+} from "@xmtp/signet-schemas";
+import { CredentialConfig, ScopeSet, ValidationError } from "@xmtp/signet-schemas";
+import { exitCodeFromCategory } from "../output/exit-codes.js";
+import { formatOutput } from "../output/formatter.js";
+import {
+  createWithDaemonClient,
+  type WithDaemonClient,
+} from "./daemon-client.js";
+
+/** Parse an integer CLI option and reject trailing junk like `10s`. */
+export function parsePositiveIntegerOption(value: string): number {
+  if (!/^[1-9][0-9]*$/.test(value)) {
+    throw new InvalidArgumentError("must be a positive integer");
+  }
+  return Number.parseInt(value, 10);
+}
+
+/** Dependencies for v1 credential commands. */
+export interface XsCredentialCommandDeps {
+  readonly withDaemonClient: WithDaemonClient;
+  readonly writeStdout: (message: string) => void;
+  readonly writeStderr: (message: string) => void;
+  readonly exit: (code: number) => void;
+}
+
+const defaultDeps: XsCredentialCommandDeps = {
+  withDaemonClient: createWithDaemonClient(),
+  writeStdout(message) {
+    process.stdout.write(message);
+  },
+  writeStderr(message) {
+    process.stderr.write(message);
+  },
+  exit(code) {
+    process.exit(code);
+  },
+};
+
+function splitScopes(value: string | undefined): string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return value
+    .split(",")
+    .map((scope) => scope.trim())
+    .filter((scope) => scope.length > 0);
+}
+
+function writeError(
+  deps: XsCredentialCommandDeps,
+  error: SignetError,
+  json: boolean,
+): void {
+  deps.writeStderr(
+    formatOutput(
+      {
+        error: error._tag,
+        category: error.category,
+        message: error.message,
+        ...(error.context !== null ? { context: error.context } : {}),
+      },
+      { json },
+    ) + "\n",
+  );
+  deps.exit(exitCodeFromCategory(error.category));
+}
+
+function summarizeCredential(
+  credential: CredentialRecordType,
+): Record<string, unknown> {
+  return {
+    credentialId: credential.id,
+    operatorId: credential.config.operatorId,
+    status: credential.status,
+    issuedAt: credential.issuedAt,
+    expiresAt: credential.expiresAt,
+  };
+}
+
+function buildIssueConfig(input: {
+  readonly operatorId: string;
+  readonly chatId: string;
+  readonly policyId?: string | undefined;
+  readonly allow?: string | undefined;
+  readonly deny?: string | undefined;
+  readonly ttlSeconds?: number | undefined;
+}): CredentialConfigType | ValidationError {
+  const parsed = CredentialConfig.safeParse({
+    operatorId: input.operatorId,
+    chatIds: [input.chatId],
+    ...(input.policyId !== undefined ? { policyId: input.policyId } : {}),
+    ...(input.allow !== undefined ? { allow: splitScopes(input.allow) } : {}),
+    ...(input.deny !== undefined ? { deny: splitScopes(input.deny) } : {}),
+    ...(input.ttlSeconds !== undefined
+      ? { ttlSeconds: input.ttlSeconds }
+      : {}),
+  });
+
+  if (!parsed.success) {
+    return ValidationError.create(
+      "credential",
+      "Credential config did not validate",
+      {
+        issues: parsed.error.issues,
+      },
+    );
+  }
+
+  return parsed.data;
+}
+
+function buildScopeSet(input: {
+  readonly allow?: string | undefined;
+  readonly deny?: string | undefined;
+}): ScopeSetType | ValidationError {
+  const parsed = ScopeSet.safeParse({
+    ...(input.allow !== undefined ? { allow: splitScopes(input.allow) ?? [] } : {}),
+    ...(input.deny !== undefined ? { deny: splitScopes(input.deny) ?? [] } : {}),
+  });
+
+  if (!parsed.success) {
+    return ValidationError.create("scopes", "Scope update did not validate", {
+      issues: parsed.error.issues,
+    });
+  }
+
+  return parsed.data;
+}
+
+/**
+ * Create the `cred` subcommand group.
+ *
+ * Subcommands: issue, list, info, revoke, update.
+ */
+export function createCredentialCommands(
+  deps: Partial<XsCredentialCommandDeps> = {},
+): Command {
+  const resolvedDeps: XsCredentialCommandDeps = { ...defaultDeps, ...deps };
+  const cmd = new Command("cred").description("Manage credentials");
+
+  cmd
+    .command("issue")
+    .description("Issue a credential")
+    .option("--config <path>", "Path to config file")
+    .requiredOption("--op <id>", "Operator ID")
+    .requiredOption("--chat <id>", "Chat ID")
+    .option("--policy <id>", "Policy ID")
+    .option("--allow <scopes>", "Allowed scopes (comma-separated)")
+    .option("--deny <scopes>", "Denied scopes (comma-separated)")
+    .option(
+      "--ttl <seconds>",
+      "Time-to-live in seconds",
+      parsePositiveIntegerOption,
+    )
+    .option("--json", "JSON output")
+    .action(
+      async (opts: {
+        config?: string;
+        op: string;
+        chat: string;
+        policy?: string;
+        allow?: string;
+        deny?: string;
+        ttl?: number;
+        json?: true;
+      }) => {
+        const json = opts.json === true;
+        const configOrError = buildIssueConfig({
+          operatorId: opts.op,
+          chatId: opts.chat,
+          policyId: opts.policy,
+          allow: opts.allow,
+          deny: opts.deny,
+          ttlSeconds: opts.ttl,
+        });
+        if (configOrError instanceof ValidationError) {
+          writeError(resolvedDeps, configOrError, json);
+          return;
+        }
+
+        const result = await resolvedDeps.withDaemonClient(
+          {
+            configPath: opts.config,
+          },
+          (client) =>
+            client.request<IssuedCredentialType>(
+              "credential.issue",
+              configOrError,
+            ),
+        );
+
+        if (result.isErr()) {
+          writeError(resolvedDeps, result.error, json);
+          return;
+        }
+
+        const output = json
+          ? result.value
+          : {
+              token: result.value.token,
+              ...result.value.credential,
+            };
+        resolvedDeps.writeStdout(formatOutput(output, { json }) + "\n");
+      },
+    );
+
+  cmd
+    .command("list")
+    .description("List credentials")
+    .option("--config <path>", "Path to config file")
+    .option("--op <id>", "Filter by operator")
+    .option("--json", "JSON output")
+    .action(async (opts: { config?: string; op?: string; json?: true }) => {
+      const json = opts.json === true;
+      const result = await resolvedDeps.withDaemonClient(
+        {
+          configPath: opts.config,
+        },
+        (client) =>
+          client.request<readonly CredentialRecordType[]>(
+            "credential.list",
+            opts.op !== undefined ? { operatorId: opts.op } : undefined,
+          ),
+      );
+
+      if (result.isErr()) {
+        writeError(resolvedDeps, result.error, json);
+        return;
+      }
+
+      const output = json
+        ? result.value
+        : result.value.map(summarizeCredential);
+      resolvedDeps.writeStdout(formatOutput(output, { json }) + "\n");
+    });
+
+  cmd
+    .command("info")
+    .description("Show credential details")
+    .argument("<id>", "Credential ID")
+    .option("--config <path>", "Path to config file")
+    .option("--json", "JSON output")
+    .action(
+      async (id: string, opts: { config?: string; json?: true }) => {
+        const json = opts.json === true;
+        const result = await resolvedDeps.withDaemonClient(
+          {
+            configPath: opts.config,
+          },
+          (client) =>
+            client.request<CredentialRecordType>("credential.lookup", {
+              credentialId: id,
+            }),
+        );
+
+        if (result.isErr()) {
+          writeError(resolvedDeps, result.error, json);
+          return;
+        }
+
+        resolvedDeps.writeStdout(
+          formatOutput(result.value, { json }) + "\n",
+        );
+      },
+    );
+
+  cmd
+    .command("revoke")
+    .description("Revoke a credential")
+    .argument("<id>", "Credential ID")
+    .option("--config <path>", "Path to config file")
+    .option("--force", "Execute without confirmation")
+    .option("--json", "JSON output")
+    .action(
+      async (
+        id: string,
+        opts: { config?: string; force?: true; json?: true },
+      ) => {
+        const json = opts.json === true;
+        const result = await resolvedDeps.withDaemonClient(
+          {
+            configPath: opts.config,
+          },
+          (client) =>
+            client.request<{ revoked: true }>("credential.revoke", {
+              credentialId: id,
+              reason: "owner-initiated",
+            }),
+        );
+
+        if (result.isErr()) {
+          writeError(resolvedDeps, result.error, json);
+          return;
+        }
+
+        resolvedDeps.writeStdout(
+          formatOutput(
+            {
+              credentialId: id,
+              force: opts.force === true,
+              ...result.value,
+            },
+            { json },
+          ) + "\n",
+        );
+      },
+    );
+
+  cmd
+    .command("update")
+    .description("Update a credential")
+    .argument("<id>", "Credential ID")
+    .option("--config <path>", "Path to config file")
+    .option("--allow <scopes>", "Update allowed scopes")
+    .option("--deny <scopes>", "Update denied scopes")
+    .option("--policy <id>", "Change policy")
+    .option("--json", "JSON output")
+    .action(
+      async (
+        id: string,
+        opts: {
+          config?: string;
+          allow?: string;
+          deny?: string;
+          policy?: string;
+          json?: true;
+        },
+      ) => {
+        const json = opts.json === true;
+
+        if (opts.policy !== undefined) {
+          writeError(
+            resolvedDeps,
+            ValidationError.create(
+              "policy",
+              "Changing policyId is not supported by `xs cred update`",
+            ),
+            json,
+          );
+          return;
+        }
+
+        const scopes = buildScopeSet({
+          allow: opts.allow,
+          deny: opts.deny,
+        });
+        if (scopes instanceof ValidationError) {
+          writeError(resolvedDeps, scopes, json);
+          return;
+        }
+        const result = await resolvedDeps.withDaemonClient(
+          {
+            configPath: opts.config,
+          },
+          (client) =>
+            client.request<{
+              updated: boolean;
+              material: boolean;
+              reason: string | null;
+            }>("credential.updateScopes", {
+              credentialId: id,
+              scopes,
+            }),
+        );
+
+        if (result.isErr()) {
+          writeError(resolvedDeps, result.error, json);
+          return;
+        }
+
+        resolvedDeps.writeStdout(
+          formatOutput(
+            {
+              credentialId: id,
+              scopes,
+              ...result.value,
+            },
+            { json },
+          ) + "\n",
+        );
+      },
+    );
+
+  return cmd;
+}

--- a/packages/cli/src/commands/xs-operator.ts
+++ b/packages/cli/src/commands/xs-operator.ts
@@ -1,0 +1,110 @@
+/**
+ * Operator management commands for the `xs operator` subcommand group.
+ *
+ * Provides CRUD operations for operators via the daemon admin socket.
+ * Each action constructs an RPC-compatible payload and delegates to
+ * the daemon client. When the daemon client is not yet wired, commands
+ * output the payload as JSON for integration testing.
+ *
+ * @module
+ */
+
+import { Command } from "commander";
+import { formatOutput } from "../output/formatter.js";
+
+/** Stub action output for commands not yet wired to the daemon. */
+function stubOutput(
+  action: string,
+  params: Record<string, unknown>,
+  json: boolean,
+): string {
+  return formatOutput({ action, ...params }, { json }) + "\n";
+}
+
+/**
+ * Create the `operator` subcommand group.
+ *
+ * Subcommands: create, list, info, rename, rm.
+ */
+export function createOperatorCommands(): Command {
+  const cmd = new Command("operator").description("Manage operators");
+
+  cmd
+    .command("create")
+    .description("Create a new operator")
+    .requiredOption("--label <name>", "Human-readable name")
+    .option("--role <role>", "Role: operator, admin", "operator")
+    .option("--scope <mode>", "Scope mode: per-chat, shared", "per-chat")
+    .option(
+      "--provider <provider>",
+      "Wallet provider: internal, ows",
+      "internal",
+    )
+    .option("--json", "JSON output")
+    .action(
+      (opts: {
+        label: string;
+        role: string;
+        scope: string;
+        provider: string;
+        json?: true;
+      }) => {
+        const json = opts.json === true;
+        process.stdout.write(
+          stubOutput(
+            "operator.create",
+            {
+              label: opts.label,
+              role: opts.role,
+              scope: opts.scope,
+              provider: opts.provider,
+            },
+            json,
+          ),
+        );
+      },
+    );
+
+  cmd
+    .command("list")
+    .description("List operators")
+    .option("--json", "JSON output")
+    .action((opts: { json?: true }) => {
+      const json = opts.json === true;
+      process.stdout.write(stubOutput("operator.list", {}, json));
+    });
+
+  cmd
+    .command("info")
+    .description("Show operator details")
+    .argument("<id>", "Operator ID")
+    .option("--json", "JSON output")
+    .action((id: string, opts: { json?: true }) => {
+      const json = opts.json === true;
+      process.stdout.write(stubOutput("operator.info", { id }, json));
+    });
+
+  cmd
+    .command("rename")
+    .description("Rename an operator")
+    .argument("<id>", "Operator ID")
+    .requiredOption("--label <name>", "New name")
+    .action((id: string, opts: { label: string }) => {
+      process.stdout.write(
+        stubOutput("operator.rename", { id, label: opts.label }, false),
+      );
+    });
+
+  cmd
+    .command("rm")
+    .description("Remove an operator")
+    .argument("<id>", "Operator ID")
+    .option("--force", "Execute without confirmation")
+    .action((id: string, opts: { force?: true }) => {
+      process.stdout.write(
+        stubOutput("operator.rm", { id, force: opts.force === true }, false),
+      );
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/xs-program.ts
+++ b/packages/cli/src/xs-program.ts
@@ -9,6 +9,8 @@
 import { Command } from "commander";
 import { createLifecycleCommands } from "./commands/lifecycle.js";
 import { createIdentityInitCommand } from "./commands/identity.js";
+import { createOperatorCommands } from "./commands/xs-operator.js";
+import { createCredentialCommands } from "./commands/xs-credential.js";
 
 /** Placeholder action for stub commands not yet implemented. */
 function stubAction(): void {
@@ -80,23 +82,11 @@ export function createXsProgram(): Command {
 
   // --- operator ---
 
-  const operator = new Command("operator").description("Operator management");
-  operator.addCommand(stub("create", "Create an operator"));
-  operator.addCommand(stub("list", "List operators"));
-  operator.addCommand(stub("info", "Show operator details"));
-  operator.addCommand(stub("rename", "Rename an operator"));
-  operator.addCommand(stub("rm", "Remove an operator"));
-  program.addCommand(operator);
+  program.addCommand(createOperatorCommands());
 
   // --- cred ---
 
-  const cred = new Command("cred").description("Credential management");
-  cred.addCommand(stub("issue", "Issue a credential"));
-  cred.addCommand(stub("list", "List credentials"));
-  cred.addCommand(stub("info", "Show credential details"));
-  cred.addCommand(stub("revoke", "Revoke a credential"));
-  cred.addCommand(stub("update", "Update a credential"));
-  program.addCommand(cred);
+  program.addCommand(createCredentialCommands());
 
   // --- chat ---
 


### PR DESCRIPTION
## Summary

Adds xs operator create/list/info/rename/rm and xs cred issue/list/
info/revoke/update with v1 flag patterns (--op, --chat, --policy,
--allow, --deny, --json, --force).

## Closes

Closes #162