### PR TITLE
docs: refresh shipped CLI docs and fix stale dev-network test entries [#243]

### DIFF
--- a/.claude/skills/xmtp-signet-dev/SKILL.md
+++ b/.claude/skills/xmtp-signet-dev/SKILL.md
@@ -301,6 +301,6 @@ Use repo tools before guessing:
 ```bash
 blz query -s xmtp "your query" --limit 5 --text
 qmd query "your query" -c xmtp-signet
-qmd query "your query" -c xmtp-signet-plans
+qmd query "your query" -c xmtp-signet-notes
 qmd query "your query" -c xmtp-signet-claude
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Current center of gravity:
 - permission system: allow/deny scope sets with deny-wins resolution
 - key runtime: local encrypted vault, admin auth, operational rotation,
   OWS-inspired direction
-- CLI: `xs` with direct v1 command groups such as `credential`
+- CLI: `xs` with direct v1 command groups (`operator`, `cred`, `chat`, `msg`, `policy`)
 
 ## Project structure
 
@@ -53,17 +53,17 @@ cd packages/<pkg> && bun test
 
 # CLI
 xs --help
-xs start
+xs daemon start
 xs status --json
-xs credential issue --operator op_a7f3 --credential @credential.json
-xs credential inspect cred_b2c1
+xs cred issue --op op_a7f3 --chat conv_9e2d1a4b8c3f7e60 --allow send,reply
+xs cred info cred_b2c1
 
 # XMTP docs lookup
 blz query -s xmtp "your query" --limit 5 --text
 
 # Repo-local docs lookup
 qmd query "your query" -c xmtp-signet
-qmd query "your query" -c xmtp-signet-plans
+qmd query "your query" -c xmtp-signet-notes
 qmd query "your query" -c xmtp-signet-claude
 ```
 
@@ -181,18 +181,27 @@ Short IDs are accepted where they resolve uniquely.
 
 ### CLI surface
 
-The current `xs` command groups are:
+Top-level commands: `init`, `status`, `reset`, `logs`, `lookup`, `search`,
+`consent`.
 
-- `start`, `stop`, `status`
-- `identity`
-- `credential`
-- `seal`
-- `message`
-- `conversation`
-- `admin`
-- `keys`
+The `xs` command groups are:
 
-`xs credential ...` is the canonical lifecycle surface for issuing, inspecting,
+- `daemon` — `start`, `stop`, `status`
+- `operator` — `create`, `list`, `info`, `rename`, `rm`
+- `cred` — `issue`, `list`, `info`, `revoke`, `update`
+- `chat` — `create`, `list`, `info`, `update`, `sync`, `join`, `invite`,
+  `leave`, `rm`, plus `members` subgroup (`list`, `add`, `rm`, `promote`,
+  `demote`)
+- `msg` — `send`, `reply`, `react`, `read`, `list`, `info`
+- `policy` — `create`, `list`, `info`, `update`, `rm`
+- `seal` _(deferred)_ — `list`, `info`, `verify`, `history`
+- `wallet` _(deferred)_ — `list`, `info`, `provider set/list`
+- `key` _(deferred)_ — `init`, `rotate`, `list`, `info`
+
+Deferred groups (`seal`, `wallet`, `key`) have command structure and help text
+but are not yet daemon-backed. Their actions exit with a deferral message.
+
+`xs cred ...` is the canonical lifecycle surface for issuing, inspecting,
 listing, and revoking v1 credentials.
 
 ## Error taxonomy

--- a/README.md
+++ b/README.md
@@ -99,23 +99,32 @@ bun run check
 
 ```bash
 # Create a local XMTP identity and key hierarchy
-xs identity init --env dev --label owner
+xs init --env dev --label owner
 
 # Start the daemon
-xs start
+xs daemon start
 
 # Inspect live state
 xs status --json
 
-# Create an operator and issue a credential
-xs cred issue --op alice-bot --chat conv_9e2d \
+# Create an operator
+xs operator create --label alice-bot --role operator --scope per-chat
+
+# Issue a credential scoped to a conversation
+xs cred issue --op alice-bot --chat conv_9e2d1a4b8c3f7e60 \
   --policy support-bot --allow send,reply --deny invite
 
 # Inspect that credential
 xs cred info cred_b2c1
 
 # Create a conversation
-xs conversation create
+xs chat create --name "Design Team"
+
+# Send a message
+xs msg send "Hello from the signet" --to conv_9e2d1a4b8c3f7e60
+
+# Create a reusable policy
+xs policy create --label chatty --allow send,reply
 ```
 
 `xs cred ...` is the canonical v1 lifecycle surface. Credential metadata
@@ -126,18 +135,19 @@ package layout.
 
 ## CLI commands
 
-| Group                     | Commands                                                            |
-| ------------------------- | ------------------------------------------------------------------- |
-| `start`, `stop`, `status` | Daemon lifecycle                                                    |
-| `config`                  | `show`, `validate`                                                  |
-| `identity`                | `init`, `list`, `info`, `rotate-keys`, `export-public`              |
-| `cred`                    | `issue`, `list`, `info`, `revoke`                                   |
-| `seal`                    | `inspect`, `verify`, `history`                                      |
-| `message`                 | `send`, `list`, `stream`                                            |
-| `conversation`            | `create`, `list`, `info`, `add-member`, `invite`, `join`, `members` |
-| `admin`                   | `token`, `verify-keys`, `export-state`, `audit-log`                 |
-| `keys`                    | `rotate`                                                            |
-| `policy`                  | `create`, `list`, `info`, `update`                                  |
+| Group                 | Commands                                                                    |
+| --------------------- | --------------------------------------------------------------------------- |
+| top-level             | `init`, `status`, `reset`, `logs`, `lookup`, `search`, `consent`            |
+| `daemon`              | `start`, `stop`, `status`                                                   |
+| `operator`            | `create`, `list`, `info`, `rename`, `rm`                                    |
+| `cred`                | `issue`, `list`, `info`, `revoke`, `update`                                 |
+| `chat`                | `create`, `list`, `info`, `update`, `sync`, `join`, `invite`, `leave`, `rm` |
+| `chat ... member`     | `list`, `add`, `rm`, `promote`, `demote`                                    |
+| `msg`                 | `send`, `reply`, `react`, `read`, `list`, `info`                            |
+| `policy`              | `create`, `list`, `info`, `update`, `rm`                                    |
+| `seal` _(deferred)_   | `list`, `info`, `verify`, `history`                                         |
+| `wallet` _(deferred)_ | `list`, `info`, `provider set`, `provider list`                             |
+| `key` _(deferred)_    | `init`, `rotate`, `list`, `info`                                            |
 
 ## What's working
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -101,9 +101,9 @@ After bootstrap, the local CLI is available as `xs`:
 
 ```bash
 xs --help
-xs start
+xs daemon start
 xs status --json
-xs cred issue --op alice-bot --chat conv_1 --allow send,reply
+xs cred issue --op alice-bot --chat conv_9e2d1a4b8c3f7e60 --allow send,reply
 xs cred info cred_b2c1
 ```
 
@@ -277,7 +277,7 @@ For searching repo-local documentation:
 ```bash
 # Repo-local docs and plans
 qmd query "your query" -c xmtp-signet
-qmd query "your query" -c xmtp-signet-plans
+qmd query "your query" -c xmtp-signet-notes
 ```
 
 ### XMTP SDK docs

--- a/packages/cli/src/__tests__/dev-network.test.ts
+++ b/packages/cli/src/__tests__/dev-network.test.ts
@@ -114,7 +114,7 @@ async function runCli(
 
 function startDaemon(configPath: string): Bun.Subprocess {
   const proc = Bun.spawn(
-    ["bun", CLI, "start", "--config", configPath, "--json"],
+    ["bun", CLI, "daemon", "start", "--config", configPath, "--json"],
     {
       cwd: repoRoot,
       stdout: "pipe",
@@ -174,7 +174,7 @@ async function waitForDaemonReady(
 
 async function stopDaemon(configPath: string): Promise<void> {
   const result = await runCli(
-    ["stop", "--config", configPath, "--json"],
+    ["daemon", "stop", "--config", configPath, "--json"],
     10_000,
   );
   if (result.exitCode !== 0) {
@@ -190,12 +190,11 @@ async function stopDaemon(configPath: string): Promise<void> {
 describe.skipIf(!process.env["XMTP_NETWORK_TESTS"])(
   "dev network smoke",
   () => {
-    test("identity init registers with devnet", async () => {
+    test("init registers with devnet", async () => {
       const dir = makeTestDir("init");
       const configPath = writeConfig(dir);
 
       const result = await runCli([
-        "identity",
         "init",
         "--env",
         "dev",
@@ -223,7 +222,6 @@ describe.skipIf(!process.env["XMTP_NETWORK_TESTS"])(
       const configPath = writeConfig(dir);
 
       const alice = await runCli([
-        "identity",
         "init",
         "--env",
         "dev",
@@ -237,7 +235,6 @@ describe.skipIf(!process.env["XMTP_NETWORK_TESTS"])(
       const aliceOutput = JSON.parse(alice.stdout) as Record<string, unknown>;
 
       const bob = await runCli([
-        "identity",
         "init",
         "--env",
         "dev",
@@ -261,7 +258,6 @@ describe.skipIf(!process.env["XMTP_NETWORK_TESTS"])(
 
       // Init two identities
       const alice = await runCli([
-        "identity",
         "init",
         "--env",
         "dev",
@@ -274,7 +270,6 @@ describe.skipIf(!process.env["XMTP_NETWORK_TESTS"])(
       expect(alice.exitCode).toBe(0);
 
       const bob = await runCli([
-        "identity",
         "init",
         "--env",
         "dev",


### PR DESCRIPTION
## Summary

- Update README.md with the real v1 CLI taxonomy and `conv_` ID examples
- Update CLAUDE.md CLI surface section with all groups, subcommands, and deferred annotations
- Fix dev-network tests to use current CLI entry points (`init`, `daemon start/stop`)
- Fix docs/development.md with `xs daemon start` and full-length `conv_` IDs
- Fix README `msg send` example to use correct `--to` flag syntax

## Test plan

- [x] `bun run docs:check` passes (100% coverage)
- [x] All dev-network tests use correct CLI paths
- [x] typecheck (21/21), full test suite (21/21 turbo tasks)

Closes https://github.com/galligan/xmtp-signet/issues/243

In-collaboration-with: [Claude Code](https://claude.com/claude-code)