### PR TITLE
feat: harden admin reads and add daemon lookup

### DIFF
--- a/.agents/notes/2026-04-13-admin-read-elevation-boundary.md
+++ b/.agents/notes/2026-04-13-admin-read-elevation-boundary.md
@@ -1,0 +1,140 @@
+# Admin Read-Elevation Boundary
+
+Date: 2026-04-13
+Issue: #296
+
+## What the code does today
+
+The current runtime already enforces credential-scoped message reads for
+harness callers, but admin callers still bypass those checks.
+
+### Where the bypass used to happen
+
+- `packages/core/src/message-actions.ts`
+  - `message.list`
+  - `message.info`
+- Earlier in the day, both handlers only enforced read scope when
+  `ctx.credentialId` was present.
+- That bypass is now closed: plain `adminAuth` reads return `permission`
+  unless an explicit `adminReadElevation` is attached to the request context.
+
+### Why that is happening
+
+Admin transports build a `HandlerContext` with `adminAuth`, not with a
+credential:
+
+- `packages/cli/src/admin/server.ts`
+  - `makeHandlerContext()` sets `adminAuth`
+- `packages/cli/src/http/server.ts`
+  - `makeHandlerContext()` sets `adminAuth` for admin routes
+
+That original behavior was exactly the gap described in `#296`.
+
+## What should stay true
+
+- Admin management access and message-read access must remain separate.
+- Plain `adminAuth` must not become an ambient read grant.
+- The existing credential-scoped path for harness callers should remain intact.
+- The new elevation model should be explicit, time-bound, auditable, and easy to
+  reason about in handler code.
+
+## Minimal model change
+
+The cleanest next step looks like a second, explicit context concept for
+message-read elevation instead of overloading `adminAuth`.
+
+Working shape:
+
+- keep `adminAuth` as the management-plane signal
+- add a separate read-elevation context, something like:
+  - approved by owner
+  - scoped to one or more chats or inboxes
+  - bounded by expiry
+  - carries an approval ID for audit and seal disclosure
+
+Then `message.list` and `message.info` can require one of:
+
+- credential scope with `read-messages`
+- owner-approved read-elevation context
+
+Everything else remains on the ordinary admin path unless we explicitly decide
+otherwise.
+
+## Why not synthesize a fake credential
+
+A synthetic admin credential would blur the distinction between:
+
+- operator-facing conversational authority
+- owner-approved management elevation
+
+That would make audit trails and later seal disclosure harder to interpret.
+Keeping elevation as its own concept should preserve the security story more
+cleanly.
+
+## Immediate next step
+The exact elevation object is now real in code:
+
+- `packages/schemas/src/admin-read-elevation.ts`
+  - `AdminReadElevationScope`
+  - `AdminReadElevation`
+- `packages/contracts/src/handler-types.ts`
+  - `HandlerContext.adminReadElevation`
+- `packages/core/src/message-actions.ts`
+  - `message.list` and `message.info` now honor the explicit elevation context
+    when it is present
+
+This first slice intentionally does **not** yet mint, persist, inject, or audit
+those elevations. It defines the stable boundary that the approval flow can
+consume next.
+
+## Current runtime shape
+
+There is now also a first real approval lifecycle across the admin transports:
+
+- `xs msg list --dangerously-allow-message-read ...`
+- `xs msg info --dangerously-allow-message-read ...`
+- HTTP admin routes with `dangerouslyAllowMessageRead: true`
+
+When that flag is present, the daemon can:
+
+- prompt the configured `adminReadElevation` biometric gate
+- mint a short-lived, chat-scoped `adminReadElevation` object
+- cache and reuse that elevation within the same authenticated admin session
+  while it remains unexpired
+- attach it to the handler context for the approved request
+- append audit entries for approval, denial, reuse, and expiry
+
+This is useful because it proves the `#296` boundary can be consumed by a real
+runtime path instead of staying purely theoretical.
+
+It also means the current default is finally honest:
+
+- credential caller: scoped and fail-closed
+- admin caller without elevation: permission denied
+- admin caller with session-scoped elevation: allowed inside the approved chat
+
+## What is still deferred
+
+- approval request action shape
+- pending elevation request storage
+- any elevation persistence beyond the in-memory session and TTL window
+- any cross-restart approval lifecycle
+
+## What landed in the latest hardening pass
+
+The current slice now also closes the disclosure gap for the local v1 runtime:
+
+- active admin read elevation is tracked in a shared in-memory disclosure store
+- the current seal for the affected chat is refreshed when elevation is
+  approved
+- the seal is refreshed again when the elevation expires
+- seal input now reflects active `adminAccess` state during issue and refresh
+- the public disclosure is intentionally root-admin scoped for now, surfaced as
+  `adminAccess.operatorId: "owner"`
+
+That leaves `#297` with a much narrower remaining tail:
+
+- any explicit approval-request queue or stored request object
+- any persistence beyond the in-memory runtime and TTL window
+- any future shift from root-admin disclosure to a richer per-admin subject
+  model

--- a/.agents/notes/2026-04-13-signet-passkey-biometric-boundary.md
+++ b/.agents/notes/2026-04-13-signet-passkey-biometric-boundary.md
@@ -1,0 +1,120 @@
+# Signet-Native Passkey / Biometric Boundary
+
+Date: 2026-04-13
+Issue: #121
+
+## Main conclusion
+
+The near-term path should be framed as **signet-native biometric approval with
+Apple-first Secure Enclave backing**, not as a generic passkey project.
+
+The repo already has most of the key primitives needed for that path:
+
+- Secure Enclave-backed vault secret protection
+- a separate Secure Enclave biometric gate primitive for privileged operations
+- config-level per-operation gate toggles
+
+What is still missing is the runtime wiring for the owner-approval flow, not
+the underlying hardware primitive.
+
+## What already exists
+
+### Separate vault-unlock and privileged-operation primitives
+
+`docs/secure-enclave-integration.md` is explicit that the current design uses
+two independent Secure Enclave keys:
+
+- vault key
+  - protects the persisted vault secret
+  - policy can be `open`, `passcode`, or `biometric`
+- gate key
+  - signs privileged operation challenges
+  - always biometric
+
+This is an important distinction. The first shipped owner-approval path does
+not need to solve "passkey unlock everything." It can keep unattended daemon
+start via the vault key while still requiring Touch ID for elevated actions.
+
+### Existing gate abstraction
+
+`packages/keys/src/biometric-gate.ts` already defines a generic per-operation
+gate abstraction driven by config and a `BiometricPrompter`.
+
+Before this note, the declared operations were:
+
+- `rootKeyCreation`
+- `operationalKeyRotation`
+- `scopeExpansion`
+- `egressExpansion`
+- `agentCreation`
+
+This tranche adds an explicit `adminReadElevation` gate target so the future
+owner-approval flow does not need to piggyback on `scopeExpansion`.
+
+### Existing SE-backed prompter
+
+`packages/keys/src/se-gate-prompter.ts` already implements the Secure
+Enclave-backed biometric prompt:
+
+- creates a dedicated biometric SE key on first use
+- signs an operation-specific challenge
+- returns cancelled or internal errors cleanly
+- fails closed on platforms without Secure Enclave support
+
+That means the hardware-backed approval mechanism for the Apple-first path is
+already real.
+
+## What the first shipped path should be
+
+For the v1 completion stack, the clean target is:
+
+- owner-approved admin read elevation
+- Apple-first
+- backed by the existing Secure Enclave biometric gate
+- explicitly separate from vault unlock
+
+In practice:
+
+- keep `vaultKeyPolicy = "open"` as a viable local default so the daemon can
+  start unattended
+- gate elevated message access with the dedicated biometric operation
+- defer generic WebAuthn or cross-platform passkey UX until after the local
+  owner-approval path is real
+
+## What this is not
+
+The first shipped slice should not promise:
+
+- cross-platform passkey support
+- WebAuthn-backed owner auth
+- Convos iOS identity derivation parity
+- hosted or split host/remote owner-approval semantics
+
+Those are legitimate future directions, but they are not required to ship a
+credible signet-native approval path.
+
+## Recommended next implementation shape
+
+1. `#296`
+   define the explicit read-elevation object and lifecycle
+
+2. `#297`
+   consume the new `adminReadElevation` gate target during owner approval
+
+3. only after that
+   decide whether "passkey" should mean anything more than the existing
+   Apple-first biometric-backed flow in v1
+
+## Why this matters
+
+If we keep saying "passkey flow" without narrowing it, we risk mixing together:
+
+- vault unlock
+- owner approval
+- XMTP identity derivation
+- cross-platform auth portability
+
+The current codebase already supports a simpler and stronger statement:
+
+> v1 will ship a signet-native, Secure-Enclave-backed biometric approval flow
+> for sensitive owner actions. Broader passkey work remains deferred.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -235,7 +235,8 @@ into a chat that tells other participants what an operator can do there.
 - `permissions` — the effective scope set (allow/deny)
 - `scopeMode` — how permissions are interpreted
 - `adminAccess` — optional, with expiry (disclosed when an admin has elevated
-  read access)
+  read access; current local v1 uses `operatorId: "owner"` for that root-admin
+  path)
 - `issuedAt` — when the seal was created
 
 The entire payload is wrapped in a `SealEnvelope` with an Ed25519 signature
@@ -282,6 +283,11 @@ seal noise while ensuring stale seals are refreshed.
 published when something material changes: scopes added or removed, allow/deny
 status flipped, credential or operator changed, or admin access granted or
 revoked. Empty deltas and routine operations do not produce new seals.
+
+In the current local v1 runtime, owner-approved admin reads republish the
+current seal with `adminAccess` attached for the duration of the elevation and
+refresh it again once the elevation expires. That disclosure is intentionally
+root-admin scoped today, not tied to a separate delegated admin operator.
 
 **Revocation seals** are a special form published when a credential is revoked.
 They contain the revoked seal ID, the previous seal reference, a reason, and a

--- a/docs/secure-enclave-integration.md
+++ b/docs/secure-enclave-integration.md
@@ -126,9 +126,12 @@ confirmation. This uses a second SE key with `biometric` policy.
 
 The current runtime wiring applies this gate to compat key lifecycle
 operations such as root key creation, agent/operational key creation, and
-operational key rotation. Scope- and egress-expansion gate toggles remain
-part of the broader intended model, but are not yet consumed by a runtime
-code path.
+operational key rotation. Admin read elevation is also now consumed by the
+runtime on both the admin socket and HTTP admin routes, and active elevation
+now refreshes the current chat seal so `adminAccess` disclosure remains
+accurate while the elevation is live. Scope-expansion and egress-expansion
+toggles remain part of the broader intended model, but are not yet consumed by
+a runtime code path.
 
 ### Gated operations
 
@@ -141,6 +144,7 @@ operationalKeyRotation = true
 scopeExpansion = true
 egressExpansion = true
 agentCreation = false
