### PR TITLE
feat(core): add chat.sync and chat.remove-member action specs [#254]

### DIFF
--- a/packages/cli/src/__tests__/action-surface-map.test.ts
+++ b/packages/cli/src/__tests__/action-surface-map.test.ts
@@ -105,7 +105,7 @@ describe("action surface map", () => {
 
     expect(surfaceMap.entries.length).toBeGreaterThan(0);
     expect(hash).toBe(
-      "1e034cb49a77348db5b512ddf9867cfe4e9819083ab596f423521169958c44cf",
+      "c7bd112a2c8b2b8461040461d841c0496d9b3d599c3b02d000eb90facb9e92e6",
     );
   });
 });

--- a/packages/cli/src/__tests__/xs-chat-command-wiring.test.ts
+++ b/packages/cli/src/__tests__/xs-chat-command-wiring.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import type { SignetError } from "@xmtp/signet-schemas";
+import type { AdminClient } from "../admin/client.js";
+import { createChatCommands } from "../commands/xs-chat.js";
+
+interface RequestCall {
+  readonly method: string;
+  readonly params: Record<string, unknown> | undefined;
+}
+
+function createHarness<T>(response: T) {
+  const requestCalls: RequestCall[] = [];
+
+  const client: AdminClient = {
+    async connect() {
+      return Result.ok(undefined);
+    },
+    async request(method, params) {
+      requestCalls.push({ method, params });
+      return Result.ok(response);
+    },
+    async close() {},
+  };
+
+  return {
+    requestCalls,
+    deps: {
+      async withDaemonClient<TResult>(
+        _options: { configPath?: string | undefined },
+        run: (
+          adminClient: AdminClient,
+        ) => Promise<Result<TResult, SignetError>>,
+      ): Promise<Result<TResult, SignetError>> {
+        return run(client);
+      },
+      writeStdout() {},
+      writeStderr() {},
+      exit() {},
+    },
+  };
+}
+
+describe("xs chat command wiring", () => {
+  test("forwards --as on chat sync as identityLabel", async () => {
+    const harness = createHarness({ synced: true });
+    const command = createChatCommands(harness.deps);
+
+    await command.parseAsync([
+      "node",
+      "chat",
+      "sync",
+      "conv_0123456789abcdef",
+      "--as",
+      "alpha",
+    ]);
+
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "chat.sync",
+        params: {
+          chatId: "conv_0123456789abcdef",
+          identityLabel: "alpha",
+        },
+      },
+    ]);
+  });
+
+  test("forwards --as on chat member rm as identityLabel", async () => {
+    const harness = createHarness({ chatId: "conv_0123456789abcdef" });
+    const command = createChatCommands(harness.deps);
+
+    await command.parseAsync([
+      "node",
+      "chat",
+      "member",
+      "rm",
+      "conv_0123456789abcdef",
+      "inbox_abc",
+      "--as",
+      "moderator",
+    ]);
+
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "chat.remove-member",
+        params: {
+          chatId: "conv_0123456789abcdef",
+          inboxId: "inbox_abc",
+          identityLabel: "moderator",
+        },
+      },
+    ]);
+  });
+});

