### PR TITLE
feat(core): implement SQLite-backed IdMappingStore

### DIFF
--- a/packages/core/src/__tests__/id-mapping-store.test.ts
+++ b/packages/core/src/__tests__/id-mapping-store.test.ts
@@ -1,0 +1,129 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { createSqliteIdMappingStore } from "../id-mapping-store.js";
+import type { IdMappingStore } from "@xmtp/signet-schemas";
+
+describe("SqliteIdMappingStore", () => {
+  let db: Database;
+  let store: IdMappingStore;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    store = createSqliteIdMappingStore(db);
+  });
+
+  describe("set", () => {
+    test("stores a message mapping", () => {
+      store.set("xmtp_abc12345feedbabe", "msg_1234567890abcdef", "message");
+      const local = store.getLocal("xmtp_abc12345feedbabe");
+      expect(local).toBe("msg_1234567890abcdef");
+    });
+
+    test("stores a conversation mapping", () => {
+      store.set(
+        "xmtp_def45678feedbabe",
+        "conv_1234567890abcdef",
+        "conversation",
+      );
+      const local = store.getLocal("xmtp_def45678feedbabe");
+      expect(local).toBe("conv_1234567890abcdef");
+    });
+
+    test("stores an inbox mapping", () => {
+      store.set("xmtp_ghi78901feedbabe", "inbox_1234567890abcdef", "inbox");
+      const local = store.getLocal("xmtp_ghi78901feedbabe");
+      expect(local).toBe("inbox_1234567890abcdef");
+    });
+
+    test("overwrites existing mapping for same network ID", () => {
+      store.set("xmtp_abc12345feedbabe", "msg_1111111111111111", "message");
+      store.set("xmtp_abc12345feedbabe", "msg_2222222222222222", "message");
+      const local = store.getLocal("xmtp_abc12345feedbabe");
+      expect(local).toBe("msg_2222222222222222");
+    });
+  });
+
+  describe("getLocal", () => {
+    test("returns local ID for known network ID", () => {
+      store.set("xmtp_abc12345feedbabe", "msg_1234567890abcdef", "message");
+      expect(store.getLocal("xmtp_abc12345feedbabe")).toBe(
+        "msg_1234567890abcdef",
+      );
+    });
+
+    test("returns null for unknown network ID", () => {
+      expect(store.getLocal("xmtp_unknown1feedbabe")).toBeNull();
+    });
+  });
+
+  describe("getNetwork", () => {
+    test("returns network ID for known local ID", () => {
+      store.set("xmtp_abc12345feedbabe", "msg_1234567890abcdef", "message");
+      expect(store.getNetwork("msg_1234567890abcdef")).toBe(
+        "xmtp_abc12345feedbabe",
+      );
+    });
+
+    test("returns null for unknown local ID", () => {
+      expect(store.getNetwork("msg_unknown123456ab")).toBeNull();
+    });
+  });
+
+  describe("resolve", () => {
+    test("resolves by network ID", () => {
+      store.set("xmtp_abc12345feedbabe", "msg_1234567890abcdef", "message");
+      const result = store.resolve("xmtp_abc12345feedbabe");
+      expect(result).toEqual({
+        networkId: "xmtp_abc12345feedbabe",
+        localId: "msg_1234567890abcdef",
+      });
+    });
+
+    test("resolves by local ID", () => {
+      store.set("xmtp_abc12345feedbabe", "msg_1234567890abcdef", "message");
+      const result = store.resolve("msg_1234567890abcdef");
+      expect(result).toEqual({
+        networkId: "xmtp_abc12345feedbabe",
+        localId: "msg_1234567890abcdef",
+      });
+    });
+
+    test("returns null for unknown ID", () => {
+      expect(store.resolve("unknown_id")).toBeNull();
+    });
+  });
+
+  describe("persistence", () => {
+    test("data survives across store instances on same db", () => {
+      store.set("xmtp_abc12345feedbabe", "msg_1234567890abcdef", "message");
+
+      // Create a new store instance on the same database
+      const store2 = createSqliteIdMappingStore(db);
+      expect(store2.getLocal("xmtp_abc12345feedbabe")).toBe(
+        "msg_1234567890abcdef",
+      );
+    });
+  });
+
+  describe("multiple resource types", () => {
+    test("stores mappings for different resource types independently", () => {
+      store.set("xmtp_aaa11111feedbabe", "msg_1234567890abcdef", "message");
+      store.set(
+        "xmtp_bbb22222feedbabe",
+        "conv_1234567890abcdef",
+        "conversation",
+      );
+      store.set("xmtp_ccc33333feedbabe", "inbox_1234567890abcdef", "inbox");
+
+      expect(store.getLocal("xmtp_aaa11111feedbabe")).toBe(
+        "msg_1234567890abcdef",
+      );
+      expect(store.getLocal("xmtp_bbb22222feedbabe")).toBe(
+        "conv_1234567890abcdef",
+      );
+      expect(store.getLocal("xmtp_ccc33333feedbabe")).toBe(
+        "inbox_1234567890abcdef",
+      );
+    });
+  });
+});

