### PR TITLE
feat(core): enforce credential scope on message reads [#294]

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -230,6 +230,57 @@ layer, not just access control.
 read access. The Secure Enclave biometric gate is the only path to message
 content outside your own credentials.
 
+## Message access control
+
+Message content is the most sensitive data in the signet. The access controls
+enforce two properties: **scope isolation** (you only see messages in
+conversations your credential covers) and **information opacity** (you cannot
+even learn whether a message exists outside your scope).
+
+### Scope enforcement
+
+When a credential-authenticated caller requests a message (e.g., `message.info`),
+the handler enforces a three-part check:
+
+1. **chatId ↔ groupId coupling.** The caller's `chatId` must resolve (via the
+   ID mapping store) to the message's actual XMTP `groupId`. This prevents
+   cross-conversation fishing — passing a valid message ID with a different chat
+   returns not-found.
+
+2. **Credential chat scope.** The message's `groupId` must be in the
+   credential's `chatIds` (resolved from `conv_*` local IDs to XMTP group IDs).
+   A credential scoped to `conv_A` cannot read messages from `conv_B`, even if
+   the underlying identity is a member of both groups.
+
+3. **read-messages permission.** The credential's effective scopes (allow minus
+   deny, deny wins) must include `read-messages`. A credential with only `send`
+   and `reply` scopes cannot read message content.
+
+### Information opacity
+
+All scope failures return `not_found` — never `permission_denied` or any other
+error that would confirm the message exists. This prevents probing: an attacker
+cannot distinguish "message does not exist" from "message exists but you cannot
+see it." The error response is identical in both cases.
+
+This is a deliberate design choice. Leaking message existence is a form of
+metadata exposure. An attacker who can confirm message IDs exist in a
+conversation gains information about activity patterns, even without reading
+content.
+
+### Admin path
+
+Admin-authenticated callers (no `credentialId` in context) still undergo
+chatId ↔ groupId validation. They cannot fish for messages across conversations
+by passing mismatched IDs. However, admins are not currently subject to
+credential scope checks — they can read any message in a conversation they
+specify.
+
+This is an interim state. The full admin message access model requires
+owner-approved elevation via the biometric gate (see Privilege elevation below).
+Until that is implemented, the admin socket is local-only and admin auth tokens
+are short-lived.
+
 ## Privilege elevation
 
 An admin can request elevated access (e.g., read access to an operator's

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -842,6 +842,9 @@ export function createProductionDeps(): SignetRuntimeDeps {
         identityStore: coreImplRef.identityStore,
         getManagedClient: (id) => coreImplRef!.getManagedClient(id),
         idMappings: idMappingStoreRef,
+        credentialLookup: credentialManagerRef
+          ? (credentialId) => credentialManagerRef!.lookup(credentialId)
+          : undefined,
       });
     },
 

--- a/packages/core/src/__tests__/message-actions.test.ts
+++ b/packages/core/src/__tests__/message-actions.test.ts
@@ -342,6 +342,146 @@ describe("message actions", () => {
         expect(result.error.category).toBe("not_found");
       }
     });