--- a/packages/cli/src/__tests__/xs-chat-msg-commands.test.ts
+++ b/packages/cli/src/__tests__/xs-chat-msg-commands.test.ts
@@ -113,10 +113,12 @@ describe("chat commands", () => {
 
   // -- sync --
 
-  test("sync subcommand accepts optional id argument", async () => {
+  test("sync subcommand accepts optional id argument and --as option", async () => {
     const cmd = await load();
     const sync = findSub(cmd, "sync");
     expect(sync).toBeDefined();
+    const flags = optionFlags(sync!);
+    expect(flags).toContain("--as");
   });
 
   // -- join --
@@ -178,6 +180,16 @@ describe("chat commands", () => {
       expect.arrayContaining(["list", "add", "rm", "promote", "demote"]),
     );
     expect(member!.commands.length).toBe(5);
+  });
+
+  test("member rm subcommand has --as option", async () => {
+    const cmd = await load();
+    const member = findSub(cmd, "member");
+    expect(member).toBeDefined();
+    const rm = findSub(member!, "rm");
+    expect(rm).toBeDefined();
+    const flags = optionFlags(rm!);
+    expect(flags).toContain("--as");
   });
 
   // -- total count --

--- a/packages/cli/src/commands/xs-chat.ts
+++ b/packages/cli/src/commands/xs-chat.ts
@@ -187,7 +187,9 @@ export function createChatCommands(
     .option("--image <url>", "New image URL")
     .option("--json", "JSON output")
     .action(async () => {
-      resolvedDeps.writeStderr("This command is not yet implemented.\n");
+      resolvedDeps.writeStderr(
+        "This command requires XMTP client support that is not yet available.\n",
+      );
       resolvedDeps.exit(1);
     });
 
@@ -198,10 +200,29 @@ export function createChatCommands(
     .option("--config <path>", "Path to config file")
     .option("--as <identity>", "Identity to act as")
     .option("--json", "JSON output")
-    .action(async () => {
-      resolvedDeps.writeStderr("This command is not yet implemented.\n");
-      resolvedDeps.exit(1);
-    });
+    .action(
+      async (
+        id: string | undefined,
+        opts: { config?: string; as?: string; json?: true },
+      ) => {
+        const json = opts.json === true;
+        const payload: Record<string, unknown> = {};
+        if (id !== undefined) payload["chatId"] = id;
+        if (opts.as !== undefined) payload["identityLabel"] = opts.as;
+
+        const result = await resolvedDeps.withDaemonClient(
+          { configPath: opts.config },
+          (client) => client.request("chat.sync", payload),
+        );
+
+        if (result.isErr()) {
+          writeError(resolvedDeps, result.error, json);
+          return;
+        }
+
+        resolvedDeps.writeStdout(formatOutput(result.value, { json }) + "\n");
+      },
+    );
 
   cmd
     .command("join")
@@ -286,7 +307,9 @@ export function createChatCommands(
     .option("--config <path>", "Path to config file")
     .option("--json", "JSON output")
     .action(async () => {
-      resolvedDeps.writeStderr("This command is not yet implemented.\n");
+      resolvedDeps.writeStderr(
+        "This command requires XMTP client support that is not yet available.\n",
+      );
       resolvedDeps.exit(1);
     });
 
@@ -298,7 +321,9 @@ export function createChatCommands(
     .option("--force", "Execute without confirmation")
     .option("--json", "JSON output")
     .action(async () => {
-      resolvedDeps.writeStderr("This command is not yet implemented.\n");
+      resolvedDeps.writeStderr(
+        "This command requires XMTP client support that is not yet available.\n",
+      );
       resolvedDeps.exit(1);
     });
 
@@ -367,10 +392,32 @@ export function createChatCommands(
     .option("--config <path>", "Path to config file")
     .option("--as <identity>", "Identity to act as")
     .option("--json", "JSON output")
-    .action(async () => {
-      resolvedDeps.writeStderr("This command is not yet implemented.\n");
-      resolvedDeps.exit(1);
-    });
+    .action(
+      async (
+        id: string,
+        inbox: string,
+        opts: { config?: string; as?: string; json?: true },
+      ) => {
+        const json = opts.json === true;
+        const payload: Record<string, unknown> = {
+          chatId: id,
+          inboxId: inbox,
+        };
+        if (opts.as !== undefined) payload["identityLabel"] = opts.as;
+
+        const result = await resolvedDeps.withDaemonClient(
+          { configPath: opts.config },
+          (client) => client.request("chat.remove-member", payload),
+        );
+
+        if (result.isErr()) {
+          writeError(resolvedDeps, result.error, json);
+          return;
+        }
+
+        resolvedDeps.writeStdout(formatOutput(result.value, { json }) + "\n");
+      },
+    );
 
   member
     .command("promote")
@@ -380,7 +427,9 @@ export function createChatCommands(
     .option("--config <path>", "Path to config file")
     .option("--json", "JSON output")
     .action(async () => {
-      resolvedDeps.writeStderr("This command is not yet implemented.\n");
+      resolvedDeps.writeStderr(
+        "This command requires XMTP client support that is not yet available.\n",
+      );
       resolvedDeps.exit(1);
     });
 
@@ -392,7 +441,9 @@ export function createChatCommands(
     .option("--config <path>", "Path to config file")
     .option("--json", "JSON output")
     .action(async () => {
-      resolvedDeps.writeStderr("This command is not yet implemented.\n");
+      resolvedDeps.writeStderr(
+        "This command requires XMTP client support that is not yet available.\n",
+      );
       resolvedDeps.exit(1);
     });
 

--- a/packages/core/src/conversation-actions.ts
+++ b/packages/core/src/conversation-actions.ts
@@ -582,5 +582,130 @@ export function createConversationActions(
     },
   };
 
-  return [create, list, info, join, invite, addMember, members];
+  const sync: ActionSpec<
+    {
+      chatId?: string | undefined;
+      identityLabel?: string | undefined;
+    },
+    { synced: true },
+    SignetError
+  > = {
+    id: "chat.sync",
+    description: "Sync conversations with the XMTP network",
+    intent: "write",
+    input: z.object({
+      chatId: z.string().optional(),
+      identityLabel: z.string().optional(),
+    }),
+    handler: async (input) => {
+      const resolved = await resolveIdentity(
+        deps.identityStore,
+        input.identityLabel,
+      );
+      if (Result.isError(resolved)) return resolved;
+
+      const managed = deps.getManagedClient(resolved.value.identityId);
+      if (!managed) {
+        return Result.err(
+          NotFoundError.create(
+            "managed-client",
+            resolved.value.identityId,
+          ) as SignetError,
+        );
+      }
+
+      if (input.chatId) {
+        const groupId = resolveGroupId(deps.idMappings, input.chatId);
+        const result = await managed.client.syncGroup(groupId);
+        if (Result.isError(result)) return result;
+      } else {
+        const result = await managed.client.syncAll();
+        if (Result.isError(result)) return result;
+      }
+      return Result.ok({ synced: true as const });
+    },
+    cli: {
+      command: "chat:sync",
+    },
+    mcp: {
+      toolName: "chat_sync",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  const removeMember: ActionSpec<
+    {
+      chatId: string;
+      inboxId: string;
+      identityLabel?: string | undefined;
+    },
+    {
+      chatId: string;
+      memberCount: number;
+    },
+    SignetError
+  > = {
+    id: "chat.remove-member",
+    description: "Remove a member from a conversation",
+    intent: "write",
+    input: z.object({
+      chatId: z.string(),
+      inboxId: z.string(),
+      identityLabel: z.string().optional(),
+    }),
+    handler: async (input) => {
+      const resolved = await resolveIdentity(
+        deps.identityStore,
+        input.identityLabel,
+      );
+      if (Result.isError(resolved)) return resolved;
+
+      const managed = deps.getManagedClient(resolved.value.identityId);
+      if (!managed) {
+        return Result.err(
+          NotFoundError.create(
+            "managed-client",
+            resolved.value.identityId,
+          ) as SignetError,
+        );
+      }
+
+      const groupId = resolveGroupId(deps.idMappings, input.chatId);
+      const removeResult = await managed.client.removeMembers(groupId, [
+        input.inboxId,
+      ]);
+      if (Result.isError(removeResult)) return removeResult;
+
+      const groupResult = await deps.getGroupInfo(groupId);
+      if (Result.isError(groupResult)) return groupResult;
+
+      return Result.ok({
+        chatId: input.chatId,
+        memberCount: groupResult.value.memberInboxIds.length,
+      });
+    },
+    cli: {
+      command: "chat:remove-member",
+    },
+    mcp: {
+      toolName: "chat_remove_member",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  return [
+    create,
+    list,
+    info,
+    join,
+    invite,
+    addMember,
+    removeMember,
+    members,
+    sync,
+  ];
 }


### PR DESCRIPTION
## Summary

- Add `chat.sync` action spec: syncs a specific conversation or all conversations via XMTP client
- Add `chat.remove-member` action spec: removes a member from a conversation
- Wire both into CLI (`xs chat sync`, `xs chat member rm`)
- 5 commands remain gated pending XMTP client interface extensions (update, leave, rm, promote, demote)

## Test plan

- [x] typecheck (21/21), core tests (242), cli tests (357)
- [x] Action surface map hash updated

Closes https://github.com/galligan/xmtp-signet/issues/254

In-collaboration-with: [Claude Code](https://claude.com/claude-code)