### PR TITLE
feat(core): implement per-operator encrypted storage partitions

### DIFF
--- a/packages/core/src/__tests__/operator-storage.test.ts
+++ b/packages/core/src/__tests__/operator-storage.test.ts
@@ -1,0 +1,123 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Result } from "better-result";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  createOperatorStorageManager,
+  type OperatorStorageManager,
+} from "../operator-storage.js";
+
+describe("OperatorStorageManager", () => {
+  let baseDir: string;
+  let manager: OperatorStorageManager;
+
+  beforeEach(() => {
+    baseDir = mkdtempSync(join(tmpdir(), "signet-op-storage-"));
+    const result = createOperatorStorageManager(baseDir);
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result)) throw new Error("setup failed");
+    manager = result.value;
+  });
+
+  afterEach(() => {
+    manager.close();
+    rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  test("creates isolated data directory per operator", () => {
+    const partA = manager.getPartition("op_aaaa111122223333");
+    const partB = manager.getPartition("op_bbbb444455556666");
+
+    expect(Result.isOk(partA)).toBe(true);
+    expect(Result.isOk(partB)).toBe(true);
+
+    if (Result.isError(partA) || Result.isError(partB)) throw new Error("fail");
+
+    expect(partA.value.dataDir).not.toBe(partB.value.dataDir);
+    expect(partA.value.dataDir).toContain("op_aaaa111122223333");
+    expect(partB.value.dataDir).toContain("op_bbbb444455556666");
+
+    expect(existsSync(partA.value.dataDir)).toBe(true);
+    expect(existsSync(partB.value.dataDir)).toBe(true);
+  });
+
+  test("returns same partition for same operator ID (cached)", () => {
+    const part1 = manager.getPartition("op_aaaa111122223333");
+    const part2 = manager.getPartition("op_aaaa111122223333");
+
+    expect(Result.isOk(part1)).toBe(true);
+    expect(Result.isOk(part2)).toBe(true);
+
+    if (Result.isError(part1) || Result.isError(part2)) throw new Error("fail");
+
+    expect(part1.value.idMappings).toBe(part2.value.idMappings);
+  });
+
+  test("each partition has its own isolated ID mapping store", () => {
+    const partA = manager.getPartition("op_aaaa111122223333");
+    const partB = manager.getPartition("op_bbbb444455556666");
+
+    if (Result.isError(partA) || Result.isError(partB)) throw new Error("fail");
+
+    partA.value.idMappings.set(
+      "xmtp_aaa11111feedbabe",
+      "msg_1234567890abcdef",
+      "message",
+    );
+
+    expect(partA.value.idMappings.getLocal("xmtp_aaa11111feedbabe")).toBe(
+      "msg_1234567890abcdef",
+    );
+
+    expect(partB.value.idMappings.getLocal("xmtp_aaa11111feedbabe")).toBeNull();
+  });
+
+  test("lists active operator partitions", () => {
+    manager.getPartition("op_aaaa111122223333");
+    manager.getPartition("op_bbbb444455556666");
+
+    const operators = manager.listOperators();
+    expect(operators).toContain("op_aaaa111122223333");
+    expect(operators).toContain("op_bbbb444455556666");
+    expect(operators).toHaveLength(2);
+  });
+
+  test("creates operators/ subdirectory structure", () => {
+    manager.getPartition("op_aaaa111122223333");
+
+    expect(existsSync(join(baseDir, "operators"))).toBe(true);
+    expect(existsSync(join(baseDir, "operators", "op_aaaa111122223333"))).toBe(
+      true,
+    );
+    expect(
+      existsSync(
+        join(baseDir, "operators", "op_aaaa111122223333", "mappings.db"),
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects invalid operator IDs (path traversal prevention)", () => {
+    const bad1 = manager.getPartition("../escape");
+    expect(Result.isError(bad1)).toBe(true);
+
+    const bad2 = manager.getPartition("not-an-operator-id");
+    expect(Result.isError(bad2)).toBe(true);
+
+    const bad3 = manager.getPartition("");
+    expect(Result.isError(bad3)).toBe(true);
+
+    const bad4 = manager.getPartition("op_../../etc/passwd");
+    expect(Result.isError(bad4)).toBe(true);
+  });
+
+  test("dataDir can be used as vault root for per-operator encryption", () => {
+    const part = manager.getPartition("op_aaaa111122223333");
+    if (Result.isError(part)) throw new Error("fail");
+
+    const dataDir = part.value.dataDir;
+    expect(existsSync(dataDir)).toBe(true);
+    expect(dataDir).toContain("op_aaaa111122223333");
+    expect(dataDir).not.toContain("op_bbbb");
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,6 +62,13 @@ export type {
 // ID mapping store
 export { createSqliteIdMappingStore } from "./id-mapping-store.js";
 
+// Operator storage partitions
+export { createOperatorStorageManager } from "./operator-storage.js";
+export type {
+  OperatorStorageManager,
+  OperatorPartition,
+} from "./operator-storage.js";
+
 // Conversation actions
 export { createConversationActions } from "./conversation-actions.js";
 export type { ConversationActionDeps } from "./conversation-actions.js";

--- a/packages/core/src/operator-storage.ts
+++ b/packages/core/src/operator-storage.ts
@@ -1,0 +1,143 @@
+import { Result } from "better-result";
+import { Database } from "bun:sqlite";
+import { join } from "node:path";
+import { mkdirSync, existsSync, chmodSync } from "node:fs";
+import { InternalError, OperatorId } from "@xmtp/signet-schemas";
+import type { IdMappingStore } from "@xmtp/signet-schemas";
+import { createSqliteIdMappingStore } from "./id-mapping-store.js";
+
+/**
+ * An isolated storage partition for a single operator.
+ *
+ * Each partition has its own:
+ * - Data directory
+ * - ID mapping store (separate SQLite database per operator)
+ */
+export interface OperatorPartition {
+  /** The operator ID this partition belongs to. */
+  readonly operatorId: string;
+  /** The operator's isolated data directory. */
+  readonly dataDir: string;
+  /** Network ID <-> local ID mapping store scoped to this operator. */
+  readonly idMappings: IdMappingStore;
+}
+
+/**
+ * Manages per-operator encrypted storage partitions.
+ *
+ * Each operator gets its own subdirectory under the base data directory
+ * with a separate ID mapping store (separate SQLite database). The vault
+ * layer is composed externally — callers use the operator's `dataDir` as
+ * the vault root to get per-operator encryption keys.
+ *
+ * This provides storage isolation at the filesystem layer. When combined
+ * with the vault (which creates a separate encryption key per data
+ * directory), each operator's data is cryptographically isolated.
+ */
+export interface OperatorStorageManager {
+  /** Get or create an isolated storage partition for an operator. */
+  getPartition(operatorId: string): Result<OperatorPartition, InternalError>;
+
+  /** List operator IDs with active partitions. */
+  listOperators(): readonly string[];
+
+  /** Release all held resources. */
+  close(): void;
+}
+
+/**
+ * Create an operator storage manager rooted at the given base directory.
+ *
+ * Directory structure:
+ * ```
+ * baseDir/
+ *   operators/
+ *     op_aaaa111122223333/
+ *       mappings.db
+ *     op_bbbb444455556666/
+ *       mappings.db
+ * ```
+ *
+ * Callers compose vault access by passing `partition.dataDir` to
+ * `createVault()` from `@xmtp/signet-keys`.
+ */
+export function createOperatorStorageManager(
+  baseDir: string,
+): Result<OperatorStorageManager, InternalError> {
+  try {
+    const operatorsDir = join(baseDir, "operators");
+    if (!existsSync(operatorsDir)) {
+      mkdirSync(operatorsDir, { recursive: true });
+      chmodSync(operatorsDir, 0o700);
+    }
+
+    const partitions = new Map<string, OperatorPartition>();
+    const databases: Database[] = [];
+
+    return Result.ok({
+      getPartition(
+        operatorId: string,
+      ): Result<OperatorPartition, InternalError> {
+        const existing = partitions.get(operatorId);
+        if (existing) return Result.ok(existing);
+
+        // Validate operator ID format to prevent path traversal
+        const parsed = OperatorId.safeParse(operatorId);
+        if (!parsed.success) {
+          return Result.err(
+            InternalError.create(`Invalid operator ID: ${operatorId}`, {
+              cause: "Must match op_<16hex> format",
+            }),
+          );
+        }
+
+        try {
+          const opDir = join(operatorsDir, operatorId);
+          if (!existsSync(opDir)) {
+            mkdirSync(opDir, { recursive: true });
+            chmodSync(opDir, 0o700);
+          }
+
+          const dbPath = join(opDir, "mappings.db");
+          const db = new Database(dbPath);
+          databases.push(db);
+          const idMappings = createSqliteIdMappingStore(db);
+
+          const partition: OperatorPartition = {
+            operatorId,
+            dataDir: opDir,
+            idMappings,
+          };
+
+          partitions.set(operatorId, partition);
+          return Result.ok(partition);
+        } catch (e) {
+          return Result.err(
+            InternalError.create(
+              `Failed to create storage partition for operator ${operatorId}`,
+              { cause: String(e) },
+            ),
+          );
+        }
+      },
+
+      listOperators(): readonly string[] {
+        return [...partitions.keys()].sort();
+      },
+
+      close(): void {
+        for (const db of databases) {
+          db.close();
+        }
+        partitions.clear();
+        databases.length = 0;
+      },
+    });
+  } catch (e) {
+    return Result.err(
+      InternalError.create("Failed to create operator storage manager", {
+        cause: String(e),
+      }),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Implement per-operator encrypted storage partitions in `@xmtp/signet-core`.

`createOperatorStorageManager(baseDir)` creates isolated storage partitions for each operator under `baseDir/operators/{operatorId}/`. Each partition provides:

- Dedicated data directory with `0o700` permissions
- Isolated SQLite-backed `IdMappingStore` (separate database per operator)
- `dataDir` suitable as vault root for per-operator encryption via `createVault()` from `@xmtp/signet-keys`
- Operator ID validation against `OperatorId` schema (`op_<16hex>`) to prevent path traversal

Design: vault composition is external — callers pass `partition.dataDir` to `createVault()` to get per-operator encryption keys. This keeps `@xmtp/signet-core` free of a dependency on `@xmtp/signet-keys` while enabling cryptographic isolation.

## Test plan

- [x] 7 tests covering:
  - Directory isolation between operators
  - Partition caching (same ID returns same instance)
  - ID mapping isolation (operator A's mappings invisible to B)
  - Operator listing
  - Directory structure verification
  - Path traversal prevention (4 invalid-ID variants)
  - Vault composition pattern documentation
- [x] `cd packages/core && bun run typecheck` — clean

Closes #203

🤘🏻 In-collaboration-with: [Claude Code](https://claude.com/claude-code)