### PR TITLE
refactor(core): rename conversation.* action specs to chat.* [#253]

### DIFF
--- a/packages/cli/src/__tests__/action-surface-map.test.ts
+++ b/packages/cli/src/__tests__/action-surface-map.test.ts
@@ -105,7 +105,7 @@ describe("action surface map", () => {
 
     expect(surfaceMap.entries.length).toBeGreaterThan(0);
     expect(hash).toBe(
-      "31cb38ef9d7484bd3d56db001545f93317b435097ca0b6c4259b0e6030bb6f0b",
+      "1e034cb49a77348db5b512ddf9867cfe4e9819083ab596f423521169958c44cf",
     );
   });
 });

--- a/packages/cli/src/__tests__/conversation-command-wiring.test.ts
+++ b/packages/cli/src/__tests__/conversation-command-wiring.test.ts
@@ -112,7 +112,7 @@ describe("conversation create", () => {
     expect(harness.withDaemonCalls).toEqual([{ configPath: "/tmp/test.toml" }]);
     expect(harness.requestCalls).toEqual([
       {
-        method: "conversation.create",
+        method: "chat.create",
         params: {
           name: "Test Group",
           memberInboxIds: ["inbox1", "inbox2", "inbox3"],
@@ -185,7 +185,7 @@ describe("conversation list", () => {
 
     expect(harness.requestCalls).toEqual([
       {
-        method: "conversation.list",
+        method: "chat.list",
         params: { identityLabel: undefined },
       },
     ]);
@@ -232,7 +232,7 @@ describe("conversation info", () => {
 
     expect(harness.requestCalls).toEqual([
       {
-        method: "conversation.info",
+        method: "chat.info",
         params: { chatId: "grp_abc" },
       },
     ]);
@@ -259,7 +259,7 @@ describe("conversation add-member", () => {
 
     expect(harness.requestCalls).toEqual([
       {
-        method: "conversation.add-member",
+        method: "chat.add-member",
         params: { chatId: "grp_abc", inboxId: "inbox_xyz" },
       },
     ]);

--- a/packages/cli/src/commands/conversation.ts
+++ b/packages/cli/src/commands/conversation.ts
@@ -62,7 +62,7 @@ export function createConversationCommands(
             typeof options.config === "string" ? options.config : undefined,
         },
         (client) =>
-          client.request<unknown>("conversation.create", {
+          client.request<unknown>("chat.create", {
             name: typeof options.name === "string" ? options.name : undefined,
             memberInboxIds,
             creatorIdentityLabel:
@@ -93,7 +93,7 @@ export function createConversationCommands(
             typeof options.config === "string" ? options.config : undefined,
         },
         (client) =>
-          client.request<unknown>("conversation.list", {
+          client.request<unknown>("chat.list", {
             identityLabel:
               typeof options.as === "string" ? options.as : undefined,
           }),
@@ -121,7 +121,7 @@ export function createConversationCommands(
           configPath:
             typeof options.config === "string" ? options.config : undefined,
         },
-        (client) => client.request<unknown>("conversation.info", { chatId }),
+        (client) => client.request<unknown>("chat.info", { chatId }),
       );
 
       if (result.isErr()) {
@@ -148,7 +148,7 @@ export function createConversationCommands(
             typeof options.config === "string" ? options.config : undefined,
         },
         (client) =>
-          client.request<unknown>("conversation.add-member", {
+          client.request<unknown>("chat.add-member", {
             chatId,
             inboxId,
           }),
@@ -188,7 +188,7 @@ export function createConversationCommands(
           configPath:
             typeof options.config === "string" ? options.config : undefined,
         },
-        (client) => client.request<unknown>("conversation.invite", params),
+        (client) => client.request<unknown>("chat.invite", params),
       );
 
       if (result.isErr()) {
@@ -249,7 +249,7 @@ export function createConversationCommands(
             typeof options.config === "string" ? options.config : undefined,
         },
         (client) =>
-          client.request<unknown>("conversation.join", {
+          client.request<unknown>("chat.join", {
             inviteUrl,
             label:
               typeof options.label === "string" ? options.label : undefined,
@@ -282,7 +282,7 @@ export function createConversationCommands(
 
       const fetchMembers = async (): Promise<unknown | undefined> => {
         const result = await d.withDaemonClient({ configPath }, (client) =>
-          client.request<unknown>("conversation.info", { chatId }),
+          client.request<unknown>("chat.info", { chatId }),
         );
 
         if (result.isErr()) {

--- a/packages/cli/src/commands/xs-chat.ts
+++ b/packages/cli/src/commands/xs-chat.ts
@@ -2,8 +2,7 @@
  * Chat management commands for the `xs chat` subcommand group.
  *
  * Daemon-backed conversation lifecycle operations via the admin socket.
- * The CLI group name is `chat` but RPC calls use the current `conversation.*`
- * action IDs registered in the runtime (the rename to `chat.*` is deferred).
+ * RPC calls use `chat.*` action IDs registered in the runtime.
  *
  * Follows the same contract-first pattern as `xs-credential.ts`.
  *
@@ -104,7 +103,7 @@ export function createChatCommands(
 
         const result = await resolvedDeps.withDaemonClient(
           { configPath: opts.config },
-          (client) => client.request("conversation.create", payload),
+          (client) => client.request("chat.create", payload),
         );
 
         if (result.isErr()) {
@@ -139,7 +138,7 @@ export function createChatCommands(
 
         const result = await resolvedDeps.withDaemonClient(
           { configPath: opts.config },
-          (client) => client.request("conversation.list", payload),
+          (client) => client.request("chat.list", payload),
         );
 
         if (result.isErr()) {
@@ -166,7 +165,7 @@ export function createChatCommands(
         const json = opts.json === true;
         const result = await resolvedDeps.withDaemonClient(
           { configPath: opts.config },
-          (client) => client.request("conversation.info", { chatId: id }),
+          (client) => client.request("chat.info", { chatId: id }),
         );
 
         if (result.isErr()) {
@@ -226,7 +225,7 @@ export function createChatCommands(
 
         const result = await resolvedDeps.withDaemonClient(
           { configPath: opts.config },
-          (client) => client.request("conversation.join", payload),
+          (client) => client.request("chat.join", payload),
         );
 
         if (result.isErr()) {
@@ -268,7 +267,7 @@ export function createChatCommands(
 
         const result = await resolvedDeps.withDaemonClient(
           { configPath: opts.config },
-          (client) => client.request("conversation.invite", payload),
+          (client) => client.request("chat.invite", payload),
         );
 
         if (result.isErr()) {
@@ -317,7 +316,7 @@ export function createChatCommands(
       const json = opts.json === true;
       const result = await resolvedDeps.withDaemonClient(
         { configPath: opts.config },
-        (client) => client.request("conversation.members", { chatId: id }),
+        (client) => client.request("chat.members", { chatId: id }),
       );
 
       if (result.isErr()) {
@@ -348,7 +347,7 @@ export function createChatCommands(
 
         const result = await resolvedDeps.withDaemonClient(
           { configPath: opts.config },
-          (client) => client.request("conversation.add-member", payload),
+          (client) => client.request("chat.add-member", payload),
         );
 
         if (result.isErr()) {

--- a/packages/core/src/__tests__/conversation-action-examples.test.ts
+++ b/packages/core/src/__tests__/conversation-action-examples.test.ts
@@ -62,9 +62,9 @@ describe("conversation action examples", () => {
     mappingDb.close();
   });
 
-  test("conversation.info examples execute and match the declared output schema", async () => {
+  test("chat.info examples execute and match the declared output schema", async () => {
     const action = createConversationActions(deps).find(
-      (candidate) => candidate.id === "conversation.info",
+      (candidate) => candidate.id === "chat.info",
     );
 
     expect(action?.examples?.length).toBeGreaterThan(0);
@@ -85,9 +85,9 @@ describe("conversation action examples", () => {
     }
   });
 
-  test("conversation.members examples execute and match the declared output schema", async () => {
+  test("chat.members examples execute and match the declared output schema", async () => {
     const action = createConversationActions(deps).find(
-      (candidate) => candidate.id === "conversation.members",
+      (candidate) => candidate.id === "chat.members",
     );
 
     expect(action?.examples?.length).toBeGreaterThan(0);

--- a/packages/core/src/__tests__/conversation-actions.test.ts
+++ b/packages/core/src/__tests__/conversation-actions.test.ts
@@ -118,10 +118,10 @@ describe("conversation actions", () => {
     setupDeps();
 
     const actions = createConversationActions(deps);
-    const createAction = actions.find((a) => a.id === "conversation.create");
-    const listAction = actions.find((a) => a.id === "conversation.list");
-    const inviteAction = actions.find((a) => a.id === "conversation.invite");
-    const membersAction = actions.find((a) => a.id === "conversation.members");
+    const createAction = actions.find((a) => a.id === "chat.create");
+    const listAction = actions.find((a) => a.id === "chat.list");
+    const inviteAction = actions.find((a) => a.id === "chat.invite");
+    const membersAction = actions.find((a) => a.id === "chat.members");
 
     expect(createAction?.description).toBe("Create a new group conversation");
     expect(createAction?.intent).toBe("write");
@@ -156,13 +156,13 @@ describe("conversation actions", () => {
     return managed;
   }
 
-  describe("conversation.create", () => {
+  describe("chat.create", () => {
     test("creates a group with members and returns metadata", async () => {
       const managed = await seedIdentity("agent-1");
       setupDeps();
 
       const actions = createConversationActions(deps);
-      const createAction = actions.find((a) => a.id === "conversation.create");
+      const createAction = actions.find((a) => a.id === "chat.create");
       expect(createAction).toBeDefined();
 
       const result = await createAction!.handler(
@@ -197,7 +197,7 @@ describe("conversation actions", () => {
       setupDeps();
 
       const actions = createConversationActions(deps);
-      const createAction = actions.find((a) => a.id === "conversation.create");
+      const createAction = actions.find((a) => a.id === "chat.create");
 
       const result = await createAction!.handler(
         {
@@ -218,7 +218,7 @@ describe("conversation actions", () => {
       setupDeps();
 
       const actions = createConversationActions(deps);
-      const createAction = actions.find((a) => a.id === "conversation.create");
+      const createAction = actions.find((a) => a.id === "chat.create");
 
       const result = await createAction!.handler(
         {
@@ -241,7 +241,7 @@ describe("conversation actions", () => {
       setupDeps();
 
       const actions = createConversationActions(deps);
-      const createAction = actions.find((a) => a.id === "conversation.create");
+      const createAction = actions.find((a) => a.id === "chat.create");
 
       const result = await createAction!.handler(
         {
@@ -258,7 +258,7 @@ describe("conversation actions", () => {
     });
   });
 
-  describe("conversation.list", () => {
+  describe("chat.list", () => {
     test("delegates to SDK client listGroups", async () => {
       const testGroups: XmtpGroupInfo[] = [
         {
@@ -282,7 +282,7 @@ describe("conversation actions", () => {
       setupDeps();
 
       const actions = createConversationActions(deps);
-      const listAction = actions.find((a) => a.id === "conversation.list");
+      const listAction = actions.find((a) => a.id === "chat.list");
       expect(listAction).toBeDefined();
 
       const result = await listAction!.handler(
@@ -304,7 +304,7 @@ describe("conversation actions", () => {
     });
   });
 
-  describe("conversation.info", () => {
+  describe("chat.info", () => {
     test("returns group details via deps.getGroupInfo with raw groupId", async () => {
       const groupInfo: XmtpGroupInfo = {
         groupId: "g-info",
@@ -316,7 +316,7 @@ describe("conversation actions", () => {
       setupDeps(async () => Result.ok(groupInfo));
 
       const actions = createConversationActions(deps);
-      const infoAction = actions.find((a) => a.id === "conversation.info");
+      const infoAction = actions.find((a) => a.id === "chat.info");
       expect(infoAction).toBeDefined();
 
       const result = await infoAction!.handler({ chatId: "g-info" }, stubCtx());
@@ -349,7 +349,7 @@ describe("conversation actions", () => {
       });
 
       const actions = createConversationActions(deps);
-      const infoAction = actions.find((a) => a.id === "conversation.info");
+      const infoAction = actions.find((a) => a.id === "chat.info");
 
       const result = await infoAction!.handler(
         { chatId: "conv_0123456789abcdef" },
@@ -365,7 +365,7 @@ describe("conversation actions", () => {
     });
   });
 
-  describe("conversation.add-member", () => {
+  describe("chat.add-member", () => {
     test("adds a member to a group and returns updated member count", async () => {
       const testGroup: XmtpGroupInfo = {
         groupId: "g-add",
@@ -407,9 +407,7 @@ describe("conversation actions", () => {
       setupDeps(async (groupId) => trackedClient.getGroupInfo(groupId));
 
       const actions = createConversationActions(deps);
-      const addMemberAction = actions.find(
-        (a) => a.id === "conversation.add-member",
-      );
+      const addMemberAction = actions.find((a) => a.id === "chat.add-member");
       expect(addMemberAction).toBeDefined();
 
       const result = await addMemberAction!.handler(
@@ -435,9 +433,7 @@ describe("conversation actions", () => {
       setupDeps();
 
       const actions = createConversationActions(deps);
-      const addMemberAction = actions.find(
-        (a) => a.id === "conversation.add-member",
-      );
+      const addMemberAction = actions.find((a) => a.id === "chat.add-member");
       expect(addMemberAction).toBeDefined();
 
       const result = await addMemberAction!.handler(
@@ -456,7 +452,7 @@ describe("conversation actions", () => {
     });
   });
 
-  describe("conversation.members", () => {
+  describe("chat.members", () => {
     test("returns member list for a group", async () => {
       const testGroup: XmtpGroupInfo = {
         groupId: "g-members",
@@ -468,9 +464,7 @@ describe("conversation actions", () => {
       setupDeps(async () => Result.ok(testGroup));
 
       const actions = createConversationActions(deps);
-      const membersAction = actions.find(
-        (a) => a.id === "conversation.members",
-      );
+      const membersAction = actions.find((a) => a.id === "chat.members");
       expect(membersAction).toBeDefined();
 
       const result = await membersAction!.handler(
@@ -497,9 +491,7 @@ describe("conversation actions", () => {
       setupDeps(); // default returns NotFoundError
 
       const actions = createConversationActions(deps);
-      const membersAction = actions.find(
-        (a) => a.id === "conversation.members",
-      );
+      const membersAction = actions.find((a) => a.id === "chat.members");
 
       const result = await membersAction!.handler(
         { chatId: "nonexistent" },
@@ -536,7 +528,7 @@ describe("conversation actions", () => {
       setupDeps();
 
       const actions = createConversationActions(deps);
-      const listAction = actions.find((a) => a.id === "conversation.list");
+      const listAction = actions.find((a) => a.id === "chat.list");
 
       const result = await listAction!.handler({}, stubCtx());
 

--- a/packages/core/src/conversation-actions.ts
+++ b/packages/core/src/conversation-actions.ts
@@ -138,7 +138,7 @@ export function createConversationActions(
     },
     SignetError
   > = {
-    id: "conversation.create",
+    id: "chat.create",
     description: "Create a new group conversation",
     intent: "write",
     input: z.object({
@@ -181,7 +181,7 @@ export function createConversationActions(
       });
     },
     cli: {
-      command: "conversation:create",
+      command: "chat:create",
     },
     mcp: {},
     http: {
@@ -194,7 +194,7 @@ export function createConversationActions(
     { groups: readonly XmtpGroupInfo[] },
     SignetError
   > = {
-    id: "conversation.list",
+    id: "chat.list",
     description: "List group conversations",
     intent: "read",
     idempotent: true,
@@ -229,7 +229,7 @@ export function createConversationActions(
       return Result.ok({ groups });
     },
     cli: {
-      command: "conversation:list",
+      command: "chat:list",
     },
     mcp: {},
     http: {
@@ -242,7 +242,7 @@ export function createConversationActions(
     XmtpGroupInfo & { chatId?: string | undefined },
     SignetError
   > = {
-    id: "conversation.info",
+    id: "chat.info",
     description: "Get group conversation details",
     intent: "read",
     idempotent: true,
@@ -273,7 +273,7 @@ export function createConversationActions(
       return Result.ok({ ...result.value, chatId: input.chatId });
     },
     cli: {
-      command: "conversation:info",
+      command: "chat:info",
     },
     mcp: {},
     http: {
@@ -298,7 +298,7 @@ export function createConversationActions(
     },
     SignetError
   > = {
-    id: "conversation.join",
+    id: "chat.join",
     description: "Join a Convos conversation via invite URL",
     intent: "write",
     input: z.object({
@@ -344,7 +344,7 @@ export function createConversationActions(
       return Result.ok({ ...joinResult.value, chatId });
     },
     cli: {
-      command: "conversation:join",
+      command: "chat:join",
     },
     mcp: {},
     http: {
@@ -369,7 +369,7 @@ export function createConversationActions(
     },
     SignetError
   > = {
-    id: "conversation.invite",
+    id: "chat.invite",
     description: "Generate a Convos-compatible invite URL for a group",
     intent: "write",
     input: z.object({
@@ -462,7 +462,7 @@ export function createConversationActions(
       });
     },
     cli: {
-      command: "conversation:invite",
+      command: "chat:invite",
     },
     mcp: {},
     http: {
@@ -479,7 +479,7 @@ export function createConversationActions(
     { chatId?: string | undefined; groupId: string; memberCount: number },
     SignetError
   > = {
-    id: "conversation.add-member",
+    id: "chat.add-member",
     description: "Add a member to a group conversation",
     intent: "write",
     input: z.object({
@@ -521,7 +521,7 @@ export function createConversationActions(
       });
     },
     cli: {
-      command: "conversation:add-member",
+      command: "chat:add-member",
     },
     mcp: {},
     http: {
@@ -539,7 +539,7 @@ export function createConversationActions(
     },
     SignetError
   > = {
-    id: "conversation.members",
+    id: "chat.members",
     description: "List members of a group conversation",
     intent: "read",
     idempotent: true,
@@ -574,7 +574,7 @@ export function createConversationActions(
       });
     },
     cli: {
-      command: "conversation:members",
+      command: "chat:members",
     },
     mcp: {},
     http: {

--- a/packages/mcp/src/__tests__/fixtures.ts
+++ b/packages/mcp/src/__tests__/fixtures.ts
@@ -191,7 +191,7 @@ export function createListSpec(
 
 export function createReadOnlySpec(): ActionSpec<unknown, unknown> {
   return {
-    id: "conversation.list",
+    id: "chat.list",
     description: "List conversations",
     intent: "read",
     handler: async () => Result.ok({ conversations: [] }),
@@ -202,7 +202,7 @@ export function createReadOnlySpec(): ActionSpec<unknown, unknown> {
 
 export function createDestructiveSpec(): ActionSpec<unknown, unknown> {
   return {
-    id: "conversation.delete",
+    id: "chat.delete",
     description: "Delete a conversation",
     intent: "destroy",
     handler: async () => Result.ok(undefined),


### PR DESCRIPTION
## Summary

Mechanical rename of all 7 conversation action spec IDs to `chat.*`, aligning with the shipped `xs chat` CLI group name. No behavioral changes.

## Test plan

- [x] All tests updated to use `chat.*` IDs
- [x] Action surface map hash updated
- [x] typecheck (21/21), full test suite green

Closes https://github.com/galligan/xmtp-signet/issues/253

In-collaboration-with: [Claude Code](https://claude.com/claude-code)