### PR TITLE
feat(keys): wire SE vault into compat runtime boot path

### DIFF
--- a/docs/secure-enclave-integration.md
+++ b/docs/secure-enclave-integration.md
@@ -1,12 +1,12 @@
 # Secure Enclave Integration
 
-This document describes the Secure Enclave integration primitives added to
-`@xmtp/signet-keys` and the intended runtime model for protecting the vault
-encryption secret and gating privileged operations. The keys package now
-contains the Secure Enclave-backed providers and bridge logic; wiring the
-daemon/runtime boot path to consume those providers remains a separate
-follow-on change. For the broader key hierarchy and threat model, see
-[security.md](security.md).
+This document describes the Secure Enclave integration primitives in
+`@xmtp/signet-keys` and the current runtime model for protecting persisted
+vault secret material and gating privileged key lifecycle operations. The
+daemon/runtime boot path now consumes the Secure Enclave-backed vault provider
+through the compat key manager's encrypted vault storage. Broader policy-level
+gates such as scope or egress expansion still require separate runtime wiring.
+For the broader key hierarchy and threat model, see [security.md](security.md).
 
 ## Overview
 
@@ -115,8 +115,8 @@ presence is required at every cold start.
 Configuration:
 
 ```toml
-[security]
-vault_key_policy = "open"  # "open" | "passcode" | "biometric"
+[keys]
+vaultKeyPolicy = "open"  # "open" | "passcode" | "biometric"
 ```
 
 ## Biometric Gate for Privileged Operations
@@ -124,17 +124,23 @@ vault_key_policy = "open"  # "open" | "passcode" | "biometric"
 Separately from vault unlock, certain operations can require Touch ID
 confirmation. This uses a second SE key with `biometric` policy.
 
+The current runtime wiring applies this gate to compat key lifecycle
+operations such as root key creation, agent/operational key creation, and
+operational key rotation. Scope- and egress-expansion gate toggles remain
+part of the broader intended model, but are not yet consumed by a runtime
+code path.
+
 ### Gated operations
 
 Configurable per-operation:
 
 ```toml
-[security.biometric]
-root_key_creation = true
-operational_key_rotation = true
-scope_expansion = true
-egress_expansion = true
-agent_creation = false
+[biometricGating]
+rootKeyCreation = true
+operationalKeyRotation = true
+scopeExpansion = true
+egressExpansion = true
+agentCreation = false
 ```
 
 When a gated operation fires:
@@ -152,8 +158,8 @@ gated operations return an error instead of silently succeeding. This
 prevents a configuration that expects biometric enforcement from being
 silently bypassed on an unsupported platform.
 
-On platforms without SE, to run without biometric gating, the
-configuration must explicitly disable all gate toggles (the defaults).
+On platforms without SE, to run without biometric gating, keep all gate
+toggles disabled (the defaults).
 
 ## Software Fallback
 
@@ -332,10 +338,16 @@ The vault secret transitions: SE-protected (old) → passphrase-protected
 
 ```text
 dataDir/
+  secrets/                 # encrypted compat key-manager secret entries
+    admin-key.bin
+    admin-key-pub.bin
+    db-key%3A<identity>.bin
+    xmtp-identity-key%3A<identity>.bin
   se-vault-keyref          # base64 SE key data representation
   vault-sealed-box.json    # { ephemeralPublicKey, nonce, ciphertext, tag }
   se-gate-keyref           # base64 SE gate key data representation (created on first gated op)
   vault-passphrase         # software fallback only (0o600, not present on SE platforms)
+  kv/                      # legacy compat layout, lazily migrated into secrets/
 ```
 
 ## Testing Strategy

--- a/docs/security.md
+++ b/docs/security.md
@@ -134,9 +134,10 @@ All persistent key material lives in an encrypted vault.
 - **Permissions:** `0o600` on both the vault database and its encryption key
 - **Zeroization:** Exported private key bytes are `fill(0)`'d immediately
   after vault storage
-- **Future:** The vault passphrase will be protected by the Secure Enclave —
-  hardware-bound, non-exportable. The only way to unlock the vault will be
-  through the enclave, gated by biometrics or a passkey.
+- **Secure Enclave protection when available:** the vault secret can be
+  hardware-bound and non-exportable via Secure Enclave ECIES. The active
+  runtime now uses that path for compat key-manager persisted secret
+  material, while broader policy-level gate wiring continues separately.
 
 ## MLS and the decryption boundary
 

--- a/packages/cli/src/__tests__/config-loader.test.ts
+++ b/packages/cli/src/__tests__/config-loader.test.ts
@@ -55,6 +55,8 @@ defaultTtlSeconds = 7200
     expect(config.credentials.defaultTtlSeconds).toBe(7200);
     // Unspecified sections get defaults
     expect(config.keys.rootKeyPolicy).toBe("biometric");
+    expect(config.keys.vaultKeyPolicy).toBe("open");
+    expect(config.biometricGating.rootKeyCreation).toBe(false);
     expect(config.logging.level).toBe("info");
   });
 

