### PR TITLE
docs: refresh contract-driven action docs

### DIFF
--- a/.agents/docs/init/xmtp-signet.md
+++ b/.agents/docs/init/xmtp-signet.md
@@ -8,6 +8,14 @@
 
 This document proposes an **agent signet** architecture for XMTP-based applications and agents.
 
+> [!IMPORTANT]
+> This PRD preserves the earlier broker/view/grant framing that informed the
+> project direction. The current repository implementation has cut over to the
+> v1 credential/policy/seal model plus a contract-driven action surface. Use
+> `README.md`, `docs/architecture.md`, `docs/development.md`, and
+> `.agents/plans/v1/v1-architecture.md` for implementation guidance; treat this
+> PRD primarily as design history and motivation.
+
 The core idea is simple:
 
 - A **signet** is the real XMTP client.

--- a/.agents/plans/v1/v1-architecture.md
+++ b/.agents/plans/v1/v1-architecture.md
@@ -5,7 +5,7 @@ Last updated: 2026-03-23
 
 ## Overview
 
-The signet is the real XMTP client. Agent harnesses connect through a controlled interface with scoped credentials and grants. This document defines the v1 identity model, access/encryption model, seal protocol, permission scopes, and the action registry that all transport surfaces (CLI, HTTP, WebSocket, MCP) are derived from.
+The signet is the real XMTP client. Agent harnesses connect through a controlled interface with scoped credentials, policies, and seals. This document defines the v1 identity model, access/encryption model, seal protocol, permission scopes, and the action registry that drives the CLI, admin socket, MCP, and HTTP action surfaces while WebSocket remains the primary sequenced harness transport.
 
 ## Identity Model
 
@@ -319,23 +319,36 @@ xs cred info a7                          # "Ambiguous: did you mean a7f3... or a
 
 ## Action Registry
 
-The action registry is the foundation. Every operation is a registered action with a typed input schema, handler, and result type. Transport surfaces (CLI, HTTP, WS, MCP) are thin adapters over the same actions.
+The action registry is the foundation. Every operation is a registered action
+with a typed input schema, handler, and result type. The authored contract
+captures the semantics once; CLI, admin socket, MCP, and HTTP then derive
+their native shapes from that shared definition.
 
 ```
 Action:
-  id: "cred.issue"
-  input: { operatorId, chatId, allow, deny, ttl }
-  handler: (input, context) → Result<Credential, SignetError>
+  id: "credential.issue"
+  description: "Issue a credential"
+  intent: "write"
+  input: { operatorId, chatIds, scopes, ttlSeconds }
+  handler: (input, context) → Result<IssuedCredential, SignetError>
+  http: { auth: "admin" }
 ```
 
 The same action is callable via:
-- **CLI**: `xs cred issue --op alice-bot --chat conv_1 --allow send,react`
-- **HTTP**: `POST /v1/actions/cred.issue { operatorId, chatId, allow, deny }`
-- **Admin socket**: JSON-RPC `{ method: "cred.issue", params: { ... } }`
-- **MCP**: Tool call with typed parameters
-- **WebSocket**: Harness request frame
+- **CLI**: `xs credential issue --operator op_alice --credential @credential.json`
+- **HTTP**: `POST /v1/actions/credential/issue { ... }`
+- **Admin socket**: JSON-RPC `{ method: "credential.issue", params: { ... } }`
+- **MCP**: `signet/credential/issue` with typed parameters and derived safety
+  annotations
 
-All transport adapters share the same input validation (Zod schemas), permission checks, and audit logging.
+Registry validation catches duplicate IDs, reserved or conflicting HTTP routes,
+and contradictory authored MCP annotations before the daemon starts. The
+contracts layer also emits a deterministic action surface map so HTTP/MCP/CLI
+drift stays visible in review.
+
+WebSocket shares the same handler/runtime model, but it is not a mechanically
+derived action surface in the same sense. It remains the primary sequenced
+event and request channel for harnesses.
 
 ## CLI Surface
 

--- a/.claude/skills/xmtp-signet-dev/SKILL.md
+++ b/.claude/skills/xmtp-signet-dev/SKILL.md
@@ -63,7 +63,7 @@ package for behavior
 -> `seals` or `verifier`
 
 **"I'm exposing or adapting an action on a transport"**
--> define or update the action spec, then wire CLI or MCP metadata where needed
+-> define or update the action spec, author semantics first, then add CLI/MCP/HTTP overrides only where needed
 
 **"I'm working on the actual XMTP integration"**
 -> `core`
