### PR TITLE
fix(policy): remove legacy session/grant/view compat shims

### DIFF
--- a/packages/policy/src/__tests__/project-message.test.ts
+++ b/packages/policy/src/__tests__/project-message.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { projectMessage } from "../pipeline/project-message.js";
-import type { ContentTypeId, ViewConfig } from "@xmtp/signet-schemas";
+import type { ContentTypeId } from "@xmtp/signet-schemas";
 import {
   createTestRawMessage,
   createFullScopes,
@@ -146,23 +146,6 @@ describe("projectMessage", () => {
       expect(result.event.senderInboxId).toBe("sender-1");
       expect(result.event.contentType).toBe("xmtp.org/text:1.0");
       expect(result.event.sentAt).toBe("2024-01-01T00:00:00Z");
-    }
-  });
-
-  test("supports legacy view-mode callers for redacted sessions", () => {
-    const message = createTestRawMessage();
-    const view: ViewConfig = {
-      mode: "redacted",
-      threadScopes: [{ groupId: "group-1", threadId: null }],
-      contentTypes: ["xmtp.org/text:1.0"],
-    };
-
-    const result = projectMessage(message, view, baseAllowlist, false);
-
-    expect(result.action).toBe("emit");
-    if (result.action === "emit") {
-      expect(result.event.visibility).toBe("redacted");
-      expect(result.event.content).toBeNull();
     }
   });
 });

--- a/packages/policy/src/__tests__/validate-send.test.ts
+++ b/packages/policy/src/__tests__/validate-send.test.ts
@@ -9,31 +9,6 @@ import {
   createEmptyScopes,
   createChatIds,
 } from "./fixtures.js";
