### PR TITLE
feat: add daemon-backed wallet actions

### DIFF
--- a/packages/cli/src/__tests__/action-surface-map.test.ts
+++ b/packages/cli/src/__tests__/action-surface-map.test.ts
@@ -3,6 +3,7 @@ import { Result } from "better-result";
 import { createActionRegistry } from "@xmtp/signet-contracts";
 import type { CredentialManager, SealManager } from "@xmtp/signet-contracts";
 import { InternalError } from "@xmtp/signet-schemas";
+import { createWalletActions } from "@xmtp/signet-keys";
 import {
   createConversationActions,
   createMessageActions,
@@ -124,12 +125,27 @@ describe("action surface map", () => {
       registry.register(spec);
     }
 
+    for (const spec of createWalletActions({
+      keyManager: {
+        createWallet: async () =>
+          Result.err(InternalError.create("not implemented")),
+        listWallets: async () =>
+          Result.err(InternalError.create("not implemented")),
+        getWallet: async () =>
+          Result.err(InternalError.create("not implemented")),
+        listWalletAccounts: async () =>
+          Result.err(InternalError.create("not implemented")),
+      } as never,
+    })) {
+      registry.register(spec);
+    }
+
     const surfaceMap = generateActionSurfaceMap(registry.list());
     const hash = hashActionSurfaceMap(surfaceMap);
 
     expect(surfaceMap.entries.length).toBeGreaterThan(0);
     expect(hash).toBe(
-      "0f3bc5f32f6ab6fc1dd5047de0c68dea564125f192773afed6c412f933dfe6a5",
+      "3379439d5eb88ca487828bf457ae5e6e755289bfcc04d2d8566e889de56d2655",
     );
   });
 });

--- a/packages/cli/src/__tests__/xs-program.test.ts
+++ b/packages/cli/src/__tests__/xs-program.test.ts
@@ -129,11 +129,12 @@ describe("v1 subcommand groups", () => {
     expect(subs).toContain("history");
   });
 
