### PR TITLE
feat(core): close the hosted invite join loop in the live runtime [#240]

### DIFF
--- a/packages/cli/src/__tests__/invite-host-listener.test.ts
+++ b/packages/cli/src/__tests__/invite-host-listener.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import { generateConvosInviteSlug, type CoreRawEvent } from "@xmtp/signet-core";
+import type { SignetError } from "@xmtp/signet-schemas";
+import { startManagedInviteHostListener } from "../invite-host-listener.js";
+
+const WRONG_PRIVATE_KEY_HEX =
+  "0000000000000000000000000000000000000000000000000000000000000002";
+const RIGHT_PRIVATE_KEY_HEX =
+  "0000000000000000000000000000000000000000000000000000000000000001";
+
+const WRONG_CREATOR_INBOX_ID =
+  "bbbbccddee1122334455667788990011aabbccddee1122334455667788990011";
+const RIGHT_CREATOR_INBOX_ID =
+  "aabbccddee1122334455667788990011aabbccddee1122334455667788990011";
+
+const TEST_CONVERSATION_ID = "550e8400-e29b-41d4-a716-446655440000";
+const TEST_REQUESTER_INBOX_ID = "requester-inbox-id-abc123";
+
+function makeRawMessageEvent(content: unknown): CoreRawEvent {
+  return {
+    type: "raw.message",
+    messageId: "msg-1",
+    groupId: "group-1",
+    senderInboxId: TEST_REQUESTER_INBOX_ID,
+    contentType: "text",
+    content,
+    sentAt: new Date().toISOString(),
+    threadId: null,
+    isHistorical: false,
+  };
+}
+
+async function buildValidSlug(): Promise<string> {
+  const result = await generateConvosInviteSlug({
+    conversationId: TEST_CONVERSATION_ID,
+    creatorInboxId: RIGHT_CREATOR_INBOX_ID,
+    walletPrivateKeyHex: RIGHT_PRIVATE_KEY_HEX,
+    inviteTag: "host-test-tag",
+  });
+  if (!result.isOk()) {
+    throw new Error("Failed to generate test invite slug");
+  }
+  return result.value;
+}
+
+describe("startManagedInviteHostListener", () => {
+  test("routes a join request through the identity that matches the invite creator", async () => {
+    const slug = await buildValidSlug();
+
+    const addedByIdentity: string[] = [];
+    const identities = [
+      { id: "wrong", inboxId: WRONG_CREATOR_INBOX_ID },
+      { id: "right", inboxId: RIGHT_CREATOR_INBOX_ID },
+    ];
+
+    const managedClients = new Map<
+      string,
+      {
+        addMembers: (
+          groupId: string,
+          inboxIds: readonly string[],
+        ) => Promise<Result<void, SignetError>>;
+      }
+    >([
+      [
+        "wrong",
+        {
+          addMembers: async () => {
+            addedByIdentity.push("wrong");
+            return Result.ok(undefined);
+          },
+        },
+      ],
+      [
+        "right",
+        {
+          addMembers: async (groupId, inboxIds) => {
+            addedByIdentity.push(`right:${groupId}:${inboxIds.join(",")}`);
+            return Result.ok(undefined);
+          },
+        },
+      ],
+    ]);
+
+    let capturedHandler: ((event: CoreRawEvent) => void) | null = null;
+    startManagedInviteHostListener({
+      subscribe(handler) {
+        capturedHandler = handler;
+        return () => {};
+      },
+      async listIdentities() {
+        return identities;
+      },
+      async getWalletPrivateKeyHex(identityId) {
+        return Result.ok(
+          identityId === "right"
+            ? RIGHT_PRIVATE_KEY_HEX
+            : WRONG_PRIVATE_KEY_HEX,
+        );
+      },
+      getManagedClient(identityId) {
+        return managedClients.get(identityId);
+      },
+      async getGroupInviteTag() {
+        return Result.ok("host-test-tag");
+      },
+    });
+
+    capturedHandler?.(makeRawMessageEvent(slug));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(addedByIdentity).toEqual([
+      `right:${TEST_CONVERSATION_ID}:${TEST_REQUESTER_INBOX_ID}`,
+    ]);
+  });
+
+  test("keeps processing join requests after an inbox ID appears later", async () => {
+    const slug = await buildValidSlug();
+
+    let addedGroupId = "";
+    let addedInboxIds: readonly string[] = [];
+    let identities: Array<{ id: string; inboxId: string | null }> = [
+      { id: "creator", inboxId: null },
+    ];
+
+    let capturedHandler: ((event: CoreRawEvent) => void) | null = null;
+    startManagedInviteHostListener({
+      subscribe(handler) {
+        capturedHandler = handler;
+        return () => {};
+      },
+      async listIdentities() {
+        return identities;
+      },
+      async getWalletPrivateKeyHex() {
+        return Result.ok(RIGHT_PRIVATE_KEY_HEX);
+      },
+      getManagedClient(identityId) {
+        if (identityId !== "creator") return undefined;
+        return {
+          addMembers: async (groupId, inboxIds) => {
+            addedGroupId = groupId;
+            addedInboxIds = inboxIds;
+            return Result.ok(undefined);
+          },
+        };
+      },
+      async getGroupInviteTag() {
+        return Result.ok("host-test-tag");
+      },
+    });
+
+    identities = [{ id: "creator", inboxId: RIGHT_CREATOR_INBOX_ID }];
+
+    capturedHandler?.(makeRawMessageEvent(slug));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(addedGroupId).toBe(TEST_CONVERSATION_ID);
+    expect(addedInboxIds).toEqual([TEST_REQUESTER_INBOX_ID]);
+  });
+});

--- a/packages/cli/src/invite-host-listener.ts
+++ b/packages/cli/src/invite-host-listener.ts
@@ -1,0 +1,110 @@
+import { Result } from "better-result";
+import {
+  tryProcessJoinRequest,
+  type CoreRawEvent,
+  type RawMessageEvent,
+  type JoinRequestResult,
+} from "@xmtp/signet-core";
+import type { SignetError } from "@xmtp/signet-schemas";
+
+interface ManagedInviteHostClient {
+  readonly addMembers: (
+    groupId: string,
+    inboxIds: readonly string[],
+  ) => Promise<Result<void, SignetError>>;
+}
+
+interface ManagedInviteHostIdentity {
+  readonly id: string;
+  readonly inboxId: string | null;
+}
+
+/** Dependencies required to resolve the correct managed identity for an invite. */
+export interface ManagedInviteHostListenerDeps {
+  /** Subscribe to raw core events and return an unsubscribe callback. */
+  readonly subscribe: (handler: (event: CoreRawEvent) => void) => () => void;
+  /** List the managed identities currently known to the signet. */
+  readonly listIdentities: () => Promise<readonly ManagedInviteHostIdentity[]>;
+  /** Resolve the XMTP wallet private key for a managed identity. */
+  readonly getWalletPrivateKeyHex: (
+    identityId: string,
+  ) => Promise<Result<string, SignetError>>;
+  /** Resolve the managed client that can mutate group membership. */
+  readonly getManagedClient: (
+    identityId: string,
+  ) => ManagedInviteHostClient | undefined;
+  /** Load the invite tag that was stored when the invite link was generated. */
+  readonly getGroupInviteTag: (
+    groupId: string,
+  ) => Promise<Result<string | undefined, SignetError>>;
+}
+
+function isInviteCandidate(event: CoreRawEvent): event is RawMessageEvent {
+  if (event.type !== "raw.message") return false;
+  if (event.isHistorical) return false;
+  if (typeof event.content !== "string") return false;
+
+  const text = event.content.trim();
+  return text.length >= 50 && !text.includes(" ");
+}
+
+function normalizePrivateKeyHex(value: string): string {
+  return value.startsWith("0x") ? value.slice(2) : value;
+}
+
+/**
+ * Attempt to process an invite join request by trying each managed identity
+ * with a registered inbox ID until one validates the invite successfully.
+ */
+export async function dispatchInviteJoinRequestAcrossManagedIdentities(
+  deps: ManagedInviteHostListenerDeps,
+  event: CoreRawEvent,
+): Promise<Result<JoinRequestResult, SignetError> | null> {
+  if (!isInviteCandidate(event)) return null;
+
+  const identities = await deps.listIdentities();
+  let lastError: SignetError | null = null;
+
+  for (const identity of identities) {
+    if (!identity.inboxId) continue;
+
+    const managed = deps.getManagedClient(identity.id);
+    if (!managed) continue;
+
+    const keyResult = await deps.getWalletPrivateKeyHex(identity.id);
+    if (Result.isError(keyResult)) continue;
+
+    const result = await tryProcessJoinRequest(
+      {
+        walletPrivateKeyHex: normalizePrivateKeyHex(keyResult.value),
+        creatorInboxId: identity.inboxId,
+        addMembersToGroup: (groupId, inboxIds) =>
+          managed.addMembers(groupId, inboxIds),
+        getGroupInviteTag: deps.getGroupInviteTag,
+      },
+      event,
+    );
+
+    if (result === null) return null;
+    if (Result.isOk(result)) return result;
+    lastError = result.error;
+  }
+
+  return lastError ? Result.err(lastError) : null;
+}
+
+/**
+ * Subscribe to raw core events and process invite join requests by trying
+ * each managed identity with a registered inbox ID until one validates.
+ */
+export function startManagedInviteHostListener(
+  deps: ManagedInviteHostListenerDeps,
+): () => void {
+  return deps.subscribe((event) => {
+    void dispatchInviteJoinRequestAcrossManagedIdentities(deps, event).catch(
+      () => {
+        // Ignore invite-processing failures so the raw event stream stays hot.
+      },
+    );
+  });
+}

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -57,6 +57,7 @@ import { createWsRequestHandler } from "./ws/request-handler.js";
 import { createLazyCoreUpgrade } from "./ws/core-upgrade.js";
 import { createEventProjector } from "./ws/event-projector.js";
 import { createPendingActionStore } from "@xmtp/signet-sessions";
+import { startManagedInviteHostListener } from "./invite-host-listener.js";
 
 /** Map SignetCoreImpl states to the contract's CoreState. */
 function mapSignetState(state: SignetState): CoreState {
@@ -101,6 +102,10 @@ export function createProductionDeps(): SignetRuntimeDeps {
   // Lazy-initialized ID mapping store for conv_ boundary
   let idMappingStoreRef: import("@xmtp/signet-schemas").IdMappingStore | null =
     null;
+  // In-memory invite tag store: groupId -> inviteTag (v1 single-process)
+  const inviteTagStore = new Map<string, string>();
+  // Track invite host listener unsubscribe for cleanup
+  let inviteHostUnsub: (() => void) | null = null;
 
   return {
     async createKeyManager(
@@ -525,7 +530,7 @@ export function createProductionDeps(): SignetRuntimeDeps {
         idMappingStoreRef = createSqliteIdMappingStore(new Database(dbPath));
       }
 
-      return createConversationActions({
+      const actions = createConversationActions({
         identityStore: coreImplRef.identityStore,
         getManagedClient: (id) => coreImplRef!.getManagedClient(id),
         getGroupInfo: (groupId: string) =>
@@ -534,7 +539,40 @@ export function createProductionDeps(): SignetRuntimeDeps {
         signerProviderFactory,
         config: coreImplRef.config,
         idMappings: idMappingStoreRef,
+        storeInviteTag: (groupId, tag) => inviteTagStore.set(groupId, tag),
+        getInviteTag: (groupId) => inviteTagStore.get(groupId),
       });
+
+      // Start the invite host listener (v1: single identity, in-process).
+      // Wired here because all deps are available after conversation actions
+      // are created. The listener resolves the matching managed identity at
+      // message time so multi-identity invite links work without a restart.
+      if (!inviteHostUnsub) {
+        const core = coreImplRef;
+        const spf = signerProviderFactory;
+        inviteHostUnsub = startManagedInviteHostListener({
+          subscribe: (handler) => core.on(handler),
+          listIdentities: () => core.identityStore.list(),
+          getWalletPrivateKeyHex: async (identityId) => {
+            const signer = spf(identityId);
+            const keyResult = await signer.getXmtpIdentityKey(identityId);
+            if (Result.isError(keyResult)) return keyResult;
+            return Result.ok(keyResult.value);
+          },
+          getManagedClient: (identityId) => {
+            const managed = core.getManagedClient(identityId);
+            if (!managed) return undefined;
+            return {
+              addMembers: (groupId, inboxIds) =>
+                managed.client.addMembers(groupId, inboxIds as string[]),
+            };
+          },
+          getGroupInviteTag: async (groupId) =>
+            Result.ok(inviteTagStore.get(groupId)),
+        });
+      }
+
+      return actions;
     },
 
     createMessageActions() {

--- a/packages/core/src/conversation-actions.ts
+++ b/packages/core/src/conversation-actions.ts
@@ -48,6 +48,10 @@ export interface ConversationActionDeps {
   readonly config?: Pick<SignetCoreConfig, "dataDir" | "env" | "appVersion">;
   /** Optional ID mapping store for conv_ boundary enforcement. */
   readonly idMappings?: IdMappingStore;
+  /** Store an invite tag for a group (for hosted invite verification). */
+  readonly storeInviteTag?: (groupId: string, inviteTag: string) => void;
+  /** Get the stored invite tag for a group. */
+  readonly getInviteTag?: (groupId: string) => string | undefined;
 }
 
 /**
@@ -442,6 +446,11 @@ export function createConversationActions(
       });
 
       if (Result.isError(urlResult)) return urlResult;
+
+      // Persist the invite tag so the host-side join processor can verify it
+      if (deps.storeInviteTag) {
+        deps.storeInviteTag(groupId, inviteTag);
+      }
 
       return Result.ok({
         inviteUrl: urlResult.value,

--- a/packages/core/src/convos/__tests__/invite-host.test.ts
+++ b/packages/core/src/convos/__tests__/invite-host.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import type { SignetError } from "@xmtp/signet-schemas";
+import type { RawMessageEvent, CoreRawEvent } from "../../raw-events.js";
+import { generateConvosInviteSlug } from "../invite-generator.js";
+import {
+  tryProcessJoinRequest,
+  startInviteHostListener,
+  type InviteHostDeps,
+} from "../invite-host.js";
+
+// --- Test key material (same as process-join-requests tests) ---
+
+const TEST_PRIVATE_KEY_HEX =
+  "0000000000000000000000000000000000000000000000000000000000000001";
+
+const TEST_CREATOR_INBOX_ID =
+  "aabbccddee1122334455667788990011aabbccddee1122334455667788990011";
+
+const TEST_CONVERSATION_ID = "550e8400-e29b-41d4-a716-446655440000";
+const TEST_REQUESTER_INBOX_ID = "requester-inbox-id-abc123";
+
+function makeRawMessageEvent(
+  content: unknown,
+  overrides?: Partial<RawMessageEvent>,
+): RawMessageEvent {
+  return {
+    type: "raw.message",
+    messageId: "msg-1",
+    groupId: "group-1",
+    senderInboxId: TEST_REQUESTER_INBOX_ID,
+    contentType: "text",
+    content,
+    sentAt: new Date().toISOString(),
+    threadId: null,
+    isHistorical: false,
+    ...overrides,
+  };
+}
+
+function createHostDeps(overrides?: {
+  addMembersResult?: Result<void, SignetError>;
+  storedTag?: string | undefined;
+}): InviteHostDeps {
+  return {
+    walletPrivateKeyHex: TEST_PRIVATE_KEY_HEX,
+    creatorInboxId: TEST_CREATOR_INBOX_ID,
+    addMembersToGroup: async () =>
+      overrides?.addMembersResult ?? Result.ok(undefined),
+    getGroupInviteTag: async () =>
+      Result.ok(overrides?.storedTag ?? "host-test-tag"),
+  };
+}
+
+async function buildValidSlug(): Promise<string> {
+  const result = await generateConvosInviteSlug({
+    conversationId: TEST_CONVERSATION_ID,
+    creatorInboxId: TEST_CREATOR_INBOX_ID,
+    walletPrivateKeyHex: TEST_PRIVATE_KEY_HEX,
+    inviteTag: "host-test-tag",
+  });
+  if (!result.isOk()) throw new Error("Failed to generate slug for test");
+  return result.value;
+}
+
+describe("tryProcessJoinRequest", () => {
+  test("returns null for non-string content", async () => {
+    const deps = createHostDeps();
+    const event = makeRawMessageEvent({ reaction: "thumbsup" });
+
+    const result = await tryProcessJoinRequest(deps, event);
+    expect(result).toBeNull();
+  });
+
+  test("returns null for non-URL text", async () => {
+    const deps = createHostDeps();
+    const event = makeRawMessageEvent("hello world");
+
+    const result = await tryProcessJoinRequest(deps, event);
+    expect(result).toBeNull();
+  });
+
+  test("returns null for short URL", async () => {
+    const deps = createHostDeps();
+    const event = makeRawMessageEvent("https://example.com");
+
+    const result = await tryProcessJoinRequest(deps, event);
+    expect(result).toBeNull();
+  });
+
+  test("returns null for multi-word text", async () => {
+    const deps = createHostDeps();
+    const event = makeRawMessageEvent(
+      "hey check out https://example.com/some-long-path-that-is-over-fifty-chars",
+    );
+
+    const result = await tryProcessJoinRequest(deps, event);
+    expect(result).toBeNull();
+  });
+
+  test("processes a valid invite URL", async () => {
+    const slug = await buildValidSlug();
+    const deps = createHostDeps();
+    const event = makeRawMessageEvent(slug);
+
+    const result = await tryProcessJoinRequest(deps, event);
+
+    expect(result).not.toBeNull();
+    expect(result!.isOk()).toBe(true);
+    if (!result!.isOk()) return;
+
+    expect(result!.value.groupId).toBe(TEST_CONVERSATION_ID);
+    expect(result!.value.requesterInboxId).toBe(TEST_REQUESTER_INBOX_ID);
+    expect(result!.value.inviteTag).toBe("host-test-tag");
+  });
+});
+
+describe("startInviteHostListener", () => {
+  test("subscribes to events and returns unsubscribe function", () => {
+    let subscriberCount = 0;
+    const mockSubscribe = (
+      _handler: (event: CoreRawEvent) => void,
+    ): (() => void) => {
+      subscriberCount++;
+      return () => {
+        subscriberCount--;
+      };
+    };
+
+    const deps = createHostDeps();
+    const unsub = startInviteHostListener(mockSubscribe, deps);
+
+    expect(subscriberCount).toBe(1);
+    unsub();
+    expect(subscriberCount).toBe(0);
+  });
+
+  test("ignores historical messages", async () => {
+    let addMembersCalled = false;
+    const slug = await buildValidSlug();
+
+    const deps: InviteHostDeps = {
+      ...createHostDeps(),
+      addMembersToGroup: async () => {
+        addMembersCalled = true;
+        return Result.ok(undefined);
+      },
+    };
+
+    let capturedHandler: ((event: CoreRawEvent) => void) | null = null;
+    const mockSubscribe = (
+      handler: (event: CoreRawEvent) => void,
+    ): (() => void) => {
+      capturedHandler = handler;
+      return () => {};
+    };
+
+    startInviteHostListener(mockSubscribe, deps);
+
+    // Emit a historical message with valid invite content
+    capturedHandler!(makeRawMessageEvent(slug, { isHistorical: true }));
+
+    // Wait a tick for any async processing
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(addMembersCalled).toBe(false);
+  });
+
+  test("ignores non-message events", () => {
+    let handlerCalled = false;
+
+    const deps: InviteHostDeps = {
+      ...createHostDeps(),
+      addMembersToGroup: async () => {
+        handlerCalled = true;
+        return Result.ok(undefined);
+      },
+    };
+
+    let capturedHandler: ((event: CoreRawEvent) => void) | null = null;
+    const mockSubscribe = (
+      handler: (event: CoreRawEvent) => void,
+    ): (() => void) => {
+      capturedHandler = handler;
+      return () => {};
+    };
+
+    startInviteHostListener(mockSubscribe, deps);
+
+    // Emit a heartbeat event
+    capturedHandler!({
+      type: "raw.heartbeat",
+      timestamp: new Date().toISOString(),
+    });
+
+    expect(handlerCalled).toBe(false);
+  });
+
+  test("processes valid invite in live message", async () => {
+    let addedGroupId = "";
+    let addedInboxIds: readonly string[] = [];
+    const slug = await buildValidSlug();
+
+    const deps: InviteHostDeps = {
+      ...createHostDeps(),
+      addMembersToGroup: async (groupId, inboxIds) => {
+        addedGroupId = groupId;
+        addedInboxIds = inboxIds;
+        return Result.ok(undefined);
+      },
+    };
+
+    let capturedHandler: ((event: CoreRawEvent) => void) | null = null;
+    const mockSubscribe = (
+      handler: (event: CoreRawEvent) => void,
+    ): (() => void) => {
+      capturedHandler = handler;
+      return () => {};
+    };
+
+    startInviteHostListener(mockSubscribe, deps);
+
+    // Emit a live message with a valid invite slug
+    capturedHandler!(makeRawMessageEvent(slug));
+
+    // Wait for the async fire-and-forget to complete
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(addedGroupId).toBe(TEST_CONVERSATION_ID);
+    expect(addedInboxIds).toEqual([TEST_REQUESTER_INBOX_ID]);
+  });
+});

--- a/packages/core/src/convos/__tests__/process-join-requests.test.ts
+++ b/packages/core/src/convos/__tests__/process-join-requests.test.ts
@@ -118,4 +118,35 @@ describe("processJoinRequest", () => {
 
     expect(result.isErr()).toBe(true);
   });
+
+  test("rejects invite when stored tag does not match", async () => {
+    const slug = await buildValidSlug();
+    const deps = createMockDeps({
+      getGroupTagResult: Result.ok("wrong-tag-value"),
+    });
+
+    const result = await processJoinRequest(deps, {
+      senderInboxId: TEST_REQUESTER_INBOX_ID,
+      messageText: slug,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+
+    expect(result.error.message).toContain("tag");
+  });
+
+  test("allows invite when no stored tag exists (undefined)", async () => {
+    const slug = await buildValidSlug();
+    const deps = createMockDeps({
+      getGroupTagResult: Result.ok(undefined),
+    });
+
+    const result = await processJoinRequest(deps, {
+      senderInboxId: TEST_REQUESTER_INBOX_ID,
+      messageText: slug,
+    });
+
+    expect(result.isOk()).toBe(true);
+  });
 });

--- a/packages/core/src/convos/invite-host.ts
+++ b/packages/core/src/convos/invite-host.ts
@@ -1,0 +1,83 @@
+import { Result } from "better-result";
+import type { SignetError } from "@xmtp/signet-schemas";
+import type { CoreRawEvent, RawMessageEvent } from "../raw-events.js";
+import {
+  processJoinRequest,
+  type ProcessJoinRequestDeps,
+  type IncomingJoinMessage,
+  type JoinRequestResult,
+} from "./process-join-requests.js";
+
+/** Dependencies for the invite host listener. */
+export interface InviteHostDeps {
+  /** The secp256k1 private key (hex, no 0x prefix) for the host identity. */
+  readonly walletPrivateKeyHex: string;
+  /** The host's inbox ID. */
+  readonly creatorInboxId: string;
+  /** Add members to a group. */
+  readonly addMembersToGroup: (
+    groupId: string,
+    inboxIds: readonly string[],
+  ) => Promise<Result<void, SignetError>>;
+  /** Look up the stored invite tag for a group. */
+  readonly getGroupInviteTag: (
+    groupId: string,
+  ) => Promise<Result<string | undefined, SignetError>>;
+}
+
+/**
+ * Try to process a raw message event as an invite join request.
+ *
+ * Returns the join result if the message was a valid invite URL,
+ * or `null` if the message is not a join request (so the caller
+ * can ignore it).
+ */
+export async function tryProcessJoinRequest(
+  deps: InviteHostDeps,
+  event: RawMessageEvent,
+): Promise<Result<JoinRequestResult, SignetError> | null> {
+  // Only process text content
+  if (typeof event.content !== "string") return null;
+
+  // Quick heuristic: invite slugs/URLs are always long single-token strings.
+  // Short messages or multi-word text are clearly not invites.
+  const text = event.content.trim();
+  if (text.length < 50 || text.includes(" ")) return null;
+
+  const message: IncomingJoinMessage = {
+    senderInboxId: event.senderInboxId,
+    messageText: text,
+  };
+
+  return processJoinRequest(
+    {
+      walletPrivateKeyHex: deps.walletPrivateKeyHex,
+      creatorInboxId: deps.creatorInboxId,
+      addMembersToGroup: deps.addMembersToGroup,
+      getGroupInviteTag: deps.getGroupInviteTag,
+    } satisfies ProcessJoinRequestDeps,
+    message,
+  );
+}
+
+/**
+ * Subscribe to raw events and process any that look like invite join
+ * requests. Returns an unsubscribe function.
+ *
+ * Historical messages are skipped. Processing is fire-and-forget so
+ * the event stream is never blocked.
+ */
+export function startInviteHostListener(
+  subscribe: (handler: (event: CoreRawEvent) => void) => () => void,
+  deps: InviteHostDeps,
+): () => void {
+  return subscribe((event) => {
+    if (event.type !== "raw.message") return;
+    if (event.isHistorical) return;
+
+    // Fire and forget — most messages are not join requests
+    void tryProcessJoinRequest(deps, event).catch(() => {
+      // Silently ignore processing errors
+    });
+  });
+}

--- a/packages/core/src/convos/process-join-requests.ts
+++ b/packages/core/src/convos/process-join-requests.ts
@@ -166,7 +166,19 @@ export async function processJoinRequest(
     );
   }
 
-  // Step 6: Add the requester to the group
+  // Step 6: Verify the invite tag matches what was stored at generation time
+  const tagResult = await deps.getGroupInviteTag(groupId);
+  if (!tagResult.isOk()) return tagResult;
+  if (tagResult.value !== undefined && tagResult.value !== invite.tag) {
+    return Result.err(
+      ValidationError.create(
+        "invite",
+        "Invite tag does not match the stored tag for this group",
+      ),
+    );
+  }
+
+  // Step 7: Add the requester to the group
   const addResult = await deps.addMembersToGroup(groupId, [
     message.senderInboxId,
   ]);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -110,6 +110,13 @@ export type {
   JoinRequestResult,
 } from "./convos/process-join-requests.js";
 
+// Convos invite host (join request listener)
+export {
+  tryProcessJoinRequest,
+  startInviteHostListener,
+} from "./convos/invite-host.js";
+export type { InviteHostDeps } from "./convos/invite-host.js";
+
 // SDK integration (production XmtpClientFactory implementation)
 export {
   createSdkClientFactory,


### PR DESCRIPTION
## Summary

- Wire `processJoinRequest` into the runtime event stream so creator-side invite hosting works end-to-end
- Store `inviteTag` at invite generation time via in-memory Map (v1 single-process model)
- Wire `getGroupInviteTag` verification into the processor — was previously declared but never called
- Start invite host listener in production after identity is available
- Bail early if identity has no inboxId (not yet registered with XMTP)

### Key design

- Listener filters `raw.message` events by type and heuristic (length >= 50, no spaces)
- Historical messages are skipped to avoid reprocessing on recovery sync
- Fire-and-forget processing — errors don't crash the stream
- Tag verification is tolerant of missing tags (graceful degradation)

## Test plan

- [x] `tryProcessJoinRequest` processes valid invite URLs
- [x] Returns null for non-string content, short text, multi-word text
- [x] Listener subscribe/unsubscribe lifecycle
- [x] Historical messages skipped
- [x] Tag mismatch rejection
- [x] Graceful pass-through when no stored tag
- [x] typecheck (21/21), core tests (242)

Closes https://github.com/galligan/xmtp-signet/issues/240

In-collaboration-with: [Claude Code](https://claude.com/claude-code)