### PR TITLE
feat(sessions): add policy action specs and wire into credential service [#238]

### DIFF
--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -15,6 +15,7 @@ import {
   createRevealActions,
   createUpdateActions,
   createOperatorActions,
+  createPolicyActions,
 } from "@xmtp/signet-sessions";
 import type { InternalCredentialManager } from "@xmtp/signet-sessions";
 import type { AdminServer } from "./admin/server.js";
@@ -96,6 +97,9 @@ export interface SignetRuntimeDeps {
   /** Optional factory for operator action specs, wired in production by start.ts. */
   createOperatorManager?: () => import("@xmtp/signet-contracts").OperatorManager;
 
+  /** Optional factory for policy action specs, wired in production by start.ts. */
+  createPolicyManager?: () => import("@xmtp/signet-contracts").PolicyManager;
+
   /** Optional callback to list registered identities with their inbox IDs. */
   listIdentities?: () => Promise<readonly { inboxId: string | null }[]>;
 }
@@ -144,6 +148,11 @@ export async function createSignetRuntime(
     null, // signerFactory -- wired by production code
     null, // clientFactory -- wired by production code
   );
+
+  // Create operator and policy managers BEFORE credential manager so their
+  // refs are available when createCredentialService captures policyManagerRef.
+  const operatorManager = deps.createOperatorManager?.() ?? null;
+  const policyManager = deps.createPolicyManager?.() ?? null;
 
   const credentialManager = deps.createCredentialManager(
     {
@@ -267,9 +276,14 @@ export async function createSignetRuntime(
     registry.register(spec);
   }
 
-  if (deps.createOperatorManager) {
-    const operatorManager = deps.createOperatorManager();
+  if (operatorManager) {
     for (const spec of createOperatorActions({ operatorManager })) {
+      registry.register(spec);
+    }
+  }
+
+  if (policyManager) {
+    for (const spec of createPolicyActions({ policyManager })) {
       registry.register(spec);
     }
   }

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -30,8 +30,10 @@ import {
   createCredentialManager as createCredentialManagerImpl,
   createCredentialService,
   createOperatorManager as createOperatorManagerImpl,
+  createPolicyManager as createPolicyManagerImpl,
   type InternalCredentialManager,
 } from "@xmtp/signet-sessions";
+import type { PolicyManager } from "@xmtp/signet-contracts";
 import { createSealManager as createSealManagerImpl } from "@xmtp/signet-seals";
 import { createSealPublisher } from "@xmtp/signet-seals";
 import type { InputResolver } from "@xmtp/signet-seals";
@@ -93,6 +95,8 @@ export function createProductionDeps(): SignetRuntimeDeps {
   let globalSealManagerRef:
     | import("@xmtp/signet-contracts").SealManager
     | null = null;
+  // Late-bound policy manager ref for credential service wiring
+  let policyManagerRef: PolicyManager | null = null;
   // Lazy-initialized ID mapping store for conv_ boundary
   let idMappingStoreRef: import("@xmtp/signet-schemas").IdMappingStore | null =
     null;
@@ -257,9 +261,11 @@ export function createProductionDeps(): SignetRuntimeDeps {
       );
       internalCredentialManagerRef = internal;
 
-      return createCredentialService({
-        manager: internal,
-      });
+      return createCredentialService(
+        policyManagerRef
+          ? { manager: internal, policyManager: policyManagerRef }
+          : { manager: internal },
+      );
     },
 
     getInternalCredentialManager() {
@@ -485,6 +491,12 @@ export function createProductionDeps(): SignetRuntimeDeps {
 
     createOperatorManager() {
       return createOperatorManagerImpl();
+    },
+
+    createPolicyManager() {
+      const pm = createPolicyManagerImpl();
+      policyManagerRef = pm;
+      return pm;
     },
 
     createConversationActions() {

--- a/packages/sessions/src/__tests__/policy-actions.test.ts
+++ b/packages/sessions/src/__tests__/policy-actions.test.ts
@@ -1,0 +1,306 @@
+import { Result } from "better-result";
+import { describe, expect, test, beforeEach } from "bun:test";
+import type { HandlerContext } from "@xmtp/signet-contracts";
+import type { PolicyManager } from "@xmtp/signet-contracts";
+import { createPolicyManager } from "../policy-manager.js";
+import { createPolicyActions } from "../policy-actions.js";
+import type { PolicyConfigType } from "@xmtp/signet-schemas";
+
+function stubCtx(): HandlerContext {
+  return { requestId: "test-req-1", signal: AbortSignal.timeout(5_000) };
+}
+
+function makeConfig(
+  overrides: Partial<PolicyConfigType> = {},
+): PolicyConfigType {
+  return {
+    label: "Test Policy",
+    allow: ["send", "reply"],
+    deny: [],
+    ...overrides,
+  };
+}
+
+/** Helper: find an action by id and invoke its handler. */
+function findAction(
+  actions: ReturnType<typeof createPolicyActions>,
+  id: string,
+) {
+  const action = actions.find((a) => a.id === id);
+  if (!action) throw new Error(`Action ${id} not found`);
+  return action;
+}
+
+let manager: PolicyManager;
+let actions: ReturnType<typeof createPolicyActions>;
+
+beforeEach(() => {
+  manager = createPolicyManager();
+  actions = createPolicyActions({ policyManager: manager });
+});
+
+describe("createPolicyActions", () => {
+  test("returns 5 action specs", () => {
+    expect(actions).toHaveLength(5);
+  });
+
+  test("action IDs follow the policy.* convention", () => {
+    const ids = actions.map((a) => a.id);
+    expect(ids).toEqual([
+      "policy.create",
+      "policy.list",
+      "policy.info",
+      "policy.update",
+      "policy.remove",
+    ]);
+  });
+
+  test("all actions declare http surface with admin auth", () => {
+    for (const action of actions) {
+      expect(action.http).toEqual({ auth: "admin" });
+    }
+  });
+
+  test("intent and idempotent metadata are correct", () => {
+    const create = findAction(actions, "policy.create");
+    expect(create.intent).toBe("write");
+    expect(create.idempotent).toBeUndefined();
+
+    const list = findAction(actions, "policy.list");
+    expect(list.intent).toBe("read");
+    expect(list.idempotent).toBe(true);
+
+    const info = findAction(actions, "policy.info");
+    expect(info.intent).toBe("read");
+    expect(info.idempotent).toBe(true);
+
+    const update = findAction(actions, "policy.update");
+    expect(update.intent).toBe("write");
+    expect(update.idempotent).toBeUndefined();
+
+    const remove = findAction(actions, "policy.remove");
+    expect(remove.intent).toBe("destroy");
+    expect(remove.idempotent).toBeUndefined();
+  });
+
+  describe("policy.create", () => {
+    test("creates policy and returns record with policy_ ID", async () => {
+      const action = findAction(actions, "policy.create");
+      const result = await action.handler(makeConfig(), stubCtx());
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect(result.value).toHaveProperty("id");
+      expect((result.value as { id: string }).id).toMatch(
+        /^policy_[0-9a-f]{16}$/,
+      );
+    });
+  });
+
+  describe("policy.list", () => {
+    test("returns empty array when no policies exist", async () => {
+      const action = findAction(actions, "policy.list");
+      const result = await action.handler({}, stubCtx());
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect(result.value).toEqual([]);
+    });
+
+    test("returns active policies and excludes removed", async () => {
+      const createAction = findAction(actions, "policy.create");
+      const r1 = await createAction.handler(
+        makeConfig({ label: "Policy A" }),
+        stubCtx(),
+      );
+      const r2 = await createAction.handler(
+        makeConfig({ label: "Policy B" }),
+        stubCtx(),
+      );
+      expect(Result.isOk(r1)).toBe(true);
+      expect(Result.isOk(r2)).toBe(true);
+      if (!Result.isOk(r1)) return;
+
+      // Remove Policy A
+      const removeAction = findAction(actions, "policy.remove");
+      await removeAction.handler(
+        { policyId: (r1.value as { id: string }).id },
+        stubCtx(),
+      );
+
+      const listAction = findAction(actions, "policy.list");
+      const listResult = await listAction.handler({}, stubCtx());
+      expect(Result.isOk(listResult)).toBe(true);
+      if (!Result.isOk(listResult)) return;
+      expect(listResult.value).toHaveLength(1);
+    });
+  });
+
+  describe("policy.info", () => {
+    test("looks up policy by ID", async () => {
+      const createAction = findAction(actions, "policy.create");
+      const created = await createAction.handler(
+        makeConfig({ label: "Found Me" }),
+        stubCtx(),
+      );
+      expect(Result.isOk(created)).toBe(true);
+      if (!Result.isOk(created)) return;
+      const id = (created.value as { id: string }).id;
+
+      const infoAction = findAction(actions, "policy.info");
+      const result = await infoAction.handler({ policyId: id }, stubCtx());
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect((result.value as { config: { label: string } }).config.label).toBe(
+        "Found Me",
+      );
+    });
+
+    test("looks up policy by label", async () => {
+      const createAction = findAction(actions, "policy.create");
+      await createAction.handler(makeConfig({ label: "read-only" }), stubCtx());
+
+      const infoAction = findAction(actions, "policy.info");
+      const result = await infoAction.handler(
+        { policyId: "read-only" },
+        stubCtx(),
+      );
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect((result.value as { config: { label: string } }).config.label).toBe(
+        "read-only",
+      );
+    });
+
+    test("returns error for unknown label", async () => {
+      const infoAction = findAction(actions, "policy.info");
+      const result = await infoAction.handler(
+        { policyId: "nonexistent" },
+        stubCtx(),
+      );
+      expect(Result.isError(result)).toBe(true);
+    });
+
+    test("rejects malformed policy_ ID", async () => {
+      const infoAction = findAction(actions, "policy.info");
+      const result = await infoAction.handler(
+        { policyId: "policy_short" },
+        stubCtx(),
+      );
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.category).toBe("validation");
+      }
+    });
+
+    test("rejects ambiguous label when multiple policies share it", async () => {
+      const createAction = findAction(actions, "policy.create");
+      await createAction.handler(
+        makeConfig({ label: "duplicate-policy" }),
+        stubCtx(),
+      );
+      await createAction.handler(
+        makeConfig({ label: "duplicate-policy" }),
+        stubCtx(),
+      );
+
+      const infoAction = findAction(actions, "policy.info");
+      const result = await infoAction.handler(
+        { policyId: "duplicate-policy" },
+        stubCtx(),
+      );
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.category).toBe("validation");
+      }
+    });
+  });
+
+  describe("policy.update", () => {
+    test("updates config fields", async () => {
+      const createAction = findAction(actions, "policy.create");
+      const created = await createAction.handler(
+        makeConfig({ label: "Old" }),
+        stubCtx(),
+      );
+      expect(Result.isOk(created)).toBe(true);
+      if (!Result.isOk(created)) return;
+      const id = (created.value as { id: string }).id;
+
+      const updateAction = findAction(actions, "policy.update");
+      const result = await updateAction.handler(
+        { policyId: id, changes: { label: "New" } },
+        stubCtx(),
+      );
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect((result.value as { config: { label: string } }).config.label).toBe(
+        "New",
+      );
+    });
+
+    test("supports label resolution for update", async () => {
+      const createAction = findAction(actions, "policy.create");
+      await createAction.handler(
+        makeConfig({ label: "updatable-policy" }),
+        stubCtx(),
+      );
+
+      const updateAction = findAction(actions, "policy.update");
+      const result = await updateAction.handler(
+        {
+          policyId: "updatable-policy",
+          changes: { deny: ["send"] },
+        },
+        stubCtx(),
+      );
+      expect(Result.isOk(result)).toBe(true);
+      if (!Result.isOk(result)) return;
+      expect(
+        (result.value as { config: { deny: string[] } }).config.deny,
+      ).toEqual(["send"]);
+    });
+  });
+
+  describe("policy.remove", () => {
+    test("removes policy, subsequent lookup fails", async () => {
+      const createAction = findAction(actions, "policy.create");
+      const created = await createAction.handler(
+        makeConfig({ label: "Doomed" }),
+        stubCtx(),
+      );
+      expect(Result.isOk(created)).toBe(true);
+      if (!Result.isOk(created)) return;
+      const id = (created.value as { id: string }).id;
+
+      const removeAction = findAction(actions, "policy.remove");
+      const removeResult = await removeAction.handler(
+        { policyId: id },
+        stubCtx(),
+      );
+      expect(Result.isOk(removeResult)).toBe(true);
+      if (!Result.isOk(removeResult)) return;
+      expect(removeResult.value).toEqual({ removed: true });
+
+      // List should exclude the removed policy
+      const listAction = findAction(actions, "policy.list");
+      const listResult = await listAction.handler({}, stubCtx());
+      expect(Result.isOk(listResult)).toBe(true);
+      if (!Result.isOk(listResult)) return;
+      expect(listResult.value).toHaveLength(0);
+    });
+
+    test("supports label resolution for remove", async () => {
+      const createAction = findAction(actions, "policy.create");
+      await createAction.handler(
+        makeConfig({ label: "removable-policy" }),
+        stubCtx(),
+      );
+
+      const removeAction = findAction(actions, "policy.remove");
+      const result = await removeAction.handler(
+        { policyId: "removable-policy" },
+        stubCtx(),
+      );
+      expect(Result.isOk(result)).toBe(true);
+    });
+  });
+});

--- a/packages/sessions/src/index.ts
+++ b/packages/sessions/src/index.ts
@@ -25,3 +25,5 @@ export { createOperatorActions } from "./operator-actions.js";
 export type { OperatorActionDeps } from "./operator-actions.js";
 export { createPolicyManager } from "./policy-manager.js";
 export type { PolicyManagerInternal } from "./policy-manager.js";
+export { createPolicyActions } from "./policy-actions.js";
+export type { PolicyActionDeps } from "./policy-actions.js";

--- a/packages/sessions/src/policy-actions.ts
+++ b/packages/sessions/src/policy-actions.ts
@@ -1,0 +1,217 @@
+/**
+ * Policy lifecycle actions for CLI and MCP surfaces.
+ */
+
+import { Result } from "better-result";
+import { z } from "zod";
+import type { ActionSpec } from "@xmtp/signet-contracts";
+import type { PolicyManager } from "@xmtp/signet-contracts";
+import type {
+  SignetError,
+  PolicyConfigType,
+  PolicyRecordType,
+} from "@xmtp/signet-schemas";
+import {
+  PolicyConfig,
+  PolicyId,
+  PermissionScope,
+  NotFoundError,
+  ValidationError,
+} from "@xmtp/signet-schemas";
+
+/** Dependencies for policy action registration. */
+export interface PolicyActionDeps {
+  readonly policyManager: PolicyManager;
+}
+
+function widenActionSpec<TInput, TOutput>(
+  spec: ActionSpec<TInput, TOutput, SignetError>,
+): ActionSpec<unknown, unknown, SignetError> {
+  // The shared registry intentionally erases per-action input/output types.
+  return spec as ActionSpec<unknown, unknown, SignetError>;
+}
+
+/**
+ * Resolve a policy by ID or label. If the value starts with `policy_`, validate
+ * it as a resource ID and use directly. Otherwise, search policies by label.
+ * Rejects ambiguous labels (multiple policies with the same label).
+ */
+async function resolvePolicyId(
+  manager: PolicyManager,
+  idOrLabel: string,
+): Promise<Result<string, SignetError>> {
+  if (idOrLabel.startsWith("policy_")) {
+    if (!PolicyId.safeParse(idOrLabel).success) {
+      return Result.err(
+        ValidationError.create(
+          "policyId",
+          `Invalid policy ID format: ${idOrLabel}`,
+        ),
+      );
+    }
+    return Result.ok(idOrLabel);
+  }
+  const listResult = await manager.list();
+  if (Result.isError(listResult)) return listResult;
+  const matches = listResult.value.filter((p) => p.config.label === idOrLabel);
+  if (matches.length === 0) {
+    return Result.err(NotFoundError.create("policy", idOrLabel));
+  }
+  if (matches.length > 1) {
+    return Result.err(
+      ValidationError.create("policyId", "Ambiguous policy label", {
+        label: idOrLabel,
+        matchingIds: matches.map((p) => p.id),
+      }),
+    );
+  }
+  return Result.ok(matches[0]!.id);
+}
+
+/** Create policy lifecycle actions for CLI and future HTTP surfaces. */
+export function createPolicyActions(
+  deps: PolicyActionDeps,
+): ActionSpec<unknown, unknown, SignetError>[] {
+  const create: ActionSpec<PolicyConfigType, unknown, SignetError> = {
+    id: "policy.create",
+    description: "Create a new permission policy",
+    intent: "write",
+    input: PolicyConfig,
+    handler: async (input) => deps.policyManager.create(input),
+    cli: {
+      command: "policy:create",
+    },
+    mcp: {
+      toolName: "policy_create",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  const list: ActionSpec<
+    Record<string, never>,
+    readonly PolicyRecordType[],
+    SignetError
+  > = {
+    id: "policy.list",
+    description: "List all registered policies",
+    intent: "read",
+    idempotent: true,
+    input: z.object({}),
+    handler: async () => deps.policyManager.list(),
+    cli: {
+      command: "policy:list",
+    },
+    mcp: {
+      toolName: "policy_list",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  const info: ActionSpec<{ policyId: string }, unknown, SignetError> = {
+    id: "policy.info",
+    description: "Look up a policy by ID or label",
+    intent: "read",
+    idempotent: true,
+    input: z.object({
+      policyId: z.string(),
+    }),
+    handler: async (input) => {
+      const resolved = await resolvePolicyId(
+        deps.policyManager,
+        input.policyId,
+      );
+      if (Result.isError(resolved)) return resolved;
+      return deps.policyManager.lookup(resolved.value);
+    },
+    cli: {
+      command: "policy:info",
+    },
+    mcp: {
+      toolName: "policy_info",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  const update: ActionSpec<
+    { policyId: string; changes: Partial<PolicyConfigType> },
+    unknown,
+    SignetError
+  > = {
+    id: "policy.update",
+    description: "Update a policy's configuration",
+    intent: "write",
+    input: z.object({
+      policyId: z.string(),
+      changes: z
+        .object({
+          label: z.string().min(1),
+          allow: z.array(PermissionScope),
+          deny: z.array(PermissionScope),
+        })
+        .partial() as z.ZodType<Partial<PolicyConfigType>>,
+    }),
+    handler: async (input) => {
+      const resolved = await resolvePolicyId(
+        deps.policyManager,
+        input.policyId,
+      );
+      if (Result.isError(resolved)) return resolved;
+      return deps.policyManager.update(resolved.value, input.changes);
+    },
+    cli: {
+      command: "policy:update",
+    },
+    mcp: {
+      toolName: "policy_update",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  const remove: ActionSpec<
+    { policyId: string },
+    { removed: true },
+    SignetError
+  > = {
+    id: "policy.remove",
+    description: "Remove a policy",
+    intent: "destroy",
+    input: z.object({
+      policyId: z.string(),
+    }),
+    handler: async (input) => {
+      const resolved = await resolvePolicyId(
+        deps.policyManager,
+        input.policyId,
+      );
+      if (Result.isError(resolved)) return resolved;
+      const result = await deps.policyManager.remove(resolved.value);
+      if (Result.isError(result)) return result;
+      return Result.ok({ removed: true as const });
+    },
+    cli: {
+      command: "policy:remove",
+    },
+    mcp: {
+      toolName: "policy_remove",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  return [
+    widenActionSpec(create),
+    widenActionSpec(list),
+    widenActionSpec(info),
+    widenActionSpec(update),
+    widenActionSpec(remove),
+  ];
+}


### PR DESCRIPTION
## Summary

- Add 5 contract-first policy action specs: `policy.create`, `policy.list`, `policy.info`, `policy.update`, `policy.remove`
- Wire `PolicyManager` into the production credential service so `cred --policy` resolves real policy references
- Label resolution for policies (same pattern as operators)

### Design decision

Named policies are the recommended path (`xs cred issue --policy watchful-agent`). Inline `--allow`/`--deny` remains as an escape hatch. Both paths are functional.

## Test plan

- [x] All 5 CRUD operations via action handler
- [x] Label resolution and malformed `policy_` ID rejection
- [x] Duplicate label ambiguity check
- [x] HTTP admin auth on all actions
- [x] `credential.issue` with `--policy` resolves in running daemon
- [x] typecheck (21/21), sessions tests (212), cli tests (354+)

Closes https://github.com/galligan/xmtp-signet/issues/238

In-collaboration-with: [Claude Code](https://claude.com/claude-code)