@@ -101,11 +101,14 @@ Rules:
 
 1. Define input/output schemas in `schemas`
 2. Register an `ActionSpec` in `contracts` with action ID, input schema, and
-   optional CLI/MCP metadata
+   authored semantics (`description`, `intent`, `idempotent`). Add output
+   schemas, examples, or CLI/MCP/HTTP overrides only when the defaults are not
+   enough. HTTP-exposed actions must declare `http.auth`.
 3. Implement the handler in the appropriate runtime package
 4. Write the test first (TDD is non-negotiable)
-5. Transport adapters pick it up via the action registry — no per-transport
-   wiring needed
+5. CLI, admin JSON-RPC, MCP, and HTTP derive their surface from the action
+   registry. WebSocket only needs extra wiring if the request/event protocol
+   itself changes
 
 ## Result types
 
@@ -245,23 +248,33 @@ The seal manager (`packages/seals/`) handles:
 
 ## Action registry
 
-The action registry is the define-once, expose-everywhere pattern.
+The action registry is the authored-contract layer for signet actions.
 
 Each action spec contains:
 
 - an action id
 - a Zod input schema
 - a handler
-- optional CLI metadata
-- optional MCP metadata
+- optional output schema and examples
+- authored semantics such as `description`, `intent`, and `idempotent`
+- optional CLI, MCP, and HTTP overrides
 
-CLI, MCP, and WebSocket consume the same action definitions.
+The registry derives:
+
+- CLI commands plus the canonical admin RPC method
+- MCP tool names plus standard safety annotations
+- HTTP method/path/input source for exposed actions
+
+Registry validation catches duplicate action IDs, reserved/conflicting HTTP
+routes, and contradictory authored MCP annotations. WebSocket still shares the
+same handlers, but it is not a mechanically generated action surface.
 
 ## Transport notes
 
 - `ws` is the primary harness-facing transport with sequenced frames and replay
 - `mcp` exposes the scoped tool surface with credential context
-- `cli` is the composition root and also owns the HTTP admin API
+- `cli` is the composition root and also owns the contract-driven HTTP
+  admin/action surface
 - `xs cred ...` is the public credential lifecycle surface
 - `xs seal ...` is the public seal inspection and verification surface
 - `xs policy ...` is the public policy management surface

--- a/.claude/skills/xmtp-signet-dev/references/architecture.md
+++ b/.claude/skills/xmtp-signet-dev/references/architecture.md
@@ -26,15 +26,15 @@ Dependencies flow downward only. No package may import from a higher tier.
 **Foundation** — Stable types and contracts. Changes here ripple everywhere, so
 they change slowly and deliberately. `schemas` defines all Zod schemas and
 inferred types (including action result and pagination schemas). `contracts`
-defines service interfaces, provider interfaces, the `ActionSpec`/`ActionRegistry`
-system, `HandlerContext`, and `ActionResult` envelope.
+defines service interfaces, provider interfaces, the `ActionSpec` /
+`ActionRegistry` system, derivation and validation helpers, surface maps,
+`HandlerContext`, and the `ActionResult` envelope.
 
 **Runtime** — Core signet functionality. Each package has a focused
 responsibility. `core` is the only package that touches the XMTP SDK (now wired
-via `createSdkClientFactory`). `policy` handles all filtering and grant
-enforcement. `keys` manages the cryptographic hierarchy plus admin keys and JWT.
-scope enforcement. `keys` manages the cryptographic hierarchy plus admin keys
-and JWT. `sessions` tracks credential authorization state. `seals` manages the
+via `createSdkClientFactory`). `policy` handles filtering and scope
+enforcement. `keys` manages the cryptographic hierarchy plus admin keys and
+JWT. `sessions` tracks credential authorization state. `seals` manages the
 lifecycle of group-visible permission declarations. `verifier` provides the
 6-check trust verification service.
 
@@ -42,8 +42,8 @@ lifecycle of group-visible permission declarations. `verifier` provides the
 with replay sequencing and backpressure tracking. `mcp`
 converts ActionSpecs to MCP tools with credential-scoped auth. `cli` is the
 composition root with 8 command groups, daemon lifecycle, admin Unix socket
-(JSON-RPC 2.0), and direct mode fallback. `http` handles non-streaming
-admin/credential/health routes via `Bun.serve()`.
+(JSON-RPC 2.0), contract-driven HTTP admin/action routes, and direct mode
+fallback.
 
 **Client** — `sdk` (`@xmtp/signet-sdk`) is the harness-facing SDK. WebSocket client with typed
 events, Result-based requests, automatic reconnection, exponential backoff.