+
+    test("returns message when credential has chat in scope with read-messages", async () => {
+      await seedIdentity("scoped-viewer", { messages: sampleMessages });
+      idMappings.set("g1", "conv_0123456789abcdef", "conversation");
+
+      deps = {
+        identityStore,
+        getManagedClient: (id) => managedClients.get(id),
+        idMappings,
+        credentialLookup: async () =>
+          Result.ok({
+            id: "cred_1234567890abcdef",
+            config: {
+              operatorId: "op_1234567890abcdef",
+              chatIds: ["conv_0123456789abcdef"],
+              allow: ["read-messages"],
+            },
+            inboxIds: [],
+            status: "active",
+            issuedAt: new Date().toISOString(),
+            expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+            issuedBy: "owner",
+          } as never),
+      };
+
+      const actions = createMessageActions(deps);
+      const infoAction = actions.find((a) => a.id === "message.info")!;
+
+      const result = await infoAction.handler(
+        {
+          chatId: "conv_0123456789abcdef",
+          messageId: "msg-aaa",
+          identityLabel: "scoped-viewer",
+        },
+        {
+          requestId: "test",
+          signal: AbortSignal.timeout(5000),
+          credentialId: "cred_1234567890abcdef",
+        },
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isOk(result)) {
+        const val = result.value as XmtpDecodedMessage;
+        expect(val.messageId).toBe("msg-aaa");
+      }
+    });
+
+    test("returns not_found when credential lacks chat scope (no info leakage)", async () => {
+      await seedIdentity("unscoped-viewer", { messages: sampleMessages });
+      idMappings.set("g1", "conv_0123456789abcdef", "conversation");
+      idMappings.set("g2", "conv_ffff456789abcdef", "conversation");
+
+      deps = {
+        identityStore,
+        getManagedClient: (id) => managedClients.get(id),
+        idMappings,
+        credentialLookup: async () =>
+          Result.ok({
+            id: "cred_1234567890abcdef",
+            config: {
+              operatorId: "op_1234567890abcdef",
+              chatIds: ["conv_ffff456789abcdef"], // different chat
+              allow: ["read-messages"],
+            },
+            inboxIds: [],
+            status: "active",
+            issuedAt: new Date().toISOString(),
+            expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+            issuedBy: "owner",
+          } as never),
+      };
+
+      const actions = createMessageActions(deps);
+      const infoAction = actions.find((a) => a.id === "message.info")!;
+
+      const result = await infoAction.handler(
+        {
+          chatId: "conv_0123456789abcdef",
+          messageId: "msg-aaa",
+          identityLabel: "unscoped-viewer",
+        },
+        {
+          requestId: "test",
+          signal: AbortSignal.timeout(5000),
+          credentialId: "cred_1234567890abcdef",
+        },
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.category).toBe("not_found");
+      }
+    });
+
+    test("returns not_found when credential lacks read-messages scope", async () => {
+      await seedIdentity("no-read-viewer", { messages: sampleMessages });
+      idMappings.set("g1", "conv_0123456789abcdef", "conversation");
+
+      deps = {
+        identityStore,
+        getManagedClient: (id) => managedClients.get(id),
+        idMappings,
+        credentialLookup: async () =>
+          Result.ok({
+            id: "cred_1234567890abcdef",
+            config: {
+              operatorId: "op_1234567890abcdef",
+              chatIds: ["conv_0123456789abcdef"],
+              allow: ["send", "reply"], // no read-messages
+            },
+            inboxIds: [],
+            status: "active",
+            issuedAt: new Date().toISOString(),
+            expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+            issuedBy: "owner",
+          } as never),
+      };
+
+      const actions = createMessageActions(deps);
+      const infoAction = actions.find((a) => a.id === "message.info")!;
+
+      const result = await infoAction.handler(
+        {
+          chatId: "conv_0123456789abcdef",
+          messageId: "msg-aaa",
+          identityLabel: "no-read-viewer",
+        },
+        {
+          requestId: "test",
+          signal: AbortSignal.timeout(5000),
+          credentialId: "cred_1234567890abcdef",
+        },
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.category).toBe("not_found");
+      }
+    });
   });
 
   describe("message.reply", () => {

--- a/packages/core/src/__tests__/message-actions.test.ts
+++ b/packages/core/src/__tests__/message-actions.test.ts
@@ -251,6 +251,90 @@ describe("message actions", () => {
         expect(val.messages[0]!.messageId).toBe("msg-aaa");
       }
     });
+
+    test("returns not_found when credential lacks chat scope", async () => {
+      await seedIdentity("unscoped-lister", { messages: sampleMessages });
+      idMappings.set("g1", "conv_0123456789abcdef", "conversation");
+
+      deps = {
+        identityStore,
+        getManagedClient: (id) => managedClients.get(id),
+        idMappings,
+        credentialLookup: async () =>
+          Result.ok({
+            id: "cred_1234567890abcdef",
+            config: {
+              operatorId: "op_1234567890abcdef",
+              chatIds: ["conv_ffff456789abcdef"], // different chat
+              allow: ["read-messages"],
+            },
+            inboxIds: [],
+            status: "active",
+            issuedAt: new Date().toISOString(),
+            expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+            issuedBy: "owner",
+          } as never),
+      };
+
+      const actions = createMessageActions(deps);
+      const listAction = actions.find((a) => a.id === "message.list")!;
+
+      const result = await listAction.handler(
+        { chatId: "conv_0123456789abcdef", identityLabel: "unscoped-lister" },
+        {
+          requestId: "test",
+          signal: AbortSignal.timeout(5000),
+          credentialId: "cred_1234567890abcdef",
+        },
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.category).toBe("not_found");
+      }
+    });
+
+    test("returns not_found when credential lacks read-messages scope", async () => {
+      await seedIdentity("no-read-lister", { messages: sampleMessages });
+      idMappings.set("g1", "conv_0123456789abcdef", "conversation");
+
+      deps = {
+        identityStore,
+        getManagedClient: (id) => managedClients.get(id),
+        idMappings,
+        credentialLookup: async () =>
+          Result.ok({
+            id: "cred_1234567890abcdef",
+            config: {
+              operatorId: "op_1234567890abcdef",
+              chatIds: ["conv_0123456789abcdef"],
+              allow: ["send"], // no read-messages
+            },
+            inboxIds: [],
+            status: "active",
+            issuedAt: new Date().toISOString(),
+            expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+            issuedBy: "owner",
+          } as never),
+      };
+
+      const actions = createMessageActions(deps);
+      const listAction = actions.find((a) => a.id === "message.list")!;
+
+      const result = await listAction.handler(
+        { chatId: "conv_0123456789abcdef", identityLabel: "no-read-lister" },
+        {
+          requestId: "test",
+          signal: AbortSignal.timeout(5000),
+          credentialId: "cred_1234567890abcdef",
+        },
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.category).toBe("not_found");
+      }
+    });
   });
 
   describe("message.info", () => {

--- a/packages/core/src/__tests__/search-actions.test.ts
+++ b/packages/core/src/__tests__/search-actions.test.ts
@@ -322,6 +322,107 @@ describe("createSearchActions", () => {
         .value;
       expect(value.matches).toHaveLength(1);
     });
+
+    test("returns empty when credential lacks read-messages scope", async () => {
+      await seedIdentity();
+
+      const msgs: Record<string, XmtpDecodedMessage[]> = {
+        "group-1": [makeMessage("group-1", "secret message")],
+      };
+      const groups = [makeGroup("group-1", "G1")];
+      const client = createMockClient({ messages: msgs, groups });
+
+      const mockCredentialManager = {
+        lookup: async () =>
+          Result.ok({
+            id: "cred_1234567890abcdef",
+            config: {
+              operatorId: "op_1234567890abcdef",
+              chatIds: ["group-1"],
+              allow: ["send"], // no read-messages
+            },
+            inboxIds: [],
+            status: "active",
+            issuedAt: new Date().toISOString(),
+            expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+            issuedBy: "owner",
+          }),
+      } as never;
+
+      const deps = buildDeps(client, {
+        credentialManager: mockCredentialManager,
+      });
+      const actions = createSearchActions(deps);
+      const spec = actions.find((a) => a.id === "search.messages");
+
+      const result = await spec!.handler!(
+        { query: "secret", chatId: "group-1" },
+        {
+          requestId: "test",
+          signal: AbortSignal.timeout(5000),
+          credentialId: "cred_1234567890abcdef",
+        },
+      );
+      expect(Result.isOk(result)).toBe(true);
+      const value = (result as { value: { matches: unknown[]; total: number } })
+        .value;
+      expect(value.matches).toHaveLength(0);
+    });
+
+    test("filters search to only scoped conversations", async () => {
+      await seedIdentity();
+
+      const msgs: Record<string, XmtpDecodedMessage[]> = {
+        "group-1": [makeMessage("group-1", "visible message")],
+        "group-2": [makeMessage("group-2", "hidden message")],
+      };
+      const groups = [
+        makeGroup("group-1", "Scoped"),
+        makeGroup("group-2", "Unscoped"),
+      ];
+      const client = createMockClient({ messages: msgs, groups });
+
+      const mockCredentialManager = {
+        lookup: async () =>
+          Result.ok({
+            id: "cred_1234567890abcdef",
+            config: {
+              operatorId: "op_1234567890abcdef",
+              chatIds: ["group-1"], // only group-1 in scope
+              allow: ["read-messages"],
+            },
+            inboxIds: [],
+            status: "active",
+            issuedAt: new Date().toISOString(),
+            expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+            issuedBy: "owner",
+          }),
+      } as never;
+
+      const deps = buildDeps(client, {
+        credentialManager: mockCredentialManager,
+      });
+      const actions = createSearchActions(deps);
+      const spec = actions.find((a) => a.id === "search.messages");
+
+      // Search across all conversations — should only see group-1
+      const result = await spec!.handler!(
+        { query: "message" },
+        {
+          requestId: "test",
+          signal: AbortSignal.timeout(5000),
+          credentialId: "cred_1234567890abcdef",
+        },
+      );
+      expect(Result.isOk(result)).toBe(true);
+      const value = (
+        result as {
+          value: { matches: Array<{ chatId: string }>; total: number };
+        }
+      ).value;
+      expect(value.matches).toHaveLength(1);
+      expect(value.matches[0]!.chatId).toBe("group-1");
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/packages/core/src/message-actions.ts
+++ b/packages/core/src/message-actions.ts
@@ -187,7 +187,34 @@ export function createMessageActions(
       after: z.string().optional(),
       identityLabel: z.string().optional(),
     }),
-    handler: async (input) => {
+    handler: async (input, ctx) => {
+      // Credential scope enforcement: verify the caller can read
+      // messages in this conversation before hitting the SDK.
+      if (ctx.credentialId && deps.credentialLookup) {
+        const credResult = await deps.credentialLookup(ctx.credentialId);
+        if (Result.isError(credResult)) {
+          return Result.err(
+            NotFoundError.create("conversation", input.chatId) as SignetError,
+          );
+        }
+        const credential = credResult.value;
+        const scopedGroupIds = credential.config.chatIds.map((chatId) =>
+          resolveGroupId(deps.idMappings, chatId),
+        );
+        const targetGroupId = resolveGroupId(deps.idMappings, input.chatId);
+        if (!scopedGroupIds.includes(targetGroupId)) {
+          return Result.err(
+            NotFoundError.create("conversation", input.chatId) as SignetError,
+          );
+        }
+        const effectiveScopes = resolveEffectiveScopes(credential.config);
+        if (!effectiveScopes.has("read-messages")) {
+          return Result.err(
+            NotFoundError.create("conversation", input.chatId) as SignetError,
+          );
+        }
+      }
+
       const resolved = await resolveIdentity(
         deps.identityStore,
         input.identityLabel,

--- a/packages/core/src/message-actions.ts
+++ b/packages/core/src/message-actions.ts
@@ -2,7 +2,11 @@ import { Result } from "better-result";
 import { z } from "zod";
 import type { ActionSpec } from "@xmtp/signet-contracts";
 import { NotFoundError } from "@xmtp/signet-schemas";
-import type { SignetError, IdMappingStore } from "@xmtp/signet-schemas";
+import type {
+  SignetError,
+  IdMappingStore,
+  CredentialRecordType,
+} from "@xmtp/signet-schemas";
 import type { SqliteIdentityStore } from "./identity-store.js";
 import type { ManagedClient } from "./client-registry.js";
 import type { XmtpDecodedMessage } from "./xmtp-client-factory.js";
@@ -15,6 +19,12 @@ export interface MessageActionDeps {
   readonly getManagedClient: (identityId: string) => ManagedClient | undefined;
   /** Optional ID mapping store for conv_ boundary enforcement. */
   readonly idMappings?: IdMappingStore;
+  /** Resolve a credential ID to its record. Used for scope enforcement. */
+  readonly credentialLookup?:
+    | ((
+        credentialId: string,
+      ) => Promise<Result<CredentialRecordType, SignetError>>)
+    | undefined;
 }
 
 /**
@@ -76,6 +86,23 @@ function resolveMessageId(
   if (!idMappings) return messageId;
   const networkId = idMappings.getNetwork(messageId);
   return networkId ?? messageId;
+}
+
+/**
+ * Compute effective scopes from credential config allow/deny.
+ * Deny always wins.
+ */
+function resolveEffectiveScopes(config: {
+  allow?: readonly string[] | undefined;
+  deny?: readonly string[] | undefined;
+}): ReadonlySet<string> {
+  const allowed = new Set(config.allow ?? []);
+  if (config.deny) {
+    for (const scope of config.deny) {
+      allowed.delete(scope);
+    }
+  }
+  return allowed;
 }
 
 function widenActionSpec<TInput, TOutput>(
@@ -223,7 +250,12 @@ export function createMessageActions(
       messageId: z.string(),
       identityLabel: z.string().optional(),
     }),
-    handler: async (input) => {
+    handler: async (input, ctx) => {
+      const notFound = () =>
+        Result.err(
+          NotFoundError.create("message", input.messageId) as SignetError,
+        );
+
       const resolved = await resolveIdentity(
         deps.identityStore,
         input.identityLabel,
@@ -245,17 +277,41 @@ export function createMessageActions(
       if (Result.isError(lookupResult)) return lookupResult;
 
       if (!lookupResult.value) {
-        return Result.err(
-          NotFoundError.create("message", input.messageId) as SignetError,
-        );
+        return notFound();
       }
 
-      // Validate the message belongs to the requested chat
+      // Validate the message belongs to the requested chat.
+      // This prevents ID space drift and cross-conversation fishing.
       const expectedGroupId = resolveGroupId(deps.idMappings, input.chatId);
       if (lookupResult.value.groupId !== expectedGroupId) {
-        return Result.err(
-          NotFoundError.create("message", input.messageId) as SignetError,
+        return notFound();
+      }
+
+      // Credential scope enforcement: when a credentialId is present,
+      // verify the credential has scope for this conversation and the
+      // read-messages permission. Always return not_found (never
+      // permission_denied) to prevent information leakage.
+      if (ctx.credentialId && deps.credentialLookup) {
+        const credResult = await deps.credentialLookup(ctx.credentialId);
+        if (Result.isError(credResult)) {
+          return notFound();
+        }
+
+        const credential = credResult.value;
+
+        // Resolve credential's conv_ chatIds to XMTP groupIds
+        const scopedGroupIds = credential.config.chatIds.map((chatId) =>
+          resolveGroupId(deps.idMappings, chatId),
         );
+
+        if (!scopedGroupIds.includes(lookupResult.value.groupId)) {
+          return notFound();
+        }
+
+        const effectiveScopes = resolveEffectiveScopes(credential.config);
+        if (!effectiveScopes.has("read-messages")) {
+          return notFound();
+        }
       }
 
       return Result.ok(lookupResult.value);

--- a/packages/core/src/message-actions.ts
+++ b/packages/core/src/message-actions.ts
@@ -290,6 +290,37 @@ export function createMessageActions(
           NotFoundError.create("message", input.messageId) as SignetError,
         );
 
+      // Credential scope enforcement: verify scope BEFORE any data
+      // access to prevent timing side-channels that leak message
+      // existence. Always return not_found to maintain information
+      // opacity. Fail closed when credentialLookup is unwired.
+      if (ctx.credentialId) {
+        if (!deps.credentialLookup) {
+          return notFound();
+        }
+        const credResult = await deps.credentialLookup(ctx.credentialId);
+        if (Result.isError(credResult)) {
+          return notFound();
+        }
+
+        const credential = credResult.value;
+
+        // Resolve credential's conv_ chatIds to XMTP groupIds
+        const scopedGroupIds = credential.config.chatIds.map((chatId) =>
+          resolveGroupId(deps.idMappings, chatId),
+        );
+
+        const expectedGroupId = resolveGroupId(deps.idMappings, input.chatId);
+        if (!scopedGroupIds.includes(expectedGroupId)) {
+          return notFound();
+        }
+
+        const effectiveScopes = resolveEffectiveScopes(credential.config);
+        if (!effectiveScopes.has("read-messages")) {
+          return notFound();
+        }
+      }
+
       const resolved = await resolveIdentity(
         deps.identityStore,
         input.identityLabel,
@@ -319,37 +350,6 @@ export function createMessageActions(
       const expectedGroupId = resolveGroupId(deps.idMappings, input.chatId);
       if (lookupResult.value.groupId !== expectedGroupId) {
         return notFound();
-      }
-
-      // Credential scope enforcement: when a credentialId is present,
-      // verify the credential has scope for this conversation and the
-      // read-messages permission. Always return not_found (never
-      // permission_denied) to prevent information leakage.
-      // Fail closed: missing credentialLookup with a credentialId denies.
-      if (ctx.credentialId && !deps.credentialLookup) {
-        return notFound();
-      }
-      if (ctx.credentialId && deps.credentialLookup) {
-        const credResult = await deps.credentialLookup(ctx.credentialId);
-        if (Result.isError(credResult)) {
-          return notFound();
-        }
-
-        const credential = credResult.value;
-
-        // Resolve credential's conv_ chatIds to XMTP groupIds
-        const scopedGroupIds = credential.config.chatIds.map((chatId) =>
-          resolveGroupId(deps.idMappings, chatId),
-        );
-
-        if (!scopedGroupIds.includes(lookupResult.value.groupId)) {
-          return notFound();
-        }
-
-        const effectiveScopes = resolveEffectiveScopes(credential.config);
-        if (!effectiveScopes.has("read-messages")) {
-          return notFound();
-        }
       }
 
       return Result.ok(lookupResult.value);

--- a/packages/core/src/message-actions.ts
+++ b/packages/core/src/message-actions.ts
@@ -190,7 +190,14 @@ export function createMessageActions(
     handler: async (input, ctx) => {
       // Credential scope enforcement: verify the caller can read
       // messages in this conversation before hitting the SDK.
-      if (ctx.credentialId && deps.credentialLookup) {
+      // Fail closed: if credentialId is present but credentialLookup
+      // is not wired, deny access rather than silently bypassing.
+      if (ctx.credentialId) {
+        if (!deps.credentialLookup) {
+          return Result.err(
+            NotFoundError.create("conversation", input.chatId) as SignetError,
+          );
+        }
         const credResult = await deps.credentialLookup(ctx.credentialId);
         if (Result.isError(credResult)) {
           return Result.err(
@@ -318,6 +325,10 @@ export function createMessageActions(
       // verify the credential has scope for this conversation and the
       // read-messages permission. Always return not_found (never
       // permission_denied) to prevent information leakage.
+      // Fail closed: missing credentialLookup with a credentialId denies.
+      if (ctx.credentialId && !deps.credentialLookup) {
+        return notFound();
+      }
       if (ctx.credentialId && deps.credentialLookup) {
         const credResult = await deps.credentialLookup(ctx.credentialId);
         if (Result.isError(credResult)) {

--- a/packages/core/src/search-actions.ts
+++ b/packages/core/src/search-actions.ts
@@ -84,6 +84,23 @@ function resolveGroupId(
   return networkId ?? chatId;
 }
 
+/**
+ * Compute effective scopes from credential config allow/deny.
+ * Deny always wins.
+ */
+function resolveEffectiveScopes(config: {
+  allow?: readonly string[] | undefined;
+  deny?: readonly string[] | undefined;
+}): ReadonlySet<string> {
+  const allowed = new Set(config.allow ?? []);
+  if (config.deny) {
+    for (const scope of config.deny) {
+      allowed.delete(scope);
+    }
+  }
+  return allowed;
+}
+
 function widenActionSpec<TInput, TOutput>(
   spec: ActionSpec<TInput, TOutput, SignetError>,
 ): ActionSpec<unknown, unknown, SignetError> {
@@ -117,7 +134,27 @@ export function createSearchActions(
       limit: z.number().int().positive().optional(),
       identityLabel: z.string().optional(),
     }),
-    handler: async (input) => {
+    handler: async (input, ctx) => {
+      // Resolve credential scope when present — used to filter
+      // which conversations the caller can search.
+      let scopedGroupIds: string[] | null = null;
+      if (ctx.credentialId && deps.credentialManager) {
+        const credResult = await deps.credentialManager.lookup(
+          ctx.credentialId,
+        );
+        if (Result.isError(credResult)) {
+          return Result.ok({ query: input.query, matches: [], total: 0 });
+        }
+        const credential = credResult.value;
+        const effectiveScopes = resolveEffectiveScopes(credential.config);
+        if (!effectiveScopes.has("read-messages")) {
+          return Result.ok({ query: input.query, matches: [], total: 0 });
+        }
+        scopedGroupIds = credential.config.chatIds.map((chatId) =>
+          resolveGroupId(deps.idMappings, chatId),
+        );
+      }
+
       const resolved = await resolveIdentity(
         deps.identityStore,
         input.identityLabel,
@@ -141,6 +178,12 @@ export function createSearchActions(
       if (input.chatId) {
         // Search a single conversation
         const groupId = resolveGroupId(deps.idMappings, input.chatId);
+
+        // If credential-scoped, verify this chat is in scope
+        if (scopedGroupIds && !scopedGroupIds.includes(groupId)) {
+          return Result.ok({ query: input.query, matches: [], total: 0 });
+        }
+
         const listResult = await managed.client.listMessages(groupId, {
           limit: MESSAGES_PER_CONVERSATION,
         });
@@ -168,6 +211,11 @@ export function createSearchActions(
 
         for (const group of groupsResult.value) {
           if (matches.length >= maxResults) break;
+
+          // If credential-scoped, skip conversations outside scope
+          if (scopedGroupIds && !scopedGroupIds.includes(group.groupId)) {
+            continue;
+          }
 
           const listResult = await managed.client.listMessages(group.groupId, {
             limit: MESSAGES_PER_CONVERSATION,

--- a/packages/core/src/search-actions.ts
+++ b/packages/core/src/search-actions.ts
@@ -137,7 +137,12 @@ export function createSearchActions(
     handler: async (input, ctx) => {
       // Resolve credential scope when present — used to filter
       // which conversations the caller can search.
+      // Fail closed: missing credentialManager with a credentialId
+      // returns empty results rather than silently bypassing.
       let scopedGroupIds: string[] | null = null;
+      if (ctx.credentialId && !deps.credentialManager) {
+        return Result.ok({ query: input.query, matches: [], total: 0 });
+      }
       if (ctx.credentialId && deps.credentialManager) {
         const credResult = await deps.credentialManager.lookup(
           ctx.credentialId,


### PR DESCRIPTION
## Summary

Closes #294

Enforce credential scope and `read-messages` permission across all message read paths. All scope failures return `not_found` (never `permission_denied`) to prevent information leakage about message existence.

### message.info
- Look up credential, verify `chatIds` scope + `read-messages` permission
- Validate `chatId` ↔ `groupId` coupling on every call

### message.list
- Check credential scope + `read-messages` **before** hitting the SDK
- Return `not_found` if the conversation isn't in the credential's scope

### search.messages
- When credential-scoped, filter to only conversations in the credential's `chatIds`
- Require `read-messages` permission; return empty results without it
- Works for both single-chat and cross-conversation search paths

### Infrastructure
- Add optional `credentialLookup` to `MessageActionDeps`
- Add `resolveEffectiveScopes` helper (deny wins over allow)
- Wire `CredentialManager.lookup` in daemon deps
- Document message access control in `docs/security.md`

## Security model

Three-part check on credential-authenticated message reads:
1. **chatId ↔ groupId coupling** — caller's chatId must resolve to the message's actual groupId
2. **Credential chat scope** — message's groupId must be in the credential's `chatIds`
3. **read-messages permission** — credential's effective scopes must include `read-messages`

All failures are indistinguishable `not_found` / empty results — an attacker cannot learn whether messages exist outside their scope.

## Follow-up issues
- #296 — admin scoped read access model with owner-approved elevation
- #297 — Secure Enclave biometric gate for message read elevation

## Test plan

- [x] message.info: credential with scope → returns message
- [x] message.info: credential without scope → not_found
- [x] message.info: credential without read-messages → not_found
- [x] message.info: chatId mismatch → not_found
- [x] message.list: credential without scope → not_found
- [x] message.list: credential without read-messages → not_found
- [x] search.messages: credential without read-messages → empty results
- [x] search.messages: credential scope filters cross-conversation search
- [x] All tests pass, full `bun run check` green