-  test("wallet group has list, info, provider subcommands", () => {
+  test("wallet group has create, list, info, provider subcommands", () => {
     const program = createXsProgram();
     const wallet = program.commands.find((c) => c.name() === "wallet");
     expect(wallet).toBeDefined();
     const subs = wallet!.commands.map((c) => c.name());
+    expect(subs).toContain("create");
     expect(subs).toContain("list");
     expect(subs).toContain("info");
     expect(subs).toContain("provider");

--- a/packages/cli/src/__tests__/xs-utility-commands.test.ts
+++ b/packages/cli/src/__tests__/xs-utility-commands.test.ts
@@ -57,6 +57,15 @@ describe("policy commands", () => {
     expect(flags).toContain("--json");
   });
 
+  test("create subcommand requires --label and supports --json", async () => {
+    const cmd = await load();
+    const create = findSub(cmd, "create");
+    expect(create).toBeDefined();
+    const flags = optionFlags(create!);
+    expect(flags).toContain("--label");
+    expect(flags).toContain("--json");
+  });
+
   test("info subcommand accepts an id argument", async () => {
     const cmd = await load();
     const info = findSub(cmd, "info");
@@ -246,11 +255,13 @@ describe("wallet commands", () => {
     expect(flags).toContain("--json");
   });
 
-  test("has exactly 3 top-level subcommands", async () => {
+  test("has exactly 4 top-level subcommands", async () => {
     const cmd = await load();
-    expect(cmd.commands.length).toBe(3);
+    expect(cmd.commands.length).toBe(4);
     const names = cmd.commands.map((c) => c.name());
-    expect(names).toEqual(expect.arrayContaining(["list", "info", "provider"]));
+    expect(names).toEqual(
+      expect.arrayContaining(["create", "list", "info", "provider"]),
+    );
   });
 });
 

--- a/packages/cli/src/__tests__/xs-wallet-command-wiring.test.ts
+++ b/packages/cli/src/__tests__/xs-wallet-command-wiring.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import { InternalError, type SignetError } from "@xmtp/signet-schemas";
+import type { AdminClient } from "../admin/client.js";
+import { createWalletCommands } from "../commands/xs-wallet.js";
+
+interface RequestCall {
+  readonly method: string;
+  readonly params: Record<string, unknown> | undefined;
+}
+
+function createHarness<T>(response: T) {
+  const requestCalls: RequestCall[] = [];
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let exitCode: number | undefined;
+
+  const client: AdminClient = {
+    async connect() {
+      return Result.ok(undefined);
+    },
+    async request(method, params) {
+      requestCalls.push({ method, params });
+      return Result.ok(response);
+    },
+    async close() {},
+  };
+
+  return {
+    deps: {
+      async withDaemonClient<TResult>(
+        options: { configPath?: string | undefined },
+        run: (
+          adminClient: AdminClient,
+        ) => Promise<Result<TResult, SignetError>>,
+      ): Promise<Result<TResult, SignetError>> {
+        expect(options).toEqual({ configPath: "/tmp/test.toml" });
+        return run(client);
+      },
+      writeStdout(message: string) {
+        stdout.push(message);
+      },
+      writeStderr(message: string) {
+        stderr.push(message);
+      },
+      exit(code: number) {
+        exitCode = code;
+      },
+    },
+    requestCalls,
+    stdout,
+    stderr,
+    get exitCode() {
+      return exitCode;
+    },
+  };
+}
+
+function createErrorHarness(error: SignetError) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let exitCode: number | undefined;
+
+  return {
+    deps: {
+      async withDaemonClient<TResult>(): Promise<Result<TResult, SignetError>> {
+        return Result.err(error);
+      },
+      writeStdout(message: string) {
+        stdout.push(message);
+      },
+      writeStderr(message: string) {
+        stderr.push(message);
+      },
+      exit(code: number) {
+        exitCode = code;
+      },
+    },
+    stdout,
+    stderr,
+    get exitCode() {
+      return exitCode;
+    },
+  };
+}
+
+describe("xs wallet commands", () => {
+  test("routes create through the daemon client", async () => {
+    const harness = createHarness({
+      id: "wallet-1",
+      label: "main",
+      provider: "internal",
+      accountCount: 0,
+      createdAt: "2026-03-31T00:00:00.000Z",
+    });
+    const command = createWalletCommands(harness.deps);
+
+    await command.parseAsync([
+      "node",
+      "wallet",
+      "create",
+      "--label",
+      "main",
+      "--config",
+      "/tmp/test.toml",
+    ]);
+
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "wallet.create",
+        params: { label: "main" },
+      },
+    ]);
+  });
+
+  test("routes list through the daemon client", async () => {
+    const harness = createHarness([]);
+    const command = createWalletCommands(harness.deps);
+
+    await command.parseAsync([
+      "node",
+      "wallet",
+      "list",
+      "--config",
+      "/tmp/test.toml",
+    ]);
+
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "wallet.list",
+        params: {},
+      },
+    ]);
+  });
+
+  test("routes info through the daemon client", async () => {
+    const harness = createHarness({
+      id: "wallet-1",
+      label: "main",
+      provider: "internal",
+      accountCount: 1,
+      createdAt: "2026-03-31T00:00:00.000Z",
+      accounts: [],
+    });
+    const command = createWalletCommands(harness.deps);
+
+    await command.parseAsync([
+      "node",
+      "wallet",
+      "info",
+      "wallet-1",
+      "--config",
+      "/tmp/test.toml",
+    ]);
+
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "wallet.info",
+        params: { walletId: "wallet-1" },
+      },
+    ]);
+  });
+});
+
+describe("xs wallet command errors", () => {
+  test("writes daemon errors to stderr", async () => {
+    const harness = createErrorHarness(InternalError.create("boom"));
+    const command = createWalletCommands(harness.deps);
+
+    await command.parseAsync(["node", "wallet", "list"]);
+
+    expect(harness.stdout).toEqual([]);
+    expect(harness.stderr[0]).toContain("category: internal");
+    expect(harness.exitCode).toBe(8);
+  });
+});

