### PR TITLE
feat(cli): add SIGNET_SEAL_BYPASS env flag for development [#255]

### DIFF
--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -351,6 +351,12 @@ export function createProductionDeps(): SignetRuntimeDeps {
           d.core.sendMessage(groupId, contentType, content),
       });
 
+      // Seal bypass: when SIGNET_SEAL_BYPASS=1, InputResolver errors are
+      // swallowed and a minimal synthetic SealInput is returned so message
+      // sends proceed without real provenance. The seal will carry a
+      // `bypassed: true` marker so clients can detect it.
+      const sealBypass = process.env["SIGNET_SEAL_BYPASS"] === "1";
+
       // Real InputResolver: derive SealInput from credential + operator records.
       // Fail closed by default — if seal input can't be resolved, the caller
       // should reject the operation unless SIGNET_SEAL_BYPASS is set.
@@ -401,10 +407,29 @@ export function createProductionDeps(): SignetRuntimeDeps {
         });
       };
 
+      // Wrap the resolver with bypass logic when SIGNET_SEAL_BYPASS=1.
+      // In bypass mode, if the real resolver fails, a synthetic SealInput
+      // is returned so issuance proceeds. The seal will contain synthetic
+      // operator/permission data — clients should verify seals cryptographically.
+      const effectiveResolver: InputResolver = sealBypass
+        ? async (credentialId, chatId) => {
+            const result = await resolveInput(credentialId, chatId);
+            if (Result.isOk(result)) return result;
+            return Result.ok({
+              credentialId,
+              operatorId: "op_0000000000000000",
+              chatId,
+              scopeMode: "per-chat" as const,
+              permissions: { allow: [], deny: [] },
+              bypassed: true,
+            });
+          }
+        : resolveInput;
+
       const sealManager = createSealManagerImpl({
         signer,
         publisher,
-        resolveInput,
+        resolveInput: effectiveResolver,
       });
       globalSealManagerRef = sealManager;
       return sealManager;

--- a/packages/schemas/src/__tests__/seal.test.ts
+++ b/packages/schemas/src/__tests__/seal.test.ts
@@ -43,6 +43,12 @@ describe("SealPayload", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts payload with bypassed marker", () => {
+    expect(SealPayload.safeParse({ ...valid, bypassed: true }).success).toBe(
+      true,
+    );
+  });
+
   it("rejects invalid sealId prefix", () => {
     expect(SealPayload.safeParse({ ...valid, sealId: "bad_id" }).success).toBe(
       false,

--- a/packages/schemas/src/seal.ts
+++ b/packages/schemas/src/seal.ts
@@ -56,6 +56,8 @@ export type SealPayloadType = {
   permissions: ScopeSetType;
   adminAccess?: { operatorId: string; expiresAt: string } | undefined;
   issuedAt: string;
+  /** True when the seal used synthetic fallback input via SIGNET_SEAL_BYPASS. */
+  bypassed?: true | undefined;
   /** Signet-managed trust tier for this operator/runtime. */
   trustTier?: TrustTierType | undefined;
   /** Operator-declared claims about the runtime environment. */
@@ -185,6 +187,8 @@ export const SealPayload: z.ZodType<SealPayloadType> = z
       .optional(),
     /** When this seal was issued. */
     issuedAt: z.string().datetime(),
+    /** Present only when seal input resolution was bypassed. */
+    bypassed: z.literal(true).optional(),
     /** Signet-managed trust tier for this operator/runtime. */
     trustTier: TrustTier.optional(),
     /** Operator-declared claims about the runtime environment. */

--- a/packages/seals/src/__tests__/manager.test.ts
+++ b/packages/seals/src/__tests__/manager.test.ts
@@ -48,6 +48,24 @@ describe("SealManager", () => {
       expect(result.value.algorithm).toBe("Ed25519");
     });
 
+    test("preserves the bypassed marker on the issued seal payload", async () => {
+      const overrides = new Map<string, SealInput>();
+      overrides.set(
+        "cred_abcd1234feedbabe:conv_abcd1234feedbabe",
+        validInput({ bypassed: true }),
+      );
+
+      const { manager } = createTestManager(overrides);
+      const result = await manager.issue(
+        "cred_abcd1234feedbabe",
+        "conv_abcd1234feedbabe",
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isError(result)) return;
+      expect(result.value.chain.current.bypassed).toBe(true);
+    });
+
     test("first seal has no previous payload", async () => {
       const { manager } = createTestManager();
       const result = await manager.issue(

--- a/packages/seals/src/build.ts
+++ b/packages/seals/src/build.ts
@@ -27,6 +27,8 @@ export interface SealInput {
   readonly scopeMode: ScopeModeType;
   readonly permissions: ScopeSetType;
   readonly adminAccess?: { operatorId: string; expiresAt: string } | undefined;
+  /** True when the seal should disclose synthetic bypass fallback input. */
+  readonly bypassed?: true | undefined;
   /** Signet-managed trust tier for this operator/runtime. */
   readonly trustTier?: TrustTierType | undefined;
   /** Operator-declared claims about the runtime environment. */
@@ -63,6 +65,7 @@ export function buildSeal(
     },
     adminAccess: input.adminAccess ? { ...input.adminAccess } : undefined,
     issuedAt: now.toISOString(),
+    bypassed: input.bypassed,
     trustTier: input.trustTier,
     operatorDisclosures: input.operatorDisclosures
       ? {


### PR DESCRIPTION
## Summary

Add `SIGNET_SEAL_BYPASS=1` env flag support. When set, InputResolver failures return a synthetic SealInput so message sends proceed without real provenance. Default behavior remains fail-closed.

Mismatch detection metadata deferred to a follow-up when provenanceMap is implemented.

## Test plan

- [x] typecheck (21/21)

Closes https://github.com/galligan/xmtp-signet/issues/255

In-collaboration-with: [Claude Code](https://claude.com/claude-code)