@@ -94,10 +94,12 @@ HTTP, or CLI. This means adding a new transport requires zero changes to
 existing handlers — just a new adapter that maps protocol frames to handler
 calls and Result values back to protocol responses.
 
-**Define-once actions.** `ActionSpec` bundles handler, input schema, and
-per-surface metadata (CLI flags, MCP tool name). The `ActionRegistry` collects
-specs; each transport reads the registry to generate its native representation.
-One spec = all transports.
+**Authored contracts with derived surfaces.** `ActionSpec` bundles handler,
+input schema, optional output/examples, and authored semantics such as
+`description`, `intent`, and `idempotent`. The `ActionRegistry` collects specs;
+CLI/admin RPC, MCP, and HTTP derive their native shapes from those authored
+contracts. Validation catches route/annotation conflicts early, and the
+surface-map hash makes drift visible in tests and review.
 
 **Projection as pipeline.** Message filtering is a composable pipeline of
 independent stages (chat scope → content-type → visibility → content projection).

--- a/.claude/skills/xmtp-signet-dev/references/packages.md
+++ b/.claude/skills/xmtp-signet-dev/references/packages.md
@@ -37,13 +37,16 @@ Service interfaces, action system, and wire format schemas that define boundarie
 - Policy types: `PolicyDelta`
 - Seal types: `SignedRevocationEnvelope`, `MessageProvenanceMetadata`
 - Handler types: `HandlerContext` (with `requestId`, `signal`, optional `adminAuth`, `operatorId`, `credentialId`), `Handler`, `AdminAuthContext`
-- Action system: `ActionSpec`, `CliSurface`, `McpSurface`, `CliOption`, `ActionRegistry`, `createActionRegistry`, `ActionResult`, `toActionResult`
+- Action system: `ActionSpec`, `ActionSurface`, `ActionIntent`, `ActionExample`, `CliSurface`, `McpSurface`, `HttpSurface`, `CliOption`, `ActionRegistry`, `createActionRegistry`
+- Action derivation + validation: `deriveCliCommand`, `deriveRpcMethod`, `deriveMcpToolName`, `deriveMcpAnnotations`, `deriveHttpMethod`, `deriveHttpPath`, `deriveHttpInputSource`, `validateActionSpecs`
+- Surface inventory: `generateActionSurfaceMap`, `hashActionSurfaceMap`
+- Result envelope: `ActionResult`, `toActionResult`
 - Service interfaces: `SignetCore`, `CredentialManager`, `OperatorManager`, `PolicyManager`, `ScopeGuard`, `SealManager`
 - Provider interfaces: `SignerProvider`, `SealStamper`, `SealPublisher`, `RevealStateStore`
 
 **Dependencies:** `@xmtp/signet-schemas`
 
-**Extending:** When a new service needs to be consumed across packages, define its interface here. Runtime packages implement these contracts. New signet operations should be defined as `ActionSpec` and registered with `createActionRegistry`.
+**Extending:** When a new service needs to be consumed across packages, define its interface here. Runtime packages implement these contracts. New signet operations should be authored as `ActionSpec` contracts first: start with `description`, `intent`, and `idempotent`, then add CLI/MCP/HTTP overrides only where the defaults are insufficient. HTTP-exposed actions must declare `http.auth`.
 
 ## Runtime Tier
 
@@ -163,7 +166,8 @@ WebSocket transport built on `Bun.serve()`.
 
 ### @xmtp/signet-mcp
 
-MCP transport. Converts ActionSpecs to MCP tools with credential-scoped auth.
+MCP transport. Converts ActionSpecs into derived MCP tools with
+credential-scoped auth and shared safety annotations.
 
 **Exports:**
 - Config: `McpServerConfigSchema`, `McpServerConfig`
@@ -178,7 +182,8 @@ MCP transport. Converts ActionSpecs to MCP tools with credential-scoped auth.
 
 ### @xmtp/signet-cli
 
-Composition root. CLI entry point, daemon lifecycle, admin socket, config loading.
+Composition root. CLI entry point, daemon lifecycle, admin socket, config
+loading, and the contract-driven HTTP action/admin surface.
 
 **Exports:**
 - CLI entry: `program` (Commander instance with 8 command groups)

--- a/README.md
+++ b/README.md
@@ -64,21 +64,21 @@ event model, and connection lifecycle details.
 
 ## Packages
 