-import type { GrantConfig, ViewConfig } from "@xmtp/signet-schemas";
-
-const fullGrant: GrantConfig = {
-  messaging: { send: true, reply: true, react: true, draftOnly: false },
-  groupManagement: {
-    addMembers: false,
-    removeMembers: false,
-    updateMetadata: false,
-    inviteUsers: false,
-  },
-  tools: { scopes: [] },
-  egress: {
-    storeExcerpts: false,
-    useForMemory: false,
-    forwardToProviders: false,
-    quoteRevealed: false,
-    summarize: false,
-  },
-};
-
-const chatView: ViewConfig = {
-  mode: "full",
-  threadScopes: [{ groupId: "group-1", threadId: null }],
-  contentTypes: ["xmtp.org/text:1.0"],
-};
 
 describe("validateSendMessage", () => {
   test("succeeds when send scope is allowed and chat is in scope", () => {
@@ -78,19 +53,15 @@ describe("validateSendMessage", () => {
     expect(Result.isError(result)).toBe(true);
   });
 
-  test("preserves draftOnly for legacy grant/view callers", () => {
+  test("always returns draftOnly false (v1 scopes)", () => {
     const result = validateSendMessage(
       { groupId: "group-1" },
-      {
-        ...fullGrant,
-        messaging: { ...fullGrant.messaging, draftOnly: true },
-      },
-      chatView,
+      createFullScopes(),
+      createChatIds("group-1"),
     );
-
     expect(Result.isOk(result)).toBe(true);
     if (Result.isOk(result)) {
-      expect(result.value.draftOnly).toBe(true);
+      expect(result.value.draftOnly).toBe(false);
     }
   });
 });

--- a/packages/policy/src/permissions/validate-send.ts
+++ b/packages/policy/src/permissions/validate-send.ts
@@ -2,45 +2,9 @@ import { Result } from "better-result";
 import { PermissionError } from "@xmtp/signet-schemas";
 import { checkChatInScope } from "./scope-check.js";
 
-interface LegacyMessagingGrant {
-  readonly send: boolean;
-  readonly draftOnly: boolean;
-}
-
-interface LegacyGrantConfig {
-  readonly messaging: LegacyMessagingGrant;
-}
-
-interface LegacyThreadScope {
-  readonly groupId: string;
-}
-
-interface LegacyViewConfig {
-  readonly threadScopes: readonly LegacyThreadScope[];
-}
-
-/** Successful send validation, including draft-only handling for legacy sessions. */
+/** Successful send validation. */
 export interface SendValidation {
   readonly draftOnly: boolean;
-}
-
-function isGrantConfig(value: unknown): value is LegacyGrantConfig {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "messaging" in value &&
-    typeof value.messaging === "object" &&
-    value.messaging !== null
-  );
-}
-
-function isViewConfig(value: unknown): value is LegacyViewConfig {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "threadScopes" in value &&
-    Array.isArray(value.threadScopes)
-  );
 }
 
 /**
@@ -51,48 +15,9 @@ function isViewConfig(value: unknown): value is LegacyViewConfig {
  */
 export function validateSendMessage(
   request: { groupId: string },
-  grant: LegacyGrantConfig,
-  view: LegacyViewConfig,
-): Result<SendValidation, PermissionError>;
-/** Validate send permissions for legacy session grant/view callers. */
-export function validateSendMessage(
-  request: { groupId: string },
   scopes: ReadonlySet<string>,
   chatIds: readonly string[],
-): Result<SendValidation, PermissionError>;
-/** Validate send permissions for resolved v1 scope callers. */
-export function validateSendMessage(
-  request: { groupId: string },
-  grantOrScopes: LegacyGrantConfig | ReadonlySet<string>,
-  viewOrChatIds: LegacyViewConfig | readonly string[],
 ): Result<SendValidation, PermissionError> {
-  if (isGrantConfig(grantOrScopes) && isViewConfig(viewOrChatIds)) {
-    const inScope = viewOrChatIds.threadScopes.some(
-      (scope: LegacyViewConfig["threadScopes"][number]) =>
-        scope.groupId === request.groupId,
-    );
-    if (!inScope) {
-      return Result.err(
-        PermissionError.create(
-          `Chat '${request.groupId}' is not in the session view`,
-          { chatId: request.groupId },
-        ),
-      );
-    }
-
-    if (!grantOrScopes.messaging.send) {
-      return Result.err(
-        PermissionError.create("Permission denied: send", { scope: "send" }),
-      );
-    }
-
-    return Result.ok({
-      draftOnly: grantOrScopes.messaging.draftOnly,
-    });
-  }
-
-  const scopes = grantOrScopes as ReadonlySet<string>;
-  const chatIds = viewOrChatIds as readonly string[];
   const scopeResult = checkChatInScope(request.groupId, chatIds);
   if (scopeResult.isErr()) return Result.err(scopeResult.error);
 

--- a/packages/policy/src/pipeline/project-message.ts
+++ b/packages/policy/src/pipeline/project-message.ts
@@ -7,53 +7,6 @@ import { projectContent } from "./content-projector.js";
 
 const DROP: ProjectionResult = { action: "drop" } as const;
 
-type LegacyViewMode = "full" | "thread-only" | "redacted" | "reveal-only";
-
-interface LegacyThreadScope {
-  readonly groupId: string;
-  readonly threadId: string | null;
-}
-
-interface LegacyViewConfig {
-  readonly mode: LegacyViewMode;
-  readonly threadScopes: readonly LegacyThreadScope[];
-}
-
-function isViewConfig(value: unknown): value is LegacyViewConfig {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "mode" in value &&
-    "threadScopes" in value &&
-    Array.isArray(value.threadScopes)
-  );
-}
-
-function matchesThreadScope(
-  message: RawMessage,
-  view: LegacyViewConfig,
-): boolean {
-  return view.threadScopes.some(
-    (scope: LegacyViewConfig["threadScopes"][number]) =>
-      scope.groupId === message.groupId &&
-      (scope.threadId === null || scope.threadId === message.threadId),
-  );
-}
-
-function resolveViewModeVisibility(mode: LegacyViewMode, isRevealed: boolean) {
-  switch (mode) {
-    case "full":
-    case "thread-only":
-      return "visible" as const;
-    case "redacted":
-      return isRevealed ? ("revealed" as const) : ("redacted" as const);
-    case "reveal-only":
-      return isRevealed ? ("revealed" as const) : ("hidden" as const);
-  }
-
-  return "hidden" as const;
-}
-
 /**
  * Projects a raw message through the scope filter, content type filter,
  * visibility logic, and content projection to produce a derived event or drop.
@@ -68,71 +21,11 @@ function resolveViewModeVisibility(mode: LegacyViewMode, isRevealed: boolean) {
  */
 export function projectMessage(
   message: RawMessage,
-  view: LegacyViewConfig,
-  effectiveAllowlist: ReadonlySet<ContentTypeId>,
-  isRevealed: boolean,
-): ProjectionResult;
-/** Project a raw message for legacy session view callers. */
-export function projectMessage(
-  message: RawMessage,
   scopes: ReadonlySet<string>,
   chatIds: readonly string[],
   effectiveAllowlist: ReadonlySet<ContentTypeId>,
   isRevealed: boolean,
-): ProjectionResult;
-/** Project a raw message for resolved v1 scope callers. */
-export function projectMessage(
-  message: RawMessage,
-  viewOrScopes: LegacyViewConfig | ReadonlySet<string>,
-  chatIdsOrAllowlist: readonly string[] | ReadonlySet<ContentTypeId>,
-  effectiveAllowlistOrIsRevealed: ReadonlySet<ContentTypeId> | boolean,
-  maybeIsRevealed?: boolean,
 ): ProjectionResult {
-  if (isViewConfig(viewOrScopes)) {
-    const effectiveAllowlist = chatIdsOrAllowlist as ReadonlySet<ContentTypeId>;
-    const isRevealed = effectiveAllowlistOrIsRevealed as boolean;
-
-    if (!matchesThreadScope(message, viewOrScopes)) {
-      return DROP;
-    }
-
-    if (!isContentTypeAllowed(message.contentType, effectiveAllowlist)) {
-      return DROP;
-    }
-
-    const visibility = resolveViewModeVisibility(viewOrScopes.mode, isRevealed);
-    if (visibility === "hidden") {
-      return DROP;
-    }
-
-    const content = projectContent(
-      message.content,
-      message.contentType,
-      visibility,
-    );
-
-    const event: MessageEvent = {
-      type: "message.visible",
-      messageId: message.messageId,
-      groupId: message.groupId,
-      senderInboxId: message.senderInboxId,
-      contentType: message.contentType,
-      content,
-      visibility,
-      sentAt: message.sentAt,
-      sealId: message.sealId,
-      threadId: message.threadId,
-    };
-
-    return { action: "emit", event };
-  }
-
-  const scopes = viewOrScopes;
-  const chatIds = chatIdsOrAllowlist as readonly string[];
-  const effectiveAllowlist =
-    effectiveAllowlistOrIsRevealed as ReadonlySet<ContentTypeId>;
-  const isRevealed = maybeIsRevealed ?? false;
-
   // Stage 1: Scope filter
   if (!isInScope(message, chatIds)) {
     return DROP;


### PR DESCRIPTION
## Summary

Remove the v0 legacy compat shims from the policy package. These bridged the old view/grant model that no longer exists in the schema layer.

- Removed `LegacyGrantConfig`, `LegacyViewConfig`, `LegacyViewMode` interfaces
- Removed function overloads that accepted legacy types
- `validateSendMessage` and `projectMessage` now accept only v1 scope-set signatures
- Tests updated to remove legacy caller paths and stale type imports
- Net -228 lines

## Test plan

- [x] `bun test packages/policy/src/__tests__/validate-send.test.ts` — 6 pass
- [x] `bun test packages/policy/src/__tests__/project-message.test.ts` — 10 pass
- [x] `cd packages/policy && bun run typecheck` — clean

Closes #198

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)