### PR TITLE
feat(cli): wire key rotate to daemon and refine deferred group messages [#258]

### DIFF
--- a/packages/cli/src/commands/xs-key.ts
+++ b/packages/cli/src/commands/xs-key.ts
@@ -1,20 +1,59 @@
 /**
  * Key management commands for the `xs key` subcommand group.
  *
- * Key commands do not have action specs yet. The command structure is
- * preserved for help text, but all actions exit with a clear deferral message.
+ * `key rotate` is backed by the `keys.rotate` action spec. Other key
+ * commands are deferred pending additional action specs.
  *
  * @module
  */
 
 import { Command } from "commander";
+import type { SignetError } from "@xmtp/signet-schemas";
+import { exitCodeFromCategory } from "../output/exit-codes.js";
+import { formatOutput } from "../output/formatter.js";
+import {
+  createWithDaemonClient,
+  type WithDaemonClient,
+} from "./daemon-client.js";
 
-/** Standard deferral message for key commands. */
-function notYetAvailable(): void {
-  process.stderr.write(
-    "Key commands are not yet available. Key action specs are pending.\n",
+/** Dependencies for v1 key commands. */
+export interface XsKeyCommandDeps {
+  readonly withDaemonClient: WithDaemonClient;
+  readonly writeStdout: (message: string) => void;
+  readonly writeStderr: (message: string) => void;
+  readonly exit: (code: number) => void;
+}
+
+const defaultDeps: XsKeyCommandDeps = {
+  withDaemonClient: createWithDaemonClient(),
+  writeStdout(message) {
+    process.stdout.write(message);
+  },
+  writeStderr(message) {
+    process.stderr.write(message);
+  },
+  exit(code) {
+    process.exit(code);
+  },
+};
+
+function writeError(
+  deps: XsKeyCommandDeps,
+  error: SignetError,
+  json: boolean,
+): void {
+  deps.writeStderr(
+    formatOutput(
+      {
+        error: error._tag,
+        category: error.category,
+        message: error.message,
+        ...(error.context !== null ? { context: error.context } : {}),
+      },
+      { json },
+    ) + "\n",
   );
-  process.exit(1);
+  deps.exit(exitCodeFromCategory(error.category));
 }
 
 /**
@@ -22,21 +61,40 @@ function notYetAvailable(): void {
  *
  * Subcommands: init, rotate, list, info.
  */
-export function createKeyCommands(): Command {
+export function createKeyCommands(
+  deps: Partial<XsKeyCommandDeps> = {},
+): Command {
+  const resolvedDeps: XsKeyCommandDeps = { ...defaultDeps, ...deps };
   const cmd = new Command("key").description("Key management");
 
   cmd
     .command("init")
     .description("Initialize key hierarchy")
     .action(() => {
-      notYetAvailable();
+      resolvedDeps.writeStderr(
+        "This command requires additional key action specs.\n",
+      );
+      resolvedDeps.exit(1);
     });
 
   cmd
     .command("rotate")
-    .description("Rotate keys")
-    .action(() => {
-      notYetAvailable();
+    .description("Rotate operational keys")
+    .option("--config <path>", "Path to config file")
+    .option("--json", "JSON output")
+    .action(async (opts: { config?: string; json?: true }) => {
+      const json = opts.json === true;
+      const result = await resolvedDeps.withDaemonClient(
+        { configPath: opts.config },
+        (client) => client.request("keys.rotate", {}),
+      );
+
+      if (result.isErr()) {
+        writeError(resolvedDeps, result.error, json);
+        return;
+      }
+
+      resolvedDeps.writeStdout(formatOutput(result.value, { json }) + "\n");
     });
 
   cmd
@@ -44,7 +102,10 @@ export function createKeyCommands(): Command {
     .description("List keys")
     .option("--json", "JSON output")
     .action(() => {
-      notYetAvailable();
+      resolvedDeps.writeStderr(
+        "This command requires additional key action specs.\n",
+      );
+      resolvedDeps.exit(1);
     });
 
   cmd
@@ -53,7 +114,10 @@ export function createKeyCommands(): Command {
     .argument("<id>", "Key ID")
     .option("--json", "JSON output")
     .action(() => {
-      notYetAvailable();
+      resolvedDeps.writeStderr(
+        "This command requires additional key action specs.\n",
+      );
+      resolvedDeps.exit(1);
     });
 
   return cmd;


### PR DESCRIPTION
## Summary

Wire `xs key rotate` to the existing `keys.rotate` action spec via daemon RPC. Other key commands (init, list, info) remain gated. Seal and wallet groups unchanged pending interface extensions.

## Test plan

- [x] typecheck (21/21), cli tests (357), docs:check (100%)

Closes https://github.com/galligan/xmtp-signet/issues/258

In-collaboration-with: [Claude Code](https://claude.com/claude-code)