### PR TITLE
refactor(cli,mcp): move transports onto derived action semantics

### DIFF
--- a/packages/cli/src/__tests__/admin-dispatcher.test.ts
+++ b/packages/cli/src/__tests__/admin-dispatcher.test.ts
@@ -28,7 +28,6 @@ function makeHandlerContext(
 function makeSpec(
   id: string,
   opts?: {
-    rpcMethod?: string;
     command?: string;
     handler?: ActionSpec<unknown, unknown, SignetError>["handler"];
     input?: z.ZodType<unknown>;
@@ -40,7 +39,6 @@ function makeSpec(
     input: opts?.input ?? z.object({}).passthrough(),
     cli: {
       command: opts?.command ?? id.replace(/\./g, ":"),
-      rpcMethod: opts?.rpcMethod,
     },
   };
 }
@@ -50,10 +48,9 @@ function makeSpec(
 // ---------------------------------------------------------------------------
 
 describe("AdminDispatcher", () => {
-  test("dispatches to correct handler via explicit rpcMethod", async () => {
+  test("dispatches to the handler via the canonical action id", async () => {
     const registry = createActionRegistry();
     const spec = makeSpec("credential.list", {
-      rpcMethod: "credential.list",
       command: "credential:list",
       handler: async () => Result.ok({ credentials: [] }),
     });
@@ -69,11 +66,10 @@ describe("AdminDispatcher", () => {
     }
   });
 
-  test("derives rpcMethod from command by replacing : with .", async () => {
+  test("does not let a CLI command override change the RPC method", async () => {
     const registry = createActionRegistry();
-    // No explicit rpcMethod -- should derive "credential.revoke" from "credential:revoke"
     const spec = makeSpec("credential.revoke", {
-      command: "credential:revoke",
+      command: "credential:rm",
       handler: async () => Result.ok({ revoked: true }),
     });
     registry.register(spec);
@@ -103,7 +99,6 @@ describe("AdminDispatcher", () => {
   test("returns validation error when input fails schema", async () => {
     const registry = createActionRegistry();
     const spec = makeSpec("credential.issue", {
-      rpcMethod: "credential.issue",
       command: "session:issue",
       input: z.object({
         agentId: z.string().min(1),
@@ -125,7 +120,6 @@ describe("AdminDispatcher", () => {
   test("wraps handler error in ActionResult", async () => {
     const registry = createActionRegistry();
     const spec = makeSpec("key.rotate", {
-      rpcMethod: "key.rotate",
       command: "key:rotate",
       handler: async () =>
         Result.err(ValidationError.create("keyId", "Key not found")),
@@ -145,7 +139,6 @@ describe("AdminDispatcher", () => {
   test("hasMethod returns true for registered method", () => {
     const registry = createActionRegistry();
     const spec = makeSpec("credential.list", {
-      rpcMethod: "credential.list",
       command: "session:list",
     });
     registry.register(spec);
@@ -163,7 +156,6 @@ describe("AdminDispatcher", () => {
   test("handler that throws returns InternalError", async () => {
     const registry = createActionRegistry();
     const spec = makeSpec("boom.action", {
-      rpcMethod: "boom.action",
       command: "boom:action",
       handler: async () => {
         throw new Error("unexpected kaboom");

--- a/packages/cli/src/__tests__/admin-socket.test.ts
+++ b/packages/cli/src/__tests__/admin-socket.test.ts
@@ -77,7 +77,6 @@ function makeStubSignerProvider(): SignerProvider {
 function makeTestSpec(
   id: string,
   handler: ActionSpec<unknown, unknown, SignetError>["handler"],
-  rpcMethod?: string,
 ): ActionSpec<unknown, unknown, SignetError> {
   return {
     id,
@@ -85,7 +84,6 @@ function makeTestSpec(
     input: z.object({}).passthrough(),
     cli: {
       command: id.replace(/\./g, ":"),
-      rpcMethod,
     },
   };
 }
@@ -139,14 +137,11 @@ describe("AdminSocket round-trip", () => {
   test("client connects, authenticates, sends request, gets response", async () => {
     const socketPath = testSocketPath();
     const registry = createActionRegistry();
-    const spec = makeTestSpec(
-      "signet.status",
-      async () =>
-        Result.ok({
-          state: "running",
-          uptime: 123,
-        }),
-      "signet.status",
+    const spec = makeTestSpec("signet.status", async () =>
+      Result.ok({
+        state: "running",
+        uptime: 123,
+      }),
     );
     registry.register(spec);
     const dispatcher = createAdminDispatcher(registry);

--- a/packages/cli/src/actions/signet-actions.ts
+++ b/packages/cli/src/actions/signet-actions.ts
@@ -24,21 +24,18 @@ export function createSignetActions(
   const createStatusSpec = (
     id: string,
     command: string,
-    rpcMethod: string,
   ): ActionSpec<Record<string, never>, DaemonStatus, SignetError> => ({
     id,
     input: z.object({}),
     handler: async () => Result.ok(await deps.status()),
     cli: {
       command,
-      rpcMethod,
     },
   });
 
   const createStopSpec = (
     id: string,
     command: string,
-    rpcMethod: string,
   ): ActionSpec<
     { force?: boolean | undefined },
     { stopped: true },
@@ -57,17 +54,12 @@ export function createSignetActions(
     },
     cli: {
       command,
-      rpcMethod,
     },
   });
 
   const specs: ActionSpec<unknown, unknown, SignetError>[] = [
-    widenActionSpec(
-      createStatusSpec("signet.status", "signet:status", "signet.status"),
-    ),
-    widenActionSpec(
-      createStopSpec("signet.stop", "signet:stop", "signet.stop"),
-    ),
+    widenActionSpec(createStatusSpec("signet.status", "signet:status")),
+    widenActionSpec(createStopSpec("signet.stop", "signet:stop")),
   ];
 
   if (deps.rotateKeys) {
@@ -82,7 +74,6 @@ export function createSignetActions(
       handler: async () => rotate(),
       cli: {
         command: "keys:rotate",
-        rpcMethod: "keys.rotate",
       },
     };
     specs.push(widenActionSpec(rotateSpec));

--- a/packages/cli/src/admin/dispatcher.ts
+++ b/packages/cli/src/admin/dispatcher.ts
@@ -4,7 +4,7 @@ import type {
   ActionSpec,
   HandlerContext,
 } from "@xmtp/signet-contracts";
-import { toActionResult } from "@xmtp/signet-contracts";
+import { deriveRpcMethod, toActionResult } from "@xmtp/signet-contracts";
 import type { SignetError, ActionResultMeta } from "@xmtp/signet-schemas";
 import {
   InternalError,
@@ -20,7 +20,7 @@ import { Result } from "better-result";
 /**
  * Dispatches JSON-RPC method calls to ActionSpec handlers via the
  * shared ActionRegistry. Maps RPC method names to ActionSpecs using
- * CliSurface.rpcMethod (or derives from CliSurface.command).
+ * the canonical action ID-derived RPC method.
  */
 export interface AdminDispatcher {
   /** Route a JSON-RPC method call to the matching ActionSpec handler. */
@@ -40,7 +40,6 @@ export interface AdminDispatcher {
 
 /**
  * Build a lookup map from RPC method name to ActionSpec.
- * If rpcMethod is not set, derive it from command by replacing : with .
  */
 function buildMethodMap(
   registry: ActionRegistry,
@@ -51,8 +50,7 @@ function buildMethodMap(
     const cli = spec.cli;
     if (cli === undefined) continue;
 
-    const rpcMethod = cli.rpcMethod ?? cli.command.replace(/:/g, ".");
-    map.set(rpcMethod, spec);
+    map.set(deriveRpcMethod(spec), spec);
   }
 
   return map;

--- a/packages/mcp/src/__tests__/call-handler.test.ts
+++ b/packages/mcp/src/__tests__/call-handler.test.ts
@@ -69,7 +69,7 @@ describe("handleCallTool", () => {
 
     const result = await handleCallTool(
       {
-        name: "signet/message/list",
+        name: "signet/message/messages",
         arguments: { conversationId: "conv_1" },
       },
       registry,

--- a/packages/mcp/src/__tests__/fixtures.ts
+++ b/packages/mcp/src/__tests__/fixtures.ts
@@ -159,14 +159,12 @@ export function createSendSpec(
 ): ActionSpec<unknown, unknown> {
   return {
     id: "message.send",
+    description: "Send a message to a conversation",
+    intent: "write",
     handler: handlerOverride ?? (async () => Result.ok({ messageId: "msg_1" })),
     input: MessageSendInputSchema,
     output: MessageSendOutputSchema,
-    mcp: {
-      toolName: "signet/message/send",
-      description: "Send a message to a conversation",
-      readOnly: false,
-    },
+    mcp: {},
   };
 }
 
@@ -175,6 +173,8 @@ export function createListSpec(
 ): ActionSpec<unknown, unknown> {
   return {
     id: "message.list",
+    description: "List messages in a conversation",
+    intent: "read",
     handler:
       handlerOverride ??
       (async () =>
@@ -184,9 +184,7 @@ export function createListSpec(
     input: MessageListInputSchema,
     output: MessageListOutputSchema,
     mcp: {
-      toolName: "signet/message/list",
-      description: "List messages in a conversation",
-      readOnly: true,
+      toolName: "signet/message/messages",
     },
   };
 }
@@ -194,27 +192,22 @@ export function createListSpec(
 export function createReadOnlySpec(): ActionSpec<unknown, unknown> {
   return {
     id: "conversation.list",
+    description: "List conversations",
+    intent: "read",
     handler: async () => Result.ok({ conversations: [] }),
     input: z.object({}),
-    mcp: {
-      toolName: "signet/conversation/list",
-      description: "List conversations",
-      readOnly: true,
-    },
+    mcp: {},
   };
 }
 
 export function createDestructiveSpec(): ActionSpec<unknown, unknown> {
   return {
     id: "conversation.delete",
+    description: "Delete a conversation",
+    intent: "destroy",
     handler: async () => Result.ok(undefined),
     input: z.object({ conversationId: z.string() }),
-    mcp: {
-      toolName: "signet/conversation/delete",
-      description: "Delete a conversation",
-      readOnly: false,
-      destructive: true,
-    },
+    mcp: {},
   };
 }
 

--- a/packages/mcp/src/__tests__/tool-registration.test.ts
+++ b/packages/mcp/src/__tests__/tool-registration.test.ts
@@ -17,13 +17,14 @@ describe("actionSpecToMcpTool", () => {
     expect(tool).toBeDefined();
     expect(tool.name).toBe("signet/message/send");
     expect(tool.description).toBe("Send a message to a conversation");
+    expect(tool.annotations?.title).toBe("Send a message to a conversation");
   });
 
-  test("uses toolName from McpSurface", () => {
+  test("uses an authored toolName override when present", () => {
     const spec = createListSpec();
     const tool = actionSpecToMcpTool(spec);
 
-    expect(tool.name).toBe("signet/message/list");
+    expect(tool.name).toBe("signet/message/messages");
   });
 
   test("converts input schema via zodToJsonSchema", () => {
@@ -43,20 +44,20 @@ describe("actionSpecToMcpTool", () => {
     expect(required).toContain("content");
   });
 
-  test("sets readOnlyHint from McpSurface.readOnly", () => {
+  test("derives readOnlyHint from intent", () => {
     const readOnlySpec = createReadOnlySpec();
     const tool = actionSpecToMcpTool(readOnlySpec);
 
     expect(tool.annotations?.readOnlyHint).toBe(true);
-    expect(tool.annotations?.destructiveHint).toBe(false);
+    expect(tool.annotations?.destructiveHint).toBeUndefined();
   });
 
-  test("sets destructiveHint from McpSurface.destructive", () => {
+  test("derives destructiveHint from intent", () => {
     const spec = createDestructiveSpec();
     const tool = actionSpecToMcpTool(spec);
 
     expect(tool.annotations?.destructiveHint).toBe(true);
-    expect(tool.annotations?.readOnlyHint).toBe(false);
+    expect(tool.annotations?.readOnlyHint).toBeUndefined();
   });
 
   test("returns undefined for spec without mcp metadata", () => {

--- a/packages/mcp/src/call-handler.ts
+++ b/packages/mcp/src/call-handler.ts
@@ -11,7 +11,7 @@ import type {
   SignerProvider,
   CredentialRecord,
 } from "@xmtp/signet-contracts";
-import { toActionResult } from "@xmtp/signet-contracts";
+import { deriveMcpToolName, toActionResult } from "@xmtp/signet-contracts";
 import type { McpContentResponse } from "./output-formatter.js";
 import { formatActionResult } from "./output-formatter.js";
 import { createHandlerContext } from "./context-factory.js";
@@ -96,7 +96,7 @@ function findSpecByToolName(
   registry: ActionRegistry,
 ): ActionSpec<unknown, unknown, SignetError> | undefined {
   const mcpSpecs = registry.listForSurface("mcp");
-  return mcpSpecs.find((spec) => spec.mcp?.toolName === toolName);
+  return mcpSpecs.find((spec) => deriveMcpToolName(spec) === toolName);
 }
 
 function formatNotFound(

--- a/packages/mcp/src/tool-registration.ts
+++ b/packages/mcp/src/tool-registration.ts
@@ -1,5 +1,9 @@
 import { zodToJsonSchema } from "zod-to-json-schema";
-import type { ActionSpec } from "@xmtp/signet-contracts";
+import {
+  deriveMcpAnnotations,
+  deriveMcpToolName,
+  type ActionSpec,
+} from "@xmtp/signet-contracts";
 import type { SignetError } from "@xmtp/signet-schemas";
 
 /**
@@ -13,6 +17,9 @@ export interface McpToolRegistration {
   readonly annotations?: {
     readonly readOnlyHint?: boolean;
     readonly destructiveHint?: boolean;
+    readonly idempotentHint?: boolean;
+    readonly title?: string;
+    readonly [key: string]: unknown;
   };
 }
 
@@ -33,12 +40,9 @@ export function actionSpecToMcpTool(
   });
 
   return {
-    name: spec.mcp.toolName,
-    description: spec.mcp.description,
+    name: deriveMcpToolName(spec),
+    description: spec.description ?? spec.id,
     inputSchema: jsonSchema as Record<string, unknown>,
-    annotations: {
-      readOnlyHint: spec.mcp.readOnly,
-      destructiveHint: spec.mcp.destructive ?? false,
-    },
+    annotations: deriveMcpAnnotations(spec),
   };
 }


### PR DESCRIPTION
## Context
This PR continues the stack from #229, is tracked under #227, and implements #222.

With derivation logic living in `@xmtp/signet-contracts`, the transport adapters should stop carrying their own interpretations of action meaning.

## What changed
- updates the CLI admin dispatcher to resolve canonical methods from the shared action derivation helpers
- updates MCP tool registration and call handling to use the shared derived semantics instead of local duplicated rules
- trims transport fixtures and tests so they assert contract-derived behavior rather than transport-specific copies
- keeps authored overrides where they belong while preventing those overrides from changing canonical routing identities

## Why
This is the cleanup step that makes the transports consumers of the contract instead of shadow contract authors. It reduces drift, narrows the amount of duplicated logic, and sets the stage for a contract-driven HTTP surface.

## Validation
- `turbo run lint`
- `turbo run test`
- `turbo run typecheck`
- `bun run docs:check`
