### PR TITLE
fix(cli): wire operator credential revocation hook in production [#257]

### DIFF
--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -540,7 +540,15 @@ export function createProductionDeps(): SignetRuntimeDeps {
     },
 
     createOperatorManager() {
-      const om = createOperatorManagerImpl();
+      const om = createOperatorManagerImpl({
+        revokeCredentials(operatorId, reason) {
+          if (!internalCredentialManagerRef) {
+            return Result.ok(undefined);
+          }
+          internalCredentialManagerRef.revokeAllCredentials(operatorId, reason);
+          return Result.ok(undefined);
+        },
+      });
       operatorManagerRef = om;
       return om;
     },


### PR DESCRIPTION
## Summary

Wire the `revokeCredentials` hook into `createOperatorManager` so `xs operator rm` cascades credential revocation using `InternalCredentialManager.revokeAllCredentials`.

## Test plan

- [x] typecheck (21/21)
- [x] Existing operator removal tests pass

Closes https://github.com/galligan/xmtp-signet/issues/257

In-collaboration-with: [Claude Code](https://claude.com/claude-code)