### PR TITLE
feat(sessions): add operator action specs with label resolution [#237]

### DIFF
--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -14,6 +14,7 @@ import {
   createCredentialActions,
   createRevealActions,
   createUpdateActions,
+  createOperatorActions,
 } from "@xmtp/signet-sessions";
 import type { InternalCredentialManager } from "@xmtp/signet-sessions";
 import type { AdminServer } from "./admin/server.js";
@@ -91,6 +92,9 @@ export interface SignetRuntimeDeps {
 
   /** Optional factory to expose the internal credential manager for update actions. */
   getInternalCredentialManager?: () => InternalCredentialManager;
+
+  /** Optional factory for operator action specs, wired in production by start.ts. */
+  createOperatorManager?: () => import("@xmtp/signet-contracts").OperatorManager;
 
   /** Optional callback to list registered identities with their inbox IDs. */
   listIdentities?: () => Promise<readonly { inboxId: string | null }[]>;
@@ -261,6 +265,13 @@ export async function createSignetRuntime(
     },
   })) {
     registry.register(spec);
+  }
+
+  if (deps.createOperatorManager) {
+    const operatorManager = deps.createOperatorManager();
+    for (const spec of createOperatorActions({ operatorManager })) {
+      registry.register(spec);
+    }
   }
 
   if (deps.createConversationActions) {

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -29,6 +29,7 @@ import {
 import {
   createCredentialManager as createCredentialManagerImpl,
   createCredentialService,
+  createOperatorManager as createOperatorManagerImpl,
   type InternalCredentialManager,
 } from "@xmtp/signet-sessions";
 import { createSealManager as createSealManagerImpl } from "@xmtp/signet-seals";
@@ -480,6 +481,10 @@ export function createProductionDeps(): SignetRuntimeDeps {
       const cfg = config as HttpServerImplConfig;
       const d = deps as HttpServerDeps;
       return createHttpServerImpl(cfg, d);
+    },
+
+    createOperatorManager() {
+      return createOperatorManagerImpl();
     },
 
     createConversationActions() {

--- a/packages/sessions/src/__tests__/operator-actions.test.ts
+++ b/packages/sessions/src/__tests__/operator-actions.test.ts
@@ -1,0 +1,295 @@
+import { Result } from "better-result";
+import { describe, expect, test, beforeEach } from "bun:test";
+import type { HandlerContext } from "@xmtp/signet-contracts";
+import type { OperatorManager } from "@xmtp/signet-contracts";
+import { createOperatorManager } from "../operator-manager.js";
+import { createOperatorActions } from "../operator-actions.js";
+import type { OperatorConfigType } from "@xmtp/signet-schemas";
+
+function stubCtx(): HandlerContext {
+  return { requestId: "test-req-1", signal: AbortSignal.timeout(5_000) };
+}
+
+function makeConfig(
+  overrides: Partial<OperatorConfigType> = {},
+): OperatorConfigType {
+  return {
+    label: "Test Operator",
+    role: "operator",
+    scopeMode: "per-chat",
+    ...overrides,
+  };
+}
+
+/** Helper: find an action by id and invoke its handler. */
+function findAction(
+  actions: ReturnType<typeof createOperatorActions>,
+  id: string,
+) {
+  const action = actions.find((a) => a.id === id);
+  if (!action) throw new Error(`Action ${id} not found`);
+  return action;
+}
+
+let manager: OperatorManager;
+let actions: ReturnType<typeof createOperatorActions>;
+
+beforeEach(() => {
+  manager = createOperatorManager();
+  actions = createOperatorActions({ operatorManager: manager });
+});
+
+describe("createOperatorActions", () => {
+  test("returns 5 action specs", () => {
+    expect(actions).toHaveLength(5);
+  });
+
+  test("action IDs follow the operator.* convention", () => {
+    const ids = actions.map((a) => a.id);
+    expect(ids).toEqual([
+      "operator.create",
+      "operator.list",
+      "operator.info",
+      "operator.update",
+      "operator.remove",
+    ]);
+  });
+
+  test("all actions declare http surface with admin auth", () => {
+    for (const action of actions) {
+      expect(action.http).toEqual({ auth: "admin" });
+    }
+  });
+
+  describe("operator.create", () => {
+    test("creates operator and returns record with op_ ID", async () => {
+      const action = findAction(actions, "operator.create");
+      const result = await action.handler(makeConfig(), stubCtx());
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect(result.value).toHaveProperty("id");
+      expect((result.value as { id: string }).id).toMatch(/^op_[0-9a-f]{16}$/);
+    });
+
+    test("has write intent", () => {
+      const action = findAction(actions, "operator.create");
+      expect(action.intent).toBe("write");
+    });
+  });
+
+  describe("operator.list", () => {
+    test("returns empty array when no operators exist", async () => {
+      const action = findAction(actions, "operator.list");
+      const result = await action.handler({}, stubCtx());
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect(result.value).toEqual([]);
+    });
+
+    test("returns active operators and excludes removed", async () => {
+      const createAction = findAction(actions, "operator.create");
+      const r1 = await createAction.handler(
+        makeConfig({ label: "Op A" }),
+        stubCtx(),
+      );
+      const r2 = await createAction.handler(
+        makeConfig({ label: "Op B" }),
+        stubCtx(),
+      );
+      expect(Result.isOk(r1)).toBe(true);
+      expect(Result.isOk(r2)).toBe(true);
+      if (!Result.isOk(r1)) return;
+
+      // Remove Op A
+      const removeAction = findAction(actions, "operator.remove");
+      await removeAction.handler(
+        { operatorId: (r1.value as { id: string }).id },
+        stubCtx(),
+      );
+
+      const listAction = findAction(actions, "operator.list");
+      const listResult = await listAction.handler({}, stubCtx());
+      expect(Result.isOk(listResult)).toBe(true);
+      if (!Result.isOk(listResult)) return;
+      expect(listResult.value).toHaveLength(1);
+    });
+
+    test("has read intent and is idempotent", () => {
+      const action = findAction(actions, "operator.list");
+      expect(action.intent).toBe("read");
+      expect(action.idempotent).toBe(true);
+    });
+  });
+
+  describe("operator.info", () => {
+    test("looks up operator by ID", async () => {
+      const createAction = findAction(actions, "operator.create");
+      const created = await createAction.handler(
+        makeConfig({ label: "Found Me" }),
+        stubCtx(),
+      );
+      expect(Result.isOk(created)).toBe(true);
+      if (!Result.isOk(created)) return;
+      const id = (created.value as { id: string }).id;
+
+      const infoAction = findAction(actions, "operator.info");
+      const result = await infoAction.handler({ operatorId: id }, stubCtx());
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect((result.value as { config: { label: string } }).config.label).toBe(
+        "Found Me",
+      );
+    });
+
+    test("looks up operator by label", async () => {
+      const createAction = findAction(actions, "operator.create");
+      await createAction.handler(makeConfig({ label: "alice-bot" }), stubCtx());
+
+      const infoAction = findAction(actions, "operator.info");
+      const result = await infoAction.handler(
+        { operatorId: "alice-bot" },
+        stubCtx(),
+      );
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect((result.value as { config: { label: string } }).config.label).toBe(
+        "alice-bot",
+      );
+    });
+
+    test("returns error for unknown label", async () => {
+      const infoAction = findAction(actions, "operator.info");
+      const result = await infoAction.handler(
+        { operatorId: "nonexistent" },
+        stubCtx(),
+      );
+      expect(Result.isError(result)).toBe(true);
+    });
+
+    test("rejects malformed op_ ID", async () => {
+      const infoAction = findAction(actions, "operator.info");
+      const result = await infoAction.handler(
+        { operatorId: "op_short" },
+        stubCtx(),
+      );
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.category).toBe("validation");
+      }
+    });
+
+    test("rejects ambiguous label when multiple operators share it", async () => {
+      const createAction = findAction(actions, "operator.create");
+      await createAction.handler(
+        makeConfig({ label: "duplicate-bot" }),
+        stubCtx(),
+      );
+      await createAction.handler(
+        makeConfig({ label: "duplicate-bot" }),
+        stubCtx(),
+      );
+
+      const infoAction = findAction(actions, "operator.info");
+      const result = await infoAction.handler(
+        { operatorId: "duplicate-bot" },
+        stubCtx(),
+      );
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.category).toBe("validation");
+      }
+    });
+  });
+
+  describe("operator.update", () => {
+    test("updates config fields", async () => {
+      const createAction = findAction(actions, "operator.create");
+      const created = await createAction.handler(
+        makeConfig({ label: "Old" }),
+        stubCtx(),
+      );
+      expect(Result.isOk(created)).toBe(true);
+      if (!Result.isOk(created)) return;
+      const id = (created.value as { id: string }).id;
+
+      const updateAction = findAction(actions, "operator.update");
+      const result = await updateAction.handler(
+        { operatorId: id, changes: { label: "New" } },
+        stubCtx(),
+      );
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect((result.value as { config: { label: string } }).config.label).toBe(
+        "New",
+      );
+    });
+
+    test("supports label resolution for update", async () => {
+      const createAction = findAction(actions, "operator.create");
+      await createAction.handler(
+        makeConfig({ label: "updatable-bot" }),
+        stubCtx(),
+      );
+
+      const updateAction = findAction(actions, "operator.update");
+      const result = await updateAction.handler(
+        { operatorId: "updatable-bot", changes: { scopeMode: "shared" } },
+        stubCtx(),
+      );
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect(
+        (result.value as { config: { scopeMode: string } }).config.scopeMode,
+      ).toBe("shared");
+    });
+  });
+
+  describe("operator.remove", () => {
+    test("removes operator, subsequent lookup fails", async () => {
+      const createAction = findAction(actions, "operator.create");
+      const created = await createAction.handler(
+        makeConfig({ label: "Doomed" }),
+        stubCtx(),
+      );
+      expect(Result.isOk(created)).toBe(true);
+      if (!Result.isOk(created)) return;
+      const id = (created.value as { id: string }).id;
+
+      const removeAction = findAction(actions, "operator.remove");
+      const removeResult = await removeAction.handler(
+        { operatorId: id },
+        stubCtx(),
+      );
+      expect(Result.isOk(removeResult)).toBe(true);
+      if (!Result.isOk(removeResult)) return;
+      expect(removeResult.value).toEqual({ removed: true });
+
+      // List should exclude the removed operator
+      const listAction = findAction(actions, "operator.list");
+      const listResult = await listAction.handler({}, stubCtx());
+      expect(Result.isOk(listResult)).toBe(true);
+      if (!Result.isOk(listResult)) return;
+      expect(listResult.value).toHaveLength(0);
+    });
+
+    test("supports label resolution for remove", async () => {
+      const createAction = findAction(actions, "operator.create");
+      await createAction.handler(
+        makeConfig({ label: "removable-bot" }),
+        stubCtx(),
+      );
+
+      const removeAction = findAction(actions, "operator.remove");
+      const result = await removeAction.handler(
+        { operatorId: "removable-bot" },
+        stubCtx(),
+      );
+      expect(Result.isOk(result)).toBe(true);
+    });
+
+    test("has destroy intent", () => {
+      const action = findAction(actions, "operator.remove");
+      expect(action.intent).toBe("destroy");
+    });
+  });
+});