-| Package                    | Layer      | Purpose                                                                           |
-| -------------------------- | ---------- | --------------------------------------------------------------------------------- |
-| `@xmtp/signet-schemas`     | Foundation | Zod schemas, inferred types, resource IDs, permission scopes, error taxonomy      |
-| `@xmtp/signet-contracts`   | Foundation | Service interfaces, handler contract, action registry, wire formats               |
-| `@xmtp/signet-core`        | Runtime    | XMTP client lifecycle, identity store, conversation and message streaming         |
-| `@xmtp/signet-keys`        | Runtime    | Key backend, encrypted vault, admin auth, BIP-39/44 derivation, key rotation      |
-| `@xmtp/signet-sessions`    | Runtime    | Credential lifecycle, reveal state, pending actions, materiality checks           |
-| `@xmtp/signet-seals`       | Runtime    | Seal issuance, chaining, signing, revocation, auto-republish with retry           |
-| `@xmtp/signet-policy`      | Runtime    | Scope resolution, projection pipeline, reveal enforcement, content type filtering |
-| `@xmtp/signet-verifier`    | Runtime    | Multi-check verification pipeline for signet trust                                |
-| `@xmtp/signet-ws`          | Transport  | WebSocket transport with sequenced frames, replay, and reconnection               |
-| `@xmtp/signet-mcp`         | Transport  | MCP transport for credential-scoped tool access                                   |
-| `@xmtp/signet-sdk`         | Client     | TypeScript harness SDK with typed events and Result-based requests                |
-| `@xmtp/signet-cli`         | Transport  | `xs` CLI, daemon lifecycle, admin socket, HTTP admin API                          |
-| `@xmtp/signet-integration` | Test       | Cross-package integration tests and fixtures                                      |
+| Package                    | Layer      | Purpose                                                                                                        |
+| -------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------- |
+| `@xmtp/signet-schemas`     | Foundation | Zod schemas, inferred types, resource IDs, permission scopes, error taxonomy                                   |
+| `@xmtp/signet-contracts`   | Foundation | Service interfaces, handler contract, authored action specs, derivation/validation, surface maps, wire formats |
+| `@xmtp/signet-core`        | Runtime    | XMTP client lifecycle, identity store, conversation and message streaming                                      |
+| `@xmtp/signet-keys`        | Runtime    | Key backend, encrypted vault, admin auth, BIP-39/44 derivation, key rotation                                   |
+| `@xmtp/signet-sessions`    | Runtime    | Credential lifecycle, reveal state, pending actions, materiality checks                                        |
+| `@xmtp/signet-seals`       | Runtime    | Seal issuance, chaining, signing, revocation, auto-republish with retry                                        |
+| `@xmtp/signet-policy`      | Runtime    | Scope resolution, projection pipeline, reveal enforcement, content type filtering                              |
+| `@xmtp/signet-verifier`    | Runtime    | Multi-check verification pipeline for signet trust                                                             |
+| `@xmtp/signet-ws`          | Transport  | WebSocket transport with sequenced frames, replay, and reconnection                                            |
+| `@xmtp/signet-mcp`         | Transport  | MCP transport for credential-scoped tool access                                                                |
+| `@xmtp/signet-sdk`         | Client     | TypeScript harness SDK with typed events and Result-based requests                                             |
+| `@xmtp/signet-cli`         | Transport  | `xs` CLI, daemon lifecycle, admin socket, contract-driven HTTP admin/action surface                            |
+| `@xmtp/signet-integration` | Test       | Cross-package integration tests and fixtures                                                                   |
 
 ## Quick start
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,7 +49,8 @@ Stable types and contracts that other packages build on.
   `CredentialManager`, `ScopeGuard`, `SealManager`
 - `HandlerContext` with `requestId`, `signal`, optional `adminAuth`,
   `operatorId`, and `credentialId`
-- Action specs, action registry, and wire-format contracts
+- Authored action specs, derivation helpers, registry validation, surface maps,
+  and wire-format contracts
 - Credential types including `CredentialRecord`, `CredentialIssuer`, and
   update/reauthorization semantics
 - Shared runtime types: reveal snapshots, daemon status surfaces, replay state
@@ -142,14 +143,15 @@ Transport packages are thin adapters over the handler contract.
 **`@xmtp/signet-mcp`**
 
 - MCP surface for credential-scoped tool access
