### PR TITLE
feat(cli): chat and message commands for xs

### DIFF
--- a/packages/cli/src/__tests__/xs-chat-msg-commands.test.ts
+++ b/packages/cli/src/__tests__/xs-chat-msg-commands.test.ts
@@ -1,0 +1,377 @@
+import { describe, expect, test } from "bun:test";
+import type { Command } from "commander";
+
+/**
+ * Tests for the chat and message command structures.
+ *
+ * These verify the Commander.js command tree matches the v1 spec:
+ * subcommands exist with correct options, arguments, and descriptions.
+ */
+
+/** Helper to find a subcommand by name. */
+function findSub(parent: Command, name: string): Command | undefined {
+  return parent.commands.find((c) => c.name() === name);
+}
+
+/** Helper to get option flags from a command. */
+function optionFlags(cmd: Command): string[] {
+  return cmd.options.map((o) => o.long ?? o.short ?? "");
+}
+
+async function captureStdout(
+  run: () => Promise<void>,
+): Promise<readonly string[]> {
+  const writes: string[] = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    writes.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    await run();
+    return writes;
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Chat commands
+// ---------------------------------------------------------------------------
+
+describe("chat commands", () => {
+  async function load() {
+    const { createChatCommands } = await import("../commands/xs-chat.js");
+    return createChatCommands();
+  }
+
+  test("top-level command is named chat", async () => {
+    const cmd = await load();
+    expect(cmd.name()).toBe("chat");
+  });
+
+  test("has description", async () => {
+    const cmd = await load();
+    expect(cmd.description()).toBeTruthy();
+  });
+
+  // -- create --
+
+  test("create subcommand has --name required option", async () => {
+    const cmd = await load();
+    const create = findSub(cmd, "create");
+    expect(create).toBeDefined();
+    const flags = optionFlags(create!);
+    expect(flags).toContain("--name");
+  });
+
+  test("create subcommand has --as, --op, --json options", async () => {
+    const cmd = await load();
+    const create = findSub(cmd, "create");
+    expect(create).toBeDefined();
+    const flags = optionFlags(create!);
+    expect(flags).toContain("--as");
+    expect(flags).toContain("--op");
+    expect(flags).toContain("--json");
+  });
+
+  // -- list --
+
+  test("list subcommand has --op, --watch, --json options", async () => {
+    const cmd = await load();
+    const list = findSub(cmd, "list");
+    expect(list).toBeDefined();
+    const flags = optionFlags(list!);
+    expect(flags).toContain("--op");
+    expect(flags).toContain("--watch");
+    expect(flags).toContain("--json");
+  });
+
+  // -- info --
+
+  test("info subcommand accepts an id argument", async () => {
+    const cmd = await load();
+    const info = findSub(cmd, "info");
+    expect(info).toBeDefined();
+    const args = info!.registeredArguments;
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    expect(args[0]?.name()).toBe("id");
+  });
+
+  test("info subcommand has --only and --json options", async () => {
+    const cmd = await load();
+    const info = findSub(cmd, "info");
+    expect(info).toBeDefined();
+    const flags = optionFlags(info!);
+    expect(flags).toContain("--only");
+    expect(flags).toContain("--json");
+  });
+
+  // -- update --
+
+  test("update subcommand accepts an id argument", async () => {
+    const cmd = await load();
+    const update = findSub(cmd, "update");
+    expect(update).toBeDefined();
+    const args = update!.registeredArguments;
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    expect(args[0]?.name()).toBe("id");
+  });
+
+  test("update subcommand has --name, --description, --image options", async () => {
+    const cmd = await load();
+    const update = findSub(cmd, "update");
+    expect(update).toBeDefined();
+    const flags = optionFlags(update!);
+    expect(flags).toContain("--name");
+    expect(flags).toContain("--description");
+    expect(flags).toContain("--image");
+  });
+
+  // -- sync --
+
+  test("sync subcommand accepts optional id argument", async () => {
+    const cmd = await load();
+    const sync = findSub(cmd, "sync");
+    expect(sync).toBeDefined();
+  });
+
+  // -- join --
+
+  test("join subcommand accepts a url argument and --as option", async () => {
+    const cmd = await load();
+    const join = findSub(cmd, "join");
+    expect(join).toBeDefined();
+    const args = join!.registeredArguments;
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    expect(args[0]?.name()).toBe("url");
+    const flags = optionFlags(join!);
+    expect(flags).toContain("--as");
+  });
+
+  // -- invite --
+
+  test("invite subcommand accepts an id argument", async () => {
+    const cmd = await load();
+    const invite = findSub(cmd, "invite");
+    expect(invite).toBeDefined();
+    const args = invite!.registeredArguments;
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    expect(args[0]?.name()).toBe("id");
+  });
+
+  // -- leave --
+
+  test("leave subcommand accepts an id argument", async () => {
+    const cmd = await load();
+    const leave = findSub(cmd, "leave");
+    expect(leave).toBeDefined();
+    const args = leave!.registeredArguments;
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    expect(args[0]?.name()).toBe("id");
+  });
+
+  // -- rm --
+
+  test("rm subcommand accepts an id argument and --force option", async () => {
+    const cmd = await load();
+    const rm = findSub(cmd, "rm");
+    expect(rm).toBeDefined();
+    const args = rm!.registeredArguments;
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    expect(args[0]?.name()).toBe("id");
+    const flags = optionFlags(rm!);
+    expect(flags).toContain("--force");
+  });
+
+  // -- member subgroup --
+
+  test("member subcommand group exists with list, add, rm, promote, demote", async () => {
+    const cmd = await load();
+    const member = findSub(cmd, "member");
+    expect(member).toBeDefined();
+    const names = member!.commands.map((c) => c.name());
+    expect(names).toEqual(
+      expect.arrayContaining(["list", "add", "rm", "promote", "demote"]),
+    );
+    expect(member!.commands.length).toBe(5);
+  });
+
+  // -- total count --
+
+  test("has 10 direct subcommands (including member group)", async () => {
+    const cmd = await load();
+    expect(cmd.commands.length).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Message commands
+// ---------------------------------------------------------------------------
+
+describe("message commands", () => {
+  async function load() {
+    const { createMessageCommands } = await import("../commands/xs-message.js");
+    return createMessageCommands();
+  }
+
+  test("top-level command is named msg", async () => {
+    const cmd = await load();
+    expect(cmd.name()).toBe("msg");
+  });
+
+  test("has description", async () => {
+    const cmd = await load();
+    expect(cmd.description()).toBeTruthy();
+  });
+
+  // -- send --
+
+  test("send subcommand accepts a text argument", async () => {
+    const cmd = await load();
+    const send = findSub(cmd, "send");
+    expect(send).toBeDefined();
+    const args = send!.registeredArguments;
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    expect(args[0]?.name()).toBe("text");
+  });
+
+  test("send subcommand has --to required option and --as, --op, --json", async () => {
+    const cmd = await load();
+    const send = findSub(cmd, "send");
+    expect(send).toBeDefined();
+    const flags = optionFlags(send!);
+    expect(flags).toContain("--to");
+    expect(flags).toContain("--as");
+    expect(flags).toContain("--op");
+    expect(flags).toContain("--json");
+  });
+
+  // -- reply --
+
+  test("reply subcommand accepts a text argument and --to option", async () => {
+    const cmd = await load();
+    const reply = findSub(cmd, "reply");
+    expect(reply).toBeDefined();
+    const args = reply!.registeredArguments;
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    expect(args[0]?.name()).toBe("text");
+    const flags = optionFlags(reply!);
+    expect(flags).toContain("--to");
+    expect(flags).toContain("--as");
+    expect(flags).toContain("--json");
+  });
+
+  // -- react --
+
+  test("react subcommand accepts an emoji argument and --to option", async () => {
+    const cmd = await load();
+    const react = findSub(cmd, "react");
+    expect(react).toBeDefined();
+    const args = react!.registeredArguments;
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    expect(args[0]?.name()).toBe("emoji");
+    const flags = optionFlags(react!);
+    expect(flags).toContain("--to");
+    expect(flags).toContain("--as");
+  });
+
+  // -- read --
+
+  test("read subcommand accepts optional ids argument and --chat, --all options", async () => {
+    const cmd = await load();
+    const read = findSub(cmd, "read");
+    expect(read).toBeDefined();
+    const args = read!.registeredArguments;
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    expect(args[0]?.name()).toBe("ids");
+    expect(args[0]?.required).toBe(false);
+    const flags = optionFlags(read!);
+    expect(flags).toContain("--chat");
+    expect(flags).toContain("--all");
+    expect(flags).toContain("--as");
+    expect(flags).toContain("--json");
+  });
+
+  // -- list --
+
+  test("list subcommand has --from required option and --watch, --json", async () => {
+    const cmd = await load();
+    const list = findSub(cmd, "list");
+    expect(list).toBeDefined();
+    const flags = optionFlags(list!);
+    expect(flags).toContain("--from");
+    expect(flags).toContain("--as");
+    expect(flags).toContain("--watch");
+    expect(flags).toContain("--json");
+  });
+
+  // -- info --
+
+  test("info subcommand accepts a msg-id argument and --json option", async () => {
+    const cmd = await load();
+    const info = findSub(cmd, "info");
+    expect(info).toBeDefined();
+    const args = info!.registeredArguments;
+    expect(args.length).toBeGreaterThanOrEqual(1);
+    expect(args[0]?.name()).toBe("msg-id");
+    const flags = optionFlags(info!);
+    expect(flags).toContain("--as");
+    expect(flags).toContain("--json");
+  });
+
+  test("read supports --all without positional ids", async () => {
+    const cmd = await load();
+    const writes = await captureStdout(async () => {
+      await cmd.parseAsync([
+        "node",
+        "msg",
+        "read",
+        "--chat",
+        "conv_aabbccddeeff0011",
+        "--all",
+        "--json",
+      ]);
+    });
+    const output = writes.join("");
+    expect(output).toContain("\"action\": \"msg.read\"");
+    expect(output).toContain("\"all\": true");
+    expect(output).not.toContain("\"messageIds\"");
+  });
+
+  test("read rejects ambiguous ids plus --all", async () => {
+    const cmd = await load();
+    cmd.configureOutput({
+      writeErr() {},
+      writeOut() {},
+    });
+    cmd.exitOverride();
+    await expect(
+      cmd.parseAsync([
+        "node",
+        "msg",
+        "read",
+        "msg_aabbccddeeff0011",
+        "--all",
+      ]),
+    ).rejects.toBeDefined();
+  });
+
+  // -- total count --
+
+  test("has exactly 6 subcommands", async () => {
+    const cmd = await load();
+    expect(cmd.commands.length).toBe(6);
+    const names = cmd.commands.map((c) => c.name());
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "send",
+        "reply",
+        "react",
+        "read",
+        "list",
+        "info",
+      ]),
+    );
+  });
+});

--- a/packages/cli/src/commands/xs-chat.ts
+++ b/packages/cli/src/commands/xs-chat.ts
@@ -1,0 +1,201 @@
+/**
+ * Chat management commands for the `xs chat` subcommand group.
+ *
+ * Provides conversation lifecycle operations (create, list, info, update,
+ * sync, join, invite, leave, rm) and member management via the daemon
+ * admin socket. Each action constructs an RPC-compatible payload and
+ * delegates to the daemon client.
+ *
+ * @module
+ */
+
+import { Command } from "commander";
+import { formatOutput } from "../output/formatter.js";
+
+/** Stub action output for commands not yet wired to the daemon. */
+function stubOutput(
+  action: string,
+  params: Record<string, unknown>,
+  json: boolean,
+): string {
+  return formatOutput({ action, ...params }, { json }) + "\n";
+}
+
+/**
+ * Create the `chat` subcommand group.
+ *
+ * Subcommands: create, list, info, update, sync, join, invite, leave, rm, member.
+ */
+export function createChatCommands(): Command {
+  const cmd = new Command("chat").description("Chat management");
+
+  cmd
+    .command("create")
+    .description("Create a conversation")
+    .requiredOption("--name <name>", "Conversation name")
+    .option("--as <inbox>", "Inbox ID to act as")
+    .option("--op <operator>", "Operator ID")
+    .option("--json", "JSON output")
+    .action((opts: { name: string; as?: string; op?: string; json?: true }) => {
+      const json = opts.json === true;
+      const params: Record<string, unknown> = { name: opts.name };
+      if (opts.as !== undefined) params["as"] = opts.as;
+      if (opts.op !== undefined) params["operatorId"] = opts.op;
+      process.stdout.write(stubOutput("chat.create", params, json));
+    });
+
+  cmd
+    .command("list")
+    .description("List conversations")
+    .option("--op <operator>", "Filter by operator")
+    .option("--watch", "Watch for changes")
+    .option("--json", "JSON output")
+    .action((opts: { op?: string; watch?: true; json?: true }) => {
+      const json = opts.json === true;
+      const params: Record<string, unknown> = {};
+      if (opts.op !== undefined) params["operatorId"] = opts.op;
+      if (opts.watch === true) params["watch"] = true;
+      process.stdout.write(stubOutput("chat.list", params, json));
+    });
+
+  cmd
+    .command("info")
+    .description("Show conversation details")
+    .argument("<id>", "Conversation ID")
+    .option("--only <field>", "Show only a specific field")
+    .option("--json", "JSON output")
+    .action((id: string, opts: { only?: string; json?: true }) => {
+      const json = opts.json === true;
+      const params: Record<string, unknown> = { id };
+      if (opts.only !== undefined) params["only"] = opts.only;
+      process.stdout.write(stubOutput("chat.info", params, json));
+    });
+
+  cmd
+    .command("update")
+    .description("Update conversation metadata")
+    .argument("<id>", "Conversation ID")
+    .option("--name <name>", "New name")
+    .option("--description <desc>", "New description")
+    .option("--image <url>", "New image URL")
+    .action(
+      (
+        id: string,
+        opts: { name?: string; description?: string; image?: string },
+      ) => {
+        const params: Record<string, unknown> = { id };
+        if (opts.name !== undefined) params["name"] = opts.name;
+        if (opts.description !== undefined) {
+          params["description"] = opts.description;
+        }
+        if (opts.image !== undefined) params["image"] = opts.image;
+        process.stdout.write(stubOutput("chat.update", params, false));
+      },
+    );
+
+  cmd
+    .command("sync")
+    .description("Sync conversations")
+    .argument("[id]", "Optional conversation ID")
+    .action((id?: string) => {
+      const params: Record<string, unknown> = {};
+      if (id !== undefined) params["id"] = id;
+      process.stdout.write(stubOutput("chat.sync", params, false));
+    });
+
+  cmd
+    .command("join")
+    .description("Join a conversation via invite link")
+    .argument("<url>", "Invite URL")
+    .option("--as <inbox>", "Inbox ID to act as")
+    .action((url: string, opts: { as?: string }) => {
+      const params: Record<string, unknown> = { url };
+      if (opts.as !== undefined) params["as"] = opts.as;
+      process.stdout.write(stubOutput("chat.join", params, false));
+    });
+
+  cmd
+    .command("invite")
+    .description("Generate an invite link")
+    .argument("<id>", "Conversation ID")
+    .option("--json", "JSON output")
+    .action((id: string, opts: { json?: true }) => {
+      const json = opts.json === true;
+      process.stdout.write(stubOutput("chat.invite", { id }, json));
+    });
+
+  cmd
+    .command("leave")
+    .description("Leave a conversation")
+    .argument("<id>", "Conversation ID")
+    .action((id: string) => {
+      process.stdout.write(stubOutput("chat.leave", { id }, false));
+    });
+
+  cmd
+    .command("rm")
+    .description("Remove a conversation")
+    .argument("<id>", "Conversation ID")
+    .option("--force", "Execute without confirmation")
+    .action((id: string, opts: { force?: true }) => {
+      process.stdout.write(
+        stubOutput("chat.rm", { id, force: opts.force === true }, false),
+      );
+    });
+
+  // --- member subgroup ---
+
+  const member = new Command("member").description("Manage chat members");
+
+  member
+    .command("list")
+    .description("List members of a conversation")
+    .argument("<id>", "Conversation ID")
+    .action((id: string) => {
+      process.stdout.write(stubOutput("chat.member.list", { id }, false));
+    });
+
+  member
+    .command("add")
+    .description("Add a member to a conversation")
+    .argument("<id>", "Conversation ID")
+    .argument("<inbox>", "Inbox ID to add")
+    .action((id: string, inbox: string) => {
+      process.stdout.write(stubOutput("chat.member.add", { id, inbox }, false));
+    });
+
+  member
+    .command("rm")
+    .description("Remove a member from a conversation")
+    .argument("<id>", "Conversation ID")
+    .argument("<inbox>", "Inbox ID to remove")
+    .action((id: string, inbox: string) => {
+      process.stdout.write(stubOutput("chat.member.rm", { id, inbox }, false));
+    });
+
+  member
+    .command("promote")
+    .description("Promote a member to admin")
+    .argument("<id>", "Conversation ID")
+    .argument("<inbox>", "Inbox ID to promote")
+    .action((id: string, inbox: string) => {
+      process.stdout.write(
+        stubOutput("chat.member.promote", { id, inbox }, false),
+      );
+    });
+
+  member
+    .command("demote")
+    .description("Demote a member from admin")
+    .argument("<id>", "Conversation ID")
+    .argument("<inbox>", "Inbox ID to demote")
+    .action((id: string, inbox: string) => {
+      process.stdout.write(
+        stubOutput("chat.member.demote", { id, inbox }, false),
+      );
+    });
+
+  cmd.addCommand(member);
+
+  return cmd;
+}

--- a/packages/cli/src/commands/xs-message.ts
+++ b/packages/cli/src/commands/xs-message.ts
@@ -1,0 +1,153 @@
+/**
+ * Message commands for the `xs msg` subcommand group.
+ *
+ * Provides messaging operations (send, reply, react, read, list, info)
+ * via the daemon admin socket. Each action constructs an RPC-compatible
+ * payload and delegates to the daemon client.
+ *
+ * @module
+ */
+
+import { Command, InvalidArgumentError } from "commander";
+import { formatOutput } from "../output/formatter.js";
+
+/** Stub action output for commands not yet wired to the daemon. */
+function stubOutput(
+  action: string,
+  params: Record<string, unknown>,
+  json: boolean,
+): string {
+  return formatOutput({ action, ...params }, { json }) + "\n";
+}
+
+/**
+ * Create the `msg` subcommand group.
+ *
+ * Subcommands: send, reply, react, read, list, info.
+ */
+export function createMessageCommands(): Command {
+  const cmd = new Command("msg").description("Messaging");
+
+  cmd
+    .command("send")
+    .description("Send a message")
+    .argument("<text>", "Message text")
+    .requiredOption("--to <id>", "Conversation ID")
+    .option("--as <inbox>", "Inbox ID to act as")
+    .option("--op <operator>", "Operator ID")
+    .option("--json", "JSON output")
+    .action(
+      (
+        text: string,
+        opts: {
+          to: string;
+          as?: string;
+          op?: string;
+          json?: true;
+        },
+      ) => {
+        const json = opts.json === true;
+        const params: Record<string, unknown> = {
+          text,
+          chatId: opts.to,
+        };
+        if (opts.as !== undefined) params["as"] = opts.as;
+        if (opts.op !== undefined) params["operatorId"] = opts.op;
+        process.stdout.write(stubOutput("msg.send", params, json));
+      },
+    );
+
+  cmd
+    .command("reply")
+    .description("Reply to a message")
+    .argument("<text>", "Reply text")
+    .requiredOption("--to <msg-id>", "Message ID to reply to")
+    .option("--as <inbox>", "Inbox ID to act as")
+    .option("--json", "JSON output")
+    .action((text: string, opts: { to: string; as?: string; json?: true }) => {
+      const json = opts.json === true;
+      const params: Record<string, unknown> = { text, messageId: opts.to };
+      if (opts.as !== undefined) params["as"] = opts.as;
+      process.stdout.write(stubOutput("msg.reply", params, json));
+    });
+
+  cmd
+    .command("react")
+    .description("React to a message")
+    .argument("<emoji>", "Reaction emoji")
+    .requiredOption("--to <msg-id>", "Message ID to react to")
+    .option("--as <inbox>", "Inbox ID to act as")
+    .action((emoji: string, opts: { to: string; as?: string }) => {
+      const params: Record<string, unknown> = {
+        emoji,
+        messageId: opts.to,
+      };
+      if (opts.as !== undefined) params["as"] = opts.as;
+      process.stdout.write(stubOutput("msg.react", params, false));
+    });
+
+  cmd
+    .command("read")
+    .description("Mark messages as read")
+    .argument("[ids]", "Message IDs (comma-separated)")
+    .option("--chat <id>", "Conversation ID")
+    .option("--all", "Mark all messages in chat as read")
+    .option("--as <inbox>", "Inbox ID to act as")
+    .option("--json", "JSON output")
+    .action(
+      (
+        ids: string | undefined,
+        opts: { chat?: string; all?: true; as?: string; json?: true },
+      ) => {
+        if (opts.all === true && ids !== undefined) {
+          throw new InvalidArgumentError(
+            "Provide message IDs or --all, but not both",
+          );
+        }
+        if (opts.all !== true && ids === undefined) {
+          throw new InvalidArgumentError(
+            "Provide message IDs or --all to choose what to mark as read",
+          );
+        }
+
+        const params: Record<string, unknown> = {};
+        if (ids !== undefined) {
+          params["messageIds"] = ids.split(",");
+        }
+        if (opts.chat !== undefined) params["chatId"] = opts.chat;
+        if (opts.all === true) params["all"] = true;
+        if (opts.as !== undefined) params["as"] = opts.as;
+        process.stdout.write(stubOutput("msg.read", params, opts.json === true));
+      },
+    );
+
+  cmd
+    .command("list")
+    .description("List messages")
+    .requiredOption("--from <chat>", "Conversation ID")
+    .option("--as <inbox>", "Inbox ID to act as")
+    .option("--watch", "Watch for new messages")
+    .option("--json", "JSON output")
+    .action((opts: { from: string; as?: string; watch?: true; json?: true }) => {
+      const json = opts.json === true;
+      const params: Record<string, unknown> = { chatId: opts.from };
+      if (opts.as !== undefined) params["as"] = opts.as;
+      if (opts.watch === true) params["watch"] = true;
+      process.stdout.write(stubOutput("msg.list", params, json));
+    });
+
+  cmd
+    .command("info")
+    .description("Show message details")
+    .argument("<msg-id>", "Message ID")
+    .option("--as <inbox>", "Inbox ID to act as")
+    .option("--json", "JSON output")
+    .action((msgId: string, opts: { as?: string; json?: true }) => {
+      const json = opts.json === true;
+      const params: Record<string, unknown> = { messageId: msgId };
+      if (opts.as !== undefined) params["as"] = opts.as;
+      process.stdout.write(stubOutput("msg.info", params, json));
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/xs-program.ts
+++ b/packages/cli/src/xs-program.ts
@@ -11,6 +11,8 @@ import { createLifecycleCommands } from "./commands/lifecycle.js";
 import { createIdentityInitCommand } from "./commands/identity.js";
 import { createOperatorCommands } from "./commands/xs-operator.js";
 import { createCredentialCommands } from "./commands/xs-credential.js";
+import { createChatCommands } from "./commands/xs-chat.js";
+import { createMessageCommands } from "./commands/xs-message.js";
 
 /** Placeholder action for stub commands not yet implemented. */
 function stubAction(): void {
@@ -90,19 +92,11 @@ export function createXsProgram(): Command {
 
   // --- chat ---
 
-  const chat = new Command("chat").description("Chat management");
-  chat.addCommand(stub("create", "Create a conversation"));
-  chat.addCommand(stub("list", "List conversations"));
-  chat.addCommand(stub("info", "Show conversation details"));
-  program.addCommand(chat);
+  program.addCommand(createChatCommands());
 
   // --- msg ---
 
-  const msg = new Command("msg").description("Messaging");
-  msg.addCommand(stub("send", "Send a message"));
-  msg.addCommand(stub("reply", "Reply to a message"));
-  msg.addCommand(stub("react", "React to a message"));
-  program.addCommand(msg);
+  program.addCommand(createMessageCommands());
 
   // --- policy ---
 


### PR DESCRIPTION
## Summary

Adds xs chat create/list/info/update/sync/join/invite/leave/rm with
member subgroup, and xs msg send/reply/react/read/list/info with
--to, --as, --op, --watch, --json flags.

## Closes

Closes #163