--- a/packages/sessions/src/index.ts
+++ b/packages/sessions/src/index.ts
@@ -21,5 +21,7 @@ export { createPendingActionStore } from "./pending-actions.js";
 export type { PendingAction, PendingActionStore } from "./pending-actions.js";
 export { createOperatorManager } from "./operator-manager.js";
 export type { OperatorManagerInternal } from "./operator-manager.js";
+export { createOperatorActions } from "./operator-actions.js";
+export type { OperatorActionDeps } from "./operator-actions.js";
 export { createPolicyManager } from "./policy-manager.js";
 export type { PolicyManagerInternal } from "./policy-manager.js";

--- a/packages/sessions/src/operator-actions.ts
+++ b/packages/sessions/src/operator-actions.ts
@@ -1,0 +1,214 @@
+/**
+ * Operator lifecycle actions for CLI and MCP surfaces.
+ */
+
+import { Result } from "better-result";
+import { z } from "zod";
+import type { ActionSpec } from "@xmtp/signet-contracts";
+import type { OperatorManager } from "@xmtp/signet-contracts";
+import type {
+  SignetError,
+  OperatorConfigType,
+  OperatorRecordType,
+} from "@xmtp/signet-schemas";
+import {
+  OperatorConfig,
+  OperatorId,
+  NotFoundError,
+  ValidationError,
+} from "@xmtp/signet-schemas";
+
+/** Dependencies for operator action registration. */
+export interface OperatorActionDeps {
+  readonly operatorManager: OperatorManager;
+}
+
+function widenActionSpec<TInput, TOutput>(
+  spec: ActionSpec<TInput, TOutput, SignetError>,
+): ActionSpec<unknown, unknown, SignetError> {
+  // The shared registry intentionally erases per-action input/output types.
+  return spec as ActionSpec<unknown, unknown, SignetError>;
+}
+
+/**
+ * Resolve an operator by ID or label. If the value starts with `op_`, validate
+ * it as a resource ID and use directly. Otherwise, search active operators by
+ * label. Rejects ambiguous labels (multiple operators with the same label).
+ */
+async function resolveOperatorId(
+  manager: OperatorManager,
+  idOrLabel: string,
+): Promise<Result<string, SignetError>> {
+  if (idOrLabel.startsWith("op_")) {
+    if (!OperatorId.safeParse(idOrLabel).success) {
+      return Result.err(
+        ValidationError.create(
+          "operatorId",
+          `Invalid operator ID format: ${idOrLabel}`,
+        ),
+      );
+    }
+    return Result.ok(idOrLabel);
+  }
+  const listResult = await manager.list();
+  if (Result.isError(listResult)) return listResult;
+  const matches = listResult.value.filter(
+    (op) => op.config.label === idOrLabel,
+  );
+  if (matches.length === 0) {
+    return Result.err(NotFoundError.create("operator", idOrLabel));
+  }
+  if (matches.length > 1) {
+    return Result.err(
+      ValidationError.create("operatorId", "Ambiguous operator label", {
+        label: idOrLabel,
+        matchingIds: matches.map((op) => op.id),
+      }),
+    );
+  }
+  return Result.ok(matches[0]!.id);
+}
+
+/** Create operator lifecycle actions for CLI and future HTTP surfaces. */
+export function createOperatorActions(
+  deps: OperatorActionDeps,
+): ActionSpec<unknown, unknown, SignetError>[] {
+  const create: ActionSpec<OperatorConfigType, unknown, SignetError> = {
+    id: "operator.create",
+    description: "Register a new operator",
+    intent: "write",
+    input: OperatorConfig as z.ZodType<OperatorConfigType>,
+    handler: async (input) => deps.operatorManager.create(input),
+    cli: {
+      command: "operator:create",
+    },
+    mcp: {
+      toolName: "operator_create",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  const list: ActionSpec<
+    Record<string, never>,
+    readonly OperatorRecordType[],
+    SignetError
+  > = {
+    id: "operator.list",
+    description: "List all active operators",
+    intent: "read",
+    idempotent: true,
+    input: z.object({}),
+    handler: async () => deps.operatorManager.list(),
+    cli: {
+      command: "operator:list",
+    },
+    mcp: {
+      toolName: "operator_list",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  const info: ActionSpec<{ operatorId: string }, unknown, SignetError> = {
+    id: "operator.info",
+    description: "Look up an operator by ID or label",
+    intent: "read",
+    idempotent: true,
+    input: z.object({
+      operatorId: z.string(),
+    }),
+    handler: async (input) => {
+      const resolved = await resolveOperatorId(
+        deps.operatorManager,
+        input.operatorId,
+      );
+      if (Result.isError(resolved)) return resolved;
+      return deps.operatorManager.lookup(resolved.value);
+    },
+    cli: {
+      command: "operator:info",
+    },
+    mcp: {
+      toolName: "operator_info",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  const update: ActionSpec<
+    { operatorId: string; changes: Partial<OperatorConfigType> },
+    unknown,
+    SignetError
+  > = {
+    id: "operator.update",
+    description: "Update an operator's configuration",
+    intent: "write",
+    input: z.object({
+      operatorId: z.string(),
+      changes: OperatorConfig.partial() as z.ZodType<
+        Partial<OperatorConfigType>
+      >,
+    }),
+    handler: async (input) => {
+      const resolved = await resolveOperatorId(
+        deps.operatorManager,
+        input.operatorId,
+      );
+      if (Result.isError(resolved)) return resolved;
+      return deps.operatorManager.update(resolved.value, input.changes);
+    },
+    cli: {
+      command: "operator:update",
+    },
+    mcp: {
+      toolName: "operator_update",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  const remove: ActionSpec<
+    { operatorId: string },
+    { removed: true },
+    SignetError
+  > = {
+    id: "operator.remove",
+    description: "Remove an operator and revoke associated credentials",
+    intent: "destroy",
+    input: z.object({
+      operatorId: z.string(),
+    }),
+    handler: async (input) => {
+      const resolved = await resolveOperatorId(
+        deps.operatorManager,
+        input.operatorId,
+      );
+      if (Result.isError(resolved)) return resolved;
+      const result = await deps.operatorManager.remove(resolved.value);
+      if (Result.isError(result)) return result;
+      return Result.ok({ removed: true as const });
+    },
+    cli: {
+      command: "operator:remove",
+    },
+    mcp: {
+      toolName: "operator_remove",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  return [
+    widenActionSpec(create),
+    widenActionSpec(list),
+    widenActionSpec(info),
+    widenActionSpec(update),
+    widenActionSpec(remove),
+  ];
+}


### PR DESCRIPTION
## Summary

- Add 5 contract-first operator action specs: `operator.create`, `operator.list`, `operator.info`, `operator.update`, `operator.remove`
- Implement `resolveOperatorId` helper that accepts both `op_` IDs and human-readable labels
- Register operator actions in the production runtime registry
- All actions declare CLI, MCP, and HTTP surfaces (admin auth)

### Key behaviors

- **Label resolution**: `operator.info alice-bot` resolves the label to the `op_` ID via list+filter
- **Format validation**: malformed `op_` IDs (e.g., `op_short`) are rejected with `ValidationError`
- **Ambiguity check**: duplicate labels produce a clear `ValidationError` with matching IDs
- **Pattern consistency**: follows the credential actions pattern (widenActionSpec, surface metadata, intent/idempotent)

## Test plan

- [x] All 5 CRUD operations via action handler
- [x] Label resolution: create with label, resolve by label
- [x] Malformed `op_` ID rejected with validation error
- [x] Duplicate label rejected with ambiguity error
- [x] HTTP surface declared with admin auth on all actions
- [x] Removed operators excluded from list
- [x] typecheck (21/21), sessions tests (196), cli tests (354)

Closes https://github.com/galligan/xmtp-signet/issues/237

In-collaboration-with: [Claude Code](https://claude.com/claude-code)