--- a/packages/cli/src/commands/xs-wallet.ts
+++ b/packages/cli/src/commands/xs-wallet.ts
@@ -1,51 +1,139 @@
 /**
  * Wallet management commands for the `xs wallet` subcommand group.
  *
- * Wallet commands do not have action specs yet. The command structure is
- * preserved for help text, but all actions exit with a clear deferral message.
+ * Create, list, and inspect wallets through the daemon action surface.
+ * Provider management remains deferred until the external provider story lands.
  *
  * @module
  */
 
 import { Command } from "commander";
+import type { SignetError } from "@xmtp/signet-schemas";
+import { exitCodeFromCategory } from "../output/exit-codes.js";
+import { formatOutput } from "../output/formatter.js";
+import {
+  createWithDaemonClient,
+  type WithDaemonClient,
+} from "./daemon-client.js";
 
-/** Standard deferral message for wallet commands. */
-function notYetAvailable(): void {
-  process.stderr.write(
-    "Wallet commands are not yet available. Wallet action specs are pending.\n",
-  );
-  process.exit(1);
+/** Dependencies for v1 wallet commands. */
+export interface XsWalletCommandDeps {
+  readonly withDaemonClient: WithDaemonClient;
+  readonly writeStdout: (message: string) => void;
+  readonly writeStderr: (message: string) => void;
+  readonly exit: (code: number) => void;
 }
 
-/**
- * Create the `wallet` subcommand group.
- *
- * Subcommands: list, info, provider (set, list).
- */
-export function createWalletCommands(): Command {
+const defaultDeps: XsWalletCommandDeps = {
+  withDaemonClient: createWithDaemonClient(),
+  writeStdout(message) {
+    process.stdout.write(message);
+  },
+  writeStderr(message) {
+    process.stderr.write(message);
+  },
+  exit(code) {
+    process.exit(code);
+  },
+};
+
+function writeError(
+  deps: XsWalletCommandDeps,
+  error: SignetError,
+  json: boolean,
+): void {
+  deps.writeStderr(
+    formatOutput(
+      {
+        error: error._tag,
+        category: error.category,
+        message: error.message,
+        ...(error.context !== null ? { context: error.context } : {}),
+      },
+      { json },
+    ) + "\n",
+  );
+  deps.exit(exitCodeFromCategory(error.category));
+}
+
+function writeDeferredProviderMessage(deps: XsWalletCommandDeps): void {
+  deps.writeStderr(
+    "Wallet provider commands remain deferred until external provider integration lands.\n",
+  );
+  deps.exit(1);
+}
+
+/** Create the `wallet` subcommand group. */
+export function createWalletCommands(
+  deps: Partial<XsWalletCommandDeps> = {},
+): Command {
+  const resolvedDeps: XsWalletCommandDeps = { ...defaultDeps, ...deps };
   const cmd = new Command("wallet").description("Wallet management");
+
+  cmd
+    .command("create")
+    .description("Create a new managed wallet")
+    .option("--config <path>", "Path to config file")
+    .requiredOption("--label <name>", "Human-readable wallet label")
+    .option("--json", "JSON output")
+    .action(async (opts: { config?: string; label: string; json?: true }) => {
+      const json = opts.json === true;
+      const result = await resolvedDeps.withDaemonClient(
+        { configPath: opts.config },
+        (client) => client.request("wallet.create", { label: opts.label }),
+      );
+
+      if (result.isErr()) {
+        writeError(resolvedDeps, result.error, json);
+        return;
+      }
+
+      resolvedDeps.writeStdout(formatOutput(result.value, { json }) + "\n");
+    });
 
   cmd
     .command("list")
     .description("List wallets")
+    .option("--config <path>", "Path to config file")
     .option("--json", "JSON output")
-    .action(() => {
-      notYetAvailable();
+    .action(async (opts: { config?: string; json?: true }) => {
+      const json = opts.json === true;
+      const result = await resolvedDeps.withDaemonClient(
+        { configPath: opts.config },
+        (client) => client.request("wallet.list", {}),
+      );
+
+      if (result.isErr()) {
+        writeError(resolvedDeps, result.error, json);
+        return;
+      }
+
+      resolvedDeps.writeStdout(formatOutput(result.value, { json }) + "\n");
     });
 
   cmd
     .command("info")
     .description("Show wallet details")
     .argument("<id>", "Wallet ID")
+    .option("--config <path>", "Path to config file")
     .option("--json", "JSON output")
-    .action(() => {
-      notYetAvailable();
+    .action(async (id: string, opts: { config?: string; json?: true }) => {
+      const json = opts.json === true;
+      const result = await resolvedDeps.withDaemonClient(
+        { configPath: opts.config },
+        (client) => client.request("wallet.info", { walletId: id }),
+      );
+
+      if (result.isErr()) {
+        writeError(resolvedDeps, result.error, json);
+        return;
+      }
+
+      resolvedDeps.writeStdout(formatOutput(result.value, { json }) + "\n");
     });
 
-  // --- provider subgroup ---
-
   const provider = new Command("provider").description(
-    "Manage wallet providers",
+    "Manage wallet providers (deferred)",
   );
 
   provider
@@ -54,7 +142,7 @@ export function createWalletCommands(): Command {
     .argument("<name>", "Provider name")
     .requiredOption("--path <path>", "Provider binary path")
     .action(() => {
-      notYetAvailable();
+      writeDeferredProviderMessage(resolvedDeps);
     });
 
   provider
@@ -62,7 +150,7 @@ export function createWalletCommands(): Command {
     .description("List wallet providers")
     .option("--json", "JSON output")
     .action(() => {
-      notYetAvailable();
+      writeDeferredProviderMessage(resolvedDeps);
     });
 
   cmd.addCommand(provider);

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -8,7 +8,7 @@ import type {
   SealManager,
 } from "@xmtp/signet-contracts";
 import { createActionRegistry } from "@xmtp/signet-contracts";
-import type { KeyManager } from "@xmtp/signet-keys";
+import { createWalletActions, type KeyManager } from "@xmtp/signet-keys";
 import type { WsServer } from "@xmtp/signet-ws";
 import {
   createCredentialActions,
@@ -279,6 +279,10 @@ export async function createSignetRuntime(
       return Result.ok({ rotated, failed: errors.length, errors });
     },
   })) {
+    registry.register(spec);
+  }
+
+  for (const spec of createWalletActions({ keyManager })) {
     registry.register(spec);
   }
 

--- a/packages/keys/src/__tests__/wallet-actions.test.ts
+++ b/packages/keys/src/__tests__/wallet-actions.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ActionSpec } from "@xmtp/signet-contracts";
+import type { SignetError } from "@xmtp/signet-schemas";
+import { createKeyManager } from "../key-manager-compat.js";
+import { createWalletActions } from "../wallet-actions.js";
+
+const testDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    testDirs.splice(0).map((dir) =>
+      rm(dir, {
+        recursive: true,
+        force: true,
+      }),
+    ),
+  );
+});
+
+async function createManager() {
+  const dataDir = await mkdtemp(join(tmpdir(), "xmtp-signet-wallet-actions-"));
+  testDirs.push(dataDir);
+
+  const managerResult = await createKeyManager({
+    dataDir,
+    rootKeyPolicy: "open",
+    operationalKeyPolicy: "open",
+    vaultKeyPolicy: "open",
+  });
+  expect(Result.isOk(managerResult)).toBe(true);
+  if (Result.isError(managerResult)) {
+    throw new Error("failed to create key manager");
+  }
+
+  const initResult = await managerResult.value.initialize();
+  expect(Result.isOk(initResult)).toBe(true);
+
+  return managerResult.value;
+}
+
+function findAction<TInput, TOutput>(
+  actions: ActionSpec<unknown, unknown, SignetError>[],
+  id: string,
+): ActionSpec<TInput, TOutput, SignetError> {
+  const action = actions.find((spec) => spec.id === id);
+  expect(action).toBeDefined();
+  return action as ActionSpec<TInput, TOutput, SignetError>;
+}
+
+describe("createWalletActions", () => {
+  test("wallet.create creates a managed wallet", async () => {
+    const keyManager = await createManager();
+    const actions = createWalletActions({ keyManager });
+    const create = findAction<
+      { label: string },
+      { id: string; label: string; accountCount: number }
+    >(actions, "wallet.create");
+
+    const result = await create.handler({ label: "main" });
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result)) {
+      throw new Error("wallet.create failed");
+    }
+
+    expect(result.value.label).toBe("main");
+    expect(result.value.accountCount).toBe(0);
+  });
+
+  test("wallet.list returns created wallets", async () => {
+    const keyManager = await createManager();
+    const actions = createWalletActions({ keyManager });
+    const create = findAction<{ label: string }, { id: string }>(
+      actions,
+      "wallet.create",
+    );
+    const list = findAction<Record<string, never>, readonly { id: string }[]>(
+      actions,
+      "wallet.list",
+    );
+
+    await create.handler({ label: "main" });
+    await create.handler({ label: "backup" });
+
+    const result = await list.handler({});
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result)) {
+      throw new Error("wallet.list failed");
+    }
+
+    expect(result.value).toHaveLength(2);
+  });
+
+  test("wallet.info returns wallet details and derived accounts", async () => {
+    const keyManager = await createManager();
+    const createResult = await keyManager.createWallet("main");
+    expect(Result.isOk(createResult)).toBe(true);
+    if (Result.isError(createResult)) {
+      throw new Error("create wallet failed");
+    }
+
+    const actions = createWalletActions({ keyManager });
+    const info = findAction<
+      { walletId: string },
+      { id: string; accounts: readonly unknown[] }
+    >(actions, "wallet.info");
+
+    const result = await info.handler({ walletId: createResult.value.id });
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result)) {
+      throw new Error("wallet.info failed");
+    }
+
+    expect(result.value.id).toBe(createResult.value.id);
+    expect(Array.isArray(result.value.accounts)).toBe(true);
+    expect(result.value.accounts).toHaveLength(0);
+  });
+});