-- Tool registration from action specs in the action registry
+- Tool registration from action specs in the action registry, including
+  derived MCP tool names and safety annotations
 - Read and reveal workflows for LLM-driven harnesses
 - Credential context threading through MCP tool calls
 
 **`@xmtp/signet-cli`**
 
 - `xs` binary and composition root
-- Daemon lifecycle, admin socket, and HTTP admin API
+- Daemon lifecycle, admin socket, and contract-driven HTTP admin/action routes
 - Direct v1 command groups: `credential`, `seal`, `policy`, `conversation`,
   `message`, `identity`, `admin`, `keys`, `config`
 - Admin fingerprint preservation through HTTP credential routes
@@ -306,25 +308,39 @@ mechanics.
 
 ## Action registry
 
-The action registry is the define-once, expose-everywhere pattern for signet
-operations.
+The action registry is the authored-contract layer for signet operations. Each
+`ActionSpec` defines the behavior once, then the registry derives the
+transport-specific shapes that should stay mechanically consistent.
 
 Each `ActionSpec` includes:
 
-- a unique action identifier (e.g., `cred.issue`)
-- a Zod input schema
-- a transport-agnostic handler
-- optional CLI and MCP metadata
+- a unique action identifier (for example `credential.issue`)
+- a Zod input schema and transport-agnostic handler
+- optional output schema and named examples for docs/tests
+- authored semantics such as `description`, `intent`, and `idempotent`
+- optional CLI, MCP, and HTTP overrides when the default projection is not
+  enough
 
-Transports consume the same registry:
+Derived surfaces currently include:
 
-- **CLI** builds command handlers from action specs
-- **MCP** builds tool definitions with typed parameters
-- **WebSocket** routes request names to handlers
-- **HTTP** exposes actions as POST endpoints
+- **CLI** command names plus the canonical admin RPC method
+- **MCP** tool names plus standard safety annotations
+- **HTTP** method, path, and input source (`GET` + query for reads, `POST` +
+  body otherwise, unless overridden)
 
-This keeps behavior centralized while letting each surface present the same
-operation in its native form.
+Registry validation fails early on:
+
+- duplicate action IDs
+- conflicting HTTP routes
+- reserved HTTP paths
+- contradictory authored MCP annotations
+
+The contracts package also emits a deterministic action surface map and stable
+hash so drift is visible in tests and reviews.
+
+WebSocket still shares the same handler/runtime model, but it remains the
+primary sequenced harness transport rather than a mechanically generated action
+surface.
 
 ## Projection pipeline
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -197,8 +197,11 @@ All domain logic uses the handler contract. To add a new operation:
    types as Zod schemas with inferred TypeScript types.
 
 2. **Register the action** in `packages/contracts/src/` — create an
-   `ActionSpec` with a unique ID, the input schema, and optional CLI/MCP
-   metadata.
+   `ActionSpec` with a unique ID, the input schema, and the authored contract
+   semantics that the transports should derive from: `description`, `intent`,
+   and `idempotent` when relevant. Add `output`, `examples`, or CLI/MCP/HTTP
+   overrides only when the defaults are not enough. HTTP-exposed actions must
+   declare `http.auth`.
 
 3. **Implement the handler** in the appropriate runtime package — the function
    receives pre-validated input and `HandlerContext`, returns
@@ -207,8 +210,10 @@ All domain logic uses the handler contract. To add a new operation:
 4. **Write the test first** — TDD is non-negotiable. Create the test in the
    package's `src/__tests__/` directory.
 
-5. **Transport adapters pick it up automatically** — CLI, WebSocket, MCP, and
-   HTTP all consume the action registry. No per-transport wiring needed.
+5. **Registry-derived surfaces pick it up automatically** — CLI, admin
+   JSON-RPC, MCP, and HTTP project from the shared action registry. WebSocket
+   still uses the same handlers, but only needs extra wiring when the request
+   or event protocol changes.
 
 ```typescript
 // Handler signature


### PR DESCRIPTION
## Summary
- refresh the public docs to describe the authored-vs-derived ActionSpec model that now drives CLI, admin RPC, MCP, and HTTP
- update the active v1 architecture and Claude dev guidance to distinguish registry-derived action surfaces from the primary WebSocket transport
- add a prominent note to the older PRD so it is treated as design history instead of live implementation guidance

## Validation
- `bun run docs:check`
- `qmd update`
- `qmd embed`
- pre-push hooks: `turbo run lint`, `turbo run test`, `turbo run typecheck`, `bun run docs:check`

## Notes
This PR is intentionally docs-only and sits at the top of the existing stack so the implementation PRs below it stay focused on code changes.