### PR TITLE
fix(keys): harden Secure Enclave test determinism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,11 @@ jobs:
 
       - name: Test
         run: bun run test
+        env:
+          # Live Secure Enclave tests are opt-in and require macOS + Apple
+          # Silicon + the compiled signet-signer binary. CI runs on
+          # ubuntu-latest where SE is unavailable, so these tests skip
+          # automatically via the SIGNET_RUN_LIVE_SE_TESTS gate.
+          #
+          # To run SE tests locally: SIGNET_RUN_LIVE_SE_TESTS=1 bun test
+          SIGNET_RUN_LIVE_SE_TESTS: "0"

--- a/packages/keys/src/__tests__/se-bridge.test.ts
+++ b/packages/keys/src/__tests__/se-bridge.test.ts
@@ -177,11 +177,18 @@ describe("se-bridge", () => {
   });
 
   describe("findSignerBinary", () => {
-    test("returns string or null", () => {
+    test("returns string on macOS with built signer, null otherwise", () => {
       const result = findSignerBinary();
-      // On macOS dev machines with a build, this should find the binary.
-      // On CI without a build, it returns null. Either is valid.
-      expect(result === null || typeof result === "string").toBe(true);
+      // findSignerBinary is environment-dependent: returns a path on macOS dev
+      // machines with a compiled signet-signer, null everywhere else (CI runs
+      // on ubuntu-latest). Both outcomes are correct — the function's contract
+      // is to probe, not to guarantee.
+      if (result !== null) {
+        expect(typeof result).toBe("string");
+        expect(result.length).toBeGreaterThan(0);
+      } else {
+        expect(result).toBeNull();
+      }
     });
   });
 });

--- a/packages/keys/src/__tests__/se-test-capability.ts
+++ b/packages/keys/src/__tests__/se-test-capability.ts
@@ -1,5 +1,20 @@
 import { findSignerBinary } from "../se-bridge.js";
 
+/**
+ * Secure Enclave test capability detection.
+ *
+ * SE tests are split into two tiers:
+ *
+ * 1. **se-bridge.test.ts** — deterministic, mock-based. Tests the bridge
+ *    protocol (JSON parsing, error handling, exit codes) using mock signer
+ *    scripts. Always runs on all platforms including CI.
+ *
+ * 2. **se-integration.test.ts** — live hardware tests. Requires macOS +
+ *    Apple Silicon + compiled signet-signer + explicit opt-in via
+ *    SIGNET_RUN_LIVE_SE_TESTS=1. Skipped everywhere else.
+ *
+ * This module gates tier 2 by probing the environment at import time.
+ */
 type SecureEnclaveTestCapability =
   | { kind: "disabled"; reason: string }
   | { kind: "unsupported" }


### PR DESCRIPTION
## Summary

Harden Secure Enclave test determinism by clearly documenting the two-tier test strategy and making CI gating explicit.

**Tier 1 (always runs):** `se-bridge.test.ts` — deterministic, mock-based. Tests the JSON bridge protocol using mock signer scripts. Works on all platforms including CI (ubuntu-latest).

**Tier 2 (opt-in):** `se-integration.test.ts` — live hardware. Requires macOS + Apple Silicon + compiled signet-signer + `SIGNET_RUN_LIVE_SE_TESTS=1`. Automatically skipped everywhere else.

Changes:
- Improved `findSignerBinary` test documentation for its environment-dependent nature
- Added `SIGNET_RUN_LIVE_SE_TESTS=0` to CI workflow with explanatory comments
- Added tier documentation to `se-test-capability.ts`

## Test plan

- [x] `bun test packages/keys/src/__tests__/se-bridge.test.ts` — 11 pass (deterministic)
- [x] `bun test packages/keys/src/__tests__/se-integration.test.ts` — 3 skip (no env var)
- [x] CI runs on ubuntu-latest where SE tests skip automatically

Closes #200

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)