+adminReadElevation = true
 ```
 
 When a gated operation fires:

--- a/docs/security.md
+++ b/docs/security.md
@@ -271,15 +271,12 @@ content.
 ### Admin path
 
 Admin-authenticated callers (no `credentialId` in context) still undergo
-chatId ↔ groupId validation. They cannot fish for messages across conversations
-by passing mismatched IDs. However, admins are not currently subject to
-credential scope checks — they can read any message in a conversation they
-specify.
+chatId ↔ groupId validation, but they now fail closed unless an explicit
+owner-approved read elevation is attached to the request context.
 
-This is an interim state. The full admin message access model requires
-owner-approved elevation via the biometric gate (see Privilege elevation below).
-Until that is implemented, the admin socket is local-only and admin auth tokens
-are short-lived.
+That means plain `adminAuth` is not enough to read message content. The daemon
+must inject a time-bound, chat-scoped `adminReadElevation` object before the
+message handlers will proceed.
 
 ## Privilege elevation
 
@@ -287,32 +284,47 @@ An admin can request elevated access (e.g., read access to an operator's
 messages). This requires owner approval via Secure Enclave biometric gate:
 
 1. Admin requests elevation
-2. Signet creates a pending elevation request
-3. Owner is prompted for biometric confirmation (Touch ID / Face ID)
-4. On approval: admin receives a time-bound, scoped read credential — logged
-   in audit trail with timestamp, scope, and approver. Credential expires
-   automatically.
-5. On denial: request logged, admin notified, no access granted
+2. Signet prompts for biometric confirmation (Touch ID / Face ID)
+3. On approval: the daemon issues a time-bound, chat-scoped read elevation for
+   the current authenticated admin session, logs the approval, and allows the
+   read
+4. On denial: the request is logged and the read is rejected
 
-When implemented, granting admin message read access will require an
-intentionally obnoxious flag (e.g., `--dangerously-allow-message-read`) to
-trigger biometric confirmation, audit log entry, seal republish with admin
-read access disclosed, and time-bound expiry. No hidden surveillance.
+The current admin transports use an intentionally obnoxious flag:
 
-> **Status:** Privilege elevation is designed but not yet implemented in the
-> v1 CLI. The biometric gate requires Secure Enclave integration.
+```bash
+xs msg list --from conv_9e2d --dangerously-allow-message-read
+xs msg info msg_1234 --chat conv_9e2d --dangerously-allow-message-read
+```
+
+The same `dangerouslyAllowMessageRead` transport control is also honored on the
+HTTP admin path.
+
+This flag remains explicit on every request. If the same authenticated admin
+session requests another read for the same chat before the short elevation TTL
+expires, the daemon reuses the cached approval instead of prompting again.
+
+> **Status:** The v1 runtime now supports short-lived, reusable admin read
+> elevation on both the admin socket and HTTP admin routes. The current head
+> seal for the affected chat is refreshed while elevation is active so public
+> disclosure stays honest. Cross-restart elevation persistence remains
+> deferred.
 
 Properties of elevated credentials:
 
 - **Explicit** — requires a deliberate request, not implicit
-- **Audited** — every elevation is logged (request, approval/denial, scope,
-  expiry)
+- **Audited** — approvals, denials, reuse, and expiry are logged
 - **Time-bound** — the read credential expires automatically
 - **Owner-approved** — biometric confirmation via Secure Enclave, cannot be
   bypassed
 - **Scoped** — grants access to specific operators/chats, not blanket access
-- **Seal-disclosed** — the seal is republished to show admin read access is
-  active
+- **Seal-disclosed** — the current public seal is republished while elevation
+  is active and refreshed again when the elevation expires
+
+In the current local v1 model, that disclosure is intentionally root-admin
+scoped rather than per-admin-user scoped. Public seals therefore surface
+temporary elevated read access as `adminAccess.operatorId: "owner"` with the
+same expiry as the active elevation.
 
 ## Threat model
 

--- a/packages/cli/src/__tests__/admin-dispatcher.test.ts
+++ b/packages/cli/src/__tests__/admin-dispatcher.test.ts
@@ -117,6 +117,62 @@ describe("AdminDispatcher", () => {
     }
   });
 
+  test("validate returns parsed params without invoking the handler", () => {
+    const registry = createActionRegistry();
+    let calls = 0;
+    const spec = makeSpec("message.info", {
+      input: z.object({
+        chatId: z.string(),
+        messageId: z.string(),
+      }),
+      handler: async () => {
+        calls++;
+        return Result.ok({});
+      },
+    });
+    registry.register(spec);
+
+    const dispatcher = createAdminDispatcher(registry);
+    const result = dispatcher.validate("message.info", {
+      chatId: "conv_validate_only",
+      messageId: "msg_1",
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+    expect(calls).toBe(0);
+  });
+
+  test("dispatchValidated skips a second parse and invokes the handler", async () => {
+    const registry = createActionRegistry();
+    const spec = makeSpec("message.info", {
+      input: z.object({
+        chatId: z.string(),
+        messageId: z.string(),
+      }),
+      handler: async (input) => Result.ok(input),
+    });
+    registry.register(spec);
+
+    const dispatcher = createAdminDispatcher(registry);
+    const ctx = makeHandlerContext();
+    const result = await dispatcher.dispatchValidated(
+      "message.info",
+      {
+        chatId: "conv_dispatch_validated",
+        messageId: "msg_1",
+      },
+      ctx,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual({
+        chatId: "conv_dispatch_validated",
+        messageId: "msg_1",
+      });
+    }
+  });
+
   test("wraps handler error in ActionResult", async () => {
     const registry = createActionRegistry();
     const spec = makeSpec("key.rotate", {

--- a/packages/cli/src/__tests__/admin-read-elevation.test.ts
+++ b/packages/cli/src/__tests__/admin-read-elevation.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import { PermissionError } from "@xmtp/signet-schemas";
+import { createAdminReadElevationManager } from "../admin/read-elevation.js";
+import { createAdminReadDisclosureStore } from "../admin/read-disclosure-store.js";
+
+describe("createAdminReadElevationManager", () => {
+  test("reuses a live elevation within the TTL window", async () => {
+    let authorizeCalls = 0;
+    let currentTime = new Date("2026-04-14T15:00:00.000Z");
+
+    const manager = createAdminReadElevationManager({
+      approver: {
+        async authorize() {
+          authorizeCalls += 1;
+          return Result.ok(undefined);
+        },
+        async getApprovalFingerprint() {
+          return Result.ok("approval-fingerprint");
+        },
+      },
+      now: () => currentTime,
+      ttlMs: 60_000,
+    });
+
+    const first = await manager.resolveForRequest({
+      method: "message.list",
+      params: {
+        chatId: "conv_reuse",
+        dangerouslyAllowMessageRead: true,
+      },
+      adminFingerprint: "admin-fingerprint",
+      sessionKey: "admin-fingerprint:test-jti",
+    });
+    currentTime = new Date("2026-04-14T15:00:20.000Z");
+    const second = await manager.resolveForRequest({
+      method: "message.info",
+      params: {
+        chatId: "conv_reuse",
+        messageId: "msg_2",
+        dangerouslyAllowMessageRead: true,
+      },
+      adminFingerprint: "admin-fingerprint",
+      sessionKey: "admin-fingerprint:test-jti",
+    });
+
+    expect(first.isOk()).toBe(true);
+    expect(second.isOk()).toBe(true);
+    if (first.isOk() && second.isOk()) {
+      expect(first.value?.approvalId).toBe(second.value?.approvalId);
+    }
+    expect(authorizeCalls).toBe(1);
+  });
+
+  test("re-prompts after the cached elevation expires", async () => {
+    let authorizeCalls = 0;
+    let currentTime = new Date("2026-04-14T15:00:00.000Z");
+    const auditActions: string[] = [];
+
+    const manager = createAdminReadElevationManager({
+      approver: {
+        async authorize() {
+          authorizeCalls += 1;
+          return Result.ok(undefined);
+        },
+        async getApprovalFingerprint() {
+          return Result.ok("approval-fingerprint");
+        },
+      },
+      auditLog: {
+        path: ":memory:",
+        async append(entry) {
+          auditActions.push(entry.action);
+        },
+        async tail() {
+          return [];
+        },
+        async readAll() {
+          return [];
+        },
+      },
+      now: () => currentTime,
+      ttlMs: 1_000,
+    });
+
+    const first = await manager.resolveForRequest({
+      method: "message.list",
+      params: {
+        chatId: "conv_expire",
+        dangerouslyAllowMessageRead: true,
+      },
+      adminFingerprint: "admin-fingerprint",
+      sessionKey: "admin-fingerprint:test-jti",
+    });
+    currentTime = new Date("2026-04-14T15:00:02.000Z");
+    const second = await manager.resolveForRequest({
+      method: "message.list",
+      params: {
+        chatId: "conv_expire",
+        dangerouslyAllowMessageRead: true,
+      },
+      adminFingerprint: "admin-fingerprint",
+      sessionKey: "admin-fingerprint:test-jti",
+    });
+
+    expect(first.isOk()).toBe(true);
+    expect(second.isOk()).toBe(true);
+    if (first.isOk() && second.isOk()) {
+      expect(first.value?.approvalId).not.toBe(second.value?.approvalId);
+    }
+    expect(authorizeCalls).toBe(2);
+    expect(auditActions).toContain("admin.read-elevation.expired");
+  });
+
+  test("returns denial errors from the local approver", async () => {
+    const manager = createAdminReadElevationManager({
+      approver: {
+        async authorize() {
+          return Result.err(PermissionError.create("Elevation denied"));
+        },
+        async getApprovalFingerprint() {
+          return Result.ok("approval-fingerprint");
+        },
+      },
+    });
+
+    const result = await manager.resolveForRequest({
+      method: "message.list",
+      params: {
+        chatId: "conv_denied",
+        dangerouslyAllowMessageRead: true,
+      },
+      adminFingerprint: "admin-fingerprint",
+      sessionKey: "admin-fingerprint:test-jti",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.category).toBe("permission");
+      expect(result.error.message).toContain("Elevation denied");
+    }
+  });
+
+  test("updates public disclosure state when approval is granted and expires", async () => {
+    let currentTime = new Date("2026-04-14T15:00:00.000Z");
+    const disclosureStore = createAdminReadDisclosureStore({
+      now: () => currentTime,
+    });
+    const changedChatBatches: string[][] = [];
+
+    const manager = createAdminReadElevationManager({
+      approver: {
+        async authorize() {
+          return Result.ok(undefined);
+        },
+        async getApprovalFingerprint() {
+          return Result.ok("approval-fingerprint");
+        },
+      },
+      disclosureStore,
+      onDisclosureChanged: async (chatIds) => {
+        changedChatBatches.push([...chatIds]);
+        return Result.ok(undefined);
+      },
+      now: () => currentTime,
+      ttlMs: 1_000,
+    });
+
+    const first = await manager.resolveForRequest({
+      method: "message.list",
+      params: {
+        chatId: "conv_disclosed",
+        dangerouslyAllowMessageRead: true,
+      },
+      adminFingerprint: "admin-fingerprint",
+      sessionKey: "admin-fingerprint:test-jti",
+    });
+
+    expect(first.isOk()).toBe(true);
+    expect(disclosureStore.get("conv_disclosed")).toEqual({
+      operatorId: "owner",
+      expiresAt: "2026-04-14T15:00:01.000Z",
+    });
+
+    currentTime = new Date("2026-04-14T15:00:02.000Z");
+    const second = await manager.resolveForRequest({
+      method: "message.list",
+      params: {
+        chatId: "conv_disclosed",
+        dangerouslyAllowMessageRead: true,
+      },
+      adminFingerprint: "admin-fingerprint",
+      sessionKey: "admin-fingerprint:test-jti",
+    });
+
+    expect(second.isOk()).toBe(true);
+    expect(changedChatBatches).toEqual([
+      ["conv_disclosed"],
+      ["conv_disclosed"],
+    ]);
+    expect(disclosureStore.get("conv_disclosed")).toEqual({
+      operatorId: "owner",
+      expiresAt: "2026-04-14T15:00:03.000Z",
+    });
+  });
+});

--- a/packages/cli/src/__tests__/admin-read-elevation.test.ts
+++ b/packages/cli/src/__tests__/admin-read-elevation.test.ts
@@ -498,4 +498,73 @@ describe("createAdminReadElevationManager", () => {
     expect(second.isErr()).toBe(true);
     expect(disclosureStore.get("conv_expiry_cleanup")).toBeUndefined();
   });
+
+  test("replays disclosure refresh to roll back partial expiry updates", async () => {
+    let currentTime = new Date("2026-04-14T15:00:00.000Z");
+    const disclosureStore = createAdminReadDisclosureStore({
+      now: () => currentTime,
+    });
+    const changedChatBatches: string[][] = [];
+    let disclosureRefreshCalls = 0;
+
+    const manager = createAdminReadElevationManager({
+      approver: {
+        async authorize() {
+          return Result.ok(undefined);
+        },
+        async getApprovalFingerprint() {
+          return Result.ok("approval-fingerprint");
+        },
+      },
+      disclosureStore,
+      onDisclosureChanged: async (chatIds) => {
+        changedChatBatches.push([...chatIds]);
+        disclosureRefreshCalls += 1;
+        if (disclosureRefreshCalls === 2) {
+          return Result.err(
+            InternalError.create("seal refresh failed", {
+              stage: "expiry",
+            }),
+          );
+        }
+        return Result.ok(undefined);
+      },
+      now: () => currentTime,
+      ttlMs: 1_000,
+    });
+
+    const first = await manager.resolveForRequest({
+      method: "message.list",
+      params: {
+        chatId: "conv_expiry_partial_refresh",
+        dangerouslyAllowMessageRead: true,
+      },
+      adminFingerprint: "admin-fingerprint",
+      sessionKey: "admin-fingerprint:test-jti",
+    });
+
+    expect(first.isOk()).toBe(true);
+    expect(disclosureStore.get("conv_expiry_partial_refresh")).toEqual({
+      operatorId: "owner",
+      expiresAt: "2026-04-14T15:00:01.000Z",
+    });
+
+    currentTime = new Date("2026-04-14T15:00:02.000Z");
+    const second = await manager.resolveForRequest({
+      method: "message.list",
+      params: {
+        chatId: "conv_expiry_partial_refresh",
+        dangerouslyAllowMessageRead: true,
+      },
+      adminFingerprint: "admin-fingerprint",
+      sessionKey: "admin-fingerprint:test-jti",
+    });
+
+    expect(second.isErr()).toBe(true);
+    expect(changedChatBatches).toEqual([
+      ["conv_expiry_partial_refresh"],
+      ["conv_expiry_partial_refresh"],
+      ["conv_expiry_partial_refresh"],
+    ]);
+  });
 });

--- a/packages/cli/src/__tests__/admin-read-elevation.test.ts
+++ b/packages/cli/src/__tests__/admin-read-elevation.test.ts
@@ -52,6 +52,35 @@ describe("createAdminReadElevationManager", () => {
     expect(authorizeCalls).toBe(1);
   });
 
+  test("treats search.messages as an elevated message-read operation", async () => {
+    let authorizeCalls = 0;
+    const manager = createAdminReadElevationManager({
+      approver: {
+        async authorize() {
+          authorizeCalls += 1;
+          return Result.ok(undefined);
+        },
+        async getApprovalFingerprint() {
+          return Result.ok("approval-fingerprint");
+        },
+      },
+    });
+
+    const result = await manager.resolveForRequest({
+      method: "search.messages",
+      params: {
+        chatId: "conv_search",
+        query: "secret",
+        dangerouslyAllowMessageRead: true,
+      },
+      adminFingerprint: "admin-fingerprint",
+      sessionKey: "admin-fingerprint:test-jti",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(authorizeCalls).toBe(1);
+  });
+
   test("re-prompts after the cached elevation expires", async () => {
     let authorizeCalls = 0;
     let currentTime = new Date("2026-04-14T15:00:00.000Z");
@@ -295,5 +324,131 @@ describe("createAdminReadElevationManager", () => {
 
     expect(result.isOk()).toBe(true);
     expect(unrefCalls).toBe(1);
+  });
+
+  test("rolls back disclosure and cache state when approval audit fails", async () => {
+    let authorizeCalls = 0;
+    let failApprovalAudit = true;
+    const disclosureStore = createAdminReadDisclosureStore();
+    const manager = createAdminReadElevationManager({
+      approver: {
+        async authorize() {
+          authorizeCalls += 1;
+          return Result.ok(undefined);
+        },
+        async getApprovalFingerprint() {
+          return Result.ok("approval-fingerprint");
+        },
+      },
+      disclosureStore,
+      auditLog: {
+        path: ":memory:",
+        async append(entry) {
+          if (
+            failApprovalAudit &&
+            entry.action === "admin.read-elevation.approved"
+          ) {
+            throw new Error("disk full");
+          }
+        },
+        async tail() {
+          return [];
+        },
+        async readAll() {
+          return [];
+        },
+      },
+    });
+
+    const first = await manager.resolveForRequest({
+      method: "message.list",
+      params: {
+        chatId: "conv_audit_fail",
+        dangerouslyAllowMessageRead: true,
+      },
+      adminFingerprint: "admin-fingerprint",
+      sessionKey: "admin-fingerprint:test-jti",
+    });
+
+    expect(first.isErr()).toBe(true);
+    expect(disclosureStore.get("conv_audit_fail")).toBeUndefined();
+
+    failApprovalAudit = false;
+    const second = await manager.resolveForRequest({
+      method: "message.list",
+      params: {
+        chatId: "conv_audit_fail",
+        dangerouslyAllowMessageRead: true,
+      },
+      adminFingerprint: "admin-fingerprint",
+      sessionKey: "admin-fingerprint:test-jti",
+    });
+
+    expect(second.isOk()).toBe(true);
+    expect(authorizeCalls).toBe(2);
+  });
+
+  test("clears disclosure state even when expiry audit fails", async () => {
+    let currentTime = new Date("2026-04-14T15:00:00.000Z");
+    const disclosureStore = createAdminReadDisclosureStore({
+      now: () => currentTime,
+    });
+    const manager = createAdminReadElevationManager({
+      approver: {
+        async authorize() {
+          return Result.ok(undefined);
+        },
+        async getApprovalFingerprint() {
+          return Result.ok("approval-fingerprint");
+        },
+      },
+      disclosureStore,
+      auditLog: {
+        path: ":memory:",
+        async append(entry) {
+          if (entry.action === "admin.read-elevation.expired") {
+            throw new Error("audit unavailable");
+          }
+        },
+        async tail() {
+          return [];
+        },
+        async readAll() {
+          return [];
+        },
+      },
+      now: () => currentTime,
+      ttlMs: 1_000,
+    });
+
+    const first = await manager.resolveForRequest({
+      method: "message.list",
+      params: {
+        chatId: "conv_expiry_cleanup",
+        dangerouslyAllowMessageRead: true,
+      },
+      adminFingerprint: "admin-fingerprint",
+      sessionKey: "admin-fingerprint:test-jti",
+    });
+
+    expect(first.isOk()).toBe(true);
+    expect(disclosureStore.get("conv_expiry_cleanup")).toEqual({
+      operatorId: "owner",
+      expiresAt: "2026-04-14T15:00:01.000Z",
+    });
+
+    currentTime = new Date("2026-04-14T15:00:02.000Z");
+    const second = await manager.resolveForRequest({
+      method: "message.list",
+      params: {
+        chatId: "conv_expiry_cleanup",
+        dangerouslyAllowMessageRead: true,
+      },
+      adminFingerprint: "admin-fingerprint",
+      sessionKey: "admin-fingerprint:test-jti",
+    });
+
+    expect(second.isErr()).toBe(true);
+    expect(disclosureStore.get("conv_expiry_cleanup")).toBeUndefined();
   });
 });

--- a/packages/cli/src/__tests__/admin-read-elevation.test.ts
+++ b/packages/cli/src/__tests__/admin-read-elevation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Result } from "better-result";
-import { PermissionError } from "@xmtp/signet-schemas";
+import { InternalError, PermissionError } from "@xmtp/signet-schemas";
 import { createAdminReadElevationManager } from "../admin/read-elevation.js";
 import { createAdminReadDisclosureStore } from "../admin/read-disclosure-store.js";
 
@@ -386,6 +386,53 @@ describe("createAdminReadElevationManager", () => {
 
     expect(second.isOk()).toBe(true);
     expect(authorizeCalls).toBe(2);
+  });
+
+  test("replays disclosure refresh to roll back partial approval updates", async () => {
+    const disclosureStore = createAdminReadDisclosureStore();
+    const changedChatBatches: string[][] = [];
+    let disclosureRefreshCalls = 0;
+
+    const manager = createAdminReadElevationManager({
+      approver: {
+        async authorize() {
+          return Result.ok(undefined);
+        },
+        async getApprovalFingerprint() {
+          return Result.ok("approval-fingerprint");
+        },
+      },
+      disclosureStore,
+      onDisclosureChanged: async (chatIds) => {
+        changedChatBatches.push([...chatIds]);
+        disclosureRefreshCalls += 1;
+        if (disclosureRefreshCalls === 1) {
+          return Result.err(
+            InternalError.create("seal refresh failed", {
+              stage: "approval",
+            }),
+          );
+        }
+        return Result.ok(undefined);
+      },
+    });
+
+    const result = await manager.resolveForRequest({
+      method: "message.list",
+      params: {
+        chatId: "conv_partial_refresh",
+        dangerouslyAllowMessageRead: true,
+      },
+      adminFingerprint: "admin-fingerprint",
+      sessionKey: "admin-fingerprint:test-jti",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(changedChatBatches).toEqual([
+      ["conv_partial_refresh"],
+      ["conv_partial_refresh"],
+    ]);
+    expect(disclosureStore.get("conv_partial_refresh")).toBeUndefined();
   });
 
   test("clears disclosure state even when expiry audit fails", async () => {

--- a/packages/cli/src/__tests__/admin-read-elevation.test.ts
+++ b/packages/cli/src/__tests__/admin-read-elevation.test.ts
@@ -203,4 +203,97 @@ describe("createAdminReadElevationManager", () => {
       expiresAt: "2026-04-14T15:00:03.000Z",
     });
   });
+
+  test("normalizes chat IDs before caching elevation and disclosure state", async () => {
+    let authorizeCalls = 0;
+    const currentTime = new Date("2026-04-14T15:00:00.000Z");
+    const disclosureStore = createAdminReadDisclosureStore({
+      now: () => currentTime,
+    });
+    const manager = createAdminReadElevationManager({
+      approver: {
+        async authorize() {
+          authorizeCalls += 1;
+          return Result.ok(undefined);
+        },
+        async getApprovalFingerprint() {
+          return Result.ok("approval-fingerprint");
+        },
+      },
+      disclosureStore,
+      normalizeChatId: (chatId) =>
+        chatId === "group_raw" ? "conv_normalized" : chatId,
+      ttlMs: 60_000,
+      now: () => currentTime,
+    });
+
+    const first = await manager.resolveForRequest({
+      method: "message.list",
+      params: {
+        chatId: "group_raw",
+        dangerouslyAllowMessageRead: true,
+      },
+      adminFingerprint: "admin-fingerprint",
+      sessionKey: "admin-fingerprint:test-jti",
+    });
+    const second = await manager.resolveForRequest({
+      method: "message.info",
+      params: {
+        chatId: "conv_normalized",
+        messageId: "msg_1",
+        dangerouslyAllowMessageRead: true,
+      },
+      adminFingerprint: "admin-fingerprint",
+      sessionKey: "admin-fingerprint:test-jti",
+    });
+
+    expect(first.isOk()).toBe(true);
+    expect(second.isOk()).toBe(true);
+    if (first.isOk() && second.isOk()) {
+      expect(first.value?.approvalId).toBe(second.value?.approvalId);
+      expect(first.value?.scope.chatIds).toEqual(["conv_normalized"]);
+      expect(second.value?.scope.chatIds).toEqual(["conv_normalized"]);
+    }
+    expect(authorizeCalls).toBe(1);
+    expect(disclosureStore.get("conv_normalized")).toEqual({
+      operatorId: "owner",
+      expiresAt: "2026-04-14T15:01:00.000Z",
+    });
+  });
+
+  test("unrefs expiry timers so elevation caching does not block shutdown", async () => {
+    let unrefCalls = 0;
+    const manager = createAdminReadElevationManager({
+      approver: {
+        async authorize() {
+          return Result.ok(undefined);
+        },
+        async getApprovalFingerprint() {
+          return Result.ok("approval-fingerprint");
+        },
+      },
+      setTimeoutFn: ((handler, delay) => {
+        void handler;
+        void delay;
+        return {
+          unref() {
+            unrefCalls += 1;
+          },
+        } as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout,
+    });
+
+    const result = await manager.resolveForRequest({
+      method: "message.list",
+      params: {
+        chatId: "conv_unref",
+        dangerouslyAllowMessageRead: true,
+      },
+      adminFingerprint: "admin-fingerprint",
+      sessionKey: "admin-fingerprint:test-jti",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(unrefCalls).toBe(1);
+  });
 });

--- a/packages/cli/src/__tests__/admin-socket.test.ts
+++ b/packages/cli/src/__tests__/admin-socket.test.ts
@@ -448,6 +448,53 @@ describe("AdminSocket round-trip", () => {
     expect(keyManager.authorizeCalls).toBe(1);
   });
 
+  test("invalid dangerous message reads fail validation before prompting for elevation", async () => {
+    const socketPath = testSocketPath();
+    const registry = createActionRegistry();
+    const keyManager = makeKeyManager();
+    registry.register({
+      id: "message.info",
+      description: "Read a message",
+      intent: "read",
+      input: z.object({
+        chatId: z.string(),
+        messageId: z.string(),
+      }),
+      handler: async () => Result.ok({ ok: true }),
+      cli: {
+        command: "message:info",
+      },
+    });
+    const dispatcher = createAdminDispatcher(registry);
+
+    server = createAdminServer(
+      { socketPath, authMode: "admin-key" },
+      {
+        keyManager,
+        dispatcher,
+        signetId: "test-signet",
+        signerProvider: makeStubSignerProvider(),
+        readElevationApprover: makeReadElevationApprover(keyManager),
+      },
+    );
+    await server.start();
+
+    client = createAdminClient(socketPath);
+    const connectResult = await client.connect("valid-jwt-token");
+    expect(connectResult.isOk()).toBe(true);
+
+    const response = await client.request("message.info", {
+      chatId: "conv_invalid_before_prompt",
+      dangerouslyAllowMessageRead: true,
+    });
+
+    expect(response.isErr()).toBe(true);
+    if (response.isErr()) {
+      expect(response.error.category).toBe("validation");
+    }
+    expect(keyManager.authorizeCalls).toBe(0);
+  });
+
   test("client preserves structured signet errors from JSON-RPC failures", async () => {
     const socketPath = testSocketPath();
     const registry = createActionRegistry();

--- a/packages/cli/src/__tests__/admin-socket.test.ts
+++ b/packages/cli/src/__tests__/admin-socket.test.ts
@@ -40,8 +40,15 @@ function testSocketPath(): string {
 }
 
 /** Minimal mock key manager for testing. */
-function makeKeyManager(opts?: { rejectAuth?: boolean }) {
+function makeKeyManager(opts?: {
+  rejectAuth?: boolean;
+  rejectElevation?: boolean;
+}) {
+  let authorizeCalls = 0;
   return {
+    get authorizeCalls() {
+      return authorizeCalls;
+    },
     admin: {
       async verifyJwt(
         token: string,
@@ -57,6 +64,19 @@ function makeKeyManager(opts?: { rejectAuth?: boolean }) {
           jti: "test-jti",
         });
       },
+      async get() {
+        return Result.ok({
+          publicKey: "test-public-key",
+          fingerprint: "approval-fingerprint",
+        } as const);
+      },
+    },
+    async authorizeSensitiveOperation() {
+      authorizeCalls++;
+      if (opts?.rejectElevation) {
+        return Result.err(PermissionError.create("Elevation denied"));
+      }
+      return Result.ok(undefined);
     },
   };
 }
@@ -71,6 +91,19 @@ function makeStubSignerProvider(): SignerProvider {
     getFingerprint: async () => err(),
     getDbEncryptionKey: async () => err(),
     getXmtpIdentityKey: async () => err(),
+  };
+}
+
+function makeReadElevationApprover(
+  keyManager: ReturnType<typeof makeKeyManager>,
+) {
+  return {
+    authorize: async () =>
+      keyManager.authorizeSensitiveOperation("adminReadElevation"),
+    async getApprovalFingerprint() {
+      const info = await keyManager.admin.get();
+      return Result.isError(info) ? info : Result.ok(info.value.fingerprint);
+    },
   };
 }
 
@@ -234,6 +267,185 @@ describe("AdminSocket round-trip", () => {
     if (r2.isOk()) {
       expect(r2.value.count).toBe(2);
     }
+  });
+
+  test("dangerous message read requests attach admin read elevation to context", async () => {
+    const socketPath = testSocketPath();
+    const registry = createActionRegistry();
+    const keyManager = makeKeyManager();
+    const spec = makeTestSpec("message.list", async (_input, ctx) =>
+      Result.ok({
+        approvalId: ctx.adminReadElevation?.approvalId ?? null,
+        chatIds: ctx.adminReadElevation?.scope.chatIds ?? [],
+        approvalKeyFingerprint:
+          ctx.adminReadElevation?.approvalKeyFingerprint ?? null,
+      }),
+    );
+    registry.register(spec);
+    const dispatcher = createAdminDispatcher(registry);
+
+    server = createAdminServer(
+      { socketPath, authMode: "admin-key" },
+      {
+        keyManager,
+        dispatcher,
+        signetId: "test-signet",
+        signerProvider: makeStubSignerProvider(),
+        readElevationApprover: makeReadElevationApprover(keyManager),
+      },
+    );
+    await server.start();
+
+    client = createAdminClient(socketPath);
+    const connectResult = await client.connect("valid-jwt-token");
+    expect(connectResult.isOk()).toBe(true);
+
+    const response = await client.request<{
+      approvalId: string | null;
+      chatIds: string[];
+      approvalKeyFingerprint: string | null;
+    }>("message.list", {
+      chatId: "conv_0123456789abcdef",
+      dangerouslyAllowMessageRead: true,
+    });
+
+    expect(response.isOk()).toBe(true);
+    if (response.isOk()) {
+      expect(response.value.approvalId).toContain("approval_");
+      expect(response.value.chatIds).toEqual(["conv_0123456789abcdef"]);
+      expect(response.value.approvalKeyFingerprint).toBe(
+        "approval-fingerprint",
+      );
+    }
+  });
+
+  test("dangerous message read request fails when local approval is denied", async () => {
+    const socketPath = testSocketPath();
+    const registry = createActionRegistry();
+    const keyManager = makeKeyManager({ rejectElevation: true });
+    const spec = makeTestSpec("message.list", async () => Result.ok({}));
+    registry.register(spec);
+    const dispatcher = createAdminDispatcher(registry);
+
+    server = createAdminServer(
+      { socketPath, authMode: "admin-key" },
+      {
+        keyManager,
+        dispatcher,
+        signetId: "test-signet",
+        signerProvider: makeStubSignerProvider(),
+        readElevationApprover: makeReadElevationApprover(keyManager),
+      },
+    );
+    await server.start();
+
+    client = createAdminClient(socketPath);
+    const connectResult = await client.connect("valid-jwt-token");
+    expect(connectResult.isOk()).toBe(true);
+
+    const response = await client.request("message.list", {
+      chatId: "conv_0123456789abcdef",
+      dangerouslyAllowMessageRead: true,
+    });
+
+    expect(response.isOk()).toBe(false);
+    if (response.isErr()) {
+      expect(response.error.category).toBe("permission");
+      expect(response.error.message).toContain("Elevation denied");
+    }
+  });
+
+  test("message read without dangerous flag does not attach elevation", async () => {
+    const socketPath = testSocketPath();
+    const registry = createActionRegistry();
+    const spec = makeTestSpec("message.list", async (_input, ctx) =>
+      Result.ok({
+        approvalId: ctx.adminReadElevation?.approvalId ?? null,
+      }),
+    );
+    registry.register(spec);
+    const dispatcher = createAdminDispatcher(registry);
+
+    server = createAdminServer(
+      { socketPath, authMode: "admin-key" },
+      {
+        keyManager: makeKeyManager(),
+        dispatcher,
+        signetId: "test-signet",
+        signerProvider: makeStubSignerProvider(),
+      },
+    );
+    await server.start();
+
+    client = createAdminClient(socketPath);
+    const connectResult = await client.connect("valid-jwt-token");
+    expect(connectResult.isOk()).toBe(true);
+
+    const response = await client.request<{ approvalId: string | null }>(
+      "message.list",
+      {
+        chatId: "conv_0123456789abcdef",
+      },
+    );
+
+    expect(response.isOk()).toBe(true);
+    if (response.isOk()) {
+      expect(response.value.approvalId).toBeNull();
+    }
+  });
+
+  test("dangerous message reads reuse a live elevation within the same admin session", async () => {
+    const socketPath = testSocketPath();
+    const registry = createActionRegistry();
+    const keyManager = makeKeyManager();
+    const spec = makeTestSpec("message.info", async (_input, ctx) =>
+      Result.ok({
+        approvalId: ctx.adminReadElevation?.approvalId ?? null,
+      }),
+    );
+    registry.register(spec);
+    const dispatcher = createAdminDispatcher(registry);
+
+    server = createAdminServer(
+      { socketPath, authMode: "admin-key" },
+      {
+        keyManager,
+        dispatcher,
+        signetId: "test-signet",
+        signerProvider: makeStubSignerProvider(),
+        readElevationApprover: makeReadElevationApprover(keyManager),
+      },
+    );
+    await server.start();
+
+    client = createAdminClient(socketPath);
+    const connectResult = await client.connect("valid-jwt-token");
+    expect(connectResult.isOk()).toBe(true);
+
+    const first = await client.request<{ approvalId: string | null }>(
+      "message.info",
+      {
+        chatId: "conv_same_session",
+        messageId: "msg_1",
+        dangerouslyAllowMessageRead: true,
+      },
+    );
+    const second = await client.request<{ approvalId: string | null }>(
+      "message.info",
+      {
+        chatId: "conv_same_session",
+        messageId: "msg_2",
+        dangerouslyAllowMessageRead: true,
+      },
+    );
+
+    expect(first.isOk()).toBe(true);
+    expect(second.isOk()).toBe(true);
+    if (first.isOk() && second.isOk()) {
+      expect(first.value.approvalId).toContain("approval_");
+      expect(second.value.approvalId).toBe(first.value.approvalId);
+    }
+    expect(keyManager.authorizeCalls).toBe(1);
   });
 
   test("client preserves structured signet errors from JSON-RPC failures", async () => {

--- a/packages/cli/src/__tests__/admin-socket.test.ts
+++ b/packages/cli/src/__tests__/admin-socket.test.ts
@@ -273,15 +273,24 @@ describe("AdminSocket round-trip", () => {
     const socketPath = testSocketPath();
     const registry = createActionRegistry();
     const keyManager = makeKeyManager();
-    const spec = makeTestSpec("message.list", async (_input, ctx) =>
-      Result.ok({
-        approvalId: ctx.adminReadElevation?.approvalId ?? null,
-        chatIds: ctx.adminReadElevation?.scope.chatIds ?? [],
-        approvalKeyFingerprint:
-          ctx.adminReadElevation?.approvalKeyFingerprint ?? null,
+    registry.register({
+      id: "message.list",
+      description: "List messages in a conversation",
+      intent: "read",
+      input: z.object({
+        chatId: z.string(),
       }),
-    );
-    registry.register(spec);
+      handler: async (_input, ctx) =>
+        Result.ok({
+          approvalId: ctx.adminReadElevation?.approvalId ?? null,
+          chatIds: ctx.adminReadElevation?.scope.chatIds ?? [],
+          approvalKeyFingerprint:
+            ctx.adminReadElevation?.approvalKeyFingerprint ?? null,
+        }),
+      cli: {
+        command: "message:list",
+      },
+    });
     const dispatcher = createAdminDispatcher(registry);
 
     server = createAdminServer(
@@ -323,8 +332,18 @@ describe("AdminSocket round-trip", () => {
     const socketPath = testSocketPath();
     const registry = createActionRegistry();
     const keyManager = makeKeyManager({ rejectElevation: true });
-    const spec = makeTestSpec("message.list", async () => Result.ok({}));
-    registry.register(spec);
+    registry.register({
+      id: "message.list",
+      description: "List messages in a conversation",
+      intent: "read",
+      input: z.object({
+        chatId: z.string(),
+      }),
+      handler: async () => Result.ok({}),
+      cli: {
+        command: "message:list",
+      },
+    });
     const dispatcher = createAdminDispatcher(registry);
 
     server = createAdminServer(

--- a/packages/cli/src/__tests__/config-schema.test.ts
+++ b/packages/cli/src/__tests__/config-schema.test.ts
@@ -15,6 +15,7 @@ describe("CliConfigSchema", () => {
     expect(config.keys.operationalKeyPolicy).toBe("open");
     expect(config.keys.vaultKeyPolicy).toBe("open");
     expect(config.biometricGating.rootKeyCreation).toBe(false);
+    expect(config.biometricGating.adminReadElevation).toBe(false);
     expect(config.ws.port).toBe(8393);
     expect(config.ws.host).toBe("127.0.0.1");
     expect(config.admin.authMode).toBe("admin-key");

--- a/packages/cli/src/__tests__/http-api-integration.test.ts
+++ b/packages/cli/src/__tests__/http-api-integration.test.ts
@@ -14,18 +14,22 @@ import {
 // ---------------------------------------------------------------------------
 
 function makeDispatcher(overrides?: Partial<AdminDispatcher>): AdminDispatcher {
+  const dispatchValidated =
+    overrides?.dispatchValidated ??
+    overrides?.dispatch ??
+    (async () => ({
+      ok: true as const,
+      data: { status: "ok" },
+      meta: {
+        requestId: "req-1",
+        timestamp: new Date().toISOString(),
+        durationMs: 1,
+      },
+    }));
   return {
-    dispatch:
-      overrides?.dispatch ??
-      (async () => ({
-        ok: true as const,
-        data: { status: "ok" },
-        meta: {
-          requestId: "req-1",
-          timestamp: new Date().toISOString(),
-          durationMs: 1,
-        },
-      })),
+    validate: overrides?.validate ?? ((_, params) => Result.ok(params)),
+    dispatchValidated,
+    dispatch: overrides?.dispatch ?? dispatchValidated,
     hasMethod: overrides?.hasMethod ?? (() => true),
   };
 }

--- a/packages/cli/src/__tests__/http-server.test.ts
+++ b/packages/cli/src/__tests__/http-server.test.ts
@@ -19,6 +19,22 @@ import {
 // Test helpers
 // ---------------------------------------------------------------------------
 
+function makeReadElevationApprover() {
+  let authorizeCalls = 0;
+  return {
+    get authorizeCalls() {
+      return authorizeCalls;
+    },
+    async authorize() {
+      authorizeCalls++;
+      return Result.ok(undefined);
+    },
+    async getApprovalFingerprint() {
+      return Result.ok("approval-fingerprint");
+    },
+  };
+}
+
 function makeDispatcher(overrides?: Partial<AdminDispatcher>): AdminDispatcher {
   return {
     dispatch:
@@ -56,6 +72,8 @@ function makeDeps(overrides?: Partial<HttpServerDeps>): HttpServerDeps {
           exp: 2,
           jti: "test-jti",
         } satisfies AdminJwtPayload)),
+    readElevationApprover: overrides?.readElevationApprover,
+    auditLog: overrides?.auditLog,
     status: overrides?.status ?? (() => ({ state: "running", pid: 1 })),
   };
 }
@@ -144,6 +162,66 @@ describe("HttpServer", () => {
     expect(seenFingerprint).toBe("admin-fingerprint");
   });
 
+  test("POST /v1/admin/:method can attach and reuse admin read elevation", async () => {
+    const approver = makeReadElevationApprover();
+    const dispatcher = makeDispatcher({
+      dispatch: async (_method, _params, ctx) => ({
+        ok: true as const,
+        data: {
+          approvalId: ctx.adminReadElevation?.approvalId ?? null,
+          chatIds: ctx.adminReadElevation?.scope.chatIds ?? [],
+        },
+        meta: {
+          requestId: "req-1",
+          timestamp: new Date().toISOString(),
+          durationMs: 1,
+        },
+      }),
+    });
+    const deps = makeDeps({
+      dispatcher,
+      readElevationApprover: approver,
+    });
+    const port = await startTestServer(deps);
+
+    const first = await fetch(
+      `http://127.0.0.1:${port}/v1/admin/message.list`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer valid-admin-jwt",
+        },
+        body: JSON.stringify({
+          chatId: "conv_http_admin",
+          dangerouslyAllowMessageRead: true,
+        }),
+      },
+    );
+    const second = await fetch(
+      `http://127.0.0.1:${port}/v1/admin/message.list`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer valid-admin-jwt",
+        },
+        body: JSON.stringify({
+          chatId: "conv_http_admin",
+          dangerouslyAllowMessageRead: true,
+        }),
+      },
+    );
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    const firstBody = await first.json();
+    const secondBody = await second.json();
+    expect(firstBody.data.chatIds).toEqual(["conv_http_admin"]);
+    expect(secondBody.data.approvalId).toBe(firstBody.data.approvalId);
+    expect(approver.authorizeCalls).toBe(1);
+  });
+
   test("derived admin action route executes directly from the registry", async () => {
     const registry = createActionRegistry();
     registry.register(
@@ -183,6 +261,52 @@ describe("HttpServer", () => {
       adminKeyFingerprint: "admin-fingerprint",
       operatorId: "op_123",
     });
+  });
+
+  test("derived admin message route attaches elevation when dangerous read is requested", async () => {
+    const approver = makeReadElevationApprover();
+    const registry = createActionRegistry();
+    registry.register(
+      makeHttpActionSpec("message.info", {
+        description: "Read a message",
+        intent: "read",
+        input: z.object({
+          chatId: z.string(),
+          messageId: z.string(),
+        }),
+        handler: async (_input, ctx) =>
+          Result.ok({
+            approvalId: ctx.adminReadElevation?.approvalId ?? null,
+            approvalKeyFingerprint:
+              ctx.adminReadElevation?.approvalKeyFingerprint ?? null,
+          }),
+        http: {
+          auth: "admin",
+        },
+      }),
+    );
+
+    const deps = makeDeps({
+      registry,
+      readElevationApprover: approver,
+    });
+    const port = await startTestServer(deps);
+
+    const res = await fetch(
+      `http://127.0.0.1:${port}/v1/actions/message/info?chatId=conv_http_route&messageId=msg_123&dangerouslyAllowMessageRead=true`,
+      {
+        headers: {
+          Authorization: "Bearer valid-admin-jwt",
+        },
+      },
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.approvalId).toContain("approval_");
+    expect(body.data.approvalKeyFingerprint).toBe("approval-fingerprint");
+    expect(approver.authorizeCalls).toBe(1);
   });
 
   test("derived credential action route executes directly from the registry", async () => {

--- a/packages/cli/src/__tests__/http-server.test.ts
+++ b/packages/cli/src/__tests__/http-server.test.ts
@@ -9,6 +9,7 @@ import {
   type HandlerContext,
 } from "@xmtp/signet-contracts";
 import type { AdminDispatcher } from "../admin/dispatcher.js";
+import { createAdminDispatcher } from "../admin/dispatcher.js";
 import {
   createHttpServer,
   type HttpServer,
@@ -36,18 +37,22 @@ function makeReadElevationApprover() {
 }
 
 function makeDispatcher(overrides?: Partial<AdminDispatcher>): AdminDispatcher {
+  const dispatchValidated =
+    overrides?.dispatchValidated ??
+    overrides?.dispatch ??
+    (async () => ({
+      ok: true as const,
+      data: { status: "ok" },
+      meta: {
+        requestId: "req-1",
+        timestamp: new Date().toISOString(),
+        durationMs: 1,
+      },
+    }));
   return {
-    dispatch:
-      overrides?.dispatch ??
-      (async () => ({
-        ok: true as const,
-        data: { status: "ok" },
-        meta: {
-          requestId: "req-1",
-          timestamp: new Date().toISOString(),
-          durationMs: 1,
-        },
-      })),
+    validate: overrides?.validate ?? ((_, params) => Result.ok(params)),
+    dispatchValidated,
+    dispatch: overrides?.dispatch ?? dispatchValidated,
     hasMethod: overrides?.hasMethod ?? (() => true),
   };
 }
@@ -220,6 +225,48 @@ describe("HttpServer", () => {
     expect(firstBody.data.chatIds).toEqual(["conv_http_admin"]);
     expect(secondBody.data.approvalId).toBe(firstBody.data.approvalId);
     expect(approver.authorizeCalls).toBe(1);
+  });
+
+  test("POST /v1/admin/:method validates dangerous reads before prompting", async () => {
+    const approver = makeReadElevationApprover();
+    const registry = createActionRegistry();
+    registry.register({
+      id: "message.info",
+      description: "Read a message",
+      intent: "read",
+      input: z.object({
+        chatId: z.string(),
+        messageId: z.string(),
+      }),
+      handler: async () => Result.ok({ ok: true }),
+      cli: {
+        command: "message:info",
+      },
+    });
+    const dispatcher = createAdminDispatcher(registry);
+    const deps = makeDeps({
+      dispatcher,
+      readElevationApprover: approver,
+    });
+    const port = await startTestServer(deps);
+
+    const res = await fetch(`http://127.0.0.1:${port}/v1/admin/message.info`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer valid-admin-jwt",
+      },
+      body: JSON.stringify({
+        chatId: "conv_http_invalid_before_prompt",
+        dangerouslyAllowMessageRead: true,
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.category).toBe("validation");
+    expect(approver.authorizeCalls).toBe(0);
   });
 
   test("derived admin action route executes directly from the registry", async () => {

--- a/packages/cli/src/__tests__/http-server.test.ts
+++ b/packages/cli/src/__tests__/http-server.test.ts
@@ -169,22 +169,30 @@ describe("HttpServer", () => {
 
   test("POST /v1/admin/:method can attach and reuse admin read elevation", async () => {
     const approver = makeReadElevationApprover();
-    const dispatcher = makeDispatcher({
-      dispatch: async (_method, _params, ctx) => ({
-        ok: true as const,
-        data: {
+    const registry = createActionRegistry();
+    registry.register({
+      id: "message.list",
+      description: "List messages in a conversation",
+      intent: "read",
+      input: z.object({
+        chatId: z.string(),
+      }),
+      handler: async (_input, ctx) =>
+        Result.ok({
           approvalId: ctx.adminReadElevation?.approvalId ?? null,
           chatIds: ctx.adminReadElevation?.scope.chatIds ?? [],
-        },
-        meta: {
-          requestId: "req-1",
-          timestamp: new Date().toISOString(),
-          durationMs: 1,
-        },
-      }),
+        }),
+      cli: {
+        command: "message:list",
+      },
+      http: {
+        auth: "admin",
+      },
     });
+    const dispatcher = createAdminDispatcher(registry);
     const deps = makeDeps({
       dispatcher,
+      registry,
       readElevationApprover: approver,
     });
     const port = await startTestServer(deps);

--- a/packages/cli/src/__tests__/http-server.test.ts
+++ b/packages/cli/src/__tests__/http-server.test.ts
@@ -309,6 +309,43 @@ describe("HttpServer", () => {
     expect(approver.authorizeCalls).toBe(1);
   });
 
+  test("derived admin action route authenticates before validating params", async () => {
+    const registry = createActionRegistry();
+    registry.register(
+      makeHttpActionSpec("message.info", {
+        description: "Read a message",
+        intent: "read",
+        input: z.object({
+          chatId: z.string(),
+          messageId: z.string(),
+        }),
+        http: {
+          auth: "admin",
+        },
+      }),
+    );
+
+    const deps = makeDeps({
+      registry,
+      verifyAdminJwt: async () => Result.err(AuthError.create("Invalid JWT")),
+    });
+    const port = await startTestServer(deps);
+
+    const res = await fetch(
+      `http://127.0.0.1:${port}/v1/actions/message/info`,
+      {
+        headers: {
+          Authorization: "Bearer bad-jwt",
+        },
+      },
+    );
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.category).toBe("auth");
+  });
+
   test("derived credential action route executes directly from the registry", async () => {
     const registry = createActionRegistry();
     registry.register(
@@ -377,6 +414,42 @@ describe("HttpServer", () => {
       authenticatedCredentialId: "cred_123",
       requestedCredentialId: "cred_123",
     });
+  });
+
+  test("derived credential action route authenticates before validating params", async () => {
+    const registry = createActionRegistry();
+    registry.register(
+      makeHttpActionSpec("reveal.list", {
+        description: "List active reveals",
+        intent: "read",
+        input: z.object({
+          credentialId: z.string(),
+        }),
+        http: {
+          auth: "credential",
+        },
+      }),
+    );
+
+    const deps = makeDeps({
+      registry,
+      credentialManager: {
+        lookupByToken: async () =>
+          Result.err(AuthError.create("Invalid credential token")),
+      } as HttpServerDeps["credentialManager"],
+    });
+    const port = await startTestServer(deps);
+
+    const res = await fetch(`http://127.0.0.1:${port}/v1/actions/reveal/list`, {
+      headers: {
+        Authorization: "Bearer bad-credential-token",
+      },
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error.category).toBe("auth");
   });
 
   test("unauthenticated request to /v1/admin returns 401", async () => {

--- a/packages/cli/src/__tests__/read-disclosure-rollback-tracker.test.ts
+++ b/packages/cli/src/__tests__/read-disclosure-rollback-tracker.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { createReadDisclosureRollbackTracker } from "../admin/read-disclosure-rollback-tracker.js";
+
+describe("createReadDisclosureRollbackTracker", () => {
+  test("keeps a chat active until all overlapping rollback windows exit", () => {
+    const tracker = createReadDisclosureRollbackTracker();
+
+    tracker.enter(["conv_overlap"]);
+    tracker.enter(["conv_overlap"]);
+    expect(tracker.has("conv_overlap")).toBe(true);
+
+    tracker.leave(["conv_overlap"]);
+    expect(tracker.has("conv_overlap")).toBe(true);
+
+    tracker.leave(["conv_overlap"]);
+    expect(tracker.has("conv_overlap")).toBe(false);
+  });
+
+  test("de-dupes repeated chat ids inside a single enter or leave call", () => {
+    const tracker = createReadDisclosureRollbackTracker();
+
+    tracker.enter(["conv_dup", "conv_dup"]);
+    expect(tracker.has("conv_dup")).toBe(true);
+
+    tracker.leave(["conv_dup", "conv_dup"]);
+    expect(tracker.has("conv_dup")).toBe(false);
+  });
+});

--- a/packages/cli/src/__tests__/runtime.test.ts
+++ b/packages/cli/src/__tests__/runtime.test.ts
@@ -300,6 +300,7 @@ describe("createSignetRuntime", () => {
         scopeExpansion: false,
         egressExpansion: false,
         agentCreation: false,
+        adminReadElevation: false,
       },
       dataDir: join(tempDir, "data"),
     });

--- a/packages/cli/src/__tests__/seal-input-resolver.test.ts
+++ b/packages/cli/src/__tests__/seal-input-resolver.test.ts
@@ -290,6 +290,40 @@ describe("InputResolver", () => {
       hostingMode: { source: "declared" },
     });
   });
+
+  test("injects active admin read disclosure into the resolved seal input", async () => {
+    const credManager = createMockCredentialManager({
+      id: "cred_0123456789abcdef",
+      config: {
+        operatorId,
+        chatIds: ["conv_aabbccdd11223344"],
+      },
+    });
+
+    const resolver = createSealInputResolver({
+      credentialManager: credManager,
+      operatorManager,
+      trustTier: "source-verified",
+      lookupAdminAccess: (chatId) =>
+        chatId === "conv_aabbccdd11223344"
+          ? {
+              operatorId: "owner",
+              expiresAt: "2026-04-14T16:30:00.000Z",
+            }
+          : undefined,
+    });
+    const result = await resolver(
+      "cred_0123456789abcdef",
+      "conv_aabbccdd11223344",
+    );
+
+    expect(Result.isOk(result)).toBe(true);
+    if (!Result.isOk(result)) return;
+    expect(result.value.adminAccess).toEqual({
+      operatorId: "owner",
+      expiresAt: "2026-04-14T16:30:00.000Z",
+    });
+  });
 });
 
 describe("buildSealProvenanceMap", () => {

--- a/packages/cli/src/__tests__/xs-chat-msg-commands.test.ts
+++ b/packages/cli/src/__tests__/xs-chat-msg-commands.test.ts
@@ -291,13 +291,14 @@ describe("message commands", () => {
 
   // -- list --
 
-  test("list subcommand has --from required option and --watch, --json", async () => {
+  test("list subcommand has read-elevation flag plus --from, --watch, --json", async () => {
     const cmd = await load();
     const list = findSub(cmd, "list");
     expect(list).toBeDefined();
     const flags = optionFlags(list!);
     expect(flags).toContain("--from");
     expect(flags).toContain("--as");
+    expect(flags).toContain("--dangerously-allow-message-read");
     expect(flags).toContain("--watch");
     expect(flags).toContain("--json");
   });
@@ -314,6 +315,7 @@ describe("message commands", () => {
     const flags = optionFlags(info!);
     expect(flags).toContain("--chat");
     expect(flags).toContain("--as");
+    expect(flags).toContain("--dangerously-allow-message-read");
     expect(flags).toContain("--json");
   });
 

--- a/packages/cli/src/__tests__/xs-message-command-wiring.test.ts
+++ b/packages/cli/src/__tests__/xs-message-command-wiring.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import type { SignetError } from "@xmtp/signet-schemas";
+import type { AdminClient } from "../admin/client.js";
+import { createMessageCommands } from "../commands/xs-message.js";
+
+interface RequestCall {
+  readonly method: string;
+  readonly params: Record<string, unknown> | undefined;
+}
+
+function createHarness<T>(response: T) {
+  const requestCalls: RequestCall[] = [];
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  const client: AdminClient = {
+    async connect() {
+      return Result.ok(undefined);
+    },
+    async request(method, params) {
+      requestCalls.push({ method, params });
+      return Result.ok(response);
+    },
+    async close() {},
+  };
+
+  return {
+    deps: {
+      async withDaemonClient<TResult>(
+        options: { configPath?: string | undefined },
+        run: (
+          adminClient: AdminClient,
+        ) => Promise<Result<TResult, SignetError>>,
+      ): Promise<Result<TResult, SignetError>> {
+        expect(options).toEqual({ configPath: "/tmp/test.toml" });
+        return run(client);
+      },
+      writeStdout(message: string) {
+        stdout.push(message);
+      },
+      writeStderr(message: string) {
+        stderr.push(message);
+      },
+      exit() {},
+    },
+    requestCalls,
+    stdout,
+    stderr,
+  };
+}
+
+describe("xs msg list", () => {
+  test("routes dangerous admin read flag through the daemon client", async () => {
+    const harness = createHarness({ chatId: "conv_1", messages: [] });
+    const command = createMessageCommands(harness.deps);
+
+    await command.parseAsync([
+      "node",
+      "msg",
+      "list",
+      "--from",
+      "conv_1",
+      "--dangerously-allow-message-read",
+      "--config",
+      "/tmp/test.toml",
+    ]);
+
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "message.list",
+        params: {
+          chatId: "conv_1",
+          dangerouslyAllowMessageRead: true,
+        },
+      },
+    ]);
+  });
+});
+
+describe("xs msg info", () => {
+  test("routes dangerous admin read flag through the daemon client", async () => {
+    const harness = createHarness({
+      messageId: "msg_1",
+      groupId: "group-1",
+    });
+    const command = createMessageCommands(harness.deps);
+
+    await command.parseAsync([
+      "node",
+      "msg",
+      "info",
+      "msg_1",
+      "--chat",
+      "conv_1",
+      "--dangerously-allow-message-read",
+      "--config",
+      "/tmp/test.toml",
+    ]);
+
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "message.info",
+        params: {
+          chatId: "conv_1",
+          messageId: "msg_1",
+          dangerouslyAllowMessageRead: true,
+        },
+      },
+    ]);
+  });
+});

--- a/packages/cli/src/__tests__/xs-utility-command-wiring.test.ts
+++ b/packages/cli/src/__tests__/xs-utility-command-wiring.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import { InternalError, type SignetError } from "@xmtp/signet-schemas";
+import type { AdminClient } from "../admin/client.js";
+import { createUtilityCommands } from "../commands/xs-utility.js";
+
+interface RequestCall {
+  readonly method: string;
+  readonly params: Record<string, unknown> | undefined;
+}
+
+function createHarness<T>(response: T) {
+  const requestCalls: RequestCall[] = [];
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let exitCode: number | undefined;
+
+  const client: AdminClient = {
+    async connect() {
+      return Result.ok(undefined);
+    },
+    async request(method, params) {
+      requestCalls.push({ method, params });
+      return Result.ok(response);
+    },
+    async close() {},
+  };
+
+  return {
+    deps: {
+      async withDaemonClient<TResult>(
+        options: { configPath?: string | undefined },
+        run: (
+          adminClient: AdminClient,
+        ) => Promise<Result<TResult, SignetError>>,
+      ): Promise<Result<TResult, SignetError>> {
+        expect(options).toEqual({ configPath: "/tmp/test.toml" });
+        return run(client);
+      },
+      writeStdout(message: string) {
+        stdout.push(message);
+      },
+      writeStderr(message: string) {
+        stderr.push(message);
+      },
+      exit(code: number) {
+        exitCode = code;
+      },
+    },
+    requestCalls,
+    stdout,
+    stderr,
+    get exitCode() {
+      return exitCode;
+    },
+  };
+}
+
+function createErrorHarness(error: SignetError) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let exitCode: number | undefined;
+
+  return {
+    deps: {
+      async withDaemonClient<TResult>(): Promise<Result<TResult, SignetError>> {
+        return Result.err(error);
+      },
+      writeStdout(message: string) {
+        stdout.push(message);
+      },
+      writeStderr(message: string) {
+        stderr.push(message);
+      },
+      exit(code: number) {
+        exitCode = code;
+      },
+    },
+    stdout,
+    stderr,
+    get exitCode() {
+      return exitCode;
+    },
+  };
+}
+
+describe("xs utility command wiring", () => {
+  test("routes lookup through the daemon client", async () => {
+    const harness = createHarness({
+      query: "support",
+      found: true,
+      mapping: {
+        localId: "inbox_1234567890abcdef",
+        networkId: "xmtp-inbox-1",
+      },
+      inbox: {
+        id: "inbox_1234567890abcdef",
+        label: "support",
+        networkInboxId: "xmtp-inbox-1",
+        groupId: null,
+        createdAt: "2026-04-13T00:00:00.000Z",
+      },
+      operator: null,
+      policy: null,
+      credential: null,
+    });
+    const commands = createUtilityCommands(harness.deps);
+    const lookup = commands.find((command) => command.name() === "lookup");
+    expect(lookup).toBeDefined();
+
+    await lookup!.parseAsync([
+      "node",
+      "lookup",
+      "support",
+      "--config",
+      "/tmp/test.toml",
+    ]);
+
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "lookup.resolve",
+        params: { query: "support" },
+      },
+    ]);
+    expect(harness.stdout[0]).toContain("Query: support");
+  });
+});
+
+describe("xs utility command errors", () => {
+  test("writes lookup errors to stderr", async () => {
+    const harness = createErrorHarness(InternalError.create("boom"));
+    const commands = createUtilityCommands(harness.deps);
+    const lookup = commands.find((command) => command.name() === "lookup");
+    expect(lookup).toBeDefined();
+
+    await lookup!.parseAsync(["node", "lookup", "support"]);
+
+    expect(harness.stdout).toEqual([]);
+    expect(harness.stderr[0]).toContain("category");
+    expect(harness.exitCode).toBe(8);
+  });
+});

--- a/packages/cli/src/__tests__/xs-utility-command-wiring.test.ts
+++ b/packages/cli/src/__tests__/xs-utility-command-wiring.test.ts
@@ -124,6 +124,76 @@ describe("xs utility command wiring", () => {
     ]);
     expect(harness.stdout[0]).toContain("Query: support");
   });
+
+  test("routes message search through the daemon with admin read elevation flag", async () => {
+    const harness = createHarness({
+      query: "secret",
+      matches: [],
+      total: 0,
+    });
+    const commands = createUtilityCommands(harness.deps);
+    const search = commands.find((command) => command.name() === "search");
+    expect(search).toBeDefined();
+
+    await search!.parseAsync([
+      "node",
+      "search",
+      "secret",
+      "--chat",
+      "conv_secret",
+      "--as",
+      "tester",
+      "--dangerously-allow-message-read",
+      "--config",
+      "/tmp/test.toml",
+    ]);
+
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "search.messages",
+        params: {
+          query: "secret",
+          chatId: "conv_secret",
+          identityLabel: "tester",
+          dangerouslyAllowMessageRead: true,
+        },
+      },
+    ]);
+    expect(harness.stdout).toEqual(["No messages found.\n"]);
+  });
+
+  test("does not pass admin read elevation flag to resource search", async () => {
+    const harness = createHarness({
+      query: "policy",
+      matches: [],
+      total: 0,
+    });
+    const commands = createUtilityCommands(harness.deps);
+    const search = commands.find((command) => command.name() === "search");
+    expect(search).toBeDefined();
+
+    await search!.parseAsync([
+      "node",
+      "search",
+      "policy",
+      "--type",
+      "policy",
+      "--dangerously-allow-message-read",
+      "--config",
+      "/tmp/test.toml",
+    ]);
+
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "search.resources",
+        params: {
+          query: "policy",
+          type: "policy",
+        },
+      },
+    ]);
+    expect(harness.stdout).toEqual(["No resources found.\n"]);
+  });
 });
 
 describe("xs utility command errors", () => {

--- a/packages/cli/src/__tests__/xs-utility-commands.test.ts
+++ b/packages/cli/src/__tests__/xs-utility-commands.test.ts
@@ -459,13 +459,14 @@ describe("utility commands", () => {
     expect(optionFlags(exportCmd!)).not.toContain("--json");
   });
 
-  test("includes a lookup command with an address argument and --json", async () => {
+  test("includes a lookup command with a query argument, --config, and --json", async () => {
     const commands = await loadProgram();
     const lookup = commands.find((c) => c.name() === "lookup");
     expect(lookup).toBeDefined();
     const args = lookup!.registeredArguments;
     expect(args.length).toBeGreaterThanOrEqual(1);
-    expect(args[0]?.name()).toBe("address");
+    expect(args[0]?.name()).toBe("query");
+    expect(optionFlags(lookup!)).toContain("--config");
     expect(optionFlags(lookup!)).toContain("--json");
   });
 

--- a/packages/cli/src/__tests__/xs-utility-commands.test.ts
+++ b/packages/cli/src/__tests__/xs-utility-commands.test.ts
@@ -482,6 +482,7 @@ describe("utility commands", () => {
     expect(flags).toContain("--type");
     expect(flags).toContain("--limit");
     expect(flags).toContain("--as");
+    expect(flags).toContain("--dangerously-allow-message-read");
     expect(flags).toContain("--config");
     expect(flags).toContain("--json");
   });

--- a/packages/cli/src/admin/dispatcher.ts
+++ b/packages/cli/src/admin/dispatcher.ts
@@ -23,6 +23,19 @@ import { Result } from "better-result";
  * the canonical action ID-derived RPC method.
  */
 export interface AdminDispatcher {
+  /** Validate params for a JSON-RPC method without invoking its handler. */
+  validate(
+    method: string,
+    params: Record<string, unknown>,
+  ): Result<Record<string, unknown>, SignetError>;
+
+  /** Dispatch a request whose params have already been validated. */
+  dispatchValidated(
+    method: string,
+    params: Record<string, unknown>,
+    ctx: HandlerContext,
+  ): Promise<ActionResult<unknown>>;
+
   /** Route a JSON-RPC method call to the matching ActionSpec handler. */
   dispatch(
     method: string,
@@ -64,6 +77,32 @@ function makeMeta(ctx: HandlerContext, startMs: number): ActionResultMeta {
   };
 }
 
+function getSpec(
+  methodMap: Map<string, ActionSpec<unknown, unknown, SignetError>>,
+  method: string,
+): Result<ActionSpec<unknown, unknown, SignetError>, SignetError> {
+  const spec = methodMap.get(method);
+  if (spec === undefined) {
+    return Result.err(NotFoundError.create("Method", method));
+  }
+  return Result.ok(spec);
+}
+
+function validateParams(
+  spec: ActionSpec<unknown, unknown, SignetError>,
+  params: Record<string, unknown>,
+): Result<Record<string, unknown>, SignetError> {
+  const parseResult = spec.input.safeParse(params);
+  if (!parseResult.success) {
+    const issues = parseResult.error.issues
+      .map((i) => `${i.path.join(".")}: ${i.message}`)
+      .join("; ");
+    return Result.err(ValidationError.create("params", issues));
+  }
+
+  return Result.ok(parseResult.data as Record<string, unknown>);
+}
+
 /**
  * Create an AdminDispatcher that routes JSON-RPC methods to ActionSpecs
  * via the shared ActionRegistry.
@@ -74,37 +113,36 @@ export function createAdminDispatcher(
   const methodMap = buildMethodMap(registry);
 
   return {
-    async dispatch(
+    validate(
+      method: string,
+      params: Record<string, unknown>,
+    ): Result<Record<string, unknown>, SignetError> {
+      const specResult = getSpec(methodMap, method);
+      if (Result.isError(specResult)) {
+        return specResult;
+      }
+
+      return validateParams(specResult.value, params);
+    },
+
+    async dispatchValidated(
       method: string,
       params: Record<string, unknown>,
       ctx: HandlerContext,
     ): Promise<ActionResult<unknown>> {
       const startMs = Date.now();
-      const spec = methodMap.get(method);
+      const specResult = getSpec(methodMap, method);
 
-      if (spec === undefined) {
-        return toActionResult(
-          Result.err(NotFoundError.create("Method", method)),
-          makeMeta(ctx, startMs),
-        );
+      if (Result.isError(specResult)) {
+        return toActionResult(specResult, makeMeta(ctx, startMs));
       }
 
-      // Validate input against spec's Zod schema
-      const parseResult = spec.input.safeParse(params);
-      if (!parseResult.success) {
-        const issues = parseResult.error.issues
-          .map((i) => `${i.path.join(".")}: ${i.message}`)
-          .join("; ");
-        return toActionResult(
-          Result.err(ValidationError.create("params", issues)),
-          makeMeta(ctx, startMs),
-        );
-      }
+      const spec = specResult.value;
 
       // Call the handler -- catch unexpected throws and wrap as InternalError
       let result: Awaited<ReturnType<typeof spec.handler>>;
       try {
-        result = await spec.handler(parseResult.data, ctx);
+        result = await spec.handler(params, ctx);
       } catch (thrown: unknown) {
         const message =
           thrown instanceof Error ? thrown.message : String(thrown);
@@ -114,6 +152,20 @@ export function createAdminDispatcher(
         );
       }
       return toActionResult(result, makeMeta(ctx, startMs));
+    },
+
+    async dispatch(
+      method: string,
+      params: Record<string, unknown>,
+      ctx: HandlerContext,
+    ): Promise<ActionResult<unknown>> {
+      const startMs = Date.now();
+      const paramsResult = this.validate(method, params);
+      if (Result.isError(paramsResult)) {
+        return toActionResult(paramsResult, makeMeta(ctx, startMs));
+      }
+
+      return this.dispatchValidated(method, paramsResult.value, ctx);
     },
 
     hasMethod(method: string): boolean {

--- a/packages/cli/src/admin/read-disclosure-rollback-tracker.ts
+++ b/packages/cli/src/admin/read-disclosure-rollback-tracker.ts
@@ -1,0 +1,38 @@
+function collectUniqueChatIds(chatIds: readonly string[]): readonly string[] {
+  return [...new Set(chatIds.filter((chatId) => chatId.length > 0))];
+}
+
+/** Tracks overlapping seal-refresh rollback windows per chat. */
+export interface ReadDisclosureRollbackTracker {
+  enter(chatIds: readonly string[]): void;
+  leave(chatIds: readonly string[]): void;
+  has(chatId: string): boolean;
+}
+
+/** Create the in-memory tracker used during disclosure rollback refreshes. */
+export function createReadDisclosureRollbackTracker(): ReadDisclosureRollbackTracker {
+  const counts = new Map<string, number>();
+
+  return {
+    enter(chatIds) {
+      for (const chatId of collectUniqueChatIds(chatIds)) {
+        counts.set(chatId, (counts.get(chatId) ?? 0) + 1);
+      }
+    },
+
+    leave(chatIds) {
+      for (const chatId of collectUniqueChatIds(chatIds)) {
+        const next = (counts.get(chatId) ?? 0) - 1;
+        if (next > 0) {
+          counts.set(chatId, next);
+          continue;
+        }
+        counts.delete(chatId);
+      }
+    },
+
+    has(chatId) {
+      return (counts.get(chatId) ?? 0) > 0;
+    },
+  };
+}

--- a/packages/cli/src/admin/read-disclosure-store.ts
+++ b/packages/cli/src/admin/read-disclosure-store.ts
@@ -24,8 +24,14 @@ export interface AdminReadDisclosureStore {
     sessionKey: string,
     disclosure: AdminReadDisclosure,
   ): readonly string[];
+  restore(
+    chatIds: readonly string[],
+    sessionKey: string,
+    disclosure: AdminReadDisclosure,
+  ): void;
   delete(chatIds: readonly string[], sessionKey: string): readonly string[];
   get(chatId: string): AdminReadDisclosure | undefined;
+  peek(chatId: string): AdminReadDisclosure | undefined;
 }
 
 function stableSerialize(value: unknown): string {
@@ -50,7 +56,10 @@ export function createAdminReadDisclosureStore(
   const now = deps.now ?? (() => new Date());
   const entries = new Map<string, Map<string, AdminReadDisclosure>>();
 
-  function aggregateForChat(chatId: string): AdminReadDisclosure | undefined {
+  function aggregateForChat(
+    chatId: string,
+    options: { includeExpired?: boolean } = {},
+  ): AdminReadDisclosure | undefined {
     const perSession = entries.get(chatId);
     if (!perSession) {
       return undefined;
@@ -61,7 +70,10 @@ export function createAdminReadDisclosureStore(
 
     for (const [sessionKey, disclosure] of perSession.entries()) {
       const expiresAt = Date.parse(disclosure.expiresAt);
-      if (!Number.isFinite(expiresAt) || expiresAt <= nowMs) {
+      if (
+        !options.includeExpired &&
+        (!Number.isFinite(expiresAt) || expiresAt <= nowMs)
+      ) {
         perSession.delete(sessionKey);
         continue;
       }
@@ -116,6 +128,15 @@ export function createAdminReadDisclosureStore(
       });
     },
 
+    restore(chatIds, sessionKey, disclosure) {
+      for (const chatId of collectUniqueChatIds(chatIds)) {
+        const perSession =
+          entries.get(chatId) ?? new Map<string, AdminReadDisclosure>();
+        perSession.set(sessionKey, cloneDisclosure(disclosure));
+        entries.set(chatId, perSession);
+      }
+    },
+
     delete(chatIds, sessionKey) {
       return mutate(chatIds, (_chatId, perSession) => {
         perSession.delete(sessionKey);
@@ -124,6 +145,10 @@ export function createAdminReadDisclosureStore(
 
     get(chatId) {
       return aggregateForChat(chatId);
+    },
+
+    peek(chatId) {
+      return aggregateForChat(chatId, { includeExpired: true });
     },
   };
 }

--- a/packages/cli/src/admin/read-disclosure-store.ts
+++ b/packages/cli/src/admin/read-disclosure-store.ts
@@ -1,0 +1,129 @@
+import type { AdminAccessActorType } from "@xmtp/signet-schemas";
+
+/** Public seal disclosure for active owner-approved admin read access. */
+export interface AdminReadDisclosure {
+  readonly operatorId: AdminAccessActorType;
+  readonly expiresAt: string;
+}
+
+/** Dependencies for the in-memory disclosure store. */
+export interface AdminReadDisclosureStoreDeps {
+  readonly now?: () => Date;
+}
+
+/**
+ * Tracks active admin-read disclosure state per chat and admin session.
+ *
+ * Public seal disclosure should remain active while any approved admin session
+ * still has live read access for a chat. The store therefore tracks per-chat,
+ * per-session disclosure entries and exposes the aggregate current state.
+ */
+export interface AdminReadDisclosureStore {
+  set(
+    chatIds: readonly string[],
+    sessionKey: string,
+    disclosure: AdminReadDisclosure,
+  ): readonly string[];
+  delete(chatIds: readonly string[], sessionKey: string): readonly string[];
+  get(chatId: string): AdminReadDisclosure | undefined;
+}
+
+function stableSerialize(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function cloneDisclosure(disclosure: AdminReadDisclosure): AdminReadDisclosure {
+  return {
+    operatorId: disclosure.operatorId,
+    expiresAt: disclosure.expiresAt,
+  };
+}
+
+function collectUniqueChatIds(chatIds: readonly string[]): string[] {
+  return [...new Set(chatIds.filter((chatId) => chatId.length > 0))];
+}
+
+/** Create the in-memory store for public admin-read disclosure state. */
+export function createAdminReadDisclosureStore(
+  deps: AdminReadDisclosureStoreDeps = {},
+): AdminReadDisclosureStore {
+  const now = deps.now ?? (() => new Date());
+  const entries = new Map<string, Map<string, AdminReadDisclosure>>();
+
+  function aggregateForChat(chatId: string): AdminReadDisclosure | undefined {
+    const perSession = entries.get(chatId);
+    if (!perSession) {
+      return undefined;
+    }
+
+    const nowMs = now().getTime();
+    let latest: AdminReadDisclosure | undefined;
+
+    for (const [sessionKey, disclosure] of perSession.entries()) {
+      const expiresAt = Date.parse(disclosure.expiresAt);
+      if (!Number.isFinite(expiresAt) || expiresAt <= nowMs) {
+        perSession.delete(sessionKey);
+        continue;
+      }
+
+      if (
+        latest === undefined ||
+        Date.parse(disclosure.expiresAt) > Date.parse(latest.expiresAt)
+      ) {
+        latest = disclosure;
+      }
+    }
+
+    if (perSession.size === 0) {
+      entries.delete(chatId);
+      return undefined;
+    }
+
+    return latest ? cloneDisclosure(latest) : undefined;
+  }
+
+  function mutate(
+    chatIds: readonly string[],
+    fn: (chatId: string, perSession: Map<string, AdminReadDisclosure>) => void,
+  ): readonly string[] {
+    const changed: string[] = [];
+
+    for (const chatId of collectUniqueChatIds(chatIds)) {
+      const before = aggregateForChat(chatId);
+      const perSession =
+        entries.get(chatId) ?? new Map<string, AdminReadDisclosure>();
+      fn(chatId, perSession);
+
+      if (perSession.size > 0) {
+        entries.set(chatId, perSession);
+      } else {
+        entries.delete(chatId);
+      }
+
+      const after = aggregateForChat(chatId);
+      if (stableSerialize(before) !== stableSerialize(after)) {
+        changed.push(chatId);
+      }
+    }
+
+    return changed;
+  }
+
+  return {
+    set(chatIds, sessionKey, disclosure) {
+      return mutate(chatIds, (_chatId, perSession) => {
+        perSession.set(sessionKey, cloneDisclosure(disclosure));
+      });
+    },
+
+    delete(chatIds, sessionKey) {
+      return mutate(chatIds, (_chatId, perSession) => {
+        perSession.delete(sessionKey);
+      });
+    },
+
+    get(chatId) {
+      return aggregateForChat(chatId);
+    },
+  };
+}

--- a/packages/cli/src/admin/read-elevation.ts
+++ b/packages/cli/src/admin/read-elevation.ts
@@ -1,0 +1,415 @@
+import { Result } from "better-result";
+import {
+  InternalError,
+  type AdminReadElevationType,
+  type SignetError,
+} from "@xmtp/signet-schemas";
+import type { AuditLog } from "../audit/log.js";
+import type {
+  AdminReadDisclosure,
+  AdminReadDisclosureStore,
+} from "./read-disclosure-store.js";
+
+const DEFAULT_READ_ELEVATION_TTL_MS = 60_000;
+
+/** Local approval surface used to mint temporary admin read elevation. */
+export interface AdminReadElevationApprover {
+  /** Prompt for local approval of an elevated admin message read. */
+  authorize(): Promise<Result<void, SignetError>>;
+
+  /** Fingerprint of the local key that approved the elevation. */
+  getApprovalFingerprint(): Promise<Result<string, SignetError>>;
+}
+
+/** Input used to resolve message-read elevation for a request. */
+export interface ResolveAdminReadElevationInput {
+  readonly method: string;
+  readonly params: Record<string, unknown>;
+  readonly adminFingerprint: string;
+  readonly sessionKey: string;
+}
+
+/** Reusable resolver for time-bound admin message-read elevation. */
+export interface AdminReadElevationManager {
+  resolveForRequest(
+    input: ResolveAdminReadElevationInput,
+  ): Promise<Result<AdminReadElevationType | undefined, SignetError>>;
+}
+
+/** Callback fired when public seal disclosure should be refreshed. */
+export type AdminReadElevationDisclosureChangeHandler = (
+  chatIds: readonly string[],
+) => Promise<Result<void, SignetError>>;
+
+/** Dependencies required to manage admin read elevation state. */
+export interface AdminReadElevationManagerDeps {
+  readonly approver?: AdminReadElevationApprover;
+  readonly auditLog?: AuditLog;
+  readonly disclosureStore?: AdminReadDisclosureStore;
+  readonly onDisclosureChanged?: AdminReadElevationDisclosureChangeHandler;
+  readonly disclosureActorId?: AdminReadDisclosure["operatorId"];
+  readonly ttlMs?: number;
+  readonly now?: () => Date;
+}
+
+interface CachedElevation {
+  readonly elevation: AdminReadElevationType;
+  readonly chatId: string;
+  readonly sessionKey: string;
+}
+
+function isMessageReadMethod(method: string): boolean {
+  return method === "message.list" || method === "message.info";
+}
+
+function wantsDangerousMessageRead(params: Record<string, unknown>): boolean {
+  return (
+    params["dangerouslyAllowMessageRead"] === true ||
+    params["dangerouslyAllowMessageRead"] === "true"
+  );
+}
+
+function resolveChatId(params: Record<string, unknown>): string | null {
+  const chatId = params["chatId"];
+  return typeof chatId === "string" && chatId.length > 0 ? chatId : null;
+}
+
+function buildCacheKey(sessionKey: string, chatId: string): string {
+  return `${sessionKey}:${chatId}`;
+}
+
+/**
+ * Create a transport-agnostic admin read-elevation manager.
+ *
+ * Elevations are cached in memory per authenticated admin session and chat.
+ * Callers must still set the explicit dangerous-read flag on each request;
+ * cache reuse only skips the repeated biometric prompt inside the TTL window.
+ */
+export function createAdminReadElevationManager(
+  deps: AdminReadElevationManagerDeps,
+): AdminReadElevationManager {
+  const ttlMs = deps.ttlMs ?? DEFAULT_READ_ELEVATION_TTL_MS;
+  const now = deps.now ?? (() => new Date());
+  const cache = new Map<string, CachedElevation>();
+  const expirationTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const disclosureActorId = deps.disclosureActorId ?? "owner";
+
+  async function appendAudit(entry: {
+    action: string;
+    success: boolean;
+    target?: string;
+    detail?: Record<string, unknown>;
+  }): Promise<Result<void, InternalError>> {
+    if (!deps.auditLog) {
+      return Result.ok(undefined);
+    }
+
+    try {
+      await deps.auditLog.append({
+        timestamp: now().toISOString(),
+        actor: "admin",
+        action: entry.action,
+        ...(entry.target !== undefined ? { target: entry.target } : {}),
+        ...(entry.detail !== undefined ? { detail: entry.detail } : {}),
+        success: entry.success,
+      });
+      return Result.ok(undefined);
+    } catch (cause) {
+      return Result.err(
+        InternalError.create("Failed to write admin read elevation audit log", {
+          cause: cause instanceof Error ? cause.message : String(cause),
+          action: entry.action,
+        }),
+      );
+    }
+  }
+
+  async function appendReuseAudit(
+    input: ResolveAdminReadElevationInput,
+    elevation: AdminReadElevationType,
+    chatId: string,
+  ): Promise<Result<void, SignetError>> {
+    const auditResult = await appendAudit({
+      action: "admin.read-elevation.reused",
+      success: true,
+      target: chatId,
+      detail: {
+        method: input.method,
+        adminKeyFingerprint: input.adminFingerprint,
+        approvalId: elevation.approvalId,
+        expiresAt: elevation.expiresAt,
+        mode: "session-scoped",
+      },
+    });
+    return Result.isError(auditResult) ? auditResult : Result.ok(undefined);
+  }
+
+  async function appendExpiredAudit(
+    input: ResolveAdminReadElevationInput,
+    elevation: AdminReadElevationType,
+    chatId: string,
+  ): Promise<Result<void, SignetError>> {
+    const auditResult = await appendAudit({
+      action: "admin.read-elevation.expired",
+      success: true,
+      target: chatId,
+      detail: {
+        method: input.method,
+        adminKeyFingerprint: input.adminFingerprint,
+        approvalId: elevation.approvalId,
+        expiresAt: elevation.expiresAt,
+        mode: "session-scoped",
+      },
+    });
+    return Result.isError(auditResult) ? auditResult : Result.ok(undefined);
+  }
+
+  async function notifyDisclosureChanged(
+    chatIds: readonly string[],
+  ): Promise<Result<void, SignetError>> {
+    if (!deps.onDisclosureChanged || chatIds.length === 0) {
+      return Result.ok(undefined);
+    }
+    return deps.onDisclosureChanged(chatIds);
+  }
+
+  function clearExpirationTimer(cacheKey: string): void {
+    const timer = expirationTimers.get(cacheKey);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      expirationTimers.delete(cacheKey);
+    }
+  }
+
+  async function syncDisclosureApproval(
+    cached: CachedElevation,
+  ): Promise<Result<void, SignetError>> {
+    if (!deps.disclosureStore) {
+      return Result.ok(undefined);
+    }
+
+    const changedChats = deps.disclosureStore.set(
+      [cached.chatId],
+      cached.sessionKey,
+      {
+        operatorId: disclosureActorId,
+        expiresAt: cached.elevation.expiresAt,
+      },
+    );
+
+    const notifyResult = await notifyDisclosureChanged(changedChats);
+    if (Result.isError(notifyResult)) {
+      deps.disclosureStore.delete([cached.chatId], cached.sessionKey);
+      return notifyResult;
+    }
+
+    return Result.ok(undefined);
+  }
+
+  async function syncDisclosureExpiry(
+    cached: CachedElevation,
+  ): Promise<Result<void, SignetError>> {
+    if (!deps.disclosureStore) {
+      return Result.ok(undefined);
+    }
+
+    const changedChats = deps.disclosureStore.delete(
+      [cached.chatId],
+      cached.sessionKey,
+    );
+    return notifyDisclosureChanged(changedChats);
+  }
+
+  async function expireCachedElevation(
+    cached: CachedElevation,
+    input?: ResolveAdminReadElevationInput,
+  ): Promise<Result<void, SignetError>> {
+    const cacheKey = buildCacheKey(cached.sessionKey, cached.chatId);
+    cache.delete(cacheKey);
+    clearExpirationTimer(cacheKey);
+
+    const expiredAudit = await appendExpiredAudit(
+      input ?? {
+        method: "message.list",
+        params: { chatId: cached.chatId },
+        adminFingerprint: "",
+        sessionKey: cached.sessionKey,
+      },
+      cached.elevation,
+      cached.chatId,
+    );
+    if (Result.isError(expiredAudit)) {
+      return expiredAudit;
+    }
+
+    const disclosureResult = await syncDisclosureExpiry(cached);
+    if (Result.isError(disclosureResult)) {
+      const auditResult = await appendAudit({
+        action: "admin.read-elevation.disclosure-refresh-failed",
+        success: false,
+        target: cached.chatId,
+        detail: {
+          approvalId: cached.elevation.approvalId,
+          expiresAt: cached.elevation.expiresAt,
+          stage: "expiry",
+          reason: disclosureResult.error.message,
+          category: disclosureResult.error.category,
+        },
+      });
+      if (Result.isError(auditResult)) {
+        return auditResult;
+      }
+      return disclosureResult;
+    }
+
+    return Result.ok(undefined);
+  }
+
+  function scheduleExpiration(cached: CachedElevation): void {
+    const cacheKey = buildCacheKey(cached.sessionKey, cached.chatId);
+    clearExpirationTimer(cacheKey);
+
+    const delayMs = Math.max(
+      0,
+      Date.parse(cached.elevation.expiresAt) - now().getTime(),
+    );
+    const timer = setTimeout(() => {
+      void expireCachedElevation(cached);
+    }, delayMs);
+    expirationTimers.set(cacheKey, timer);
+  }
+
+  return {
+    async resolveForRequest(
+      input: ResolveAdminReadElevationInput,
+    ): Promise<Result<AdminReadElevationType | undefined, SignetError>> {
+      if (
+        !isMessageReadMethod(input.method) ||
+        !wantsDangerousMessageRead(input.params)
+      ) {
+        return Result.ok(undefined);
+      }
+
+      const chatId = resolveChatId(input.params);
+      if (chatId === null) {
+        return Result.ok(undefined);
+      }
+
+      const cacheKey = buildCacheKey(input.sessionKey, chatId);
+      const cached = cache.get(cacheKey);
+      const nowMs = now().getTime();
+
+      if (cached) {
+        const expiresAtMs = Date.parse(cached.elevation.expiresAt);
+        if (Number.isFinite(expiresAtMs) && expiresAtMs > nowMs) {
+          const reuseAudit = await appendReuseAudit(
+            input,
+            cached.elevation,
+            chatId,
+          );
+          if (Result.isError(reuseAudit)) {
+            return reuseAudit;
+          }
+          return Result.ok(cached.elevation);
+        }
+
+        const expiryResult = await expireCachedElevation(cached, input);
+        if (Result.isError(expiryResult)) {
+          return expiryResult;
+        }
+      }
+
+      if (!deps.approver) {
+        return Result.err(
+          InternalError.create(
+            "Admin read elevation approver is not configured",
+            { method: input.method },
+          ),
+        );
+      }
+
+      const authorizeResult = await deps.approver.authorize();
+      if (Result.isError(authorizeResult)) {
+        const auditResult = await appendAudit({
+          action: "admin.read-elevation.denied",
+          success: false,
+          target: chatId,
+          detail: {
+            method: input.method,
+            adminKeyFingerprint: input.adminFingerprint,
+            reason: authorizeResult.error.message,
+            category: authorizeResult.error.category,
+            mode: "session-scoped",
+          },
+        });
+        if (Result.isError(auditResult)) {
+          return auditResult;
+        }
+        return authorizeResult;
+      }
+
+      const fingerprintResult = await deps.approver.getApprovalFingerprint();
+      if (Result.isError(fingerprintResult)) {
+        return fingerprintResult;
+      }
+
+      const approvedAt = now();
+      const elevation: AdminReadElevationType = {
+        approvalId: `approval_${crypto.randomUUID().replaceAll("-", "")}`,
+        scope: { chatIds: [chatId] },
+        approvedAt: approvedAt.toISOString(),
+        expiresAt: new Date(approvedAt.getTime() + ttlMs).toISOString(),
+        approvalKeyFingerprint: fingerprintResult.value,
+      };
+      const nextCached: CachedElevation = {
+        elevation,
+        chatId,
+        sessionKey: input.sessionKey,
+      };
+
+      const disclosureResult = await syncDisclosureApproval(nextCached);
+      if (Result.isError(disclosureResult)) {
+        const auditResult = await appendAudit({
+          action: "admin.read-elevation.disclosure-refresh-failed",
+          success: false,
+          target: chatId,
+          detail: {
+            method: input.method,
+            adminKeyFingerprint: input.adminFingerprint,
+            approvalId: elevation.approvalId,
+            expiresAt: elevation.expiresAt,
+            stage: "approval",
+            reason: disclosureResult.error.message,
+            category: disclosureResult.error.category,
+          },
+        });
+        if (Result.isError(auditResult)) {
+          return auditResult;
+        }
+        return disclosureResult;
+      }
+
+      cache.set(cacheKey, nextCached);
+      scheduleExpiration(nextCached);
+
+      const auditResult = await appendAudit({
+        action: "admin.read-elevation.approved",
+        success: true,
+        target: chatId,
+        detail: {
+          method: input.method,
+          adminKeyFingerprint: input.adminFingerprint,
+          approvalId: elevation.approvalId,
+          expiresAt: elevation.expiresAt,
+          approvalKeyFingerprint: elevation.approvalKeyFingerprint,
+          mode: "session-scoped",
+        },
+      });
+      if (Result.isError(auditResult)) {
+        return auditResult;
+      }
+
+      return Result.ok(elevation);
+    },
+  };
+}

--- a/packages/cli/src/admin/read-elevation.ts
+++ b/packages/cli/src/admin/read-elevation.ts
@@ -39,6 +39,7 @@ export interface AdminReadElevationManager {
 /** Callback fired when public seal disclosure should be refreshed. */
 export type AdminReadElevationDisclosureChangeHandler = (
   chatIds: readonly string[],
+  options?: { includeExpired?: boolean },
 ) => Promise<Result<void, SignetError>>;
 
 /** Dependencies required to manage admin read elevation state. */
@@ -174,11 +175,12 @@ export function createAdminReadElevationManager(
 
   async function notifyDisclosureChanged(
     chatIds: readonly string[],
+    options?: { includeExpired?: boolean },
   ): Promise<Result<void, SignetError>> {
     if (!deps.onDisclosureChanged || chatIds.length === 0) {
       return Result.ok(undefined);
     }
-    return deps.onDisclosureChanged(chatIds);
+    return deps.onDisclosureChanged(chatIds, options);
   }
 
   function clearExpirationTimer(cacheKey: string): void {
@@ -242,7 +244,31 @@ export function createAdminReadElevationManager(
       [cached.chatId],
       cached.sessionKey,
     );
-    return notifyDisclosureChanged(changedChats);
+    const notifyResult = await notifyDisclosureChanged(changedChats);
+    if (Result.isError(notifyResult)) {
+      deps.disclosureStore.restore([cached.chatId], cached.sessionKey, {
+        operatorId: disclosureActorId,
+        expiresAt: cached.elevation.expiresAt,
+      });
+      const rollbackResult = await notifyDisclosureChanged([cached.chatId], {
+        includeExpired: true,
+      });
+      if (Result.isError(rollbackResult)) {
+        return Result.err(
+          InternalError.create(
+            "Failed to roll back expired admin read disclosure refresh",
+            {
+              reason: notifyResult.error.message,
+              category: notifyResult.error.category,
+              rollbackReason: rollbackResult.error.message,
+              rollbackCategory: rollbackResult.error.category,
+            },
+          ),
+        );
+      }
+      return notifyResult;
+    }
+    return Result.ok(undefined);
   }
 
   async function expireCachedElevation(

--- a/packages/cli/src/admin/read-elevation.ts
+++ b/packages/cli/src/admin/read-elevation.ts
@@ -48,6 +48,8 @@ export interface AdminReadElevationManagerDeps {
   readonly disclosureStore?: AdminReadDisclosureStore;
   readonly onDisclosureChanged?: AdminReadElevationDisclosureChangeHandler;
   readonly disclosureActorId?: AdminReadDisclosure["operatorId"];
+  readonly normalizeChatId?: (chatId: string) => string;
+  readonly setTimeoutFn?: typeof setTimeout;
   readonly ttlMs?: number;
   readonly now?: () => Date;
 }
@@ -90,6 +92,8 @@ export function createAdminReadElevationManager(
 ): AdminReadElevationManager {
   const ttlMs = deps.ttlMs ?? DEFAULT_READ_ELEVATION_TTL_MS;
   const now = deps.now ?? (() => new Date());
+  const normalizeChatId = deps.normalizeChatId ?? ((chatId: string) => chatId);
+  const setTimeoutFn = deps.setTimeoutFn ?? setTimeout;
   const cache = new Map<string, CachedElevation>();
   const expirationTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const disclosureActorId = deps.disclosureActorId ?? "owner";
@@ -273,9 +277,15 @@ export function createAdminReadElevationManager(
       0,
       Date.parse(cached.elevation.expiresAt) - now().getTime(),
     );
-    const timer = setTimeout(() => {
+    const timer = setTimeoutFn(() => {
       void expireCachedElevation(cached);
     }, delayMs);
+    if (typeof timer === "object" && timer !== null && "unref" in timer) {
+      const unref = timer.unref;
+      if (typeof unref === "function") {
+        unref.call(timer);
+      }
+    }
     expirationTimers.set(cacheKey, timer);
   }
 
@@ -294,8 +304,9 @@ export function createAdminReadElevationManager(
       if (chatId === null) {
         return Result.ok(undefined);
       }
+      const canonicalChatId = normalizeChatId(chatId);
 
-      const cacheKey = buildCacheKey(input.sessionKey, chatId);
+      const cacheKey = buildCacheKey(input.sessionKey, canonicalChatId);
       const cached = cache.get(cacheKey);
       const nowMs = now().getTime();
 
@@ -305,7 +316,7 @@ export function createAdminReadElevationManager(
           const reuseAudit = await appendReuseAudit(
             input,
             cached.elevation,
-            chatId,
+            canonicalChatId,
           );
           if (Result.isError(reuseAudit)) {
             return reuseAudit;
@@ -333,7 +344,7 @@ export function createAdminReadElevationManager(
         const auditResult = await appendAudit({
           action: "admin.read-elevation.denied",
           success: false,
-          target: chatId,
+          target: canonicalChatId,
           detail: {
             method: input.method,
             adminKeyFingerprint: input.adminFingerprint,
@@ -356,14 +367,14 @@ export function createAdminReadElevationManager(
       const approvedAt = now();
       const elevation: AdminReadElevationType = {
         approvalId: `approval_${crypto.randomUUID().replaceAll("-", "")}`,
-        scope: { chatIds: [chatId] },
+        scope: { chatIds: [canonicalChatId] },
         approvedAt: approvedAt.toISOString(),
         expiresAt: new Date(approvedAt.getTime() + ttlMs).toISOString(),
         approvalKeyFingerprint: fingerprintResult.value,
       };
       const nextCached: CachedElevation = {
         elevation,
-        chatId,
+        chatId: canonicalChatId,
         sessionKey: input.sessionKey,
       };
 
@@ -372,7 +383,7 @@ export function createAdminReadElevationManager(
         const auditResult = await appendAudit({
           action: "admin.read-elevation.disclosure-refresh-failed",
           success: false,
-          target: chatId,
+          target: canonicalChatId,
           detail: {
             method: input.method,
             adminKeyFingerprint: input.adminFingerprint,
@@ -395,7 +406,7 @@ export function createAdminReadElevationManager(
       const auditResult = await appendAudit({
         action: "admin.read-elevation.approved",
         success: true,
-        target: chatId,
+        target: canonicalChatId,
         detail: {
           method: input.method,
           adminKeyFingerprint: input.adminFingerprint,

--- a/packages/cli/src/admin/read-elevation.ts
+++ b/packages/cli/src/admin/read-elevation.ts
@@ -61,7 +61,11 @@ interface CachedElevation {
 }
 
 function isMessageReadMethod(method: string): boolean {
-  return method === "message.list" || method === "message.info";
+  return (
+    method === "message.list" ||
+    method === "message.info" ||
+    method === "search.messages"
+  );
 }
 
 function wantsDangerousMessageRead(params: Record<string, unknown>): boolean {
@@ -232,6 +236,7 @@ export function createAdminReadElevationManager(
     cache.delete(cacheKey);
     clearExpirationTimer(cacheKey);
 
+    const disclosureResult = await syncDisclosureExpiry(cached);
     const expiredAudit = await appendExpiredAudit(
       input ?? {
         method: "message.list",
@@ -242,11 +247,7 @@ export function createAdminReadElevationManager(
       cached.elevation,
       cached.chatId,
     );
-    if (Result.isError(expiredAudit)) {
-      return expiredAudit;
-    }
 
-    const disclosureResult = await syncDisclosureExpiry(cached);
     if (Result.isError(disclosureResult)) {
       const auditResult = await appendAudit({
         action: "admin.read-elevation.disclosure-refresh-failed",
@@ -264,6 +265,10 @@ export function createAdminReadElevationManager(
         return auditResult;
       }
       return disclosureResult;
+    }
+
+    if (Result.isError(expiredAudit)) {
+      return expiredAudit;
     }
 
     return Result.ok(undefined);
@@ -400,9 +405,6 @@ export function createAdminReadElevationManager(
         return disclosureResult;
       }
 
-      cache.set(cacheKey, nextCached);
-      scheduleExpiration(nextCached);
-
       const auditResult = await appendAudit({
         action: "admin.read-elevation.approved",
         success: true,
@@ -417,8 +419,15 @@ export function createAdminReadElevationManager(
         },
       });
       if (Result.isError(auditResult)) {
+        const rollbackResult = await syncDisclosureExpiry(nextCached);
+        if (Result.isError(rollbackResult)) {
+          return rollbackResult;
+        }
         return auditResult;
       }
+
+      cache.set(cacheKey, nextCached);
+      scheduleExpiration(nextCached);
 
       return Result.ok(elevation);
     },

--- a/packages/cli/src/admin/read-elevation.ts
+++ b/packages/cli/src/admin/read-elevation.ts
@@ -207,7 +207,24 @@ export function createAdminReadElevationManager(
 
     const notifyResult = await notifyDisclosureChanged(changedChats);
     if (Result.isError(notifyResult)) {
-      deps.disclosureStore.delete([cached.chatId], cached.sessionKey);
+      const rollbackChats = deps.disclosureStore.delete(
+        [cached.chatId],
+        cached.sessionKey,
+      );
+      const rollbackResult = await notifyDisclosureChanged(rollbackChats);
+      if (Result.isError(rollbackResult)) {
+        return Result.err(
+          InternalError.create(
+            "Failed to roll back admin read disclosure refresh",
+            {
+              reason: notifyResult.error.message,
+              category: notifyResult.error.category,
+              rollbackReason: rollbackResult.error.message,
+              rollbackCategory: rollbackResult.error.category,
+            },
+          ),
+        );
+      }
       return notifyResult;
     }
 

--- a/packages/cli/src/admin/server.ts
+++ b/packages/cli/src/admin/server.ts
@@ -13,8 +13,14 @@ import {
   type AdminJwtPayload,
 } from "./protocol.js";
 import type { AdminServerConfig } from "../config/schema.js";
+import type { AuditLog } from "../audit/log.js";
 import { existsSync, unlinkSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
+import {
+  createAdminReadElevationManager,
+  type AdminReadElevationApprover,
+  type AdminReadElevationManager,
+} from "./read-elevation.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -44,6 +50,9 @@ export interface AdminServerDeps {
   readonly dispatcher: AdminDispatcher;
   readonly signetId: string;
   readonly signerProvider: HandlerContext["signerProvider"];
+  readonly readElevationManager?: AdminReadElevationManager;
+  readonly readElevationApprover?: AdminReadElevationApprover;
+  readonly auditLog?: AuditLog;
 }
 
 // ---------------------------------------------------------------------------
@@ -53,7 +62,23 @@ export interface AdminServerDeps {
 interface ConnectionState {
   authenticated: boolean;
   adminFingerprint: string | null;
+  adminSessionKey: string | null;
   buffer: string;
+}
+
+function jsonRpcCodeForCategory(category: string): number {
+  switch (category) {
+    case "validation":
+      return JSON_RPC_ERRORS.INVALID_PARAMS;
+    case "auth":
+      return JSON_RPC_ERRORS.AUTH_FAILED;
+    case "permission":
+      return JSON_RPC_ERRORS.PERMISSION_DENIED;
+    case "not_found":
+      return JSON_RPC_ERRORS.NOT_FOUND;
+    default:
+      return JSON_RPC_ERRORS.INTERNAL_ERROR;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -72,6 +97,14 @@ export function createAdminServer(
   let serverState: "idle" | "listening" | "stopped" = "idle";
   let listener: ReturnType<typeof Bun.listen> | undefined;
   const socketPath = config.socketPath ?? "/tmp/xmtp-signet/admin.sock";
+  const readElevationManager =
+    deps.readElevationManager ??
+    createAdminReadElevationManager({
+      ...(deps.readElevationApprover
+        ? { approver: deps.readElevationApprover }
+        : {}),
+      ...(deps.auditLog ? { auditLog: deps.auditLog } : {}),
+    });
 
   const connectionStates = new WeakMap<object, ConnectionState>();
 
@@ -81,6 +114,7 @@ export function createAdminServer(
       state = {
         authenticated: false,
         adminFingerprint: null,
+        adminSessionKey: null,
         buffer: "",
       };
       connectionStates.set(socket, state);
@@ -112,13 +146,17 @@ export function createAdminServer(
     );
   }
 
-  function makeHandlerContext(fingerprint: string): HandlerContext {
+  function makeHandlerContext(
+    fingerprint: string,
+    adminReadElevation?: HandlerContext["adminReadElevation"],
+  ): HandlerContext {
     return {
       signetId: deps.signetId,
       signerProvider: deps.signerProvider,
       requestId: crypto.randomUUID(),
       signal: AbortSignal.timeout(30_000),
       adminAuth: { adminKeyFingerprint: fingerprint },
+      ...(adminReadElevation !== undefined ? { adminReadElevation } : {}),
     };
   }
 
@@ -167,6 +205,7 @@ export function createAdminServer(
 
       connState.authenticated = true;
       connState.adminFingerprint = verifyResult.value.iss;
+      connState.adminSessionKey = `${verifyResult.value.iss}:${verifyResult.value.jti}`;
       // Send auth success acknowledgment
       socket.write(
         JSON.stringify({ jsonrpc: "2.0", result: { authenticated: true } }) +
@@ -200,7 +239,28 @@ export function createAdminServer(
       return;
     }
 
-    const ctx = makeHandlerContext(connState.adminFingerprint ?? "");
+    const elevationResult = await readElevationManager.resolveForRequest({
+      method: request.method,
+      params: request.params,
+      adminFingerprint: connState.adminFingerprint ?? "",
+      sessionKey: connState.adminSessionKey ?? connState.adminFingerprint ?? "",
+    });
+    if (Result.isError(elevationResult)) {
+      socket.write(
+        makeJsonRpcError(
+          request.id,
+          jsonRpcCodeForCategory(elevationResult.error.category),
+          elevationResult.error.message,
+          elevationResult.error,
+        ),
+      );
+      return;
+    }
+
+    const ctx = makeHandlerContext(
+      connState.adminFingerprint ?? "",
+      elevationResult.value,
+    );
 
     const actionResult = await deps.dispatcher.dispatch(
       request.method,
@@ -211,16 +271,7 @@ export function createAdminServer(
     if (actionResult.ok) {
       socket.write(makeJsonRpcSuccess(request.id, actionResult));
     } else {
-      const errorCode =
-        actionResult.error.category === "validation"
-          ? JSON_RPC_ERRORS.INVALID_PARAMS
-          : actionResult.error.category === "auth"
-            ? JSON_RPC_ERRORS.AUTH_FAILED
-            : actionResult.error.category === "permission"
-              ? JSON_RPC_ERRORS.PERMISSION_DENIED
-              : actionResult.error.category === "not_found"
-                ? JSON_RPC_ERRORS.NOT_FOUND
-                : JSON_RPC_ERRORS.INTERNAL_ERROR;
+      const errorCode = jsonRpcCodeForCategory(actionResult.error.category);
 
       socket.write(
         makeJsonRpcError(

--- a/packages/cli/src/admin/server.ts
+++ b/packages/cli/src/admin/server.ts
@@ -239,9 +239,25 @@ export function createAdminServer(
       return;
     }
 
+    const paramsResult = deps.dispatcher.validate(
+      request.method,
+      request.params,
+    );
+    if (Result.isError(paramsResult)) {
+      socket.write(
+        makeJsonRpcError(
+          request.id,
+          jsonRpcCodeForCategory(paramsResult.error.category),
+          paramsResult.error.message,
+          paramsResult.error,
+        ),
+      );
+      return;
+    }
+
     const elevationResult = await readElevationManager.resolveForRequest({
       method: request.method,
-      params: request.params,
+      params: paramsResult.value,
       adminFingerprint: connState.adminFingerprint ?? "",
       sessionKey: connState.adminSessionKey ?? connState.adminFingerprint ?? "",
     });
@@ -262,9 +278,9 @@ export function createAdminServer(
       elevationResult.value,
     );
 
-    const actionResult = await deps.dispatcher.dispatch(
+    const actionResult = await deps.dispatcher.dispatchValidated(
       request.method,
-      request.params,
+      paramsResult.value,
       ctx,
     );
 

--- a/packages/cli/src/admin/server.ts
+++ b/packages/cli/src/admin/server.ts
@@ -81,6 +81,24 @@ function jsonRpcCodeForCategory(category: string): number {
   }
 }
 
+function mergeTransportControls(
+  rawParams: Record<string, unknown>,
+  validatedParams: Record<string, unknown>,
+): Record<string, unknown> {
+  const dangerousMessageReadFlag = rawParams["dangerouslyAllowMessageRead"];
+  if (
+    dangerousMessageReadFlag !== true &&
+    dangerousMessageReadFlag !== "true"
+  ) {
+    return validatedParams;
+  }
+
+  return {
+    ...validatedParams,
+    dangerouslyAllowMessageRead: dangerousMessageReadFlag,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Implementation
 // ---------------------------------------------------------------------------
@@ -257,7 +275,7 @@ export function createAdminServer(
 
     const elevationResult = await readElevationManager.resolveForRequest({
       method: request.method,
-      params: paramsResult.value,
+      params: mergeTransportControls(request.params, paramsResult.value),
       adminFingerprint: connState.adminFingerprint ?? "",
       sessionKey: connState.adminSessionKey ?? connState.adminFingerprint ?? "",
     });

--- a/packages/cli/src/commands/xs-message.ts
+++ b/packages/cli/src/commands/xs-message.ts
@@ -231,6 +231,10 @@ export function createMessageCommands(
     .option("--config <path>", "Path to config file")
     .requiredOption("--from <chat>", "Conversation ID")
     .option("--as <inbox>", "Inbox ID to act as")
+    .option(
+      "--dangerously-allow-message-read",
+      "Request a locally approved admin read elevation for this command",
+    )
     .option("--watch", "Watch for new messages")
     .option("--json", "JSON output")
     .action(
@@ -238,12 +242,16 @@ export function createMessageCommands(
         config?: string;
         from: string;
         as?: string;
+        dangerouslyAllowMessageRead?: true;
         watch?: true;
         json?: true;
       }) => {
         const json = opts.json === true;
         const payload: Record<string, unknown> = { chatId: opts.from };
         if (opts.as !== undefined) payload["identityLabel"] = opts.as;
+        if (opts.dangerouslyAllowMessageRead === true) {
+          payload["dangerouslyAllowMessageRead"] = true;
+        }
 
         const result = await resolvedDeps.withDaemonClient(
           { configPath: opts.config },
@@ -266,11 +274,21 @@ export function createMessageCommands(
     .option("--config <path>", "Path to config file")
     .requiredOption("--chat <id>", "Conversation ID")
     .option("--as <inbox>", "Inbox ID to act as")
+    .option(
+      "--dangerously-allow-message-read",
+      "Request a locally approved admin read elevation for this command",
+    )
     .option("--json", "JSON output")
     .action(
       async (
         msgId: string,
-        opts: { config?: string; chat: string; as?: string; json?: true },
+        opts: {
+          config?: string;
+          chat: string;
+          as?: string;
+          dangerouslyAllowMessageRead?: true;
+          json?: true;
+        },
       ) => {
         const json = opts.json === true;
         const payload: Record<string, unknown> = {
@@ -278,6 +296,9 @@ export function createMessageCommands(
           messageId: msgId,
         };
         if (opts.as !== undefined) payload["identityLabel"] = opts.as;
+        if (opts.dangerouslyAllowMessageRead === true) {
+          payload["dangerouslyAllowMessageRead"] = true;
+        }
 
         const result = await resolvedDeps.withDaemonClient(
           { configPath: opts.config },

--- a/packages/cli/src/commands/xs-utility.ts
+++ b/packages/cli/src/commands/xs-utility.ts
@@ -10,6 +10,7 @@
 
 import { Command, Option } from "commander";
 import { Result } from "better-result";
+import type { SignetError } from "@xmtp/signet-schemas";
 import type { AuditEntry } from "../audit/log.js";
 import { formatOutput } from "../output/formatter.js";
 import { exitCodeFromCategory } from "../output/exit-codes.js";
@@ -18,23 +19,127 @@ import {
   type WithDaemonClient,
 } from "./daemon-client.js";
 
-/** Stub action output for commands not yet wired to the daemon. */
-function stubOutput(
-  action: string,
-  params: Record<string, unknown>,
-  json: boolean,
-): string {
-  return formatOutput({ action, ...params }, { json }) + "\n";
-}
-
 /** Dependencies for utility commands. */
 export interface XsUtilityCommandDeps {
   readonly withDaemonClient: WithDaemonClient;
+  readonly writeStdout: (message: string) => void;
+  readonly writeStderr: (message: string) => void;
+  readonly exit: (code: number) => void;
 }
 
 const defaultUtilityDeps: XsUtilityCommandDeps = {
   withDaemonClient: createWithDaemonClient(),
+  writeStdout(message) {
+    process.stdout.write(message);
+  },
+  writeStderr(message) {
+    process.stderr.write(message);
+  },
+  exit(code) {
+    process.exit(code);
+  },
 };
+
+interface LookupResolveResult {
+  readonly query: string;
+  readonly found: boolean;
+  readonly mapping: {
+    readonly localId: string;
+    readonly networkId: string;
+  } | null;
+  readonly inbox: {
+    readonly id: string;
+    readonly label: string | null;
+    readonly networkInboxId: string | null;
+    readonly groupId: string | null;
+    readonly createdAt: string;
+  } | null;
+  readonly operator: {
+    readonly id: string;
+    readonly label: string;
+    readonly role: string;
+    readonly status: string;
+  } | null;
+  readonly policy: {
+    readonly id: string;
+    readonly label: string;
+    readonly updatedAt: string;
+  } | null;
+  readonly credential: {
+    readonly id: string;
+    readonly operatorId: string;
+    readonly policyId: string | null;
+    readonly chatIds: readonly string[];
+    readonly status: string;
+    readonly expiresAt: string;
+  } | null;
+}
+
+function writeError(
+  deps: XsUtilityCommandDeps,
+  error: SignetError,
+  json: boolean,
+): void {
+  deps.writeStderr(
+    formatOutput(
+      {
+        error: error._tag,
+        category: error.category,
+        message: error.message,
+        ...(error.context !== null ? { context: error.context } : {}),
+      },
+      { json },
+    ) + "\n",
+  );
+  deps.exit(exitCodeFromCategory(error.category));
+}
+
+function formatLookupResult(result: LookupResolveResult): string {
+  if (!result.found) {
+    return `No local match found for "${result.query}".`;
+  }
+
+  const lines = [`Query: ${result.query}`];
+
+  if (result.mapping) {
+    lines.push(`Local ID: ${result.mapping.localId}`);
+    lines.push(`Network ID: ${result.mapping.networkId}`);
+  }
+
+  if (result.inbox) {
+    lines.push(
+      `Inbox: ${result.inbox.id}${result.inbox.label ? ` (${result.inbox.label})` : ""}`,
+    );
+    if (result.inbox.networkInboxId) {
+      lines.push(`Inbox Network ID: ${result.inbox.networkInboxId}`);
+    }
+    if (result.inbox.groupId) {
+      lines.push(`Bound Group: ${result.inbox.groupId}`);
+    }
+  }
+
+  if (result.operator) {
+    lines.push(
+      `Operator: ${result.operator.id} (${result.operator.label}) role=${result.operator.role} status=${result.operator.status}`,
+    );
+  }
+
+  if (result.policy) {
+    lines.push(`Policy: ${result.policy.id} (${result.policy.label})`);
+  }
+
+  if (result.credential) {
+    lines.push(
+      `Credential: ${result.credential.id} operator=${result.credential.operatorId} status=${result.credential.status}`,
+    );
+    if (result.credential.policyId) {
+      lines.push(`Credential Policy: ${result.credential.policyId}`);
+    }
+    lines.push(`Credential Chats: ${result.credential.chatIds.join(", ")}`);
+  }
+
+  return lines.join("\n");
+}
 
 /**
  * Create utility commands for the top-level program.
@@ -45,7 +150,11 @@ const defaultUtilityDeps: XsUtilityCommandDeps = {
 export function createUtilityCommands(
   deps: Partial<XsUtilityCommandDeps> = {},
 ): Command[] {
-  const { withDaemonClient } = { ...defaultUtilityDeps, ...deps };
+  const resolvedDeps: XsUtilityCommandDeps = {
+    ...defaultUtilityDeps,
+    ...deps,
+  };
+  const { withDaemonClient } = resolvedDeps;
   const commands: Command[] = [];
 
   // --- logs ---
@@ -77,18 +186,16 @@ export function createUtilityCommands(
         );
 
         if (Result.isError(result)) {
-          process.stderr.write(
-            formatOutput({ error: result.error.message }, { json }) + "\n",
-          );
-          process.exit(exitCodeFromCategory(result.error.category));
+          writeError(resolvedDeps, result.error, json);
+          return;
         }
 
         if (json) {
-          process.stdout.write(formatOutput(result.value, { json }) + "\n");
+          resolvedDeps.writeStdout(formatOutput(result.value, { json }) + "\n");
         } else {
           for (const entry of result.value) {
             const line = `${entry.timestamp} [${entry.actor}] ${entry.action}${entry.success ? "" : " FAILED"}${entry.target !== undefined ? ` target=${entry.target}` : ""}`;
-            process.stdout.write(line + "\n");
+            resolvedDeps.writeStdout(line + "\n");
           }
         }
       },
@@ -105,15 +212,13 @@ export function createUtilityCommands(
       );
 
       if (Result.isError(result)) {
-        process.stderr.write(
-          formatOutput({ error: result.error.message }, { json: true }) + "\n",
-        );
-        process.exit(exitCodeFromCategory(result.error.category));
+        writeError(resolvedDeps, result.error, true);
+        return;
       }
 
       // NDJSON: one JSON object per line
       for (const entry of result.value) {
-        process.stdout.write(JSON.stringify(entry) + "\n");
+        resolvedDeps.writeStdout(JSON.stringify(entry) + "\n");
       }
     });
   commands.push(logs);
@@ -121,13 +226,29 @@ export function createUtilityCommands(
   // --- lookup ---
 
   const lookup = new Command("lookup")
-    .description("Look up an address or ID")
-    .argument("<address>", "Address or ID to look up")
+    .description("Resolve a local or network identifier")
+    .argument("<query>", "Address, label, or ID to look up")
+    .option("--config <path>", "Path to config file")
     .option("--json", "JSON output")
-    .action((address: string, opts: { json?: true }) => {
-      process.stdout.write(
-        stubOutput("lookup", { address }, opts.json === true),
+    .action(async (query: string, opts: { config?: string; json?: true }) => {
+      const json = opts.json === true;
+      const result = await withDaemonClient(
+        { configPath: opts.config },
+        async (client) =>
+          client.request<LookupResolveResult>("lookup.resolve", { query }),
       );
+
+      if (Result.isError(result)) {
+        writeError(resolvedDeps, result.error, json);
+        return;
+      }
+
+      if (json) {
+        resolvedDeps.writeStdout(formatOutput(result.value, { json }) + "\n");
+        return;
+      }
+
+      resolvedDeps.writeStdout(formatLookupResult(result.value) + "\n");
     });
   commands.push(lookup);
 
@@ -199,22 +320,24 @@ export function createUtilityCommands(
           );
 
           if (Result.isError(result)) {
-            process.stderr.write(
-              formatOutput({ error: result.error.message }, { json }) + "\n",
-            );
-            process.exit(exitCodeFromCategory(result.error.category));
+            writeError(resolvedDeps, result.error, json);
+            return;
           }
 
           if (json) {
-            process.stdout.write(formatOutput(result.value, { json }) + "\n");
+            resolvedDeps.writeStdout(
+              formatOutput(result.value, { json }) + "\n",
+            );
           } else {
             if (result.value.matches.length === 0) {
-              process.stdout.write("No resources found.\n");
+              resolvedDeps.writeStdout("No resources found.\n");
             } else {
               for (const hit of result.value.matches) {
-                process.stdout.write(`[${hit.type}] ${hit.id}  ${hit.label}\n`);
+                resolvedDeps.writeStdout(
+                  `[${hit.type}] ${hit.id}  ${hit.label}\n`,
+                );
               }
-              process.stdout.write(`\n${result.value.total} result(s)\n`);
+              resolvedDeps.writeStdout(`\n${result.value.total} result(s)\n`);
             }
           }
         } else {
@@ -243,17 +366,17 @@ export function createUtilityCommands(
           );
 
           if (Result.isError(result)) {
-            process.stderr.write(
-              formatOutput({ error: result.error.message }, { json }) + "\n",
-            );
-            process.exit(exitCodeFromCategory(result.error.category));
+            writeError(resolvedDeps, result.error, json);
+            return;
           }
 
           if (json) {
-            process.stdout.write(formatOutput(result.value, { json }) + "\n");
+            resolvedDeps.writeStdout(
+              formatOutput(result.value, { json }) + "\n",
+            );
           } else {
             if (result.value.matches.length === 0) {
-              process.stdout.write("No messages found.\n");
+              resolvedDeps.writeStdout("No messages found.\n");
             } else {
               for (const hit of result.value.matches) {
                 const ts = hit.sentAt;
@@ -261,11 +384,11 @@ export function createUtilityCommands(
                   hit.content.length > 80
                     ? hit.content.slice(0, 80) + "..."
                     : hit.content;
-                process.stdout.write(
+                resolvedDeps.writeStdout(
                   `${ts} [${hit.chatId}] ${hit.senderInboxId}: ${preview}\n`,
                 );
               }
-              process.stdout.write(`\n${result.value.total} result(s)\n`);
+              resolvedDeps.writeStdout(`\n${result.value.total} result(s)\n`);
             }
           }
         }
@@ -306,13 +429,11 @@ export function createUtilityCommands(
         );
 
         if (Result.isError(result)) {
-          process.stderr.write(
-            formatOutput({ error: result.error.message }, { json }) + "\n",
-          );
-          process.exit(exitCodeFromCategory(result.error.category));
+          writeError(resolvedDeps, result.error, json);
+          return;
         }
 
-        process.stdout.write(formatOutput(result.value, { json }) + "\n");
+        resolvedDeps.writeStdout(formatOutput(result.value, { json }) + "\n");
       },
     );
 
@@ -345,13 +466,11 @@ export function createUtilityCommands(
         );
 
         if (Result.isError(result)) {
-          process.stderr.write(
-            formatOutput({ error: result.error.message }, { json }) + "\n",
-          );
-          process.exit(exitCodeFromCategory(result.error.category));
+          writeError(resolvedDeps, result.error, json);
+          return;
         }
 
-        process.stdout.write(formatOutput(result.value, { json }) + "\n");
+        resolvedDeps.writeStdout(formatOutput(result.value, { json }) + "\n");
       },
     );
 
@@ -384,13 +503,11 @@ export function createUtilityCommands(
         );
 
         if (Result.isError(result)) {
-          process.stderr.write(
-            formatOutput({ error: result.error.message }, { json }) + "\n",
-          );
-          process.exit(exitCodeFromCategory(result.error.category));
+          writeError(resolvedDeps, result.error, json);
+          return;
         }
 
-        process.stdout.write(formatOutput(result.value, { json }) + "\n");
+        resolvedDeps.writeStdout(formatOutput(result.value, { json }) + "\n");
       },
     );
 

--- a/packages/cli/src/commands/xs-utility.ts
+++ b/packages/cli/src/commands/xs-utility.ts
@@ -270,6 +270,10 @@ export function createUtilityCommands(
     .addOption(searchTypeOption)
     .option("--limit <n>", "Limit results")
     .option("--as <label>", "Identity label for message search")
+    .option(
+      "--dangerously-allow-message-read",
+      "Request a locally approved admin read elevation for message search",
+    )
     .option("--config <path>", "Path to config file")
     .option("--json", "JSON output")
     .action(
@@ -280,6 +284,7 @@ export function createUtilityCommands(
           type?: string;
           limit?: string;
           as?: string;
+          dangerouslyAllowMessageRead?: true;
           config?: string;
           json?: true;
         },
@@ -348,6 +353,9 @@ export function createUtilityCommands(
             input["limit"] = Number.parseInt(opts.limit, 10);
           }
           if (opts.as !== undefined) input["identityLabel"] = opts.as;
+          if (opts.dangerouslyAllowMessageRead === true) {
+            input["dangerouslyAllowMessageRead"] = true;
+          }
 
           const result = await withDaemonClient(
             { configPath: opts.config },

--- a/packages/cli/src/http/server.ts
+++ b/packages/cli/src/http/server.ts
@@ -15,6 +15,12 @@ import {
   matchHttpActionRoute,
   type HttpActionRoute,
 } from "./action-routes.js";
+import type { AuditLog } from "../audit/log.js";
+import {
+  createAdminReadElevationManager,
+  type AdminReadElevationApprover,
+  type AdminReadElevationManager,
+} from "../admin/read-elevation.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -36,6 +42,9 @@ export interface HttpServerDeps {
   readonly verifyAdminJwt: (
     token: string,
   ) => Promise<Result<AdminJwtPayload, SignetError>>;
+  readonly readElevationManager?: AdminReadElevationManager;
+  readonly readElevationApprover?: AdminReadElevationApprover;
+  readonly auditLog?: AuditLog;
   readonly status: () => unknown | Promise<unknown>;
 }
 
@@ -115,10 +124,19 @@ export function createHttpServer(
   let serverState: "idle" | "listening" | "stopped" = "idle";
   let bunServer: ReturnType<typeof Bun.serve> | undefined;
   let actionRoutes: readonly HttpActionRoute[] = [];
+  const readElevationManager =
+    deps.readElevationManager ??
+    createAdminReadElevationManager({
+      ...(deps.readElevationApprover
+        ? { approver: deps.readElevationApprover }
+        : {}),
+      ...(deps.auditLog ? { auditLog: deps.auditLog } : {}),
+    });
 
   function makeHandlerContext(options?: {
     adminAuth?: { adminKeyFingerprint: string };
     credential?: Pick<CredentialRecord, "credentialId" | "operatorId">;
+    adminReadElevation?: HandlerContext["adminReadElevation"];
   }): HandlerContext {
     const base: HandlerContext = {
       signetId: deps.signetId,
@@ -134,6 +152,9 @@ export function createHttpServer(
             credentialId: options.credential.credentialId,
             operatorId: options.credential.operatorId,
           }
+        : {}),
+      ...(options?.adminReadElevation
+        ? { adminReadElevation: options.adminReadElevation }
         : {}),
     };
   }
@@ -193,10 +214,25 @@ export function createHttpServer(
       return errorResponse("validation", "Invalid JSON body", null);
     }
 
+    const elevationResult = await readElevationManager.resolveForRequest({
+      method,
+      params,
+      adminFingerprint: verifyResult.value.iss,
+      sessionKey: `${verifyResult.value.iss}:${verifyResult.value.jti}`,
+    });
+    if (Result.isError(elevationResult)) {
+      return errorResponse(
+        elevationResult.error.category,
+        elevationResult.error.message,
+        elevationResult.error.context ?? null,
+      );
+    }
+
     const ctx = makeHandlerContext({
       adminAuth: {
         adminKeyFingerprint: verifyResult.value.iss,
       },
+      adminReadElevation: elevationResult.value,
     });
 
     const actionResult = await deps.dispatcher.dispatch(method, params, ctx);
@@ -272,38 +308,6 @@ export function createHttpServer(
       );
     }
 
-    let ctx: HandlerContext;
-
-    if (route.auth === "admin") {
-      const verifyResult = await deps.verifyAdminJwt(token);
-      if (Result.isError(verifyResult)) {
-        return errorResponse(
-          "auth",
-          verifyResult.error.message,
-          verifyResult.error.context ?? null,
-        );
-      }
-
-      ctx = makeHandlerContext({
-        adminAuth: {
-          adminKeyFingerprint: verifyResult.value.iss,
-        },
-      });
-    } else {
-      const credentialResult =
-        await deps.credentialManager.lookupByToken(token);
-      if (!credentialResult.isOk()) {
-        return errorResponse("auth", "Invalid credential token", null);
-      }
-
-      ctx = makeHandlerContext({
-        credential: {
-          credentialId: credentialResult.value.credentialId,
-          operatorId: credentialResult.value.operatorId,
-        },
-      });
-    }
-
     const paramsResult = await parseActionParams(req, route.inputSource);
     if (!paramsResult.isOk()) {
       return errorResponse(
@@ -327,6 +331,70 @@ export function createHttpServer(
         error.context ?? null,
       );
     }
+
+    if (route.auth === "admin") {
+      const verifyResult = await deps.verifyAdminJwt(token);
+      if (Result.isError(verifyResult)) {
+        return errorResponse(
+          "auth",
+          verifyResult.error.message,
+          verifyResult.error.context ?? null,
+        );
+      }
+
+      const elevationResult = await readElevationManager.resolveForRequest({
+        method: route.spec.id,
+        params: paramsResult.value,
+        adminFingerprint: verifyResult.value.iss,
+        sessionKey: `${verifyResult.value.iss}:${verifyResult.value.jti}`,
+      });
+      if (Result.isError(elevationResult)) {
+        return errorResponse(
+          elevationResult.error.category,
+          elevationResult.error.message,
+          elevationResult.error.context ?? null,
+        );
+      }
+
+      const ctx = makeHandlerContext({
+        adminAuth: {
+          adminKeyFingerprint: verifyResult.value.iss,
+        },
+        adminReadElevation: elevationResult.value,
+      });
+      try {
+        const result = await route.spec.handler(parseResult.data, ctx);
+        if (result.isOk()) {
+          return successResponse(result.value);
+        }
+
+        return errorResponse(
+          result.error.category,
+          result.error.message,
+          result.error.context ?? null,
+        );
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        const internalError = InternalError.create(`Handler threw: ${message}`);
+        return errorResponse(
+          internalError.category,
+          internalError.message,
+          internalError.context ?? null,
+        );
+      }
+    }
+
+    const credentialResult = await deps.credentialManager.lookupByToken(token);
+    if (!credentialResult.isOk()) {
+      return errorResponse("auth", "Invalid credential token", null);
+    }
+
+    const ctx = makeHandlerContext({
+      credential: {
+        credentialId: credentialResult.value.credentialId,
+        operatorId: credentialResult.value.operatorId,
+      },
+    });
 
     try {
       const result = await route.spec.handler(parseResult.data, ctx);

--- a/packages/cli/src/http/server.ts
+++ b/packages/cli/src/http/server.ts
@@ -214,9 +214,18 @@ export function createHttpServer(
       return errorResponse("validation", "Invalid JSON body", null);
     }
 
+    const paramsResult = deps.dispatcher.validate(method, params);
+    if (Result.isError(paramsResult)) {
+      return errorResponse(
+        paramsResult.error.category,
+        paramsResult.error.message,
+        paramsResult.error.context ?? null,
+      );
+    }
+
     const elevationResult = await readElevationManager.resolveForRequest({
       method,
-      params,
+      params: paramsResult.value,
       adminFingerprint: verifyResult.value.iss,
       sessionKey: `${verifyResult.value.iss}:${verifyResult.value.jti}`,
     });
@@ -235,7 +244,11 @@ export function createHttpServer(
       adminReadElevation: elevationResult.value,
     });
 
-    const actionResult = await deps.dispatcher.dispatch(method, params, ctx);
+    const actionResult = await deps.dispatcher.dispatchValidated(
+      method,
+      paramsResult.value,
+      ctx,
+    );
 
     if (actionResult.ok) {
       return successResponse(actionResult.data);

--- a/packages/cli/src/http/server.ts
+++ b/packages/cli/src/http/server.ts
@@ -308,30 +308,6 @@ export function createHttpServer(
       );
     }
 
-    const paramsResult = await parseActionParams(req, route.inputSource);
-    if (!paramsResult.isOk()) {
-      return errorResponse(
-        paramsResult.error.category,
-        paramsResult.error.message,
-        paramsResult.error.context ?? null,
-      );
-    }
-
-    const parseResult = route.spec.input.safeParse(paramsResult.value);
-    if (!parseResult.success) {
-      const firstIssue = parseResult.error.issues[0];
-      const field = firstIssue?.path.join(".") ?? "params";
-      const reason = firstIssue?.message ?? "Validation failed";
-      const error = ValidationError.create(field, reason, {
-        issues: parseResult.error.issues,
-      });
-      return errorResponse(
-        error.category,
-        error.message,
-        error.context ?? null,
-      );
-    }
-
     if (route.auth === "admin") {
       const verifyResult = await deps.verifyAdminJwt(token);
       if (Result.isError(verifyResult)) {
@@ -339,6 +315,30 @@ export function createHttpServer(
           "auth",
           verifyResult.error.message,
           verifyResult.error.context ?? null,
+        );
+      }
+
+      const paramsResult = await parseActionParams(req, route.inputSource);
+      if (!paramsResult.isOk()) {
+        return errorResponse(
+          paramsResult.error.category,
+          paramsResult.error.message,
+          paramsResult.error.context ?? null,
+        );
+      }
+
+      const parseResult = route.spec.input.safeParse(paramsResult.value);
+      if (!parseResult.success) {
+        const firstIssue = parseResult.error.issues[0];
+        const field = firstIssue?.path.join(".") ?? "params";
+        const reason = firstIssue?.message ?? "Validation failed";
+        const error = ValidationError.create(field, reason, {
+          issues: parseResult.error.issues,
+        });
+        return errorResponse(
+          error.category,
+          error.message,
+          error.context ?? null,
         );
       }
 
@@ -387,6 +387,30 @@ export function createHttpServer(
     const credentialResult = await deps.credentialManager.lookupByToken(token);
     if (!credentialResult.isOk()) {
       return errorResponse("auth", "Invalid credential token", null);
+    }
+
+    const paramsResult = await parseActionParams(req, route.inputSource);
+    if (!paramsResult.isOk()) {
+      return errorResponse(
+        paramsResult.error.category,
+        paramsResult.error.message,
+        paramsResult.error.context ?? null,
+      );
+    }
+
+    const parseResult = route.spec.input.safeParse(paramsResult.value);
+    if (!parseResult.success) {
+      const firstIssue = parseResult.error.issues[0];
+      const field = firstIssue?.path.join(".") ?? "params";
+      const reason = firstIssue?.message ?? "Validation failed";
+      const error = ValidationError.create(field, reason, {
+        issues: parseResult.error.issues,
+      });
+      return errorResponse(
+        error.category,
+        error.message,
+        error.context ?? null,
+      );
     }
 
     const ctx = makeHandlerContext({

--- a/packages/cli/src/http/server.ts
+++ b/packages/cli/src/http/server.ts
@@ -73,6 +73,24 @@ function categoryToStatus(category: string): number {
   return CATEGORY_STATUS[category] ?? 500;
 }
 
+function mergeTransportControls(
+  rawParams: Record<string, unknown>,
+  validatedParams: Record<string, unknown>,
+): Record<string, unknown> {
+  const dangerousMessageReadFlag = rawParams["dangerouslyAllowMessageRead"];
+  if (
+    dangerousMessageReadFlag !== true &&
+    dangerousMessageReadFlag !== "true"
+  ) {
+    return validatedParams;
+  }
+
+  return {
+    ...validatedParams,
+    dangerouslyAllowMessageRead: dangerousMessageReadFlag,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Response helpers
 // ---------------------------------------------------------------------------
@@ -225,7 +243,7 @@ export function createHttpServer(
 
     const elevationResult = await readElevationManager.resolveForRequest({
       method,
-      params: paramsResult.value,
+      params: mergeTransportControls(params, paramsResult.value),
       adminFingerprint: verifyResult.value.iss,
       sessionKey: `${verifyResult.value.iss}:${verifyResult.value.jti}`,
     });

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -33,6 +33,10 @@ import type { DaemonState } from "./daemon/lifecycle.js";
 import { createAdminDispatcher } from "./admin/dispatcher.js";
 import type { DaemonStatus } from "./daemon/status.js";
 import { createSignetActions } from "./actions/signet-actions.js";
+import {
+  createAdminReadElevationManager,
+  type AdminReadElevationManager,
+} from "./admin/read-elevation.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -91,6 +95,13 @@ export interface SignetRuntimeDeps {
 
   createHttpServer?: (config: unknown, deps: unknown) => HttpServer;
 
+  /** Optional factory for the shared admin read-elevation manager. */
+  createReadElevationManager?: (deps: {
+    keyManager: KeyManager;
+    sealManager: SealManager;
+    auditLog: AuditLog;
+  }) => AdminReadElevationManager;
+
   /** Optional factory for conversation action specs, wired in production by start.ts. */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   createConversationActions?: () => ActionSpec<any, any, SignetError>[];
@@ -107,6 +118,9 @@ export interface SignetRuntimeDeps {
 
   /** Optional factory for search action specs, wired in production by start.ts. */
   createSearchActions?: () => ActionSpec<unknown, unknown, SignetError>[];
+
+  /** Optional factory for lookup action specs, wired in production by start.ts. */
+  createLookupActions?: () => ActionSpec<unknown, unknown, SignetError>[];
 
   /** Optional factory for seal action specs, wired in production by start.ts. */
   createSealActions?: () => ActionSpec<unknown, unknown, SignetError>[];
@@ -202,6 +216,25 @@ export async function createSignetRuntime(
   );
 
   const auditLog = createAuditLog(paths.auditLog);
+  const readElevationManager = deps.createReadElevationManager
+    ? deps.createReadElevationManager({
+        keyManager,
+        sealManager,
+        auditLog,
+      })
+    : createAdminReadElevationManager({
+        approver: {
+          authorize: async () =>
+            keyManager.authorizeSensitiveOperation("adminReadElevation"),
+          getApprovalFingerprint: async () => {
+            const info = await keyManager.admin.get();
+            return Result.isError(info)
+              ? info
+              : Result.ok(info.value.fingerprint);
+          },
+        },
+        auditLog,
+      });
 
   // Admin handlers are admin-auth only and don't use the signer.
   // Provide a stub that returns InternalError if ever called.
@@ -420,6 +453,12 @@ export async function createSignetRuntime(
     }
   }
 
+  if (deps.createLookupActions) {
+    for (const spec of deps.createLookupActions()) {
+      registry.register(spec);
+    }
+  }
+
   if (deps.createSealActions) {
     for (const spec of deps.createSealActions()) {
       registry.register(spec);
@@ -438,6 +477,8 @@ export async function createSignetRuntime(
       dispatcher,
       signetId: "signet",
       signerProvider: adminSignerStub,
+      readElevationManager,
+      auditLog,
     },
   );
 
@@ -455,6 +496,8 @@ export async function createSignetRuntime(
         verifyAdminJwt: async (token: string) => {
           return keyManager.admin.verifyJwt(token);
         },
+        readElevationManager,
+        auditLog,
         status: async () => {
           if (runtimeRef === undefined) {
             return { state: "starting" };

--- a/packages/cli/src/seal-input-resolver.ts
+++ b/packages/cli/src/seal-input-resolver.ts
@@ -11,12 +11,16 @@ import type {
 } from "@xmtp/signet-contracts";
 import { checkChatInScope } from "@xmtp/signet-policy";
 import type { InputResolver } from "@xmtp/signet-seals";
+import type { AdminReadDisclosure } from "./admin/read-disclosure-store.js";
 
 /** Dependencies required to resolve real seal input from runtime state. */
 export interface CreateSealInputResolverDeps {
   readonly credentialManager: CredentialManager;
   readonly operatorManager: OperatorManager;
   readonly trustTier: TrustTierType;
+  readonly lookupAdminAccess?:
+    | ((chatId: string) => AdminReadDisclosure | undefined)
+    | undefined;
 }
 
 /**
@@ -82,12 +86,14 @@ export function createSealInputResolver(
     }
 
     const operatorDisclosures = op.config.operatorDisclosures;
+    const adminAccess = deps.lookupAdminAccess?.(chatId);
     return Result.ok({
       credentialId,
       operatorId: cred.config.operatorId,
       chatId,
       scopeMode: op.config.scopeMode,
       permissions,
+      ...(adminAccess !== undefined ? { adminAccess } : {}),
       trustTier: deps.trustTier,
       operatorDisclosures,
       provenanceMap: buildSealProvenanceMap({

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -29,6 +29,7 @@ import {
   createConsentActions,
   createConversationActions,
   createInboxActions as createInboxActionSpecs,
+  createLookupActions,
   createMessageActions,
   createSearchActions,
   createSqliteIdMappingStore,
@@ -62,6 +63,11 @@ import {
 import type { AdminServerConfig } from "./config/schema.js";
 import type { SignetRuntimeDeps } from "./runtime.js";
 import { createSealActions as createSealActionSpecs } from "./actions/seal-actions.js";
+import {
+  createAdminReadElevationManager,
+  type AdminReadElevationManager,
+} from "./admin/read-elevation.js";
+import { createAdminReadDisclosureStore } from "./admin/read-disclosure-store.js";
 import { createWsRequestHandler } from "./ws/request-handler.js";
 import { createLazyCoreUpgrade } from "./ws/core-upgrade.js";
 import { createEventProjector } from "./ws/event-projector.js";
@@ -117,6 +123,10 @@ export function createProductionDeps(): SignetRuntimeDeps {
   // Lazy-initialized ID mapping store for conv_ boundary
   let idMappingStoreRef: import("@xmtp/signet-schemas").IdMappingStore | null =
     null;
+  // Shared in-memory disclosure state for owner-approved admin message reads.
+  const readDisclosureStore = createAdminReadDisclosureStore();
+  // Late-bound shared elevation manager for admin socket + HTTP parity.
+  let readElevationManagerRef: AdminReadElevationManager | null = null;
   // In-memory invite tag store: groupId -> inviteTag (v1 single-process)
   const inviteTagStore = new Map<string, string>();
   // Track invite host listener unsubscribe for cleanup
@@ -373,6 +383,7 @@ export function createProductionDeps(): SignetRuntimeDeps {
         credentialManager: d.credentialManager,
         operatorManager: operatorManagerRef,
         trustTier: keyManagerRef?.trustTier ?? "unverified",
+        lookupAdminAccess: (chatId) => readDisclosureStore.get(chatId),
       });
 
       const sealManager = createSealManagerImpl({
@@ -382,6 +393,60 @@ export function createProductionDeps(): SignetRuntimeDeps {
       });
       globalSealManagerRef = sealManager;
       return sealManager;
+    },
+
+    createReadElevationManager(deps: unknown) {
+      const d = deps as {
+        keyManager: KeyManager;
+        sealManager: import("@xmtp/signet-contracts").SealManager;
+        auditLog: import("./audit/log.js").AuditLog;
+      };
+
+      const manager =
+        readElevationManagerRef ??
+        createAdminReadElevationManager({
+          approver: {
+            authorize: async () =>
+              d.keyManager.authorizeSensitiveOperation("adminReadElevation"),
+            getApprovalFingerprint: async () => {
+              const info = await d.keyManager.admin.get();
+              return Result.isError(info)
+                ? info
+                : Result.ok(info.value.fingerprint);
+            },
+          },
+          auditLog: d.auditLog,
+          disclosureStore: readDisclosureStore,
+          disclosureActorId: "owner",
+          onDisclosureChanged: async (chatIds) => {
+            const refreshedSealIds = new Set<string>();
+
+            for (const chatId of chatIds) {
+              const listResult = await d.sealManager.list({ chatId });
+              if (Result.isError(listResult)) {
+                return listResult;
+              }
+
+              for (const seal of listResult.value) {
+                const sealId = seal.chain.current.sealId;
+                if (refreshedSealIds.has(sealId)) {
+                  continue;
+                }
+                refreshedSealIds.add(sealId);
+
+                const refreshResult = await d.sealManager.refresh(sealId);
+                if (Result.isError(refreshResult)) {
+                  return refreshResult;
+                }
+              }
+            }
+
+            return Result.ok(undefined);
+          },
+        });
+
+      readElevationManagerRef = manager;
+      return manager;
     },
 
     createWsServer(config: unknown, deps: unknown): WsServer {
@@ -889,6 +954,30 @@ export function createProductionDeps(): SignetRuntimeDeps {
       };
 
       return createSearchActions(searchDeps);
+    },
+
+    createLookupActions() {
+      if (coreImplRef === null) {
+        throw new Error("SignetCoreImpl not initialized before lookup actions");
+      }
+
+      if (!idMappingStoreRef) {
+        const dbPath =
+          coreImplRef.config.dataDir === ":memory:"
+            ? ":memory:"
+            : `${coreImplRef.config.dataDir}/id-mappings.db`;
+        idMappingStoreRef = createSqliteIdMappingStore(new Database(dbPath));
+      }
+
+      return createLookupActions({
+        identityStore: coreImplRef.identityStore,
+        idMappings: idMappingStoreRef,
+        ...(operatorManagerRef ? { operatorManager: operatorManagerRef } : {}),
+        ...(policyManagerRef ? { policyManager: policyManagerRef } : {}),
+        ...(credentialManagerRef
+          ? { credentialManager: credentialManagerRef }
+          : {}),
+      });
     },
 
     async listIdentities() {

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -125,6 +125,9 @@ export function createProductionDeps(): SignetRuntimeDeps {
     null;
   // Shared in-memory disclosure state for owner-approved admin message reads.
   const readDisclosureStore = createAdminReadDisclosureStore();
+  // Chat IDs whose disclosure refresh is temporarily rolling back an expired
+  // adminAccess state after a partial seal refresh failure.
+  const rollbackDisclosureChatIds = new Set<string>();
   // Late-bound shared elevation manager for admin socket + HTTP parity.
   let readElevationManagerRef: AdminReadElevationManager | null = null;
   // In-memory invite tag store: groupId -> inviteTag (v1 single-process)
@@ -383,7 +386,10 @@ export function createProductionDeps(): SignetRuntimeDeps {
         credentialManager: d.credentialManager,
         operatorManager: operatorManagerRef,
         trustTier: keyManagerRef?.trustTier ?? "unverified",
-        lookupAdminAccess: (chatId) => readDisclosureStore.get(chatId),
+        lookupAdminAccess: (chatId) =>
+          rollbackDisclosureChatIds.has(chatId)
+            ? readDisclosureStore.peek(chatId)
+            : readDisclosureStore.get(chatId),
       });
 
       const sealManager = createSealManagerImpl({
@@ -420,30 +426,43 @@ export function createProductionDeps(): SignetRuntimeDeps {
           disclosureActorId: "owner",
           normalizeChatId: (chatId) =>
             idMappingStoreRef?.resolve(chatId)?.localId ?? chatId,
-          onDisclosureChanged: async (chatIds) => {
+          onDisclosureChanged: async (chatIds, options) => {
             const refreshedSealIds = new Set<string>();
-
-            for (const chatId of chatIds) {
-              const listResult = await d.sealManager.list({ chatId });
-              if (Result.isError(listResult)) {
-                return listResult;
-              }
-
-              for (const seal of listResult.value) {
-                const sealId = seal.chain.current.sealId;
-                if (refreshedSealIds.has(sealId)) {
-                  continue;
-                }
-                refreshedSealIds.add(sealId);
-
-                const refreshResult = await d.sealManager.refresh(sealId);
-                if (Result.isError(refreshResult)) {
-                  return refreshResult;
-                }
+            if (options?.includeExpired) {
+              for (const chatId of chatIds) {
+                rollbackDisclosureChatIds.add(chatId);
               }
             }
 
-            return Result.ok(undefined);
+            try {
+              for (const chatId of chatIds) {
+                const listResult = await d.sealManager.list({ chatId });
+                if (Result.isError(listResult)) {
+                  return listResult;
+                }
+
+                for (const seal of listResult.value) {
+                  const sealId = seal.chain.current.sealId;
+                  if (refreshedSealIds.has(sealId)) {
+                    continue;
+                  }
+                  refreshedSealIds.add(sealId);
+
+                  const refreshResult = await d.sealManager.refresh(sealId);
+                  if (Result.isError(refreshResult)) {
+                    return refreshResult;
+                  }
+                }
+              }
+
+              return Result.ok(undefined);
+            } finally {
+              if (options?.includeExpired) {
+                for (const chatId of chatIds) {
+                  rollbackDisclosureChatIds.delete(chatId);
+                }
+              }
+            }
           },
         });
 

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -68,6 +68,7 @@ import {
   type AdminReadElevationManager,
 } from "./admin/read-elevation.js";
 import { createAdminReadDisclosureStore } from "./admin/read-disclosure-store.js";
+import { createReadDisclosureRollbackTracker } from "./admin/read-disclosure-rollback-tracker.js";
 import { createWsRequestHandler } from "./ws/request-handler.js";
 import { createLazyCoreUpgrade } from "./ws/core-upgrade.js";
 import { createEventProjector } from "./ws/event-projector.js";
@@ -125,9 +126,9 @@ export function createProductionDeps(): SignetRuntimeDeps {
     null;
   // Shared in-memory disclosure state for owner-approved admin message reads.
   const readDisclosureStore = createAdminReadDisclosureStore();
-  // Chat IDs whose disclosure refresh is temporarily rolling back an expired
+  // Chats whose disclosure refresh is temporarily rolling back an expired
   // adminAccess state after a partial seal refresh failure.
-  const rollbackDisclosureChatIds = new Set<string>();
+  const rollbackDisclosureTracker = createReadDisclosureRollbackTracker();
   // Late-bound shared elevation manager for admin socket + HTTP parity.
   let readElevationManagerRef: AdminReadElevationManager | null = null;
   // In-memory invite tag store: groupId -> inviteTag (v1 single-process)
@@ -387,7 +388,7 @@ export function createProductionDeps(): SignetRuntimeDeps {
         operatorManager: operatorManagerRef,
         trustTier: keyManagerRef?.trustTier ?? "unverified",
         lookupAdminAccess: (chatId) =>
-          rollbackDisclosureChatIds.has(chatId)
+          rollbackDisclosureTracker.has(chatId)
             ? readDisclosureStore.peek(chatId)
             : readDisclosureStore.get(chatId),
       });
@@ -429,9 +430,7 @@ export function createProductionDeps(): SignetRuntimeDeps {
           onDisclosureChanged: async (chatIds, options) => {
             const refreshedSealIds = new Set<string>();
             if (options?.includeExpired) {
-              for (const chatId of chatIds) {
-                rollbackDisclosureChatIds.add(chatId);
-              }
+              rollbackDisclosureTracker.enter(chatIds);
             }
 
             try {
@@ -458,9 +457,7 @@ export function createProductionDeps(): SignetRuntimeDeps {
               return Result.ok(undefined);
             } finally {
               if (options?.includeExpired) {
-                for (const chatId of chatIds) {
-                  rollbackDisclosureChatIds.delete(chatId);
-                }
+                rollbackDisclosureTracker.leave(chatIds);
               }
             }
           },

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -418,6 +418,8 @@ export function createProductionDeps(): SignetRuntimeDeps {
           auditLog: d.auditLog,
           disclosureStore: readDisclosureStore,
           disclosureActorId: "owner",
+          normalizeChatId: (chatId) =>
+            idMappingStoreRef?.resolve(chatId)?.localId ?? chatId,
           onDisclosureChanged: async (chatIds) => {
             const refreshedSealIds = new Set<string>();
 

--- a/packages/contracts/src/handler-types.ts
+++ b/packages/contracts/src/handler-types.ts
@@ -1,5 +1,5 @@
 import type { Result } from "better-result";
-import type { SignetError } from "@xmtp/signet-schemas";
+import type { AdminReadElevationType, SignetError } from "@xmtp/signet-schemas";
 import type { CoreContext } from "./core-types.js";
 
 /**
@@ -39,6 +39,13 @@ export interface HandlerContext extends CoreContext {
    * harness credential holder. Absent for admin callers.
    */
   readonly credentialId?: string;
+
+  /**
+   * Owner-approved, time-bound elevation for admin message reads.
+   * This is intentionally separate from `adminAuth`; plain admin access does
+   * not imply conversational read access.
+   */
+  readonly adminReadElevation?: AdminReadElevationType;
 }
 
 /**

--- a/packages/core/src/__tests__/lookup-actions.test.ts
+++ b/packages/core/src/__tests__/lookup-actions.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { Result } from "better-result";
+import type { HandlerContext } from "@xmtp/signet-contracts";
+import { SqliteIdentityStore } from "../identity-store.js";
+import { createSqliteIdMappingStore } from "../id-mapping-store.js";
+import {
+  createLookupActions,
+  type LookupActionDeps,
+} from "../lookup-actions.js";
+
+function stubCtx(): HandlerContext {
+  return {
+    requestId: "test-req-1",
+    signal: AbortSignal.timeout(5_000),
+  };
+}
+
+describe("createLookupActions", () => {
+  let identityStore: SqliteIdentityStore;
+  let idMappings: ReturnType<typeof createSqliteIdMappingStore>;
+
+  beforeEach(() => {
+    identityStore = new SqliteIdentityStore(":memory:");
+    idMappings = createSqliteIdMappingStore(new Database(":memory:"));
+  });
+
+  function buildDeps(extra?: Partial<LookupActionDeps>): LookupActionDeps {
+    return {
+      identityStore,
+      idMappings,
+      ...extra,
+    };
+  }
+
+  test("resolves a mapped network inbox ID to the local inbox record", async () => {
+    const created = await identityStore.create("group-1", "support");
+    expect(Result.isOk(created)).toBe(true);
+    if (Result.isError(created)) {
+      throw new Error("identityStore.create failed");
+    }
+
+    await identityStore.setInboxId(created.value.id, "xmtp-inbox-1");
+    idMappings.set("xmtp-inbox-1", created.value.id, "inbox");
+
+    const actions = createLookupActions(buildDeps());
+    const spec = actions.find((action) => action.id === "lookup.resolve");
+    expect(spec).toBeDefined();
+
+    const result = await spec!.handler!({ query: "xmtp-inbox-1" }, stubCtx());
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result)) {
+      throw new Error("lookup.resolve failed");
+    }
+
+    expect(result.value.found).toBe(true);
+    expect(result.value.mapping).toEqual({
+      localId: created.value.id,
+      networkId: "xmtp-inbox-1",
+    });
+    expect(result.value.inbox).toEqual(
+      expect.objectContaining({
+        id: created.value.id,
+        label: "support",
+        networkInboxId: "xmtp-inbox-1",
+        groupId: "group-1",
+      }),
+    );
+  });
+
+  test("resolves an operator by exact label", async () => {
+    const operatorManager = {
+      list: async () =>
+        Result.ok([
+          {
+            id: "op_1234567890abcdef",
+            config: {
+              label: "alpha",
+              role: "operator",
+              scopeMode: "shared",
+              provider: "internal",
+            },
+            createdAt: "2026-04-13T00:00:00.000Z",
+            createdBy: "owner",
+            status: "active",
+          },
+        ]),
+      lookup: async () => Result.err(new Error("unused") as never),
+      create: async () => Result.err(new Error("unused") as never),
+      update: async () => Result.err(new Error("unused") as never),
+      remove: async () => Result.err(new Error("unused") as never),
+    };
+
+    const actions = createLookupActions(
+      buildDeps({ operatorManager: operatorManager as never }),
+    );
+    const spec = actions.find((action) => action.id === "lookup.resolve");
+    expect(spec).toBeDefined();
+
+    const result = await spec!.handler!({ query: "alpha" }, stubCtx());
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result)) {
+      throw new Error("lookup.resolve failed");
+    }
+
+    expect(result.value.operator).toEqual({
+      id: "op_1234567890abcdef",
+      label: "alpha",
+      role: "operator",
+      status: "active",
+    });
+    expect(result.value.found).toBe(true);
+  });
+
+  test("resolves a credential by ID", async () => {
+    const credentialManager = {
+      lookup: async () =>
+        Result.ok({
+          credentialId: "cred_1234567890abcdef",
+          operatorId: "op_1234567890abcdef",
+          config: {
+            operatorId: "op_1234567890abcdef",
+            chatIds: ["conv_1234567890abcdef"],
+            policyId: "policy_1234567890abcdef",
+          },
+          inboxIds: [],
+          status: "active",
+          issuedAt: "2026-04-13T00:00:00.000Z",
+          expiresAt: "2026-04-13T01:00:00.000Z",
+          issuedBy: "owner",
+          effectiveScopes: { allow: [], deny: [] },
+          isExpired: false,
+          lastHeartbeat: "2026-04-13T00:00:00.000Z",
+        }),
+    };
+
+    const actions = createLookupActions(
+      buildDeps({ credentialManager: credentialManager as never }),
+    );
+    const spec = actions.find((action) => action.id === "lookup.resolve");
+    expect(spec).toBeDefined();
+
+    const result = await spec!.handler!(
+      { query: "cred_1234567890abcdef" },
+      stubCtx(),
+    );
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result)) {
+      throw new Error("lookup.resolve failed");
+    }
+
+    expect(result.value.credential).toEqual({
+      id: "cred_1234567890abcdef",
+      operatorId: "op_1234567890abcdef",
+      policyId: "policy_1234567890abcdef",
+      chatIds: ["conv_1234567890abcdef"],
+      status: "active",
+      expiresAt: "2026-04-13T01:00:00.000Z",
+    });
+  });
+
+  test("returns an unfound result when nothing matches locally", async () => {
+    const actions = createLookupActions(buildDeps());
+    const spec = actions.find((action) => action.id === "lookup.resolve");
+    expect(spec).toBeDefined();
+
+    const result = await spec!.handler!({ query: "missing-value" }, stubCtx());
+    expect(Result.isOk(result)).toBe(true);
+    if (Result.isError(result)) {
+      throw new Error("lookup.resolve failed");
+    }
+
+    expect(result.value).toEqual({
+      query: "missing-value",
+      found: false,
+      mapping: null,
+      inbox: null,
+      operator: null,
+      policy: null,
+      credential: null,
+    });
+  });
+
+  test("exposes a single idempotent read action", () => {
+    const actions = createLookupActions(buildDeps());
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.id).toBe("lookup.resolve");
+    expect(actions[0]?.intent).toBe("read");
+    expect(actions[0]?.idempotent).toBe(true);
+  });
+});

--- a/packages/core/src/__tests__/message-actions.test.ts
+++ b/packages/core/src/__tests__/message-actions.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { Database } from "bun:sqlite";
 import { Result } from "better-result";
 import { NotFoundError } from "@xmtp/signet-schemas";
-import type { SignetError, IdMappingStore } from "@xmtp/signet-schemas";
+import type {
+  SignetError,
+  IdMappingStore,
+  AdminReadElevationType,
+} from "@xmtp/signet-schemas";
 import type { HandlerContext } from "@xmtp/signet-contracts";
 import { SqliteIdentityStore } from "../identity-store.js";
 import { createSqliteIdMappingStore } from "../id-mapping-store.js";
@@ -18,6 +22,26 @@ function stubCtx(): HandlerContext {
   return {
     requestId: "test-req-1",
     signal: AbortSignal.timeout(5_000),
+  };
+}
+
+function stubAdminReadCtx(
+  overrides: Partial<AdminReadElevationType> = {},
+): HandlerContext {
+  return {
+    requestId: "test-admin-read-req-1",
+    signal: AbortSignal.timeout(5_000),
+    adminAuth: { adminKeyFingerprint: "admin-fingerprint-1" },
+    adminReadElevation: {
+      approvalId: "approval_read_1",
+      scope: {
+        chatIds: ["conv_0123456789abcdef"],
+      },
+      approvedAt: "2026-04-13T16:00:00.000Z",
+      expiresAt: "2099-04-13T17:00:00.000Z",
+      approvalKeyFingerprint: "local-approval-fingerprint",
+      ...overrides,
+    },
   };
 }
 
@@ -335,6 +359,81 @@ describe("message actions", () => {
         expect(result.error.category).toBe("not_found");
       }
     });
+
+    test("allows admin reads when owner-approved elevation covers the chat", async () => {
+      await seedIdentity("elevated-lister", { messages: sampleMessages });
+      idMappings.set("g1", "conv_0123456789abcdef", "conversation");
+      setupDeps();
+
+      const actions = createMessageActions(deps);
+      const listAction = actions.find((a) => a.id === "message.list")!;
+
+      const result = await listAction.handler(
+        { chatId: "conv_0123456789abcdef", identityLabel: "elevated-lister" },
+        stubAdminReadCtx(),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isOk(result)) {
+        expect(result.value.messages).toHaveLength(2);
+      }
+    });
+
+    test("rejects expired admin read elevation", async () => {
+      await seedIdentity("expired-elevation-lister", {
+        messages: sampleMessages,
+      });
+      idMappings.set("g1", "conv_0123456789abcdef", "conversation");
+      setupDeps();
+
+      const actions = createMessageActions(deps);
+      const listAction = actions.find((a) => a.id === "message.list")!;
+
+      const result = await listAction.handler(
+        {
+          chatId: "conv_0123456789abcdef",
+          identityLabel: "expired-elevation-lister",
+        },
+        stubAdminReadCtx({
+          expiresAt: "2026-04-13T15:59:00.000Z",
+        }),
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.category).toBe("permission");
+        expect(result.error.message).toContain("expired");
+      }
+    });
+
+    test("rejects plain admin reads without explicit elevation", async () => {
+      await seedIdentity("plain-admin-lister", { messages: sampleMessages });
+      idMappings.set("g1", "conv_0123456789abcdef", "conversation");
+      setupDeps();
+
+      const actions = createMessageActions(deps);
+      const listAction = actions.find((a) => a.id === "message.list")!;
+
+      const result = await listAction.handler(
+        {
+          chatId: "conv_0123456789abcdef",
+          identityLabel: "plain-admin-lister",
+        },
+        {
+          requestId: "test-admin-no-elevation",
+          signal: AbortSignal.timeout(5000),
+          adminAuth: { adminKeyFingerprint: "admin-fingerprint-1" },
+        },
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.category).toBe("permission");
+        expect(result.error.message).toContain(
+          "require owner-approved elevation",
+        );
+      }
+    });
   });
 
   describe("message.info", () => {
@@ -564,6 +663,88 @@ describe("message actions", () => {
       expect(Result.isError(result)).toBe(true);
       if (Result.isError(result)) {
         expect(result.error.category).toBe("not_found");
+      }
+    });
+
+    test("allows admin info reads when owner-approved elevation covers the chat", async () => {
+      await seedIdentity("elevated-viewer", { messages: sampleMessages });
+      idMappings.set("g1", "conv_0123456789abcdef", "conversation");
+      setupDeps();
+
+      const actions = createMessageActions(deps);
+      const infoAction = actions.find((a) => a.id === "message.info")!;
+
+      const result = await infoAction.handler(
+        {
+          chatId: "conv_0123456789abcdef",
+          messageId: "msg-aaa",
+          identityLabel: "elevated-viewer",
+        },
+        stubAdminReadCtx(),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isOk(result)) {
+        expect(result.value.messageId).toBe("msg-aaa");
+      }
+    });
+
+    test("rejects admin info reads when elevation does not cover the chat", async () => {
+      await seedIdentity("wrong-chat-viewer", { messages: sampleMessages });
+      idMappings.set("g1", "conv_0123456789abcdef", "conversation");
+      idMappings.set("g2", "conv_ffff456789abcdef", "conversation");
+      setupDeps();
+
+      const actions = createMessageActions(deps);
+      const infoAction = actions.find((a) => a.id === "message.info")!;
+
+      const result = await infoAction.handler(
+        {
+          chatId: "conv_0123456789abcdef",
+          messageId: "msg-aaa",
+          identityLabel: "wrong-chat-viewer",
+        },
+        stubAdminReadCtx({
+          scope: {
+            chatIds: ["conv_ffff456789abcdef"],
+          },
+        }),
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.category).toBe("permission");
+        expect(result.error.message).toContain("does not cover");
+      }
+    });
+
+    test("rejects plain admin info reads without explicit elevation", async () => {
+      await seedIdentity("plain-admin-viewer", { messages: sampleMessages });
+      idMappings.set("g1", "conv_0123456789abcdef", "conversation");
+      setupDeps();
+
+      const actions = createMessageActions(deps);
+      const infoAction = actions.find((a) => a.id === "message.info")!;
+
+      const result = await infoAction.handler(
+        {
+          chatId: "conv_0123456789abcdef",
+          messageId: "msg-aaa",
+          identityLabel: "plain-admin-viewer",
+        },
+        {
+          requestId: "test-admin-no-elevation",
+          signal: AbortSignal.timeout(5000),
+          adminAuth: { adminKeyFingerprint: "admin-fingerprint-1" },
+        },
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.category).toBe("permission");
+        expect(result.error.message).toContain(
+          "require owner-approved elevation",
+        );
       }
     });
   });

--- a/packages/core/src/__tests__/search-actions.test.ts
+++ b/packages/core/src/__tests__/search-actions.test.ts
@@ -280,6 +280,103 @@ describe("createSearchActions", () => {
       expect(value.matches).toHaveLength(0);
     });
 
+    test("requires admin read elevation for message search", async () => {
+      await seedIdentity();
+
+      const msgs: Record<string, XmtpDecodedMessage[]> = {
+        "group-1": [makeMessage("group-1", "secret message")],
+      };
+      const groups = [makeGroup("group-1", "G1")];
+      const client = createMockClient({ messages: msgs, groups });
+      const deps = buildDeps(client);
+      const actions = createSearchActions(deps);
+
+      const spec = actions.find((a) => a.id === "search.messages");
+      const result = await spec!.handler!(
+        { query: "secret", chatId: "group-1" },
+        {
+          requestId: "test",
+          signal: AbortSignal.timeout(5000),
+          adminAuth: { adminKeyFingerprint: "admin-fingerprint" },
+        },
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.category).toBe("permission");
+        expect(result.error.message).toContain("owner-approved elevation");
+      }
+    });
+
+    test("requires a specific chat for admin message search", async () => {
+      await seedIdentity();
+
+      const msgs: Record<string, XmtpDecodedMessage[]> = {
+        "group-1": [makeMessage("group-1", "secret message")],
+      };
+      const groups = [makeGroup("group-1", "G1")];
+      const client = createMockClient({ messages: msgs, groups });
+      const deps = buildDeps(client);
+      const actions = createSearchActions(deps);
+
+      const spec = actions.find((a) => a.id === "search.messages");
+      const result = await spec!.handler!(
+        { query: "secret" },
+        {
+          requestId: "test",
+          signal: AbortSignal.timeout(5000),
+          adminAuth: { adminKeyFingerprint: "admin-fingerprint" },
+          adminReadElevation: {
+            approvalId: "approval_123",
+            scope: { chatIds: ["group-1"] },
+            approvedAt: "2026-04-14T15:00:00.000Z",
+            expiresAt: "2999-01-01T00:00:00.000Z",
+            approvalKeyFingerprint: "approval-fingerprint",
+          },
+        },
+      );
+
+      expect(Result.isError(result)).toBe(true);
+      if (Result.isError(result)) {
+        expect(result.error.category).toBe("permission");
+        expect(result.error.message).toContain("specific conversation");
+      }
+    });
+
+    test("allows admin message search when elevation covers the chat", async () => {
+      await seedIdentity();
+
+      const msgs: Record<string, XmtpDecodedMessage[]> = {
+        "group-1": [makeMessage("group-1", "secret message")],
+      };
+      const groups = [makeGroup("group-1", "G1")];
+      const client = createMockClient({ messages: msgs, groups });
+      const deps = buildDeps(client);
+      const actions = createSearchActions(deps);
+
+      const spec = actions.find((a) => a.id === "search.messages");
+      const result = await spec!.handler!(
+        { query: "secret", chatId: "group-1" },
+        {
+          requestId: "test",
+          signal: AbortSignal.timeout(5000),
+          adminAuth: { adminKeyFingerprint: "admin-fingerprint" },
+          adminReadElevation: {
+            approvalId: "approval_123",
+            scope: { chatIds: ["group-1"] },
+            approvedAt: "2026-04-14T15:00:00.000Z",
+            expiresAt: "2999-01-01T00:00:00.000Z",
+            approvalKeyFingerprint: "approval-fingerprint",
+          },
+        },
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isOk(result)) {
+        expect(result.value.matches).toHaveLength(1);
+      }
+    });
+
     test("errors when no identity exists", async () => {
       const client = createMockClient();
       const deps = buildDeps(client);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,6 +97,17 @@ export type { MessageActionDeps } from "./message-actions.js";
 export { createSearchActions } from "./search-actions.js";
 export type { SearchActionDeps } from "./search-actions.js";
 
+// Lookup actions
+export { createLookupActions } from "./lookup-actions.js";
+export type {
+  LookupActionDeps,
+  LookupResolveResult,
+  LookupInboxResult,
+  LookupOperatorResult,
+  LookupPolicyResult,
+  LookupCredentialResult,
+} from "./lookup-actions.js";
+
 // Convos invite parsing and join protocol
 export {
   parseConvosInviteUrl,

--- a/packages/core/src/lookup-actions.ts
+++ b/packages/core/src/lookup-actions.ts
@@ -1,0 +1,339 @@
+import { Result } from "better-result";
+import { z } from "zod";
+import type {
+  ActionSpec,
+  CredentialManager,
+  OperatorManager,
+  PolicyManager,
+} from "@xmtp/signet-contracts";
+import type { IdMappingStore, SignetError } from "@xmtp/signet-schemas";
+import { parseResourceId } from "@xmtp/signet-schemas";
+import type { AgentIdentity, SqliteIdentityStore } from "./identity-store.js";
+
+/** Dependencies used to build lookup-related action specs. */
+export interface LookupActionDeps {
+  readonly identityStore: SqliteIdentityStore;
+  readonly idMappings?: IdMappingStore;
+  readonly operatorManager?: OperatorManager;
+  readonly policyManager?: PolicyManager;
+  readonly credentialManager?: CredentialManager;
+}
+
+/** Local/network ID mapping summary returned by `lookup.resolve`. */
+export interface LookupMappingResult {
+  readonly localId: string;
+  readonly networkId: string;
+}
+
+/** Managed inbox summary returned by `lookup.resolve`. */
+export interface LookupInboxResult {
+  readonly id: string;
+  readonly label: string | null;
+  readonly networkInboxId: string | null;
+  readonly groupId: string | null;
+  readonly createdAt: string;
+}
+
+/** Operator summary returned by `lookup.resolve`. */
+export interface LookupOperatorResult {
+  readonly id: string;
+  readonly label: string;
+  readonly role: string;
+  readonly status: string;
+}
+
+/** Policy summary returned by `lookup.resolve`. */
+export interface LookupPolicyResult {
+  readonly id: string;
+  readonly label: string;
+  readonly updatedAt: string;
+}
+
+/** Credential summary returned by `lookup.resolve`. */
+export interface LookupCredentialResult {
+  readonly id: string;
+  readonly operatorId: string;
+  readonly policyId: string | null;
+  readonly chatIds: readonly string[];
+  readonly status: string;
+  readonly expiresAt: string;
+}
+
+/** Result returned by `lookup.resolve`. */
+export interface LookupResolveResult {
+  readonly query: string;
+  readonly found: boolean;
+  readonly mapping: LookupMappingResult | null;
+  readonly inbox: LookupInboxResult | null;
+  readonly operator: LookupOperatorResult | null;
+  readonly policy: LookupPolicyResult | null;
+  readonly credential: LookupCredentialResult | null;
+}
+
+function widenActionSpec<TInput, TOutput>(
+  spec: ActionSpec<TInput, TOutput, SignetError>,
+): ActionSpec<unknown, unknown, SignetError> {
+  return spec as ActionSpec<unknown, unknown, SignetError>;
+}
+
+function toMappingResult(
+  mapping: {
+    networkId: string;
+    localId: string;
+  } | null,
+): LookupMappingResult | null {
+  if (!mapping) {
+    return null;
+  }
+
+  return {
+    localId: mapping.localId,
+    networkId: mapping.networkId,
+  };
+}
+
+function toInboxResult(identity: AgentIdentity): LookupInboxResult {
+  return {
+    id: identity.id,
+    label: identity.label,
+    networkInboxId: identity.inboxId,
+    groupId: identity.groupId,
+    createdAt: identity.createdAt,
+  };
+}
+
+function isNotFoundError(error: SignetError): boolean {
+  return error.category === "not_found";
+}
+
+async function resolveInbox(
+  deps: LookupActionDeps,
+  query: string,
+  mapping: LookupMappingResult | null,
+): Promise<Result<LookupInboxResult | null, SignetError>> {
+  let identity: AgentIdentity | null = null;
+
+  try {
+    const parsed = parseResourceId(query);
+    if (parsed.type === "inbox") {
+      identity = await deps.identityStore.getById(query);
+    }
+  } catch {
+    // Non-resource identifiers are handled below.
+  }
+
+  if (identity === null && mapping?.localId.startsWith("inbox_")) {
+    identity = await deps.identityStore.getById(mapping.localId);
+  }
+
+  if (identity === null) {
+    identity = await deps.identityStore.getByLabel(query);
+  }
+
+  if (identity === null) {
+    identity = await deps.identityStore.getByInboxId(query);
+  }
+
+  return Result.ok(identity ? toInboxResult(identity) : null);
+}
+
+async function resolveOperator(
+  deps: LookupActionDeps,
+  query: string,
+): Promise<Result<LookupOperatorResult | null, SignetError>> {
+  if (!deps.operatorManager) {
+    return Result.ok(null);
+  }
+
+  try {
+    const parsed = parseResourceId(query);
+    if (parsed.type === "operator") {
+      const direct = await deps.operatorManager.lookup(query);
+      if (Result.isError(direct)) {
+        return isNotFoundError(direct.error) ? Result.ok(null) : direct;
+      }
+
+      return Result.ok({
+        id: direct.value.id,
+        label: direct.value.config.label,
+        role: direct.value.config.role,
+        status: direct.value.status,
+      });
+    }
+  } catch {
+    // Fall through to exact-label lookup.
+  }
+
+  const operators = await deps.operatorManager.list();
+  if (Result.isError(operators)) {
+    return operators;
+  }
+
+  const match = operators.value.find(
+    (candidate) => candidate.config.label === query,
+  );
+  if (!match) {
+    return Result.ok(null);
+  }
+
+  return Result.ok({
+    id: match.id,
+    label: match.config.label,
+    role: match.config.role,
+    status: match.status,
+  });
+}
+
+async function resolvePolicy(
+  deps: LookupActionDeps,
+  query: string,
+): Promise<Result<LookupPolicyResult | null, SignetError>> {
+  if (!deps.policyManager) {
+    return Result.ok(null);
+  }
+
+  try {
+    const parsed = parseResourceId(query);
+    if (parsed.type === "policy") {
+      const direct = await deps.policyManager.lookup(query);
+      if (Result.isError(direct)) {
+        return isNotFoundError(direct.error) ? Result.ok(null) : direct;
+      }
+
+      return Result.ok({
+        id: direct.value.id,
+        label: direct.value.config.label,
+        updatedAt: direct.value.updatedAt,
+      });
+    }
+  } catch {
+    // Fall through to exact-label lookup.
+  }
+
+  const policies = await deps.policyManager.list();
+  if (Result.isError(policies)) {
+    return policies;
+  }
+
+  const match = policies.value.find(
+    (candidate) => candidate.config.label === query,
+  );
+  if (!match) {
+    return Result.ok(null);
+  }
+
+  return Result.ok({
+    id: match.id,
+    label: match.config.label,
+    updatedAt: match.updatedAt,
+  });
+}
+
+async function resolveCredential(
+  deps: LookupActionDeps,
+  query: string,
+): Promise<Result<LookupCredentialResult | null, SignetError>> {
+  if (!deps.credentialManager) {
+    return Result.ok(null);
+  }
+
+  try {
+    const parsed = parseResourceId(query);
+    if (parsed.type !== "credential") {
+      return Result.ok(null);
+    }
+  } catch {
+    return Result.ok(null);
+  }
+
+  const credential = await deps.credentialManager.lookup(query);
+  if (Result.isError(credential)) {
+    return isNotFoundError(credential.error) ? Result.ok(null) : credential;
+  }
+
+  return Result.ok({
+    id: credential.value.credentialId,
+    operatorId: credential.value.operatorId,
+    policyId: credential.value.config.policyId ?? null,
+    chatIds: credential.value.config.chatIds,
+    status: credential.value.status,
+    expiresAt: credential.value.expiresAt,
+  });
+}
+
+/** Create ActionSpecs for lookup operations. */
+export function createLookupActions(
+  deps: LookupActionDeps,
+): ActionSpec<unknown, unknown, SignetError>[] {
+  const resolve: ActionSpec<
+    { query: string },
+    LookupResolveResult,
+    SignetError
+  > = {
+    id: "lookup.resolve",
+    description: "Resolve local signet resources and network ID mappings",
+    intent: "read",
+    idempotent: true,
+    input: z.object({
+      query: z.string().min(1),
+    }),
+    handler: async (input) => {
+      let mapping = toMappingResult(
+        deps.idMappings?.resolve(input.query) ?? null,
+      );
+
+      const inbox = await resolveInbox(deps, input.query, mapping);
+      if (Result.isError(inbox)) {
+        return inbox;
+      }
+
+      if (mapping === null && inbox.value !== null) {
+        mapping =
+          toMappingResult(deps.idMappings?.resolve(inbox.value.id) ?? null) ??
+          toMappingResult(
+            inbox.value.networkInboxId
+              ? (deps.idMappings?.resolve(inbox.value.networkInboxId) ?? null)
+              : null,
+          );
+      }
+
+      const operator = await resolveOperator(deps, input.query);
+      if (Result.isError(operator)) {
+        return operator;
+      }
+
+      const policy = await resolvePolicy(deps, input.query);
+      if (Result.isError(policy)) {
+        return policy;
+      }
+
+      const credential = await resolveCredential(deps, input.query);
+      if (Result.isError(credential)) {
+        return credential;
+      }
+
+      return Result.ok({
+        query: input.query,
+        found:
+          mapping !== null ||
+          inbox.value !== null ||
+          operator.value !== null ||
+          policy.value !== null ||
+          credential.value !== null,
+        mapping,
+        inbox: inbox.value,
+        operator: operator.value,
+        policy: policy.value,
+        credential: credential.value,
+      });
+    },
+    cli: {
+      command: "lookup:resolve",
+    },
+    http: {
+      auth: "admin",
+    },
+  };
+
+  return [widenActionSpec(resolve)];
+}

--- a/packages/core/src/message-actions.ts
+++ b/packages/core/src/message-actions.ts
@@ -1,11 +1,12 @@
 import { Result } from "better-result";
 import { z } from "zod";
-import type { ActionSpec } from "@xmtp/signet-contracts";
-import { NotFoundError } from "@xmtp/signet-schemas";
+import type { ActionSpec, HandlerContext } from "@xmtp/signet-contracts";
+import { NotFoundError, PermissionError } from "@xmtp/signet-schemas";
 import type {
   SignetError,
   IdMappingStore,
   CredentialRecordType,
+  AdminReadElevationType,
 } from "@xmtp/signet-schemas";
 import type { SqliteIdentityStore } from "./identity-store.js";
 import type { ManagedClient } from "./client-registry.js";
@@ -105,6 +106,69 @@ function resolveEffectiveScopes(config: {
   return allowed;
 }
 
+function authorizeAdminReadElevation(
+  elevation: AdminReadElevationType,
+  chatId: string,
+  idMappings: IdMappingStore | undefined,
+): Result<void, SignetError> {
+  const expiresAt = Date.parse(elevation.expiresAt);
+  if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
+    return Result.err(
+      PermissionError.create("Admin read elevation has expired", {
+        approvalId: elevation.approvalId,
+        expiresAt: elevation.expiresAt,
+      }) as SignetError,
+    );
+  }
+
+  const targetGroupId = resolveGroupId(idMappings, chatId);
+  const scopedGroupIds = elevation.scope.chatIds.map((scopedChatId) =>
+    resolveGroupId(idMappings, scopedChatId),
+  );
+  if (!scopedGroupIds.includes(targetGroupId)) {
+    return Result.err(
+      PermissionError.create(
+        "Admin read elevation does not cover this conversation",
+        {
+          approvalId: elevation.approvalId,
+          chatId,
+        },
+      ) as SignetError,
+    );
+  }
+
+  return Result.ok(undefined);
+}
+
+function authorizeAdminReadAccess(
+  ctx: HandlerContext,
+  chatId: string,
+  idMappings: IdMappingStore | undefined,
+): Result<void, SignetError> {
+  if (ctx.credentialId) {
+    return Result.ok(undefined);
+  }
+  if (ctx.adminReadElevation) {
+    return authorizeAdminReadElevation(
+      ctx.adminReadElevation,
+      chatId,
+      idMappings,
+    );
+  }
+  if (ctx.adminAuth) {
+    return Result.err(
+      PermissionError.create(
+        "Admin message reads require owner-approved elevation",
+        {
+          chatId,
+          hint: "--dangerously-allow-message-read",
+        },
+      ) as SignetError,
+    );
+  }
+  return Result.ok(undefined);
+}
+
 function widenActionSpec<TInput, TOutput>(
   spec: ActionSpec<TInput, TOutput, SignetError>,
 ): ActionSpec<unknown, unknown, SignetError> {
@@ -188,6 +252,15 @@ export function createMessageActions(
       identityLabel: z.string().optional(),
     }),
     handler: async (input, ctx) => {
+      const elevationResult = authorizeAdminReadAccess(
+        ctx,
+        input.chatId,
+        deps.idMappings,
+      );
+      if (Result.isError(elevationResult)) {
+        return elevationResult;
+      }
+
       // Credential scope enforcement: verify the caller can read
       // messages in this conversation before hitting the SDK.
       // Fail closed: if credentialId is present but credentialLookup
@@ -289,6 +362,15 @@ export function createMessageActions(
         Result.err(
           NotFoundError.create("message", input.messageId) as SignetError,
         );
+
+      const elevationResult = authorizeAdminReadAccess(
+        ctx,
+        input.chatId,
+        deps.idMappings,
+      );
+      if (Result.isError(elevationResult)) {
+        return elevationResult;
+      }
 
       // Credential scope enforcement: verify scope BEFORE any data
       // access to prevent timing side-channels that leak message

--- a/packages/core/src/search-actions.ts
+++ b/packages/core/src/search-actions.ts
@@ -2,12 +2,17 @@ import { Result } from "better-result";
 import { z } from "zod";
 import type {
   ActionSpec,
+  HandlerContext,
   OperatorManager,
   PolicyManager,
   CredentialManager,
 } from "@xmtp/signet-contracts";
-import { NotFoundError } from "@xmtp/signet-schemas";
-import type { SignetError, IdMappingStore } from "@xmtp/signet-schemas";
+import { NotFoundError, PermissionError } from "@xmtp/signet-schemas";
+import type {
+  SignetError,
+  IdMappingStore,
+  AdminReadElevationType,
+} from "@xmtp/signet-schemas";
 import type { SqliteIdentityStore } from "./identity-store.js";
 import type { ManagedClient } from "./client-registry.js";
 
@@ -101,6 +106,83 @@ function resolveEffectiveScopes(config: {
   return allowed;
 }
 
+function authorizeAdminReadElevation(
+  elevation: AdminReadElevationType,
+  chatId: string,
+  idMappings: IdMappingStore | undefined,
+): Result<void, SignetError> {
+  const expiresAt = Date.parse(elevation.expiresAt);
+  if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
+    return Result.err(
+      PermissionError.create("Admin read elevation has expired", {
+        approvalId: elevation.approvalId,
+        expiresAt: elevation.expiresAt,
+      }) as SignetError,
+    );
+  }
+
+  const targetGroupId = resolveGroupId(idMappings, chatId);
+  const scopedGroupIds = elevation.scope.chatIds.map((scopedChatId) =>
+    resolveGroupId(idMappings, scopedChatId),
+  );
+  if (!scopedGroupIds.includes(targetGroupId)) {
+    return Result.err(
+      PermissionError.create(
+        "Admin read elevation does not cover this conversation",
+        {
+          approvalId: elevation.approvalId,
+          chatId,
+        },
+      ) as SignetError,
+    );
+  }
+
+  return Result.ok(undefined);
+}
+
+function authorizeAdminSearchAccess(
+  ctx: HandlerContext,
+  chatId: string | undefined,
+  idMappings: IdMappingStore | undefined,
+): Result<void, SignetError> {
+  if (ctx.credentialId) {
+    return Result.ok(undefined);
+  }
+
+  if (!ctx.adminAuth && !ctx.adminReadElevation) {
+    return Result.ok(undefined);
+  }
+
+  if (!chatId) {
+    return Result.err(
+      PermissionError.create(
+        "Admin message search requires a specific conversation",
+        {
+          hint: "--chat",
+        },
+      ) as SignetError,
+    );
+  }
+
+  if (ctx.adminReadElevation) {
+    return authorizeAdminReadElevation(
+      ctx.adminReadElevation,
+      chatId,
+      idMappings,
+    );
+  }
+
+  return Result.err(
+    PermissionError.create(
+      "Admin message search requires owner-approved elevation",
+      {
+        chatId,
+        hint: "--dangerously-allow-message-read",
+      },
+    ) as SignetError,
+  );
+}
+
 function widenActionSpec<TInput, TOutput>(
   spec: ActionSpec<TInput, TOutput, SignetError>,
 ): ActionSpec<unknown, unknown, SignetError> {
@@ -135,6 +217,15 @@ export function createSearchActions(
       identityLabel: z.string().optional(),
     }),
     handler: async (input, ctx) => {
+      const elevationResult = authorizeAdminSearchAccess(
+        ctx,
+        input.chatId,
+        deps.idMappings,
+      );
+      if (Result.isError(elevationResult)) {
+        return elevationResult;
+      }
+
       // Resolve credential scope when present — used to filter
       // which conversations the caller can search.
       // Fail closed: missing credentialManager with a credentialId

--- a/packages/keys/src/__tests__/biometric-gate.test.ts
+++ b/packages/keys/src/__tests__/biometric-gate.test.ts
@@ -15,6 +15,7 @@ describe("BiometricGateConfig", () => {
     expect(config.scopeExpansion).toBe(false);
     expect(config.egressExpansion).toBe(false);
     expect(config.agentCreation).toBe(false);
+    expect(config.adminReadElevation).toBe(false);
   });
 });
 
@@ -25,6 +26,7 @@ describe("createBiometricGate", () => {
     scopeExpansion: false,
     egressExpansion: false,
     agentCreation: false,
+    adminReadElevation: false,
   };
 
   const allOn: BiometricGateConfig = {
@@ -33,6 +35,7 @@ describe("createBiometricGate", () => {
     scopeExpansion: true,
     egressExpansion: true,
     agentCreation: true,
+    adminReadElevation: true,
   };
 
   test("passes through when operation is disabled", async () => {

--- a/packages/keys/src/__tests__/config.test.ts
+++ b/packages/keys/src/__tests__/config.test.ts
@@ -46,6 +46,7 @@ describe("KeyManagerConfigSchema", () => {
     expect(config.operationalKeyPolicy).toBe("open");
     expect(config.vaultKeyPolicy).toBe("open");
     expect(config.biometricGating.rootKeyCreation).toBe(false);
+    expect(config.biometricGating.adminReadElevation).toBe(false);
     expect(config.rotationIntervalSeconds).toBe(86400);
   });
 
@@ -55,13 +56,17 @@ describe("KeyManagerConfigSchema", () => {
       rootKeyPolicy: "open",
       operationalKeyPolicy: "passcode",
       vaultKeyPolicy: "biometric",
-      biometricGating: { operationalKeyRotation: true },
+      biometricGating: {
+        operationalKeyRotation: true,
+        adminReadElevation: true,
+      },
       rotationIntervalSeconds: 7200,
     });
     expect(config.rootKeyPolicy).toBe("open");
     expect(config.operationalKeyPolicy).toBe("passcode");
     expect(config.vaultKeyPolicy).toBe("biometric");
     expect(config.biometricGating.operationalKeyRotation).toBe(true);
+    expect(config.biometricGating.adminReadElevation).toBe(true);
     expect(config.rotationIntervalSeconds).toBe(7200);
   });
 

--- a/packages/keys/src/__tests__/key-manager-compat.test.ts
+++ b/packages/keys/src/__tests__/key-manager-compat.test.ts
@@ -345,4 +345,20 @@ describe("createKeyManager biometric gating", () => {
     expect(created.error.message).toContain("Biometric gate unavailable");
     expect(manager.admin.exists()).toBe(false);
   });
+
+  test("prompts for admin read elevation when enabled", async () => {
+    const prompted: string[] = [];
+    const manager = await setupCompatKeyManager({
+      biometricGating: { adminReadElevation: true },
+      biometricPrompter: async (operation) => {
+        prompted.push(operation);
+        return Result.ok(undefined);
+      },
+    });
+
+    const authorized =
+      await manager.authorizeSensitiveOperation("adminReadElevation");
+    expect(Result.isOk(authorized)).toBe(true);
+    expect(prompted).toEqual(["adminReadElevation"]);
+  });
 });

--- a/packages/keys/src/biometric-gate.ts
+++ b/packages/keys/src/biometric-gate.ts
@@ -10,6 +10,7 @@ export type BiometricGateConfig = {
   scopeExpansion: boolean;
   egressExpansion: boolean;
   agentCreation: boolean;
+  adminReadElevation: boolean;
 };
 
 /** Input type with all fields optional for configuration merging. */
@@ -19,6 +20,7 @@ export type BiometricGateConfigInput = {
   scopeExpansion?: boolean | undefined;
   egressExpansion?: boolean | undefined;
   agentCreation?: boolean | undefined;
+  adminReadElevation?: boolean | undefined;
 };
 
 /** Per-operation toggles for biometric gating. */
@@ -48,6 +50,10 @@ export const BiometricGateConfigSchema: z.ZodType<
       .boolean()
       .default(false)
       .describe("Require biometric for creating new agent inboxes"),
+    adminReadElevation: z
+      .boolean()
+      .default(false)
+      .describe("Require biometric for owner-approved admin read elevation"),
   })
   .describe("Per-operation biometric gating configuration");
 
@@ -57,7 +63,8 @@ export type GatedOperation =
   | "operationalKeyRotation"
   | "scopeExpansion"
   | "egressExpansion"
-  | "agentCreation";
+  | "agentCreation"
+  | "adminReadElevation";
 
 /** Callback to prompt biometric authentication. Returns Ok if confirmed. */
 export type BiometricPrompter = (

--- a/packages/keys/src/key-manager-compat.ts
+++ b/packages/keys/src/key-manager-compat.ts
@@ -14,6 +14,7 @@ import { detectPlatform, platformToTrustTier } from "./platform.js";
 import type { TrustTier } from "./platform.js";
 import {
   createBiometricGate,
+  type GatedOperation,
   type BiometricPrompter,
 } from "./biometric-gate.js";
 import type { RootKeyHandle, OperationalKey, CredentialKey } from "./types.js";
@@ -201,6 +202,11 @@ export interface KeyManager {
 
   /** Stop operational key auto-rotation. */
   stopAutoRotation(): void;
+
+  /** Prompt for a configured privileged operation without performing it yet. */
+  authorizeSensitiveOperation(
+    operation: GatedOperation,
+  ): Promise<Result<void, SignetError>>;
 
   /** Release resources held by the compat manager. */
   close(): void;
@@ -836,6 +842,10 @@ export async function createKeyManager(
         clearInterval(rotationTimer);
         rotationTimer = null;
       }
+    },
+
+    async authorizeSensitiveOperation(operation) {
+      return gate(operation);
     },
 
     close() {

--- a/packages/schemas/src/__tests__/admin-read-elevation.test.ts
+++ b/packages/schemas/src/__tests__/admin-read-elevation.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import {
+  AdminReadElevation,
+  AdminReadElevationScope,
+} from "../admin-read-elevation.js";
+
+describe("admin read elevation schema", () => {
+  test("accepts a scoped, time-bound elevation", () => {
+    const parsed = AdminReadElevation.parse({
+      approvalId: "approval_read_1",
+      scope: {
+        chatIds: ["conv_0123456789abcdef", "group-123"],
+      },
+      approvedAt: "2026-04-13T16:00:00.000Z",
+      expiresAt: "2026-04-13T17:00:00.000Z",
+      approvalKeyFingerprint: "local-approval-fingerprint",
+    });
+
+    expect(parsed.scope.chatIds).toEqual([
+      "conv_0123456789abcdef",
+      "group-123",
+    ]);
+  });
+
+  test("rejects an elevation without scoped chats", () => {
+    const result = AdminReadElevationScope.safeParse({
+      chatIds: [],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects an elevation with a non-datetime expiry", () => {
+    const result = AdminReadElevation.safeParse({
+      approvalId: "approval_read_1",
+      scope: {
+        chatIds: ["conv_0123456789abcdef"],
+      },
+      approvedAt: "2026-04-13T16:00:00.000Z",
+      expiresAt: "tomorrow-ish",
+      approvalKeyFingerprint: "local-approval-fingerprint",
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/schemas/src/__tests__/seal.test.ts
+++ b/packages/schemas/src/__tests__/seal.test.ts
@@ -38,6 +38,17 @@ describe("SealPayload", () => {
     expect(SealPayload.safeParse(withAdmin).success).toBe(true);
   });
 
+  it("accepts payload with owner-scoped adminAccess", () => {
+    const withOwnerAdmin = {
+      ...valid,
+      adminAccess: {
+        operatorId: "owner",
+        expiresAt: "2024-01-02T00:00:00Z",
+      },
+    };
+    expect(SealPayload.safeParse(withOwnerAdmin).success).toBe(true);
+  });
+
   it("accepts payload without adminAccess", () => {
     const result = SealPayload.safeParse(valid);
     expect(result.success).toBe(true);

--- a/packages/schemas/src/admin-read-elevation.ts
+++ b/packages/schemas/src/admin-read-elevation.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+/** Scoped target set for owner-approved admin message access. */
+export type AdminReadElevationScopeType = {
+  chatIds: string[];
+};
+
+/** Explicit, time-bound admin message-read elevation. */
+export type AdminReadElevationType = {
+  approvalId: string;
+  scope: AdminReadElevationScopeType;
+  approvedAt: string;
+  expiresAt: string;
+  approvalKeyFingerprint: string;
+};
+
+/**
+ * Scope carried by an owner-approved admin read elevation.
+ *
+ * Chat IDs may be local `conv_` identifiers or raw XMTP group IDs; handlers
+ * resolve them through the normal mapping layer before enforcement.
+ */
+export const AdminReadElevationScope: z.ZodType<AdminReadElevationScopeType> = z
+  .object({
+    chatIds: z
+      .array(z.string())
+      .min(1)
+      .describe("Conversations covered by the temporary read elevation"),
+  })
+  .describe("Scoped target set for owner-approved admin message access");
+
+/** Owner-approved, time-bound admin read elevation. */
+export const AdminReadElevation: z.ZodType<AdminReadElevationType> = z
+  .object({
+    approvalId: z
+      .string()
+      .min(1)
+      .describe("Audit identifier for the owner-approved elevation"),
+    scope: AdminReadElevationScope,
+    approvedAt: z
+      .string()
+      .datetime()
+      .describe("When the owner approved the elevation"),
+    expiresAt: z
+      .string()
+      .datetime()
+      .describe("When the elevation expires automatically"),
+    approvalKeyFingerprint: z
+      .string()
+      .min(1)
+      .describe("Fingerprint of the local approval key used for the elevation"),
+  })
+  .describe("Explicit, time-bound admin message-read elevation");

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -91,6 +91,8 @@ export {
 
 // Seal
 export {
+  AdminAccessActor,
+  type AdminAccessActorType,
   InferenceMode,
   ContentEgressScope,
   HostingMode,
@@ -120,6 +122,14 @@ export {
   type IdMappingType,
   type IdMappingStore,
 } from "./id-mapping.js";
+
+// Admin read elevation
+export {
+  AdminReadElevationScope,
+  type AdminReadElevationScopeType,
+  AdminReadElevation,
+  type AdminReadElevationType,
+} from "./admin-read-elevation.js";
 
 // Credentials
 export {

--- a/packages/schemas/src/seal.ts
+++ b/packages/schemas/src/seal.ts
@@ -25,6 +25,9 @@ export type TrustTierType =
   | "reproducibly-verified"
   | "runtime-attested";
 
+/** Public subject disclosed when temporary admin read access is active. */
+export type AdminAccessActorType = "owner" | string;
+
 /** Core payload of a capability seal. */
 export type SealPayloadType = {
   sealId: string;
@@ -33,7 +36,12 @@ export type SealPayloadType = {
   chatId: string;
   scopeMode: ScopeModeType;
   permissions: ScopeSetType;
-  adminAccess?: { operatorId: string; expiresAt: string } | undefined;
+  adminAccess?:
+    | {
+        operatorId: AdminAccessActorType;
+        expiresAt: string;
+      }
+    | undefined;
   issuedAt: string;
   /** True when the seal used synthetic fallback input via SIGNET_SEAL_BYPASS. */
   bypassed?: true | undefined;
@@ -96,6 +104,11 @@ export const TrustTier: z.ZodEnum<
   "runtime-attested",
 ]);
 
+/** Public subject disclosed when temporary admin read access is active. */
+export const AdminAccessActor: z.ZodUnion<
+  [z.ZodType<string>, z.ZodLiteral<"owner">]
+> = z.union([OperatorId, z.literal("owner")]);
+
 export {
   InferenceMode,
   ContentEgressScope,
@@ -133,8 +146,11 @@ export const SealPayload: z.ZodType<SealPayloadType> = z
     /** Disclosed admin read access, if any. */
     adminAccess: z
       .object({
-        /** Admin operator who has read access. */
-        operatorId: OperatorId,
+        /**
+         * Delegated admin operator, or `owner` for the root-admin path used by
+         * the current local Secure Enclave elevation flow.
+         */
+        operatorId: AdminAccessActor,
         /** When the admin access expires. */
         expiresAt: z.string().datetime(),
       })

--- a/packages/seals/src/__tests__/build.test.ts
+++ b/packages/seals/src/__tests__/build.test.ts
@@ -100,16 +100,14 @@ describe("buildSeal", () => {
     const result = buildSeal(
       validInput({
         adminAccess: {
-          operatorId: "op_adcd0123feedbabe",
+          operatorId: "owner",
           expiresAt: "2025-12-31T23:59:59.000Z",
         },
       }),
     );
     expect(Result.isOk(result)).toBe(true);
     if (Result.isError(result)) return;
-    expect(result.value.chain.current.adminAccess?.operatorId).toBe(
-      "op_adcd0123feedbabe",
-    );
+    expect(result.value.chain.current.adminAccess?.operatorId).toBe("owner");
   });
 
   test("maps trustTier from input", () => {


### PR DESCRIPTION
## Summary
- replace the `xs lookup` stub with daemon-backed `lookup.resolve` wiring
- harden admin message reads behind explicit owner-approved elevation on the admin socket and HTTP admin surface
- refresh public seal disclosure while admin read elevation is active so `adminAccess` stays honest

## Testing
- `bun test packages/cli/src/__tests__/admin-read-elevation.test.ts packages/cli/src/__tests__/admin-socket.test.ts packages/cli/src/__tests__/http-server.test.ts packages/cli/src/__tests__/seal-input-resolver.test.ts packages/cli/src/__tests__/xs-message-command-wiring.test.ts packages/cli/src/__tests__/xs-utility-command-wiring.test.ts packages/core/src/__tests__/lookup-actions.test.ts packages/core/src/__tests__/message-actions.test.ts packages/schemas/src/__tests__/admin-read-elevation.test.ts packages/schemas/src/__tests__/seal.test.ts packages/seals/src/__tests__/build.test.ts packages/cli/src/__tests__/runtime.test.ts`
- `bun run test --filter=@xmtp/signet-cli`
- `bun run typecheck`
- `bun run lint`

## Notes
- local and self-hosted v1 scope only; this intentionally does not add network seal validation or external wallet provider work
- the first biometric and passkey approval path stays Signet-native and Apple-first
- Refs: #121

Closes: #279
Closes: #296
Closes: #297