--- a/packages/keys/src/index.ts
+++ b/packages/keys/src/index.ts
@@ -29,6 +29,8 @@ export type {
 
 // Key backend implementation (v1)
 export { createInternalKeyBackend } from "./key-manager.js";
+export { createWalletActions } from "./wallet-actions.js";
+export type { WalletActionDeps } from "./wallet-actions.js";
 
 // Platform detection
 export {

--- a/packages/keys/src/key-manager-compat.ts
+++ b/packages/keys/src/key-manager-compat.ts
@@ -38,7 +38,12 @@ import {
 import { join } from "node:path";
 import { createVault, type Vault } from "./vault.js";
 import { resolveGatePrompter } from "./se-gate-prompter.js";
-import type { VaultSecretProvider } from "./vault-secret-provider.js";
+import {
+  resolveVaultSecretProvider,
+  type VaultSecretProvider,
+} from "./vault-secret-provider.js";
+import { createInternalKeyBackend } from "./key-manager.js";
+import type { AccountInfo, KeyBackend, WalletInfo } from "./key-backend.js";
 
 type AdminKeyInfo = string & {
   readonly publicKey: string;
@@ -106,6 +111,20 @@ export interface KeyManager {
 
   /** Admin key operations. */
   readonly admin: AdminKeyManager;
+
+  /** Create a new managed wallet backed by the internal provider. */
+  createWallet(label: string): Promise<Result<WalletInfo, SignetError>>;
+
+  /** List all managed wallets. */
+  listWallets(): Promise<Result<readonly WalletInfo[], SignetError>>;
+
+  /** Look up a wallet by ID. */
+  getWallet(walletId: string): Promise<Result<WalletInfo, SignetError>>;
+
+  /** List derived accounts for a wallet. */
+  listWalletAccounts(
+    walletId: string,
+  ): Promise<Result<readonly AccountInfo[], SignetError>>;
 
   /** Create an Ed25519 operational key for an identity. */
   createOperationalKey(
@@ -382,16 +401,20 @@ export async function createKeyManager(
 
   const config = parsed.data;
   mkdirSync(config.dataDir, { recursive: true });
+  const resolvedVaultSecretProvider =
+    vaultSecretProvider ??
+    resolveVaultSecretProvider(config.dataDir, config.vaultKeyPolicy);
 
   const vaultResult = await createVault(config.dataDir, {
-    secretProvider: vaultSecretProvider,
+    secretProvider: resolvedVaultSecretProvider,
     vaultKeyPolicy: config.vaultKeyPolicy,
   });
   if (Result.isError(vaultResult)) {
     return vaultResult;
   }
+  const vault = vaultResult.value;
 
-  const kv = createCompatSecretStore(config.dataDir, vaultResult.value);
+  const kv = createCompatSecretStore(config.dataDir, vault);
   const opKeys = new Map<string, OperationalKeyEntry>();
   const groupIdIndex = new Map<string, string>();
   const credentialKeys = new Map<string, CredentialKeyEntry>();
@@ -406,6 +429,25 @@ export async function createKeyManager(
   let rotationTimer: ReturnType<typeof setInterval> | null = null;
   let adminPublicKeyHex: string | null = null;
   let adminPrivateKey: CryptoKey | null = null;
+  let walletBackend: KeyBackend | null = null;
+
+  async function getWalletBackend(): Promise<Result<KeyBackend, SignetError>> {
+    if (walletBackend !== null) {
+      return Result.ok(walletBackend);
+    }
+
+    const walletPassphraseResult =
+      await resolvedVaultSecretProvider.getSecret();
+    if (Result.isError(walletPassphraseResult)) {
+      return walletPassphraseResult;
+    }
+
+    walletBackend = createInternalKeyBackend(
+      vault,
+      walletPassphraseResult.value,
+    );
+    return Result.ok(walletBackend);
+  }
 
   async function readAdminInfo(): Promise<
     Result<AdminKeyInfo, NotFoundError | InternalError>
@@ -570,6 +612,38 @@ export async function createKeyManager(
 
     get admin() {
       return admin;
+    },
+
+    async createWallet(label) {
+      const backend = await getWalletBackend();
+      if (Result.isError(backend)) {
+        return backend;
+      }
+      return backend.value.createWallet(label, "");
+    },
+
+    async listWallets() {
+      const backend = await getWalletBackend();
+      if (Result.isError(backend)) {
+        return backend;
+      }
+      return backend.value.listWallets();
+    },
+
+    async getWallet(walletId) {
+      const backend = await getWalletBackend();
+      if (Result.isError(backend)) {
+        return backend;
+      }
+      return backend.value.getWallet(walletId);
+    },
+
+    async listWalletAccounts(walletId) {
+      const backend = await getWalletBackend();
+      if (Result.isError(backend)) {
+        return backend;
+      }
+      return backend.value.listAccounts(walletId);
     },
 
     async initialize(): Promise<

--- a/packages/keys/src/wallet-actions.ts
+++ b/packages/keys/src/wallet-actions.ts
@@ -1,0 +1,125 @@
+import { Result } from "better-result";
+import { z } from "zod";
+import type { ActionSpec } from "@xmtp/signet-contracts";
+import {
+  WalletProvider,
+  type SignetError,
+  type WalletProviderType,
+} from "@xmtp/signet-schemas";
+import type { AccountInfo, WalletInfo } from "./key-backend.js";
+import type { KeyManager } from "./key-manager-compat.js";
+
+/** Dependencies required to expose wallet actions through the runtime. */
+export interface WalletActionDeps {
+  readonly keyManager: KeyManager;
+}
+
+type WalletDetails = WalletInfo & {
+  readonly accounts: readonly AccountInfo[];
+};
+
+const WalletInfoSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  provider: WalletProvider as z.ZodType<WalletProviderType>,
+  accountCount: z.number().int().nonnegative(),
+  createdAt: z.string(),
+});
+
+const AccountInfoSchema = z.object({
+  index: z.number().int().nonnegative(),
+  address: z.string(),
+  chain: z.union([z.literal("evm"), z.literal("ed25519")]),
+  publicKey: z.string(),
+});
+
+const WalletDetailsSchema: z.ZodType<WalletDetails> = WalletInfoSchema.extend({
+  accounts: z.array(AccountInfoSchema),
+});
+
+function widenActionSpec<TInput, TOutput>(
+  spec: ActionSpec<TInput, TOutput, SignetError>,
+): ActionSpec<unknown, unknown, SignetError> {
+  return spec as ActionSpec<unknown, unknown, SignetError>;
+}
+
+/** Create wallet lifecycle actions for the CLI and admin surfaces. */
+export function createWalletActions(
+  deps: WalletActionDeps,
+): ActionSpec<unknown, unknown, SignetError>[] {
+  const create: ActionSpec<{ label: string }, WalletInfo, SignetError> = {
+    id: "wallet.create",
+    description: "Create a new managed wallet",
+    intent: "write",
+    input: z.object({
+      label: z.string().min(1),
+    }),
+    output: WalletInfoSchema,
+    handler: async (input) => deps.keyManager.createWallet(input.label),
+    cli: {
+      command: "wallet:create",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  const list: ActionSpec<
+    Record<string, never>,
+    readonly WalletInfo[],
+    SignetError
+  > = {
+    id: "wallet.list",
+    description: "List all managed wallets",
+    intent: "read",
+    idempotent: true,
+    input: z.object({}),
+    output: z.array(WalletInfoSchema),
+    handler: async () => deps.keyManager.listWallets(),
+    cli: {
+      command: "wallet:list",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  const info: ActionSpec<{ walletId: string }, WalletDetails, SignetError> = {
+    id: "wallet.info",
+    description: "Show wallet details and derived accounts",
+    intent: "read",
+    idempotent: true,
+    input: z.object({
+      walletId: z.string().min(1),
+    }),
+    output: WalletDetailsSchema,
+    handler: async (input) => {
+      const wallet = await deps.keyManager.getWallet(input.walletId);
+      if (Result.isError(wallet)) {
+        return wallet;
+      }
+
+      const accounts = await deps.keyManager.listWalletAccounts(input.walletId);
+      if (Result.isError(accounts)) {
+        return accounts;
+      }
+
+      return Result.ok({
+        ...wallet.value,
+        accounts: [...accounts.value],
+      });
+    },
+    cli: {
+      command: "wallet:info",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  return [
+    widenActionSpec(create),
+    widenActionSpec(list),
+    widenActionSpec(info),
+  ];
+}


### PR DESCRIPTION
## Context

Adds the #267 wallet surface on top of the seal inspection layer.

## What Changed

- extends the compat key manager with wallet create/list/info account accessors backed by the managed internal wallet backend
- adds `wallet.create`, `wallet.list`, and `wallet.info` action specs in the keys package
- replaces the `xs wallet` create/list/info stubs with real daemon-backed commands
- keeps `xs wallet provider ...` explicitly deferred until external provider integration lands
- adds action, CLI wiring, runtime, and command-shape coverage

## How To Test

- `bun run check`

## Notes

- this branch uses the runtime-managed vault secret as the internal wallet passphrase source, which keeps the shipped CLI aligned with the v1 design where wallet encryption is owned by the signet rather than prompted per command

## Issues

Closes #267
Refs #270
Refs #269