--- a/packages/core/src/id-mapping-store.ts
+++ b/packages/core/src/id-mapping-store.ts
@@ -1,0 +1,91 @@
+import type { Database } from "bun:sqlite";
+import type {
+  IdMappingStore,
+  IdMappingResourceTypeType,
+} from "@xmtp/signet-schemas";
+
+const CREATE_TABLE = `
+  CREATE TABLE IF NOT EXISTS id_mappings (
+    network_id   TEXT PRIMARY KEY,
+    local_id     TEXT NOT NULL UNIQUE,
+    resource_type TEXT NOT NULL,
+    created_at   TEXT NOT NULL DEFAULT (datetime('now'))
+  )
+`;
+
+const UPSERT = `
+  INSERT INTO id_mappings (network_id, local_id, resource_type)
+  VALUES (?1, ?2, ?3)
+  ON CONFLICT (network_id) DO UPDATE SET
+    local_id = excluded.local_id,
+    resource_type = excluded.resource_type
+`;
+
+const GET_BY_NETWORK = `SELECT local_id FROM id_mappings WHERE network_id = ?1`;
+const GET_BY_LOCAL = `SELECT network_id FROM id_mappings WHERE local_id = ?1`;
+const RESOLVE_BY_NETWORK = `SELECT network_id, local_id FROM id_mappings WHERE network_id = ?1`;
+const RESOLVE_BY_LOCAL = `SELECT network_id, local_id FROM id_mappings WHERE local_id = ?1`;
+
+/**
+ * Creates a SQLite-backed implementation of {@link IdMappingStore}.
+ *
+ * Stores bidirectional mappings between XMTP network IDs and local signet
+ * resource IDs. Uses `bun:sqlite` for zero-dependency persistence.
+ *
+ * @param db - A bun:sqlite Database instance (in-memory or file-backed)
+ */
+export function createSqliteIdMappingStore(db: Database): IdMappingStore {
+  db.run(CREATE_TABLE);
+
+  const upsertStmt = db.prepare(UPSERT);
+  const getByNetworkStmt = db.prepare<{ local_id: string }, [string]>(
+    GET_BY_NETWORK,
+  );
+  const getByLocalStmt = db.prepare<{ network_id: string }, [string]>(
+    GET_BY_LOCAL,
+  );
+  const resolveByNetworkStmt = db.prepare<
+    { network_id: string; local_id: string },
+    [string]
+  >(RESOLVE_BY_NETWORK);
+  const resolveByLocalStmt = db.prepare<
+    { network_id: string; local_id: string },
+    [string]
+  >(RESOLVE_BY_LOCAL);
+
+  return {
+    set(
+      networkId: string,
+      localId: string,
+      _resourceType: IdMappingResourceTypeType,
+    ): void {
+      upsertStmt.run(networkId, localId, _resourceType);
+    },
+
+    getLocal(networkId: string): string | null {
+      const row = getByNetworkStmt.get(networkId);
+      return row?.local_id ?? null;
+    },
+
+    getNetwork(localId: string): string | null {
+      const row = getByLocalStmt.get(localId);
+      return row?.network_id ?? null;
+    },
+
+    resolve(id: string): { networkId: string; localId: string } | null {
+      // Try network ID first (xmtp_ prefix is the common lookup path)
+      const byNetwork = resolveByNetworkStmt.get(id);
+      if (byNetwork) {
+        return { networkId: byNetwork.network_id, localId: byNetwork.local_id };
+      }
+
+      // Fall back to local ID lookup
+      const byLocal = resolveByLocalStmt.get(id);
+      if (byLocal) {
+        return { networkId: byLocal.network_id, localId: byLocal.local_id };
+      }
+
+      return null;
+    },
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,6 +59,9 @@ export type {
   RegisteredIdentity,
 } from "./identity-registration.js";
 
+// ID mapping store
+export { createSqliteIdMappingStore } from "./id-mapping-store.js";
+
 // Conversation actions
 export { createConversationActions } from "./conversation-actions.js";
 export type { ConversationActionDeps } from "./conversation-actions.js";


### PR DESCRIPTION
## Summary

Implement a concrete SQLite-backed `IdMappingStore` in `@xmtp/signet-core` that satisfies the interface defined in `@xmtp/signet-schemas`.

- `createSqliteIdMappingStore(db)` — factory that takes a `bun:sqlite` Database
- Bidirectional lookup: network ID -> local ID and reverse
- `resolve(id)` tries both directions for any-ID lookup
- Upsert semantics on conflict
- Prepared statements for performance
- Schema auto-creation (`CREATE TABLE IF NOT EXISTS`)
- Exported from `@xmtp/signet-core`

## Test plan

- [x] 13 tests covering forward/reverse lookup, persistence, upsert, multi-resource-type independence
- [x] `cd packages/core && bun run typecheck` — clean

Closes #204

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)