### PR TITLE
feat(core): add message action specs for tester-facing chat flows [#239]

### DIFF
--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -91,6 +91,9 @@ export interface SignetRuntimeDeps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   createConversationActions?: () => ActionSpec<any, any, SignetError>[];
 
+  /** Optional factory for message action specs, wired in production by start.ts. */
+  createMessageActions?: () => ActionSpec<unknown, unknown, SignetError>[];
+
   /** Optional factory to expose the internal credential manager for update actions. */
   getInternalCredentialManager?: () => InternalCredentialManager;
 
@@ -290,6 +293,12 @@ export async function createSignetRuntime(
 
   if (deps.createConversationActions) {
     for (const spec of deps.createConversationActions()) {
+      registry.register(spec);
+    }
+  }
+
+  if (deps.createMessageActions) {
+    for (const spec of deps.createMessageActions()) {
       registry.register(spec);
     }
   }

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -22,6 +22,7 @@ import {
   SignetCoreConfigSchema,
   createSdkClientFactory,
   createConversationActions,
+  createMessageActions,
   createSqliteIdMappingStore,
   type SignetState,
   type SignerProviderFactory,
@@ -532,6 +533,29 @@ export function createProductionDeps(): SignetRuntimeDeps {
         clientFactory: createSdkClientFactory(),
         signerProviderFactory,
         config: coreImplRef.config,
+        idMappings: idMappingStoreRef,
+      });
+    },
+
+    createMessageActions() {
+      if (coreImplRef === null) {
+        throw new Error(
+          "SignetCoreImpl not initialized before message actions",
+        );
+      }
+
+      // Lazily create the ID mapping store on the same dataDir
+      if (!idMappingStoreRef) {
+        const dbPath =
+          coreImplRef.config.dataDir === ":memory:"
+            ? ":memory:"
+            : `${coreImplRef.config.dataDir}/id-mappings.db`;
+        idMappingStoreRef = createSqliteIdMappingStore(new Database(dbPath));
+      }
+
+      return createMessageActions({
+        identityStore: coreImplRef.identityStore,
+        getManagedClient: (id) => coreImplRef!.getManagedClient(id),
         idMappings: idMappingStoreRef,
       });
     },

--- a/packages/core/src/__tests__/message-actions.test.ts
+++ b/packages/core/src/__tests__/message-actions.test.ts
@@ -1,0 +1,502 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { Result } from "better-result";
+import { NotFoundError } from "@xmtp/signet-schemas";
+import type { SignetError, IdMappingStore } from "@xmtp/signet-schemas";
+import type { HandlerContext } from "@xmtp/signet-contracts";
+import { SqliteIdentityStore } from "../identity-store.js";
+import { createSqliteIdMappingStore } from "../id-mapping-store.js";
+import type { ManagedClient } from "../client-registry.js";
+import type { XmtpClient, XmtpDecodedMessage } from "../xmtp-client-factory.js";
+import {
+  createMessageActions,
+  type MessageActionDeps,
+} from "../message-actions.js";
+
+/** Minimal handler context for tests. */
+function stubCtx(): HandlerContext {
+  return {
+    requestId: "test-req-1",
+    signal: AbortSignal.timeout(5_000),
+  };
+}
+
+/** Create a mock XmtpClient with message support. */
+function createMockClient(options?: {
+  inboxId?: string;
+  messages?: XmtpDecodedMessage[];
+  sentMessageId?: string;
+}): XmtpClient {
+  const inboxId = options?.inboxId ?? "mock-inbox-1";
+  const messages = options?.messages ?? [];
+  const sentMessageId = options?.sentMessageId ?? "msg-1";
+
+  // Track calls for assertion
+  const sendCalls: {
+    groupId: string;
+    content: unknown;
+    contentType?: string;
+  }[] = [];
+
+  const client: XmtpClient & {
+    _sendCalls: typeof sendCalls;
+  } = {
+    inboxId,
+    _sendCalls: sendCalls,
+    sendMessage: async (groupId, content, contentType?) => {
+      sendCalls.push({ groupId, content, contentType });
+      return Result.ok(sentMessageId);
+    },
+    createDm: async (peerInboxId) => Result.ok({ dmId: "dm-1", peerInboxId }),
+    sendDmMessage: async () => Result.ok("dm-msg-1"),
+    syncAll: async () => Result.ok(),
+    syncGroup: async () => Result.ok(),
+    getGroupInfo: async (groupId) => {
+      return Result.err(NotFoundError.create("group", groupId) as SignetError);
+    },
+    listGroups: async () => Result.ok([]),
+    addMembers: async () => Result.ok(),
+    removeMembers: async () => Result.ok(),
+    createGroup: async (memberInboxIds, opts) => {
+      return Result.ok({
+        groupId: "new-group-1",
+        name: opts?.name ?? "",
+        description: "",
+        memberInboxIds: [inboxId, ...memberInboxIds],
+        createdAt: new Date().toISOString(),
+      });
+    },
+    listMessages: async () => Result.ok(messages),
+    streamAllMessages: async () =>
+      Result.ok({ messages: emptyAsyncIterable(), abort: () => {} }),
+    streamGroups: async () =>
+      Result.ok({ groups: emptyAsyncIterable(), abort: () => {} }),
+  };
+
+  return client;
+}
+
+function emptyAsyncIterable<T>(): AsyncIterable<T> {
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          return { done: true as const, value: undefined as unknown as T };
+        },
+      };
+    },
+  };
+}
+
+const sampleMessages: XmtpDecodedMessage[] = [
+  {
+    messageId: "msg-aaa",
+    groupId: "g1",
+    senderInboxId: "inbox-a",
+    contentType: "text",
+    content: "Hello",
+    sentAt: "2026-03-30T10:00:00.000Z",
+    threadId: null,
+  },
+  {
+    messageId: "msg-bbb",
+    groupId: "g1",
+    senderInboxId: "inbox-b",
+    contentType: "text",
+    content: "World",
+    sentAt: "2026-03-30T10:01:00.000Z",
+    threadId: null,
+  },
+];
+
+describe("message actions", () => {
+  let identityStore: SqliteIdentityStore;
+  let idMappings: IdMappingStore;
+  let mappingDb: Database;
+  let managedClients: Map<string, ManagedClient>;
+  let deps: MessageActionDeps;
+
+  beforeEach(async () => {
+    identityStore = new SqliteIdentityStore(":memory:");
+    mappingDb = new Database(":memory:");
+    idMappings = createSqliteIdMappingStore(mappingDb);
+    managedClients = new Map();
+  });
+
+  afterEach(() => {
+    identityStore.close();
+    mappingDb.close();
+  });
+
+  function setupDeps(): void {
+    deps = {
+      identityStore,
+      getManagedClient: (id) => managedClients.get(id),
+      idMappings,
+    };
+  }
+
+  /** Seed an identity and a managed client in the test harness. */
+  async function seedIdentity(
+    label: string,
+    clientOpts?: Parameters<typeof createMockClient>[0],
+  ): Promise<ManagedClient & { client: ReturnType<typeof createMockClient> }> {
+    const identityResult = await identityStore.create(null, label);
+    expect(identityResult.isOk()).toBe(true);
+    const identity = identityResult.value;
+
+    const client = createMockClient({
+      inboxId: `inbox-${identity.id}`,
+      ...clientOpts,
+    });
+    const managed = {
+      identityId: identity.id,
+      inboxId: client.inboxId,
+      client,
+      groupIds: new Set<string>(),
+    };
+    managedClients.set(identity.id, managed);
+    return managed;
+  }
+
+  test("declares HTTP admin auth on all actions", () => {
+    setupDeps();
+    const actions = createMessageActions(deps);
+
+    for (const action of actions) {
+      expect(action.http?.auth).toBe("admin");
+    }
+  });
+
+  describe("message.send", () => {
+    test("sends text and returns messageId", async () => {
+      await seedIdentity("sender", { sentMessageId: "msg-sent-1" });
+      setupDeps();
+
+      const actions = createMessageActions(deps);
+      const sendAction = actions.find((a) => a.id === "message.send");
+      expect(sendAction).toBeDefined();
+
+      const result = await sendAction!.handler(
+        { chatId: "g1", text: "Hello world", identityLabel: "sender" },
+        stubCtx(),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isOk(result)) {
+        const val = result.value as { messageId: string; chatId: string };
+        expect(val.messageId).toBe("msg-sent-1");
+        expect(val.chatId).toBe("g1");
+      }
+    });
+
+    test("returns NotFoundError for unknown identity", async () => {
+      setupDeps();
+
+      const actions = createMessageActions(deps);
+      const sendAction = actions.find((a) => a.id === "message.send");
+
+      const result = await sendAction!.handler(
+        { chatId: "g1", text: "Hello", identityLabel: "nonexistent" },
+        stubCtx(),
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.category).toBe("not_found");
+      }
+    });
+  });
+
+  describe("message.list", () => {
+    test("lists messages with pagination options", async () => {
+      await seedIdentity("lister", { messages: sampleMessages });
+      setupDeps();
+
+      const actions = createMessageActions(deps);
+      const listAction = actions.find((a) => a.id === "message.list");
+      expect(listAction).toBeDefined();
+      expect(listAction!.idempotent).toBe(true);
+
+      const parsed = listAction!.input.parse({
+        chatId: "g1",
+        limit: "5",
+        identityLabel: "lister",
+      }) as {
+        chatId: string;
+        limit?: number;
+        identityLabel?: string;
+      };
+      expect(parsed.limit).toBe(5);
+
+      const result = await listAction!.handler(
+        { chatId: "g1", identityLabel: "lister" },
+        stubCtx(),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isOk(result)) {
+        const val = result.value as {
+          chatId: string;
+          messages: readonly XmtpDecodedMessage[];
+        };
+        expect(val.chatId).toBe("g1");
+        expect(val.messages).toHaveLength(2);
+        expect(val.messages[0]!.messageId).toBe("msg-aaa");
+      }
+    });
+  });
+
+  describe("message.info", () => {
+    test("finds a specific message by ID", async () => {
+      await seedIdentity("viewer", { messages: sampleMessages });
+      setupDeps();
+
+      const actions = createMessageActions(deps);
+      const infoAction = actions.find((a) => a.id === "message.info");
+      expect(infoAction).toBeDefined();
+      expect(infoAction!.idempotent).toBe(true);
+
+      const result = await infoAction!.handler(
+        { chatId: "g1", messageId: "msg-bbb", identityLabel: "viewer" },
+        stubCtx(),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isOk(result)) {
+        const val = result.value as XmtpDecodedMessage;
+        expect(val.messageId).toBe("msg-bbb");
+        expect(val.content).toBe("World");
+      }
+    });
+
+    test("returns NotFoundError for unknown messageId", async () => {
+      await seedIdentity("viewer", { messages: sampleMessages });
+      setupDeps();
+
+      const actions = createMessageActions(deps);
+      const infoAction = actions.find((a) => a.id === "message.info");
+
+      const result = await infoAction!.handler(
+        { chatId: "g1", messageId: "msg-unknown", identityLabel: "viewer" },
+        stubCtx(),
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.category).toBe("not_found");
+      }
+    });
+  });
+
+  describe("message.reply", () => {
+    test("sends reply content type with reference", async () => {
+      const managed = await seedIdentity("replier", {
+        sentMessageId: "msg-reply-1",
+      });
+      setupDeps();
+
+      const actions = createMessageActions(deps);
+      const replyAction = actions.find((a) => a.id === "message.reply");
+      expect(replyAction).toBeDefined();
+
+      const result = await replyAction!.handler(
+        {
+          chatId: "g1",
+          messageId: "msg-aaa",
+          text: "Reply text",
+          identityLabel: "replier",
+        },
+        stubCtx(),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isOk(result)) {
+        const val = result.value as {
+          messageId: string;
+          chatId: string;
+          inReplyTo: string;
+        };
+        expect(val.messageId).toBe("msg-reply-1");
+        expect(val.chatId).toBe("g1");
+        expect(val.inReplyTo).toBe("msg-aaa");
+      }
+
+      // Verify the content type was sent correctly
+      const sendCalls = (
+        managed.client as unknown as {
+          _sendCalls: {
+            groupId: string;
+            content: unknown;
+            contentType?: string;
+          }[];
+        }
+      )._sendCalls;
+      expect(sendCalls).toHaveLength(1);
+      expect(sendCalls[0]!.contentType).toBe("reply");
+      expect(sendCalls[0]!.content).toEqual({
+        text: "Reply text",
+        reference: "msg-aaa",
+      });
+    });
+  });
+
+  describe("message.react", () => {
+    test("sends reaction content type with reference", async () => {
+      const managed = await seedIdentity("reactor", {
+        sentMessageId: "msg-react-1",
+      });
+      setupDeps();
+
+      const actions = createMessageActions(deps);
+      const reactAction = actions.find((a) => a.id === "message.react");
+      expect(reactAction).toBeDefined();
+
+      const result = await reactAction!.handler(
+        {
+          chatId: "g1",
+          messageId: "msg-aaa",
+          reaction: "👍",
+          identityLabel: "reactor",
+        },
+        stubCtx(),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isOk(result)) {
+        const val = result.value as {
+          messageId: string;
+          chatId: string;
+          reactedTo: string;
+        };
+        expect(val.messageId).toBe("msg-react-1");
+        expect(val.chatId).toBe("g1");
+        expect(val.reactedTo).toBe("msg-aaa");
+      }
+
+      // Verify the content type was sent correctly
+      const sendCalls = (
+        managed.client as unknown as {
+          _sendCalls: {
+            groupId: string;
+            content: unknown;
+            contentType?: string;
+          }[];
+        }
+      )._sendCalls;
+      expect(sendCalls).toHaveLength(1);
+      expect(sendCalls[0]!.contentType).toBe("reaction");
+      expect(sendCalls[0]!.content).toEqual({
+        reference: "msg-aaa",
+        action: "added",
+        content: "👍",
+        schema: "unicode",
+      });
+    });
+  });
+
+  describe("message.read", () => {
+    test("sends read receipt content type", async () => {
+      const managed = await seedIdentity("reader", {
+        sentMessageId: "msg-receipt-1",
+      });
+      setupDeps();
+
+      const actions = createMessageActions(deps);
+      const readAction = actions.find((a) => a.id === "message.read");
+      expect(readAction).toBeDefined();
+
+      const result = await readAction!.handler(
+        { chatId: "g1", identityLabel: "reader" },
+        stubCtx(),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isOk(result)) {
+        const val = result.value as { chatId: string; markedRead: boolean };
+        expect(val.chatId).toBe("g1");
+        expect(val.markedRead).toBe(true);
+      }
+
+      // Verify the content type was sent correctly
+      const sendCalls = (
+        managed.client as unknown as {
+          _sendCalls: {
+            groupId: string;
+            content: unknown;
+            contentType?: string;
+          }[];
+        }
+      )._sendCalls;
+      expect(sendCalls).toHaveLength(1);
+      expect(sendCalls[0]!.contentType).toBe("readReceipt");
+      expect(sendCalls[0]!.content).toEqual({});
+    });
+  });
+
+  describe("conv_ ID resolution", () => {
+    test("resolves conv_ chatId to groupId via mapping", async () => {
+      await seedIdentity("mapper", {
+        messages: sampleMessages,
+        sentMessageId: "msg-mapped-1",
+      });
+      // Pre-store a mapping: g1 <-> conv_0123456789abcdef
+      idMappings.set("g1", "conv_0123456789abcdef", "conversation");
+      setupDeps();
+
+      const actions = createMessageActions(deps);
+      const sendAction = actions.find((a) => a.id === "message.send");
+
+      const result = await sendAction!.handler(
+        {
+          chatId: "conv_0123456789abcdef",
+          text: "Mapped send",
+          identityLabel: "mapper",
+        },
+        stubCtx(),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isOk(result)) {
+        const val = result.value as { messageId: string; chatId: string };
+        expect(val.messageId).toBe("msg-mapped-1");
+        // chatId in output should be the conv_ ID, not the groupId
+        expect(val.chatId).toBe("conv_0123456789abcdef");
+      }
+
+      // Verify the underlying send used the network groupId
+      const managed = managedClients.values().next().value;
+      const sendCalls = (
+        managed!.client as unknown as {
+          _sendCalls: {
+            groupId: string;
+            content: unknown;
+            contentType?: string;
+          }[];
+        }
+      )._sendCalls;
+      expect(sendCalls[0]!.groupId).toBe("g1");
+    });
+  });
+
+  describe("first identity fallback", () => {
+    test("uses first identity when no label is provided", async () => {
+      await seedIdentity("default-agent", { sentMessageId: "msg-default-1" });
+      setupDeps();
+
+      const actions = createMessageActions(deps);
+      const sendAction = actions.find((a) => a.id === "message.send");
+
+      const result = await sendAction!.handler(
+        { chatId: "g1", text: "Fallback" },
+        stubCtx(),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isOk(result)) {
+        const val = result.value as { messageId: string };
+        expect(val.messageId).toBe("msg-default-1");
+      }
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,6 +73,10 @@ export type {
 export { createConversationActions } from "./conversation-actions.js";
 export type { ConversationActionDeps } from "./conversation-actions.js";
 
+// Message actions
+export { createMessageActions } from "./message-actions.js";
+export type { MessageActionDeps } from "./message-actions.js";
+
 // Convos invite parsing and join protocol
 export {
   parseConvosInviteUrl,

--- a/packages/core/src/message-actions.ts
+++ b/packages/core/src/message-actions.ts
@@ -1,0 +1,448 @@
+import { Result } from "better-result";
+import { z } from "zod";
+import type { ActionSpec } from "@xmtp/signet-contracts";
+import { NotFoundError } from "@xmtp/signet-schemas";
+import type { SignetError, IdMappingStore } from "@xmtp/signet-schemas";
+import type { SqliteIdentityStore } from "./identity-store.js";
+import type { ManagedClient } from "./client-registry.js";
+import type { XmtpDecodedMessage } from "./xmtp-client-factory.js";
+
+/** Dependencies used to build message-related action specs. */
+export interface MessageActionDeps {
+  /** Identity store used to resolve message senders/viewers. */
+  readonly identityStore: SqliteIdentityStore;
+  /** Lookup for the managed client tied to a signet identity. */
+  readonly getManagedClient: (identityId: string) => ManagedClient | undefined;
+  /** Optional ID mapping store for conv_ boundary enforcement. */
+  readonly idMappings?: IdMappingStore;
+}
+
+/**
+ * Resolve an identity by label, or fall back to the first identity
+ * in the store when no label is provided.
+ */
+async function resolveIdentity(
+  identityStore: SqliteIdentityStore,
+  label: string | undefined,
+): Promise<
+  Result<{ identityId: string; inboxId: string | null }, SignetError>
+> {
+  if (label) {
+    const identity = await identityStore.getByLabel(label);
+    if (!identity) {
+      return Result.err(NotFoundError.create("identity", label) as SignetError);
+    }
+    return Result.ok({
+      identityId: identity.id,
+      inboxId: identity.inboxId,
+    });
+  }
+
+  // Fall back to first identity
+  const identities = await identityStore.list();
+  const first = identities[0];
+  if (!first) {
+    return Result.err(
+      NotFoundError.create("identity", "(none)") as SignetError,
+    );
+  }
+  return Result.ok({
+    identityId: first.id,
+    inboxId: first.inboxId,
+  });
+}
+
+/**
+ * Resolve a chatId (which may be a conv_ local ID or a raw groupId)
+ * to the underlying network groupId using the mapping store.
+ */
+function resolveGroupId(
+  idMappings: IdMappingStore | undefined,
+  chatId: string,
+): string {
+  if (!idMappings) return chatId;
+  const networkId = idMappings.getNetwork(chatId);
+  return networkId ?? chatId;
+}
+
+function widenActionSpec<TInput, TOutput>(
+  spec: ActionSpec<TInput, TOutput, SignetError>,
+): ActionSpec<unknown, unknown, SignetError> {
+  return spec as ActionSpec<unknown, unknown, SignetError>;
+}
+
+/** Create ActionSpecs for message operations. */
+export function createMessageActions(
+  deps: MessageActionDeps,
+): ActionSpec<unknown, unknown, SignetError>[] {
+  const send: ActionSpec<
+    { chatId: string; text: string; identityLabel?: string | undefined },
+    { messageId: string; chatId: string },
+    SignetError
+  > = {
+    id: "message.send",
+    description: "Send a text message to a conversation",
+    intent: "write",
+    input: z.object({
+      chatId: z.string(),
+      text: z.string(),
+      identityLabel: z.string().optional(),
+    }),
+    handler: async (input) => {
+      const resolved = await resolveIdentity(
+        deps.identityStore,
+        input.identityLabel,
+      );
+      if (Result.isError(resolved)) return resolved;
+
+      const managed = deps.getManagedClient(resolved.value.identityId);
+      if (!managed) {
+        return Result.err(
+          NotFoundError.create(
+            "managed-client",
+            resolved.value.identityId,
+          ) as SignetError,
+        );
+      }
+
+      const groupId = resolveGroupId(deps.idMappings, input.chatId);
+      const sendResult = await managed.client.sendMessage(groupId, input.text);
+      if (Result.isError(sendResult)) return sendResult;
+
+      return Result.ok({
+        messageId: sendResult.value,
+        chatId: input.chatId,
+      });
+    },
+    cli: {
+      command: "message:send",
+    },
+    mcp: {
+      toolName: "message_send",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  const list: ActionSpec<
+    {
+      chatId: string;
+      limit?: number | undefined;
+      before?: string | undefined;
+      after?: string | undefined;
+      identityLabel?: string | undefined;
+    },
+    { chatId: string; messages: readonly XmtpDecodedMessage[] },
+    SignetError
+  > = {
+    id: "message.list",
+    description: "List messages in a conversation",
+    intent: "read",
+    idempotent: true,
+    input: z.object({
+      chatId: z.string(),
+      limit: z.coerce.number().optional(),
+      before: z.string().optional(),
+      after: z.string().optional(),
+      identityLabel: z.string().optional(),
+    }),
+    handler: async (input) => {
+      const resolved = await resolveIdentity(
+        deps.identityStore,
+        input.identityLabel,
+      );
+      if (Result.isError(resolved)) return resolved;
+
+      const managed = deps.getManagedClient(resolved.value.identityId);
+      if (!managed) {
+        return Result.err(
+          NotFoundError.create(
+            "managed-client",
+            resolved.value.identityId,
+          ) as SignetError,
+        );
+      }
+
+      const groupId = resolveGroupId(deps.idMappings, input.chatId);
+      const listOpts: {
+        limit?: number;
+        before?: string;
+        after?: string;
+      } = {};
+      if (input.limit !== undefined) listOpts.limit = input.limit;
+      if (input.before !== undefined) listOpts.before = input.before;
+      if (input.after !== undefined) listOpts.after = input.after;
+      const listResult = await managed.client.listMessages(groupId, listOpts);
+      if (Result.isError(listResult)) return listResult;
+
+      return Result.ok({
+        chatId: input.chatId,
+        messages: listResult.value,
+      });
+    },
+    cli: {
+      command: "message:list",
+    },
+    mcp: {
+      toolName: "message_list",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  const info: ActionSpec<
+    {
+      chatId: string;
+      messageId: string;
+      identityLabel?: string | undefined;
+    },
+    XmtpDecodedMessage,
+    SignetError
+  > = {
+    id: "message.info",
+    description: "Get details for a specific message",
+    intent: "read",
+    idempotent: true,
+    input: z.object({
+      chatId: z.string(),
+      messageId: z.string(),
+      identityLabel: z.string().optional(),
+    }),
+    handler: async (input) => {
+      const resolved = await resolveIdentity(
+        deps.identityStore,
+        input.identityLabel,
+      );
+      if (Result.isError(resolved)) return resolved;
+
+      const managed = deps.getManagedClient(resolved.value.identityId);
+      if (!managed) {
+        return Result.err(
+          NotFoundError.create(
+            "managed-client",
+            resolved.value.identityId,
+          ) as SignetError,
+        );
+      }
+
+      const groupId = resolveGroupId(deps.idMappings, input.chatId);
+      // TODO: replace with direct getMessageById when the XMTP SDK supports it.
+      // For now, scan recent messages with a reasonable limit.
+      const listResult = await managed.client.listMessages(groupId, {
+        limit: 500,
+      });
+      if (Result.isError(listResult)) return listResult;
+
+      const message = listResult.value.find(
+        (m) => m.messageId === input.messageId,
+      );
+      if (!message) {
+        return Result.err(
+          NotFoundError.create("message", input.messageId) as SignetError,
+        );
+      }
+
+      return Result.ok(message);
+    },
+    cli: {
+      command: "message:info",
+    },
+    mcp: {
+      toolName: "message_info",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  const reply: ActionSpec<
+    {
+      chatId: string;
+      messageId: string;
+      text: string;
+      identityLabel?: string | undefined;
+    },
+    { messageId: string; chatId: string; inReplyTo: string },
+    SignetError
+  > = {
+    id: "message.reply",
+    description: "Reply to a specific message in a conversation",
+    intent: "write",
+    input: z.object({
+      chatId: z.string(),
+      messageId: z.string(),
+      text: z.string(),
+      identityLabel: z.string().optional(),
+    }),
+    handler: async (input) => {
+      const resolved = await resolveIdentity(
+        deps.identityStore,
+        input.identityLabel,
+      );
+      if (Result.isError(resolved)) return resolved;
+
+      const managed = deps.getManagedClient(resolved.value.identityId);
+      if (!managed) {
+        return Result.err(
+          NotFoundError.create(
+            "managed-client",
+            resolved.value.identityId,
+          ) as SignetError,
+        );
+      }
+
+      const groupId = resolveGroupId(deps.idMappings, input.chatId);
+      const sendResult = await managed.client.sendMessage(
+        groupId,
+        { text: input.text, reference: input.messageId },
+        "reply",
+      );
+      if (Result.isError(sendResult)) return sendResult;
+
+      return Result.ok({
+        messageId: sendResult.value,
+        chatId: input.chatId,
+        inReplyTo: input.messageId,
+      });
+    },
+    cli: {
+      command: "message:reply",
+    },
+    mcp: {
+      toolName: "message_reply",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  const react: ActionSpec<
+    {
+      chatId: string;
+      messageId: string;
+      reaction: string;
+      identityLabel?: string | undefined;
+    },
+    { messageId: string; chatId: string; reactedTo: string },
+    SignetError
+  > = {
+    id: "message.react",
+    description: "React to a specific message in a conversation",
+    intent: "write",
+    input: z.object({
+      chatId: z.string(),
+      messageId: z.string(),
+      reaction: z.string(),
+      identityLabel: z.string().optional(),
+    }),
+    handler: async (input) => {
+      const resolved = await resolveIdentity(
+        deps.identityStore,
+        input.identityLabel,
+      );
+      if (Result.isError(resolved)) return resolved;
+
+      const managed = deps.getManagedClient(resolved.value.identityId);
+      if (!managed) {
+        return Result.err(
+          NotFoundError.create(
+            "managed-client",
+            resolved.value.identityId,
+          ) as SignetError,
+        );
+      }
+
+      const groupId = resolveGroupId(deps.idMappings, input.chatId);
+      const sendResult = await managed.client.sendMessage(
+        groupId,
+        {
+          reference: input.messageId,
+          action: "added",
+          content: input.reaction,
+          schema: "unicode",
+        },
+        "reaction",
+      );
+      if (Result.isError(sendResult)) return sendResult;
+
+      return Result.ok({
+        messageId: sendResult.value,
+        chatId: input.chatId,
+        reactedTo: input.messageId,
+      });
+    },
+    cli: {
+      command: "message:react",
+    },
+    mcp: {
+      toolName: "message_react",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  const read: ActionSpec<
+    { chatId: string; identityLabel?: string | undefined },
+    { chatId: string; markedRead: true },
+    SignetError
+  > = {
+    id: "message.read",
+    description: "Mark a conversation as read",
+    intent: "write",
+    input: z.object({
+      chatId: z.string(),
+      identityLabel: z.string().optional(),
+    }),
+    handler: async (input) => {
+      const resolved = await resolveIdentity(
+        deps.identityStore,
+        input.identityLabel,
+      );
+      if (Result.isError(resolved)) return resolved;
+
+      const managed = deps.getManagedClient(resolved.value.identityId);
+      if (!managed) {
+        return Result.err(
+          NotFoundError.create(
+            "managed-client",
+            resolved.value.identityId,
+          ) as SignetError,
+        );
+      }
+
+      const groupId = resolveGroupId(deps.idMappings, input.chatId);
+      const sendResult = await managed.client.sendMessage(
+        groupId,
+        {},
+        "readReceipt",
+      );
+      if (Result.isError(sendResult)) return sendResult;
+
+      return Result.ok({
+        chatId: input.chatId,
+        markedRead: true as const,
+      });
+    },
+    cli: {
+      command: "message:read",
+    },
+    mcp: {
+      toolName: "message_read",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  return [
+    widenActionSpec(send),
+    widenActionSpec(list),
+    widenActionSpec(info),
+    widenActionSpec(reply),
+    widenActionSpec(react),
+    widenActionSpec(read),
+  ];
+}


### PR DESCRIPTION
## Summary

- Add 6 contract-first message action specs: `message.send`, `message.list`, `message.info`, `message.reply`, `message.react`, `message.read`
- All actions use `conv_` IDs at the public boundary with internal groupId resolution
- Uses `widenActionSpec` pattern (no `any` leakage) matching operator/policy/credential actions
- Content types: plain text for send, reply reference for reply, reaction for react, readReceipt for read

### Note

`message.info` does a bounded scan (`limit: 500`) since the XMTP SDK has no `getMessageById`. TODO comment marks this for replacement when available.

## Test plan

- [x] All 6 operations via action handler (send/list/info/reply/react/read)
- [x] conv_ ID resolution via IdMappingStore
- [x] Identity fallback when no label provided
- [x] Unknown identity fails with not_found
- [x] HTTP admin auth on all actions
- [x] typecheck (21/21), core tests (231), cli tests (359)

Closes https://github.com/galligan/xmtp-signet/issues/239

In-collaboration-with: [Claude Code](https://claude.com/claude-code)