--- a/packages/cli/src/__tests__/config-schema.test.ts
+++ b/packages/cli/src/__tests__/config-schema.test.ts
@@ -13,6 +13,8 @@ describe("CliConfigSchema", () => {
     expect(config.signet.dataDir).toBeUndefined();
     expect(config.keys.rootKeyPolicy).toBe("biometric");
     expect(config.keys.operationalKeyPolicy).toBe("open");
+    expect(config.keys.vaultKeyPolicy).toBe("open");
+    expect(config.biometricGating.rootKeyCreation).toBe(false);
     expect(config.ws.port).toBe(8393);
     expect(config.ws.host).toBe("127.0.0.1");
     expect(config.admin.authMode).toBe("admin-key");

--- a/packages/cli/src/__tests__/runtime.test.ts
+++ b/packages/cli/src/__tests__/runtime.test.ts
@@ -44,12 +44,17 @@ function createCallTracker(): {
 function makeMockDeps(tracker: {
   calls: string[];
   record(name: string): void;
-}): SignetRuntimeDeps & { _dispatcher: () => AdminDispatcher | undefined } {
+}): SignetRuntimeDeps & {
+  _dispatcher: () => AdminDispatcher | undefined;
+  _keyManagerConfig: () => unknown;
+} {
   let capturedDispatcher: AdminDispatcher | undefined;
+  let capturedKeyManagerConfig: unknown;
 
   return {
-    createKeyManager: async () => {
+    createKeyManager: async (config) => {
       tracker.record("keyManager.create");
+      capturedKeyManagerConfig = config;
       return Result.ok({
         initialize: async () => {
           tracker.record("keyManager.initialize");
@@ -221,6 +226,7 @@ function makeMockDeps(tracker: {
       };
     },
     _dispatcher: () => capturedDispatcher,
+    _keyManagerConfig: () => capturedKeyManagerConfig,
   };
 }
 
@@ -260,6 +266,43 @@ describe("createSignetRuntime", () => {
     expect(runtime.wsServer).toBeDefined();
     expect(runtime.adminServer).toBeDefined();
     expect(runtime.paths).toBeDefined();
+  });
+
+  test("passes vault and biometric config through to createKeyManager", async () => {
+    const tracker = createCallTracker();
+    const config = CliConfigSchema.parse({
+      signet: { dataDir: join(tempDir, "data") },
+      admin: { socketPath: join(tempDir, "admin.sock") },
+      logging: { auditLogPath: join(tempDir, "audit.jsonl") },
+      keys: {
+        rootKeyPolicy: "passcode",
+        operationalKeyPolicy: "open",
+        vaultKeyPolicy: "biometric",
+      },
+      biometricGating: {
+        rootKeyCreation: true,
+        operationalKeyRotation: true,
+      },
+    });
+    const deps = makeMockDeps(tracker);
+
+    const result = await createSignetRuntime(config, deps);
+
+    expect(Result.isOk(result)).toBe(true);
+    expect(deps._keyManagerConfig()).toEqual({
+      platform: "software-vault",
+      rootKeyPolicy: "passcode",
+      operationalKeyPolicy: "open",
+      vaultKeyPolicy: "biometric",
+      biometricGating: {
+        rootKeyCreation: true,
+        operationalKeyRotation: true,
+        scopeExpansion: false,
+        egressExpansion: false,
+        agentCreation: false,
+      },
+      dataDir: join(tempDir, "data"),
+    });
   });
 
   test("start() transitions through states correctly", async () => {

--- a/packages/cli/src/commands/admin.ts
+++ b/packages/cli/src/commands/admin.ts
@@ -49,6 +49,8 @@ export function createAdminCommands(): Command {
       const kmResult = await createKeyManager({
         rootKeyPolicy: config.keys.rootKeyPolicy,
         operationalKeyPolicy: config.keys.operationalKeyPolicy,
+        vaultKeyPolicy: config.keys.vaultKeyPolicy,
+        biometricGating: config.biometricGating,
         dataDir: paths.dataDir,
       });
       if (Result.isError(kmResult)) {

--- a/packages/cli/src/commands/daemon-client.ts
+++ b/packages/cli/src/commands/daemon-client.ts
@@ -84,6 +84,8 @@ export function createWithDaemonClient(
     const keyManagerResult = await resolvedDeps.createKeyManager({
       rootKeyPolicy: config.keys.rootKeyPolicy,
       operationalKeyPolicy: config.keys.operationalKeyPolicy,
+      vaultKeyPolicy: config.keys.vaultKeyPolicy,
+      biometricGating: config.biometricGating,
       dataDir: paths.dataDir,
     });
     if (keyManagerResult.isErr()) {

--- a/packages/cli/src/commands/identity.ts
+++ b/packages/cli/src/commands/identity.ts
@@ -119,6 +119,8 @@ export function createIdentityInitCommand(): Command {
       const kmResult = await createKeyManager({
         rootKeyPolicy: config.keys.rootKeyPolicy,
         operationalKeyPolicy: config.keys.operationalKeyPolicy,
+        vaultKeyPolicy: config.keys.vaultKeyPolicy,
+        biometricGating: config.biometricGating,
         dataDir: paths.dataDir,
       });
       if (Result.isError(kmResult)) {

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -94,6 +94,7 @@ export type CliConfig = {
   keys: {
     rootKeyPolicy: "biometric" | "passcode" | "open";
     operationalKeyPolicy: "biometric" | "passcode" | "open";
+    vaultKeyPolicy: "biometric" | "passcode" | "open";
   };
   biometricGating: BiometricGateConfig;
   ws: {
@@ -119,6 +120,7 @@ type CliConfigInput = {
     | {
         rootKeyPolicy?: "biometric" | "passcode" | "open" | undefined;
         operationalKeyPolicy?: "biometric" | "passcode" | "open" | undefined;
+        vaultKeyPolicy?: "biometric" | "passcode" | "open" | undefined;
       }
     | undefined;
   biometricGating?: BiometricGateConfigInput | undefined;
@@ -176,6 +178,10 @@ const CliConfigBaseSchema = z
           .enum(["biometric", "passcode", "open"])
           .default("open")
           .describe("Protection level for operational keys"),
+        vaultKeyPolicy: z
+          .enum(["biometric", "passcode", "open"])
+          .default("open")
+          .describe("Protection level for persisted vault secret material"),
       })
       .default({}),
     biometricGating: BiometricGateConfigSchema.default({}),

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -119,6 +119,8 @@ export async function createSignetRuntime(
     platform: "software-vault",
     rootKeyPolicy: config.keys.rootKeyPolicy,
     operationalKeyPolicy: config.keys.operationalKeyPolicy,
+    vaultKeyPolicy: config.keys.vaultKeyPolicy,
+    biometricGating: config.biometricGating,
     dataDir: paths.dataDir,
   });
 

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -99,11 +99,15 @@ export function createProductionDeps(): SignetRuntimeDeps {
         platform: string;
         rootKeyPolicy: KeyManagerConfig["rootKeyPolicy"];
         operationalKeyPolicy: KeyManagerConfig["operationalKeyPolicy"];
+        vaultKeyPolicy: KeyManagerConfig["vaultKeyPolicy"];
+        biometricGating: KeyManagerConfig["biometricGating"];
         dataDir: string;
       };
       const result = await createKeyManager({
         rootKeyPolicy: cfg.rootKeyPolicy,
         operationalKeyPolicy: cfg.operationalKeyPolicy,
+        vaultKeyPolicy: cfg.vaultKeyPolicy,
+        biometricGating: cfg.biometricGating,
         dataDir: cfg.dataDir,
       });
       if (Result.isOk(result)) {

--- a/packages/keys/src/__tests__/biometric-gate.test.ts
+++ b/packages/keys/src/__tests__/biometric-gate.test.ts
@@ -8,9 +8,9 @@ import {
 } from "../biometric-gate.js";
 
 describe("BiometricGateConfig", () => {
-  test("defaults: rootKeyCreation on, everything else off", () => {
+  test("defaults all gating off", () => {
     const config = BiometricGateConfigSchema.parse({});
-    expect(config.rootKeyCreation).toBe(true);
+    expect(config.rootKeyCreation).toBe(false);
     expect(config.operationalKeyRotation).toBe(false);
     expect(config.scopeExpansion).toBe(false);
     expect(config.egressExpansion).toBe(false);

--- a/packages/keys/src/__tests__/config.test.ts
+++ b/packages/keys/src/__tests__/config.test.ts
@@ -44,6 +44,8 @@ describe("KeyManagerConfigSchema", () => {
     expect(config.dataDir).toBe("/tmp/keys");
     expect(config.rootKeyPolicy).toBe("biometric");
     expect(config.operationalKeyPolicy).toBe("open");
+    expect(config.vaultKeyPolicy).toBe("open");
+    expect(config.biometricGating.rootKeyCreation).toBe(false);
     expect(config.rotationIntervalSeconds).toBe(86400);
   });
 
@@ -52,10 +54,14 @@ describe("KeyManagerConfigSchema", () => {
       dataDir: "/tmp/keys",
       rootKeyPolicy: "open",
       operationalKeyPolicy: "passcode",
+      vaultKeyPolicy: "biometric",
+      biometricGating: { operationalKeyRotation: true },
       rotationIntervalSeconds: 7200,
     });
     expect(config.rootKeyPolicy).toBe("open");
     expect(config.operationalKeyPolicy).toBe("passcode");
+    expect(config.vaultKeyPolicy).toBe("biometric");
+    expect(config.biometricGating.operationalKeyRotation).toBe(true);
     expect(config.rotationIntervalSeconds).toBe(7200);
   });
 

--- a/packages/keys/src/__tests__/key-manager-compat.test.ts
+++ b/packages/keys/src/__tests__/key-manager-compat.test.ts
@@ -1,11 +1,21 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { Result } from "better-result";
+import { InternalError } from "@xmtp/signet-schemas";
 import { mkdtemp, rm } from "node:fs/promises";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createKeyManager } from "../key-manager-compat.js";
 import { createSealStamper } from "../seal-stamper.js";
 import { createSignerProvider } from "../signer-provider.js";
+import type { VaultSecretProvider } from "../vault-secret-provider.js";
+import type { BiometricPrompter } from "../biometric-gate.js";
+import {
+  exportPrivateKey,
+  exportPublicKey,
+  generateEd25519KeyPair,
+  toHex,
+} from "../crypto-keys.js";
 
 const testDirs: string[] = [];
 
@@ -20,7 +30,34 @@ afterEach(async () => {
   );
 });
 
-async function setupCompatKeyManager() {
+function createDeterministicVaultSecretProvider(): VaultSecretProvider {
+  return {
+    kind: "software",
+    async getSecret() {
+      return Result.ok("11".repeat(32));
+    },
+  };
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function setupCompatKeyManager(
+  overrides: {
+    biometricGating?: {
+      rootKeyCreation?: boolean;
+      operationalKeyRotation?: boolean;
+      scopeExpansion?: boolean;
+      egressExpansion?: boolean;
+      agentCreation?: boolean;
+    };
+    biometricPrompter?: BiometricPrompter;
+    vaultSecretProvider?: VaultSecretProvider;
+  } = {},
+) {
   const dataDir = await mkdtemp(join(tmpdir(), "xmtp-signet-keymgr-compat-"));
   testDirs.push(dataDir);
 
@@ -28,6 +65,11 @@ async function setupCompatKeyManager() {
     dataDir,
     rootKeyPolicy: "open",
     operationalKeyPolicy: "open",
+    vaultKeyPolicy: "open",
+    biometricGating: overrides.biometricGating,
+    biometricPrompter: overrides.biometricPrompter,
+    vaultSecretProvider:
+      overrides.vaultSecretProvider ?? createDeterministicVaultSecretProvider(),
   });
   expect(Result.isOk(managerResult)).toBe(true);
   if (Result.isError(managerResult)) {
@@ -56,6 +98,8 @@ describe("createKeyManager admin key persistence", () => {
       dataDir: testDirs[0] ?? "",
       rootKeyPolicy: "open",
       operationalKeyPolicy: "open",
+      vaultKeyPolicy: "open",
+      vaultSecretProvider: createDeterministicVaultSecretProvider(),
     });
     expect(Result.isOk(secondManager)).toBe(true);
     if (Result.isError(secondManager)) return;
@@ -95,6 +139,81 @@ describe("createKeyManager admin key persistence", () => {
 
     const verified = await manager.admin.verifyJwt(tampered);
     expect(Result.isError(verified)).toBe(true);
+  });
+
+  test("persists compat secret material in the encrypted vault layout", async () => {
+    const manager = await setupCompatKeyManager();
+
+    const created = await manager.admin.create();
+    expect(Result.isOk(created)).toBe(true);
+
+    const dbKey = await manager.getOrCreateDbKey("identity-a");
+    expect(Result.isOk(dbKey)).toBe(true);
+
+    const identityKey = await manager.getOrCreateXmtpIdentityKey("identity-a");
+    expect(Result.isOk(identityKey)).toBe(true);
+
+    const dataDir = testDirs[0] ?? "";
+    expect(existsSync(join(dataDir, "secrets", "admin-key.bin"))).toBe(true);
+    expect(existsSync(join(dataDir, "secrets", "admin-key-pub.bin"))).toBe(
+      true,
+    );
+    expect(
+      existsSync(join(dataDir, "secrets", "db-key%3Aidentity-a.bin")),
+    ).toBe(true);
+    expect(
+      existsSync(
+        join(dataDir, "secrets", "xmtp-identity-key%3Aidentity-a.bin"),
+      ),
+    ).toBe(true);
+    expect(existsSync(join(dataDir, "kv", "admin-key"))).toBe(false);
+  });
+
+  test("migrates legacy kv admin material into the encrypted vault on initialize", async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), "xmtp-signet-keymgr-legacy-"));
+    testDirs.push(dataDir);
+
+    const pair = await generateEd25519KeyPair();
+    expect(Result.isOk(pair)).toBe(true);
+    if (Result.isError(pair)) return;
+
+    const privateKey = await exportPrivateKey(pair.value.privateKey);
+    const publicKey = await exportPublicKey(pair.value.publicKey);
+    expect(Result.isOk(privateKey)).toBe(true);
+    expect(Result.isOk(publicKey)).toBe(true);
+    if (Result.isError(privateKey) || Result.isError(publicKey)) return;
+
+    const publicKeyHex = toHex(publicKey.value);
+    const kvDir = join(dataDir, "kv");
+    mkdirSync(kvDir, { recursive: true });
+    writeFileSync(join(kvDir, "admin-key"), bytesToHex(privateKey.value));
+    writeFileSync(
+      join(kvDir, "admin-key-pub"),
+      bytesToHex(new TextEncoder().encode(publicKeyHex)),
+    );
+
+    const managerResult = await createKeyManager({
+      dataDir,
+      rootKeyPolicy: "open",
+      operationalKeyPolicy: "open",
+      vaultKeyPolicy: "open",
+      vaultSecretProvider: createDeterministicVaultSecretProvider(),
+    });
+    expect(Result.isOk(managerResult)).toBe(true);
+    if (Result.isError(managerResult)) return;
+
+    const initialized = await managerResult.value.initialize();
+    expect(Result.isOk(initialized)).toBe(true);
+    expect(managerResult.value.admin.exists()).toBe(true);
+
+    const signed = await managerResult.value.admin.signJwt({ ttlSeconds: 120 });
+    expect(Result.isOk(signed)).toBe(true);
+    expect(existsSync(join(kvDir, "admin-key"))).toBe(false);
+    expect(existsSync(join(kvDir, "admin-key-pub"))).toBe(false);
+    expect(existsSync(join(dataDir, "secrets", "admin-key.bin"))).toBe(true);
+    expect(existsSync(join(dataDir, "secrets", "admin-key-pub.bin"))).toBe(
+      true,
+    );
   });
 });
 
@@ -157,5 +276,73 @@ describe("compat signer and stamper helpers", () => {
       issuer: "owner",
     });
     expect(Result.isOk(revocation)).toBe(true);
+  });
+});
+
+describe("createKeyManager biometric gating", () => {
+  test("prompts for root key creation when enabled", async () => {
+    const prompted: string[] = [];
+    const manager = await setupCompatKeyManager({
+      biometricGating: { rootKeyCreation: true },
+      biometricPrompter: async (operation) => {
+        prompted.push(operation);
+        return Result.ok(undefined);
+      },
+    });
+
+    const created = await manager.admin.create();
+    expect(Result.isOk(created)).toBe(true);
+    expect(prompted).toEqual(["rootKeyCreation"]);
+  });
+
+  test("prompts for agent creation when enabled", async () => {
+    const prompted: string[] = [];
+    const manager = await setupCompatKeyManager({
+      biometricGating: { agentCreation: true },
+      biometricPrompter: async (operation) => {
+        prompted.push(operation);
+        return Result.ok(undefined);
+      },
+    });
+
+    const created = await manager.createOperationalKey("identity-gated", null);
+    expect(Result.isOk(created)).toBe(true);
+    expect(prompted).toEqual(["agentCreation"]);
+  });
+
+  test("prompts for operational key rotation when enabled", async () => {
+    const prompted: string[] = [];
+    const manager = await setupCompatKeyManager({
+      biometricGating: { operationalKeyRotation: true },
+      biometricPrompter: async (operation) => {
+        prompted.push(operation);
+        return Result.ok(undefined);
+      },
+    });
+
+    const created = await manager.createOperationalKey("identity-rot", null);
+    expect(Result.isOk(created)).toBe(true);
+
+    const rotated = await manager.rotateOperationalKey("identity-rot");
+    expect(Result.isOk(rotated)).toBe(true);
+    expect(prompted).toEqual(["operationalKeyRotation"]);
+  });
+
+  test("fails closed when root key creation is gated and denied", async () => {
+    const manager = await setupCompatKeyManager({
+      biometricGating: { rootKeyCreation: true },
+      biometricPrompter: async () =>
+        Result.err(
+          InternalError.create("Biometric gate unavailable", {
+            category: "cancelled",
+          }),
+        ),
+    });
+
+    const created = await manager.admin.create();
+    expect(Result.isError(created)).toBe(true);
+    if (Result.isOk(created)) return;
+    expect(created.error.message).toContain("Biometric gate unavailable");
+    expect(manager.admin.exists()).toBe(false);
   });
 });

--- a/packages/keys/src/biometric-gate.ts
+++ b/packages/keys/src/biometric-gate.ts
@@ -30,7 +30,7 @@ export const BiometricGateConfigSchema: z.ZodType<
   .object({
     rootKeyCreation: z
       .boolean()
-      .default(true)
+      .default(false)
       .describe("Require biometric for root key creation"),
     operationalKeyRotation: z
       .boolean()

--- a/packages/keys/src/config.ts
+++ b/packages/keys/src/config.ts
@@ -1,4 +1,9 @@
 import { z } from "zod";
+import {
+  BiometricGateConfigSchema,
+  type BiometricGateConfig,
+  type BiometricGateConfigInput,
+} from "./biometric-gate.js";
 
 /** Access policy for a specific key tier. */
 export const KeyPolicySchema: z.ZodEnum<["biometric", "passcode", "open"]> = z
@@ -23,6 +28,8 @@ export type KeyManagerConfig = {
   dataDir: string;
   rootKeyPolicy: KeyPolicy;
   operationalKeyPolicy: KeyPolicy;
+  vaultKeyPolicy: KeyPolicy;
+  biometricGating: BiometricGateConfig;
   /** Auto-rotation interval in seconds. 0 disables auto-rotation. */
   rotationIntervalSeconds: number;
 };
@@ -32,6 +39,8 @@ type KeyManagerConfigInput = {
   dataDir: string;
   rootKeyPolicy?: KeyPolicy | undefined;
   operationalKeyPolicy?: KeyPolicy | undefined;
+  vaultKeyPolicy?: KeyPolicy | undefined;
+  biometricGating?: BiometricGateConfigInput | undefined;
   rotationIntervalSeconds?: number | undefined;
 };
 
@@ -48,6 +57,12 @@ export const KeyManagerConfigSchema: z.ZodType<
     ),
     operationalKeyPolicy: KeyPolicySchema.default("open").describe(
       "Access policy for routine operations",
+    ),
+    vaultKeyPolicy: KeyPolicySchema.default("open").describe(
+      "Access policy for persisted vault secret protection",
+    ),
+    biometricGating: BiometricGateConfigSchema.default({}).describe(
+      "Per-operation biometric gate configuration",
     ),
     rotationIntervalSeconds: z
       .number()

--- a/packages/keys/src/index.ts
+++ b/packages/keys/src/index.ts
@@ -60,7 +60,12 @@ export type {
 
 // Vault
 export { createVault } from "./vault.js";
-export type { Vault, WalletFileInfo, AccountEntry } from "./vault.js";
+export type {
+  Vault,
+  WalletFileInfo,
+  AccountEntry,
+  CreateVaultOptions,
+} from "./vault.js";
 
 // Signer provider
 export { createSignerProvider } from "./signer-provider.js";

--- a/packages/keys/src/key-manager-compat.ts
+++ b/packages/keys/src/key-manager-compat.ts
@@ -12,6 +12,10 @@ import {
 } from "./config.js";
 import { detectPlatform, platformToTrustTier } from "./platform.js";
 import type { TrustTier } from "./platform.js";
+import {
+  createBiometricGate,
+  type BiometricPrompter,
+} from "./biometric-gate.js";
 import type { RootKeyHandle, OperationalKey, CredentialKey } from "./types.js";
 import { verifyJwt as verifyAdminJwt, type AdminJwtPayload } from "./jwt.js";
 import {
@@ -29,9 +33,12 @@ import {
   readFileSync,
   readdirSync,
   unlinkSync,
-  writeFileSync,
+  rmdirSync,
 } from "node:fs";
 import { join } from "node:path";
+import { createVault, type Vault } from "./vault.js";
+import { resolveGatePrompter } from "./se-gate-prompter.js";
+import type { VaultSecretProvider } from "./vault-secret-provider.js";
 
 type AdminKeyInfo = string & {
   readonly publicKey: string;
@@ -39,10 +46,11 @@ type AdminKeyInfo = string & {
 };
 
 interface SimpleKvStore {
-  get(key: string): Result<Uint8Array, NotFoundError | InternalError>;
-  set(key: string, value: Uint8Array): Result<void, InternalError>;
-  delete(key: string): Result<void, NotFoundError>;
+  get(key: string): Promise<Result<Uint8Array, NotFoundError | InternalError>>;
+  set(key: string, value: Uint8Array): Promise<Result<void, InternalError>>;
+  delete(key: string): Promise<Result<void, NotFoundError>>;
   list(): readonly string[];
+  close(): void;
 }
 
 interface OperationalKeyEntry {
@@ -55,6 +63,11 @@ interface CredentialKeyEntry {
   readonly privateKey: CryptoKey;
 }
 
+type CreateKeyManagerDeps = {
+  readonly vaultSecretProvider?: VaultSecretProvider;
+  readonly biometricPrompter?: BiometricPrompter;
+};
+
 /**
  * Admin key operations used by the CLI and runtime boot path.
  */
@@ -63,7 +76,7 @@ export interface AdminKeyManager {
   exists(): boolean;
 
   /** Create and persist the admin signing key. */
-  create(): Promise<Result<AdminKeyInfo, InternalError>>;
+  create(): Promise<Result<AdminKeyInfo, SignetError>>;
 
   /** Read the existing admin key metadata without re-creating it. */
   get(): Promise<Result<AdminKeyInfo, NotFoundError | InternalError>>;
@@ -98,7 +111,7 @@ export interface KeyManager {
   createOperationalKey(
     identityId: string,
     groupId: string | null,
-  ): Promise<Result<OperationalKey, InternalError>>;
+  ): Promise<Result<OperationalKey, SignetError>>;
 
   /** Lookup an operational key by identity ID. */
   getOperationalKey(identityId: string): Result<OperationalKey, NotFoundError>;
@@ -111,7 +124,7 @@ export interface KeyManager {
   /** Rotate an operational key in place. */
   rotateOperationalKey(
     identityId: string,
-  ): Promise<Result<OperationalKey, InternalError | NotFoundError>>;
+  ): Promise<Result<OperationalKey, SignetError>>;
 
   /** List all known operational keys. */
   listOperationalKeys(): readonly OperationalKey[];
@@ -215,57 +228,135 @@ async function fingerprintBytes(bytes: Uint8Array): Promise<string> {
   return bytesToHex(new Uint8Array(digest));
 }
 
-function createSimpleKvStore(dataDir: string): SimpleKvStore {
-  const kvDir = join(dataDir, "kv");
-  mkdirSync(kvDir, { recursive: true });
+function legacyKvDirPath(dataDir: string): string {
+  return join(dataDir, "kv");
+}
 
-  function keyPath(key: string): string {
-    return join(kvDir, encodeURIComponent(key));
+function legacyKvKeyPath(dataDir: string, key: string): string {
+  return join(legacyKvDirPath(dataDir), encodeURIComponent(key));
+}
+
+function readLegacyKvEntry(
+  dataDir: string,
+  key: string,
+): Result<Uint8Array, NotFoundError | InternalError> {
+  const path = legacyKvKeyPath(dataDir, key);
+  if (!existsSync(path)) {
+    return Result.err(NotFoundError.create("kv-entry", key));
   }
 
+  try {
+    const hex = readFileSync(path, "utf8");
+    return Result.ok(hexToBytes(hex));
+  } catch (error: unknown) {
+    return Result.err(
+      InternalError.create("Failed to read legacy compat vault entry", {
+        key,
+        cause: error instanceof Error ? error.message : String(error),
+      }),
+    );
+  }
+}
+
+function removeLegacyKvEntry(dataDir: string, key: string): void {
+  const path = legacyKvKeyPath(dataDir, key);
+  if (!existsSync(path)) {
+    return;
+  }
+
+  try {
+    unlinkSync(path);
+  } catch {
+    return;
+  }
+
+  const kvDir = legacyKvDirPath(dataDir);
+  if (!existsSync(kvDir)) {
+    return;
+  }
+
+  try {
+    if (readdirSync(kvDir).length === 0) {
+      rmdirSync(kvDir);
+    }
+  } catch {
+    // Best-effort cleanup only.
+  }
+}
+
+function listLegacyKvEntries(dataDir: string): readonly string[] {
+  const kvDir = legacyKvDirPath(dataDir);
+  if (!existsSync(kvDir)) {
+    return [];
+  }
+
+  return readdirSync(kvDir).map(decodeURIComponent);
+}
+
+function createCompatSecretStore(dataDir: string, vault: Vault): SimpleKvStore {
   return {
-    get(key) {
-      const path = keyPath(key);
-      if (!existsSync(path)) {
-        return Result.err(NotFoundError.create("kv-entry", key));
+    async get(key) {
+      const current = await vault.get(key);
+      if (Result.isOk(current)) {
+        return current;
       }
-      try {
-        const hex = readFileSync(path, "utf8");
-        return Result.ok(hexToBytes(hex));
-      } catch (error: unknown) {
-        return Result.err(
-          InternalError.create("Failed to read compat vault entry", {
-            key,
-            cause: error instanceof Error ? error.message : String(error),
-          }),
-        );
+      if (current.error._tag !== "NotFoundError") {
+        return current;
       }
+
+      const legacy = readLegacyKvEntry(dataDir, key);
+      if (Result.isError(legacy)) {
+        return legacy;
+      }
+
+      const migrated = await vault.set(key, legacy.value);
+      if (Result.isError(migrated)) {
+        return migrated;
+      }
+
+      removeLegacyKvEntry(dataDir, key);
+      return Result.ok(legacy.value);
     },
-    set(key, value) {
-      try {
-        writeFileSync(keyPath(key), bytesToHex(value), "utf8");
+
+    async set(key, value) {
+      const result = await vault.set(key, value);
+      if (Result.isOk(result)) {
+        removeLegacyKvEntry(dataDir, key);
+      }
+      return result;
+    },
+
+    async delete(key) {
+      const current = await vault.delete(key);
+      const hadLegacy = existsSync(legacyKvKeyPath(dataDir, key));
+
+      if (Result.isOk(current)) {
+        if (hadLegacy) {
+          removeLegacyKvEntry(dataDir, key);
+        }
+        return current;
+      }
+
+      if (current.error._tag !== "NotFoundError") {
+        return current;
+      }
+
+      if (hadLegacy) {
+        removeLegacyKvEntry(dataDir, key);
         return Result.ok(undefined);
-      } catch (error: unknown) {
-        return Result.err(
-          InternalError.create("Failed to write compat vault entry", {
-            key,
-            cause: error instanceof Error ? error.message : String(error),
-          }),
-        );
       }
+
+      return current;
     },
-    delete(key) {
-      const path = keyPath(key);
-      if (!existsSync(path)) {
-        return Result.err(NotFoundError.create("kv-entry", key));
-      }
-      unlinkSync(path);
-      return Result.ok(undefined);
-    },
+
     list() {
-      return existsSync(kvDir)
-        ? readdirSync(kvDir).map(decodeURIComponent)
-        : [];
+      return Array.from(
+        new Set([...vault.list(), ...listLegacyKvEntries(dataDir)]),
+      );
+    },
+
+    close() {
+      vault.close();
     },
   };
 }
@@ -276,9 +367,11 @@ function createSimpleKvStore(dataDir: string): SimpleKvStore {
 export async function createKeyManager(
   rawConfig: Partial<KeyManagerConfig> & {
     dataDir: string;
-  },
+  } & CreateKeyManagerDeps,
 ): Promise<Result<KeyManager, InternalError>> {
-  const parsed = KeyManagerConfigSchema.safeParse(rawConfig);
+  const { vaultSecretProvider, biometricPrompter, ...configInput } = rawConfig;
+
+  const parsed = KeyManagerConfigSchema.safeParse(configInput);
   if (!parsed.success) {
     return Result.err(
       InternalError.create("Invalid key manager config", {
@@ -290,10 +383,22 @@ export async function createKeyManager(
   const config = parsed.data;
   mkdirSync(config.dataDir, { recursive: true });
 
-  const kv = createSimpleKvStore(config.dataDir);
+  const vaultResult = await createVault(config.dataDir, {
+    secretProvider: vaultSecretProvider,
+    vaultKeyPolicy: config.vaultKeyPolicy,
+  });
+  if (Result.isError(vaultResult)) {
+    return vaultResult;
+  }
+
+  const kv = createCompatSecretStore(config.dataDir, vaultResult.value);
   const opKeys = new Map<string, OperationalKeyEntry>();
   const groupIdIndex = new Map<string, string>();
   const credentialKeys = new Map<string, CredentialKeyEntry>();
+  const gate = createBiometricGate(
+    config.biometricGating,
+    biometricPrompter ?? resolveGatePrompter(config.dataDir),
+  );
 
   let activePlatform = detectPlatform();
   let activeTrustTier = platformToTrustTier(activePlatform);
@@ -361,9 +466,14 @@ export async function createKeyManager(
       return adminPublicKeyHex !== null;
     },
 
-    async create(): Promise<Result<AdminKeyInfo, InternalError>> {
+    async create(): Promise<Result<AdminKeyInfo, SignetError>> {
       if (adminPublicKeyHex !== null) {
         return Result.err(InternalError.create("Admin key already exists"));
+      }
+
+      const gateResult = await gate("rootKeyCreation");
+      if (Result.isError(gateResult)) {
+        return gateResult;
       }
 
       const pairResult = await generateEd25519KeyPair();
@@ -386,11 +496,14 @@ export async function createKeyManager(
       adminPublicKeyHex = toHex(publicKeyResult.value);
       adminPrivateKey = pairResult.value.privateKey;
 
-      const setPrivateResult = kv.set("admin-key", privateKeyResult.value);
+      const setPrivateResult = await kv.set(
+        "admin-key",
+        privateKeyResult.value,
+      );
       if (Result.isError(setPrivateResult)) {
         return setPrivateResult;
       }
-      const setPublicResult = kv.set(
+      const setPublicResult = await kv.set(
         "admin-key-pub",
         new TextEncoder().encode(adminPublicKeyHex),
       );
@@ -466,12 +579,12 @@ export async function createKeyManager(
         return Result.ok(rootKeyHandle);
       }
 
-      const existingPublic = kv.get("admin-key-pub");
+      const existingPublic = await kv.get("admin-key-pub");
       if (Result.isOk(existingPublic)) {
         adminPublicKeyHex = new TextDecoder().decode(existingPublic.value);
       }
 
-      const existingPrivate = kv.get("admin-key");
+      const existingPrivate = await kv.get("admin-key");
       if (Result.isOk(existingPrivate)) {
         const imported = await importEd25519PrivateKey(existingPrivate.value);
         if (Result.isError(imported)) {
@@ -492,6 +605,10 @@ export async function createKeyManager(
     },
 
     async createOperationalKey(identityId, groupId) {
+      const gateResult = await gate("agentCreation");
+      if (Result.isError(gateResult)) {
+        return gateResult;
+      }
       return createOperationalKeyRecord(identityId, groupId);
     },
 
@@ -514,6 +631,12 @@ export async function createKeyManager(
       if (existing === undefined) {
         return Result.err(NotFoundError.create("operational-key", identityId));
       }
+
+      const gateResult = await gate("operationalKeyRotation");
+      if (Result.isError(gateResult)) {
+        return gateResult;
+      }
+
       return createOperationalKeyRecord(identityId, existing.key.groupId);
     },
 
@@ -576,7 +699,7 @@ export async function createKeyManager(
 
     async getOrCreateDbKey(identityId) {
       const key = `db-key:${identityId}`;
-      const existing = kv.get(key);
+      const existing = await kv.get(key);
       if (Result.isOk(existing)) {
         return Result.ok(existing.value);
       }
@@ -584,13 +707,13 @@ export async function createKeyManager(
         return existing as Result<Uint8Array, InternalError>;
       }
       const generated = crypto.getRandomValues(new Uint8Array(32));
-      const setResult = kv.set(key, generated);
+      const setResult = await kv.set(key, generated);
       return Result.isError(setResult) ? setResult : Result.ok(generated);
     },
 
     async getOrCreateXmtpIdentityKey(identityId) {
       const key = `xmtp-identity-key:${identityId}`;
-      const existing = kv.get(key);
+      const existing = await kv.get(key);
       if (Result.isOk(existing)) {
         return Result.ok(`0x${bytesToHex(existing.value)}` as `0x${string}`);
       }
@@ -598,7 +721,7 @@ export async function createKeyManager(
         return existing as Result<`0x${string}`, InternalError>;
       }
       const generated = crypto.getRandomValues(new Uint8Array(32));
-      const setResult = kv.set(key, generated);
+      const setResult = await kv.set(key, generated);
       if (Result.isError(setResult)) {
         return setResult;
       }
@@ -643,6 +766,7 @@ export async function createKeyManager(
 
     close() {
       manager.stopAutoRotation();
+      kv.close();
     },
   };
 

--- a/packages/keys/src/vault.ts
+++ b/packages/keys/src/vault.ts
@@ -14,6 +14,11 @@ import { hkdf } from "@noble/hashes/hkdf";
 import { sha256 } from "@noble/hashes/sha256";
 import { gcm } from "@noble/ciphers/aes.js";
 import { bytesToHex, hexToBytes } from "@noble/ciphers/utils.js";
+import type { KeyPolicy } from "./config.js";
+import {
+  resolveVaultSecretProvider,
+  type VaultSecretProvider,
+} from "./vault-secret-provider.js";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -110,6 +115,14 @@ export interface Vault {
   close(): void;
 }
 
+/** Optional overrides when constructing a file-backed vault. */
+export interface CreateVaultOptions {
+  /** Inject a pre-resolved secret provider, primarily for deterministic tests. */
+  readonly secretProvider?: VaultSecretProvider | undefined;
+  /** Access policy to use if the vault secret provider is resolved automatically. */
+  readonly vaultKeyPolicy?: KeyPolicy | undefined;
+}
+
 // ---------------------------------------------------------------------------
 // Scrypt parameters
 // ---------------------------------------------------------------------------
@@ -192,26 +205,6 @@ async function importSecretKey(raw: Uint8Array): Promise<CryptoKey> {
     false,
     ["encrypt", "decrypt"],
   );
-}
-
-async function getOrCreateSecretKey(dataDir: string): Promise<CryptoKey> {
-  const keyPath = join(dataDir, "vault.key");
-  const file = Bun.file(keyPath);
-
-  if (await file.exists()) {
-    const raw = new Uint8Array(await file.arrayBuffer());
-    if (raw.byteLength !== 32) {
-      throw new Error(
-        `Vault key file has invalid length: expected 32 bytes, got ${raw.byteLength}`,
-      );
-    }
-    return importSecretKey(raw);
-  }
-
-  const raw = crypto.getRandomValues(new Uint8Array(32));
-  await Bun.write(keyPath, raw);
-  chmodSync(keyPath, 0o600);
-  return importSecretKey(raw);
 }
 
 async function encryptSecret(
@@ -944,10 +937,12 @@ function createFileVault(dataDir: string, secretKey: CryptoKey): Vault {
  * Create an encrypted vault.
  *
  * For `:memory:` mode (tests), uses an in-memory Map-based store.
- * For file-based mode, creates a directory structure under `dataDir`.
+ * For file-based mode, creates a directory structure under `dataDir` and
+ * resolves the vault secret through the configured secret provider.
  */
 export async function createVault(
   dataDir: string,
+  options: CreateVaultOptions = {},
 ): Promise<Result<Vault, InternalError>> {
   try {
     if (dataDir === ":memory:") {
@@ -960,7 +955,21 @@ export async function createVault(
       chmodSync(dataDir, 0o700);
     }
 
-    const secretKey = await getOrCreateSecretKey(dataDir);
+    const secretProvider =
+      options.secretProvider ??
+      resolveVaultSecretProvider(dataDir, options.vaultKeyPolicy ?? "open");
+    const secretResult = await secretProvider.getSecret();
+    if (Result.isError(secretResult)) {
+      return Result.err(
+        InternalError.create("Failed to resolve vault secret", {
+          dataDir,
+          providerKind: secretProvider.kind,
+          cause: secretResult.error.message,
+        }),
+      );
+    }
+
+    const secretKey = await importSecretKey(hexToBytes(secretResult.value));
     return Result.ok(createFileVault(dataDir, secretKey));
   } catch (e) {
     return Result.err(


### PR DESCRIPTION
## Summary

Stacked follow-up to #216.

#216 added the Secure Enclave vault and biometric-gate primitives in `@xmtp/signet-keys`. This PR wires those primitives into the active compat runtime boot path so the daemon actually persists compat secret material through the encrypted vault.

## What Changed

- route compat key-manager persisted secret material through `createVault()`
- add lazy migration from legacy `kv/` entries into encrypted `secrets/*.bin` storage
- plumb `keys.vaultKeyPolicy` and `biometricGating` through CLI/runtime config
- apply runtime biometric gates to compat key lifecycle operations:
  - root key creation
  - agent / operational key creation
  - operational key rotation
- keep biometric gating opt-in by default so software-only installs still boot cleanly
- update docs to describe the current runtime truth instead of the earlier planned model

## Verification

- `bun run check`
- `qmd update`
- `qmd embed`
- targeted tracer bullet on a fresh local workspace:
  - `xs init`
  - `xs daemon start`
  - `xs status`
  - `xs cred issue/list/info/revoke`
  - `xs daemon stop`
  - verified runtime data landed in encrypted `secrets/admin-key*.bin` with SE vault metadata on disk and did not create legacy `kv/` files

## Notes

- This intentionally stops at compat runtime wiring. Broader policy-level biometric gates like scope or egress expansion are still documented as follow-on work and are not claimed as active runtime behavior here.
- Existing legacy compat `kv/` material is migrated lazily on read so current installs are preserved without requiring a one-shot migration step.

Refs #217
