### PR TITLE
feat: add convos protocol foundation

### DIFF
--- a/packages/cli/src/__tests__/invite-host-listener.test.ts
+++ b/packages/cli/src/__tests__/invite-host-listener.test.ts
@@ -231,6 +231,52 @@ describe("startManagedInviteHostListener", () => {
     ]);
   });
 
+  test("processes structured join requests alongside plain slug fallback", async () => {
+    const slug = await buildValidSlug();
+
+    const addedByIdentity: string[] = [];
+    let capturedHandler: ((event: CoreRawEvent) => void) | null = null;
+
+    startManagedInviteHostListener({
+      subscribe(handler) {
+        capturedHandler = handler;
+        return () => {};
+      },
+      async listIdentities() {
+        return [{ id: "right", inboxId: RIGHT_CREATOR_INBOX_ID }];
+      },
+      async getWalletPrivateKeyHex() {
+        return Result.ok(RIGHT_PRIVATE_KEY_HEX);
+      },
+      getManagedClient() {
+        return {
+          addMembers: async (groupId, inboxIds) => {
+            addedByIdentity.push(`${groupId}:${inboxIds.join(",")}`);
+            return Result.ok(undefined);
+          },
+          listMessages: async () => Result.ok([]),
+        };
+      },
+      async getGroupInviteTag() {
+        return Result.ok("host-test-tag");
+      },
+    });
+
+    capturedHandler?.({
+      ...makeRawMessageEvent({
+        inviteSlug: slug,
+        profile: { memberKind: "agent" },
+      }),
+      messageId: "structured-join-request-1",
+      contentType: "join_request",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(addedByIdentity).toEqual([
+      `${TEST_CONVERSATION_ID}:${TEST_REQUESTER_INBOX_ID}`,
+    ]);
+  });
+
   test("does not process the same invite twice when the message stream catches up", async () => {
     const slug = await buildValidSlug();
 

--- a/packages/cli/src/invite-host-listener.ts
+++ b/packages/cli/src/invite-host-listener.ts
@@ -1,6 +1,7 @@
 import { Result } from "better-result";
 import {
   tryProcessJoinRequest,
+  isJoinRequestContentType,
   type CoreRawEvent,
   type ListMessagesOptions,
   type RawMessageEvent,
@@ -60,6 +61,9 @@ interface InviteRecoveryScanResult {
 function isInviteCandidate(event: CoreRawEvent): event is RawMessageEvent {
   if (event.type !== "raw.message") return false;
   if (event.isHistorical) return false;
+  if (isJoinRequestContentType(event.contentType)) {
+    return true;
+  }
   if (typeof event.content !== "string") return false;
 
   const text = event.content.trim();

--- a/packages/core/src/__tests__/conversation-actions.test.ts
+++ b/packages/core/src/__tests__/conversation-actions.test.ts
@@ -159,7 +159,7 @@ function createJoinMockClient(): XmtpClient {
 
   return {
     inboxId: "joiner-inbox-123",
-    sendMessage: notImplemented,
+    sendMessage: async () => Result.ok("join-msg-1"),
     createDm: async (peerInboxId) => Result.ok({ dmId: "dm-1", peerInboxId }),
     sendDmMessage: async () => Result.ok("dm-msg-1"),
     syncAll: async () => {

--- a/packages/core/src/__tests__/conversation-actions.test.ts
+++ b/packages/core/src/__tests__/conversation-actions.test.ts
@@ -179,7 +179,7 @@ function createJoinMockClient(): XmtpClient {
     removeSuperAdmin: notImplemented,
     createGroup: notImplemented,
     getMessageById: notImplemented,
-    listMessages: notImplemented,
+    listMessages: async () => Result.ok([]),
     streamAllMessages: async () =>
       Result.ok({ messages: emptyAsyncIterable(), abort: () => {} }),
     streamGroups: async () =>

--- a/packages/core/src/__tests__/sdk-client-factory.test.ts
+++ b/packages/core/src/__tests__/sdk-client-factory.test.ts
@@ -65,7 +65,7 @@ describe("createSdkClientFactory", () => {
     expect(capturedOptions["env"]).toBe("local");
     expect(capturedOptions["appVersion"]).toBe("test/0.1.0");
     expect(Array.isArray(capturedOptions["codecs"])).toBe(true);
-    expect(capturedOptions["codecs"] as unknown[]).toHaveLength(3);
+    expect(capturedOptions["codecs"] as unknown[]).toHaveLength(4);
   });
 
   test("creates signer from signerPrivateKey in options", async () => {

--- a/packages/core/src/__tests__/sdk-client-factory.test.ts
+++ b/packages/core/src/__tests__/sdk-client-factory.test.ts
@@ -64,6 +64,8 @@ describe("createSdkClientFactory", () => {
     expect(capturedOptions["dbPath"]).toBe("/tmp/test.db3");
     expect(capturedOptions["env"]).toBe("local");
     expect(capturedOptions["appVersion"]).toBe("test/0.1.0");
+    expect(Array.isArray(capturedOptions["codecs"])).toBe(true);
+    expect(capturedOptions["codecs"] as unknown[]).toHaveLength(3);
   });
 
   test("creates signer from signerPrivateKey in options", async () => {

--- a/packages/core/src/__tests__/sdk-client.test.ts
+++ b/packages/core/src/__tests__/sdk-client.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { encodeProfileSnapshot } from "../convos/profile-messages.js";
 import { createSdkClient } from "../sdk/sdk-client.js";
 import {
   createMockSdkNativeClient,
@@ -43,6 +44,32 @@ describe("createSdkClient", () => {
       if (result.isErr()) {
         expect(result.error._tag).toBe("NotFoundError");
       }
+    });
+
+    test("sends encoded convos payloads without JSON re-encoding", async () => {
+      let capturedPayload: unknown = null;
+      const group = createMockGroup({ id: "g1" });
+      group.send = async (encoded: unknown) => {
+        capturedPayload = encoded;
+        return "msg-id-encoded";
+      };
+      const native = createMockSdkNativeClient({ groups: [group] });
+      const client = createSdkClient({ client: native, syncTimeoutMs: 5000 });
+      const snapshot = encodeProfileSnapshot({
+        profiles: [{ inboxId: "abcd", name: "Codex" }],
+      });
+
+      const result = await client.sendMessage(
+        "g1",
+        snapshot,
+        "convos.org/profile_snapshot:1.0",
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe("msg-id-encoded");
+      }
+      expect(capturedPayload).toEqual(snapshot);
     });
   });
 

--- a/packages/core/src/convos/__tests__/invite-join-error.test.ts
+++ b/packages/core/src/convos/__tests__/invite-join-error.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ContentTypeInviteJoinError,
+  InviteJoinErrorCodec,
+  InviteJoinErrorType,
+  decodeInviteJoinError,
+  encodeInviteJoinError,
+  extractInviteJoinError,
+  getInviteJoinErrorMessage,
+  isInviteJoinErrorContentType,
+} from "../invite-join-error.js";
+
+describe("invite-join-error", () => {
+  test("round-trips invite join errors", () => {
+    const timestamp = new Date("2026-04-15T14:00:00.000Z");
+    const encoded = encodeInviteJoinError({
+      errorType: InviteJoinErrorType.ConversationExpired,
+      inviteTag: "tag-123",
+      timestamp,
+    });
+
+    expect(encoded.type).toEqual(ContentTypeInviteJoinError);
+
+    const decoded = decodeInviteJoinError(encoded);
+    expect(decoded).toEqual({
+      errorType: InviteJoinErrorType.ConversationExpired,
+      inviteTag: "tag-123",
+      timestamp,
+    });
+  });
+
+  test("extracts already-decoded errors", () => {
+    const timestamp = new Date("2026-04-15T14:00:00.000Z");
+    expect(
+      extractInviteJoinError({
+        errorType: InviteJoinErrorType.GenericFailure,
+        inviteTag: "tag-456",
+        timestamp,
+      }),
+    ).toEqual({
+      errorType: InviteJoinErrorType.GenericFailure,
+      inviteTag: "tag-456",
+      timestamp,
+    });
+  });
+
+  test("extracts encoded errors", () => {
+    const encoded = encodeInviteJoinError({
+      errorType: InviteJoinErrorType.Unknown,
+      inviteTag: "tag-789",
+      timestamp: new Date("2026-04-15T14:00:00.000Z"),
+    });
+
+    expect(extractInviteJoinError(encoded)?.inviteTag).toBe("tag-789");
+  });
+
+  test("exposes the current SDK error content type", () => {
+    expect(isInviteJoinErrorContentType("inviteJoinError")).toBe(true);
+    expect(isInviteJoinErrorContentType("convos.app/inviteJoinError:1.0")).toBe(
+      true,
+    );
+    expect(
+      isInviteJoinErrorContentType("convos.org/invite_join_error:1.0"),
+    ).toBe(true);
+    expect(isInviteJoinErrorContentType("text")).toBe(false);
+  });
+
+  test("provides a useful fallback string", () => {
+    const codec = new InviteJoinErrorCodec();
+    expect(
+      codec.fallback({
+        errorType: InviteJoinErrorType.ConversationExpired,
+        inviteTag: "tag-123",
+        timestamp: new Date("2026-04-15T14:00:00.000Z"),
+      }),
+    ).toBe("This conversation is no longer available");
+    expect(
+      getInviteJoinErrorMessage({
+        errorType: InviteJoinErrorType.GenericFailure,
+        inviteTag: "tag-123",
+        timestamp: new Date("2026-04-15T14:00:00.000Z"),
+      }),
+    ).toBe("Failed to join conversation");
+  });
+});

--- a/packages/core/src/convos/__tests__/join-request-content.test.ts
+++ b/packages/core/src/convos/__tests__/join-request-content.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ContentTypeJoinRequest,
+  JoinRequestCodec,
+  decodeJoinRequest,
+  extractJoinRequestContent,
+  type JoinRequestContent,
+} from "../join-request-content.js";
+
+describe("join-request-content", () => {
+  test("round-trips a structured join request with profile metadata", () => {
+    const original: JoinRequestContent = {
+      inviteSlug: "signed-slug-123",
+      profile: {
+        name: "Codex",
+        memberKind: "agent",
+      },
+      metadata: {
+        source: "signet",
+      },
+    };
+
+    const codec = new JoinRequestCodec();
+    const encoded = codec.encode(original);
+    const decoded = decodeJoinRequest(encoded);
+
+    expect(encoded.type).toEqual(ContentTypeJoinRequest);
+    expect(decoded).toEqual(original);
+    expect(codec.fallback(original)).toBe("signed-slug-123");
+  });
+
+  test("extracts join request content from decoded message payloads", () => {
+    const payload = {
+      inviteSlug: "signed-slug-456",
+      profile: { memberKind: "agent" },
+    };
+
+    expect(extractJoinRequestContent(payload)).toEqual(payload);
+  });
+});

--- a/packages/core/src/convos/__tests__/join.test.ts
+++ b/packages/core/src/convos/__tests__/join.test.ts
@@ -12,6 +12,7 @@ import type {
   XmtpGroupInfo,
   SignerProviderLike,
 } from "../../xmtp-client-factory.js";
+import { InviteJoinErrorType } from "../invite-join-error.js";
 import { joinConversation, type JoinConversationDeps } from "../join.js";
 
 // --- Protobuf setup (same as invite-parser tests) ---
@@ -115,6 +116,7 @@ function createMockClient(options?: {
     content: unknown,
     contentType?: string,
   ) => void;
+  listMessagesImpl?: XmtpClient["listMessages"];
   groupsAfterSync?: XmtpGroupInfo[];
   syncCount?: { value: number };
 }): XmtpClient {
@@ -146,7 +148,7 @@ function createMockClient(options?: {
     syncGroup: notImplemented,
     getGroupInfo: notImplemented,
     getMessageById: notImplemented,
-    listMessages: notImplemented,
+    listMessages: options?.listMessagesImpl ?? (async () => Result.ok([])),
     listGroups: async () => {
       // Return groups only after sync has been called (simulating acceptance)
       if (syncCount.value > 0 && groupsAfterSync.length > 0) {
@@ -280,6 +282,45 @@ describe("joinConversation", () => {
 
     const result = await joinConversation(deps, "not-a-valid-invite");
     expect(result.isErr()).toBe(true);
+  });
+
+  test("surfaces invite-join errors returned on the creator DM", async () => {
+    const client = createMockClient({
+      listMessagesImpl: async () =>
+        Result.ok([
+          {
+            messageId: "invite-error-1",
+            groupId: "dm-1",
+            senderInboxId: TEST_CREATOR_INBOX_ID,
+            contentType: "convos.app/inviteJoinError:1.0",
+            content: {
+              errorType: InviteJoinErrorType.ConversationExpired,
+              inviteTag: "test-join-tag",
+              timestamp: "2026-04-16T12:00:00.000Z",
+            },
+            sentAt: "2026-04-16T12:00:00.000Z",
+            threadId: null,
+          },
+        ]),
+      groupsAfterSync: [],
+    });
+    const deps = createDeps({ client });
+
+    const result = await joinConversation(deps, buildTestUrl(), {
+      pollIntervalMs: 10,
+      maxPollAttempts: 3,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+
+    expect(result.error.category).toBe("validation");
+    expect(result.error.message).toContain(
+      "This conversation is no longer available",
+    );
+
+    const identities = await deps.identityStore.list();
+    expect(identities).toHaveLength(0);
   });
 
   test("returns error when invite is expired", async () => {

--- a/packages/core/src/convos/__tests__/join.test.ts
+++ b/packages/core/src/convos/__tests__/join.test.ts
@@ -109,6 +109,11 @@ function createMockClient(options?: {
   inboxId?: string;
   onCreateDm?: (peerInboxId: string) => void;
   onSendDm?: (dmId: string, text: string) => void;
+  onSendMessage?: (
+    conversationId: string,
+    content: unknown,
+    contentType?: string,
+  ) => void;
   groupsAfterSync?: XmtpGroupInfo[];
   syncCount?: { value: number };
 }): XmtpClient {
@@ -121,7 +126,10 @@ function createMockClient(options?: {
 
   return {
     inboxId,
-    sendMessage: notImplemented,
+    sendMessage: async (conversationId, content, contentType) => {
+      options?.onSendMessage?.(conversationId, content, contentType);
+      return Result.ok("msg-structured-1");
+    },
     createDm: async (peerInboxId) => {
       options?.onCreateDm?.(peerInboxId);
       return Result.ok({ dmId: "dm-1", peerInboxId });
@@ -203,10 +211,17 @@ describe("joinConversation", () => {
   test("successful join flow: creates identity, DMs slug, discovers group", async () => {
     const dmCalls: Array<{ peerInboxId: string }> = [];
     const sendCalls: Array<{ dmId: string; text: string }> = [];
+    const structuredCalls: Array<{
+      conversationId: string;
+      content: unknown;
+      contentType: string | undefined;
+    }> = [];
 
     const client = createMockClient({
       onCreateDm: (peerInboxId) => dmCalls.push({ peerInboxId }),
       onSendDm: (dmId, text) => sendCalls.push({ dmId, text }),
+      onSendMessage: (conversationId, content, contentType) =>
+        structuredCalls.push({ conversationId, content, contentType }),
       groupsAfterSync: [
         {
           groupId: "joined-group-1",
@@ -237,9 +252,21 @@ describe("joinConversation", () => {
     expect(dmCalls).toHaveLength(1);
     expect(dmCalls[0]?.peerInboxId).toBe(TEST_CREATOR_INBOX_ID);
 
+    expect(structuredCalls).toEqual([
+      {
+        conversationId: "dm-1",
+        content: {
+          inviteSlug: buildTestSlug(),
+          profile: { memberKind: "agent" },
+        },
+        contentType: "convos.org/join_request:1.0",
+      },
+    ]);
+
     // Verify slug was sent as DM text
     expect(sendCalls).toHaveLength(1);
     expect(sendCalls[0]?.dmId).toBe("dm-1");
+    expect(sendCalls[0]?.text).toBe(buildTestSlug());
 
     // Verify identity was persisted
     const identities = await deps.identityStore.list();

--- a/packages/core/src/convos/__tests__/join.test.ts
+++ b/packages/core/src/convos/__tests__/join.test.ts
@@ -109,6 +109,7 @@ function createMockClient(options?: {
   inboxId?: string;
   onCreateDm?: (peerInboxId: string) => void;
   onSendDm?: (dmId: string, text: string) => void;
+  sendDmResult?: Result<string, InternalError>;
   onSendMessage?: (
     conversationId: string,
     content: unknown,
@@ -136,7 +137,7 @@ function createMockClient(options?: {
     },
     sendDmMessage: async (dmId, text) => {
       options?.onSendDm?.(dmId, text);
-      return Result.ok("dm-msg-1");
+      return options?.sendDmResult ?? Result.ok("dm-msg-1");
     },
     syncAll: async () => {
       syncCount.value++;
@@ -366,5 +367,41 @@ describe("joinConversation", () => {
     // Identity should have been cleaned up
     const identities = await store.list();
     expect(identities).toHaveLength(0);
+  });
+
+  test("keeps polling when plain-text fallback delivery fails", async () => {
+    const client = createMockClient({
+      sendDmResult: Result.err(
+        InternalError.create("temporary DM fallback failure"),
+      ),
+      groupsAfterSync: [
+        {
+          groupId: "joined-group-1",
+          name: "Joined Group",
+          description: "",
+          imageUrl: "",
+          memberInboxIds: ["joiner-inbox-123", TEST_CREATOR_INBOX_ID],
+          admins: [],
+          superAdmins: [],
+          consentState: "allowed",
+          createdAt: "2026-04-15T14:00:00.000Z",
+          updatedAt: "2026-04-15T14:00:00.000Z",
+        },
+      ],
+    });
+    const deps = createDeps({ client });
+
+    const result = await joinConversation(deps, buildTestUrl(), {
+      pollIntervalMs: 10,
+      maxPollAttempts: 3,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.groupId).toBe("joined-group-1");
+    const identities = await deps.identityStore.list();
+    expect(identities).toHaveLength(1);
+    expect(identities[0]?.inboxId).toBe("joiner-inbox-123");
   });
 });

--- a/packages/core/src/convos/__tests__/join.test.ts
+++ b/packages/core/src/convos/__tests__/join.test.ts
@@ -381,11 +381,7 @@ describe("joinConversation", () => {
           description: "",
           imageUrl: "",
           memberInboxIds: ["joiner-inbox-123", TEST_CREATOR_INBOX_ID],
-          admins: [],
-          superAdmins: [],
-          consentState: "allowed",
           createdAt: "2026-04-15T14:00:00.000Z",
-          updatedAt: "2026-04-15T14:00:00.000Z",
         },
       ],
     });

--- a/packages/core/src/convos/__tests__/join.test.ts
+++ b/packages/core/src/convos/__tests__/join.test.ts
@@ -285,9 +285,13 @@ describe("joinConversation", () => {
   });
 
   test("surfaces invite-join errors returned on the creator DM", async () => {
+    const listCalls: Array<Record<string, unknown> | undefined> = [];
     const client = createMockClient({
-      listMessagesImpl: async () =>
-        Result.ok([
+      listMessagesImpl: async (_groupId, options) => {
+        listCalls.push(
+          options ? ({ ...options } as Record<string, unknown>) : undefined,
+        );
+        return Result.ok([
           {
             messageId: "invite-error-1",
             groupId: "dm-1",
@@ -301,7 +305,8 @@ describe("joinConversation", () => {
             sentAt: "2026-04-16T12:00:00.000Z",
             threadId: null,
           },
-        ]),
+        ]);
+      },
       groupsAfterSync: [],
     });
     const deps = createDeps({ client });
@@ -318,6 +323,12 @@ describe("joinConversation", () => {
     expect(result.error.message).toContain(
       "This conversation is no longer available",
     );
+    expect(listCalls).toEqual([
+      {
+        limit: 20,
+        direction: "descending",
+      },
+    ]);
 
     const identities = await deps.identityStore.list();
     expect(identities).toHaveLength(0);

--- a/packages/core/src/convos/__tests__/process-join-requests.test.ts
+++ b/packages/core/src/convos/__tests__/process-join-requests.test.ts
@@ -6,6 +6,7 @@ import {
   processJoinRequest,
   type ProcessJoinRequestDeps,
 } from "../process-join-requests.js";
+import { type JoinRequestContent } from "../join-request-content.js";
 
 // --- Test key material ---
 
@@ -54,7 +55,7 @@ describe("processJoinRequest", () => {
 
     const result = await processJoinRequest(deps, {
       senderInboxId: TEST_REQUESTER_INBOX_ID,
-      messageText: slug,
+      content: slug,
     });
 
     expect(result.isOk()).toBe(true);
@@ -72,7 +73,7 @@ describe("processJoinRequest", () => {
 
     const result = await processJoinRequest(deps, {
       senderInboxId: TEST_REQUESTER_INBOX_ID,
-      messageText: slug,
+      content: slug,
     });
 
     expect(result.isErr()).toBe(true);
@@ -100,7 +101,7 @@ describe("processJoinRequest", () => {
     const deps = createMockDeps();
     const result = await processJoinRequest(deps, {
       senderInboxId: TEST_REQUESTER_INBOX_ID,
-      messageText: slugResult.value,
+      content: slugResult.value,
     });
 
     expect(result.isErr()).toBe(true);
@@ -113,7 +114,7 @@ describe("processJoinRequest", () => {
     const deps = createMockDeps();
     const result = await processJoinRequest(deps, {
       senderInboxId: TEST_REQUESTER_INBOX_ID,
-      messageText: "hello, I would like to join!",
+      content: "hello, I would like to join!",
     });
 
     expect(result.isErr()).toBe(true);
@@ -127,7 +128,7 @@ describe("processJoinRequest", () => {
 
     const result = await processJoinRequest(deps, {
       senderInboxId: TEST_REQUESTER_INBOX_ID,
-      messageText: slug,
+      content: slug,
     });
 
     expect(result.isErr()).toBe(true);
@@ -144,9 +145,32 @@ describe("processJoinRequest", () => {
 
     const result = await processJoinRequest(deps, {
       senderInboxId: TEST_REQUESTER_INBOX_ID,
-      messageText: slug,
+      content: slug,
     });
 
     expect(result.isOk()).toBe(true);
+  });
+
+  test("accepts a structured join request payload", async () => {
+    const slug = await buildValidSlug();
+    const deps = createMockDeps();
+    const joinRequest: JoinRequestContent = {
+      inviteSlug: slug,
+      profile: {
+        name: "Codex",
+        memberKind: "agent",
+      },
+    };
+
+    const result = await processJoinRequest(deps, {
+      senderInboxId: TEST_REQUESTER_INBOX_ID,
+      content: joinRequest,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.groupId).toBe(TEST_CONVERSATION_ID);
+    expect(result.value.requesterInboxId).toBe(TEST_REQUESTER_INBOX_ID);
   });
 });

--- a/packages/core/src/convos/__tests__/profile-messages.test.ts
+++ b/packages/core/src/convos/__tests__/profile-messages.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ContentTypeProfileSnapshot,
+  ContentTypeProfileUpdate,
+  MemberKind,
+  decodeProfileSnapshot,
+  decodeProfileUpdate,
+  encodeProfileSnapshot,
+  encodeProfileUpdate,
+} from "../profile-messages.js";
+
+describe("profile-messages", () => {
+  test("round-trips a profile update", () => {
+    const encoded = encodeProfileUpdate({
+      name: "Codex",
+      memberKind: MemberKind.Agent,
+      metadata: {
+        trusted: { type: "bool", value: true },
+      },
+    });
+
+    const decoded = decodeProfileUpdate(encoded);
+
+    expect(encoded.type).toEqual(ContentTypeProfileUpdate);
+    expect(decoded.name).toBe("Codex");
+    expect(decoded.memberKind).toBe(MemberKind.Agent);
+    expect(decoded.metadata?.["trusted"]).toEqual({
+      type: "bool",
+      value: true,
+    });
+  });
+
+  test("round-trips a profile snapshot", () => {
+    const encoded = encodeProfileSnapshot({
+      profiles: [
+        {
+          inboxId: "aa".repeat(32),
+          name: "Codex",
+          memberKind: MemberKind.Agent,
+        },
+      ],
+    });
+
+    const decoded = decodeProfileSnapshot(encoded);
+
+    expect(encoded.type).toEqual(ContentTypeProfileSnapshot);
+    expect(decoded.profiles).toHaveLength(1);
+    expect(decoded.profiles[0]).toMatchObject({
+      inboxId: "aa".repeat(32),
+      name: "Codex",
+      memberKind: MemberKind.Agent,
+    });
+  });
+});

--- a/packages/core/src/convos/__tests__/profile-messages.test.ts
+++ b/packages/core/src/convos/__tests__/profile-messages.test.ts
@@ -30,6 +30,22 @@ describe("profile-messages", () => {
     });
   });
 
+  test("round-trips default-valued metadata variants in a profile update", () => {
+    const encoded = encodeProfileUpdate({
+      metadata: {
+        retries: { type: "number", value: 0 },
+        suspended: { type: "bool", value: false },
+      },
+    });
+
+    const decoded = decodeProfileUpdate(encoded);
+
+    expect(decoded.metadata).toEqual({
+      retries: { type: "number", value: 0 },
+      suspended: { type: "bool", value: false },
+    });
+  });
+
   test("round-trips a profile snapshot", () => {
     const encoded = encodeProfileSnapshot({
       profiles: [
@@ -49,6 +65,30 @@ describe("profile-messages", () => {
       inboxId: "aa".repeat(32),
       name: "Codex",
       memberKind: MemberKind.Agent,
+    });
+  });
+
+  test("round-trips default-valued metadata variants in a profile snapshot", () => {
+    const encoded = encodeProfileSnapshot({
+      profiles: [
+        {
+          inboxId: "bb".repeat(32),
+          metadata: {
+            retries: { type: "number", value: 0 },
+            suspended: { type: "bool", value: false },
+          },
+        },
+      ],
+    });
+
+    const decoded = decodeProfileSnapshot(encoded);
+
+    expect(decoded.profiles[0]).toMatchObject({
+      inboxId: "bb".repeat(32),
+      metadata: {
+        retries: { type: "number", value: 0 },
+        suspended: { type: "bool", value: false },
+      },
     });
   });
 });

--- a/packages/core/src/convos/__tests__/profile-state.test.ts
+++ b/packages/core/src/convos/__tests__/profile-state.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import type { XmtpDecodedMessage } from "../../xmtp-client-factory.js";
+import { encodeProfileSnapshot, MemberKind } from "../profile-messages.js";
+import {
+  buildProfileSnapshotFromMessages,
+  extractProfileSnapshotContent,
+  extractProfileUpdateContent,
+  resolveProfilesFromMessages,
+} from "../profile-state.js";
+
+function makeMessage(
+  overrides?: Partial<XmtpDecodedMessage>,
+): XmtpDecodedMessage {
+  return {
+    messageId: overrides?.messageId ?? "msg-1",
+    groupId: overrides?.groupId ?? "group-1",
+    senderInboxId: overrides?.senderInboxId ?? "inbox-a",
+    contentType: overrides?.contentType ?? "text",
+    content: overrides?.content ?? "hello",
+    sentAt: overrides?.sentAt ?? "2026-04-15T14:00:00.000Z",
+    threadId: overrides?.threadId ?? null,
+  };
+}
+
+describe("profile-state", () => {
+  test("prefers the latest profile update over older snapshots", () => {
+    const messages = [
+      makeMessage({
+        messageId: "profile-update",
+        senderInboxId: "inbox-a",
+        contentType: "profile_update",
+        content: { name: "Codex", memberKind: MemberKind.Agent },
+        sentAt: "2026-04-15T14:05:00.000Z",
+      }),
+      makeMessage({
+        messageId: "profile-snapshot",
+        senderInboxId: "host",
+        contentType: "profile_snapshot",
+        content: {
+          profiles: [
+            { inboxId: "inbox-a", name: "Older Name" },
+            { inboxId: "inbox-b", name: "Other Member" },
+          ],
+        },
+        sentAt: "2026-04-15T14:00:00.000Z",
+      }),
+    ];
+
+    const resolved = resolveProfilesFromMessages(messages, [
+      "inbox-a",
+      "inbox-b",
+    ]);
+
+    expect(resolved.get("inbox-a")).toEqual({
+      inboxId: "inbox-a",
+      name: "Codex",
+      memberKind: MemberKind.Agent,
+    });
+    expect(resolved.get("inbox-b")).toEqual({
+      inboxId: "inbox-b",
+      name: "Other Member",
+    });
+  });
+
+  test("can build fallback snapshot entries for unresolved members", () => {
+    const snapshot = buildProfileSnapshotFromMessages(
+      [],
+      ["inbox-a", "inbox-b"],
+      {
+        includeFallbackEntries: true,
+      },
+    );
+
+    expect(snapshot).toEqual({
+      profiles: [{ inboxId: "inbox-a" }, { inboxId: "inbox-b" }],
+    });
+  });
+
+  test("extracts profile updates and snapshots from encoded content", () => {
+    const encodedSnapshot = encodeProfileSnapshot({
+      profiles: [{ inboxId: "aabbccdd", name: "Codex" }],
+    });
+
+    expect(
+      extractProfileUpdateContent({
+        name: "Codex",
+        memberKind: MemberKind.Agent,
+      }),
+    ).toEqual({
+      name: "Codex",
+      memberKind: MemberKind.Agent,
+    });
+    expect(extractProfileSnapshotContent(encodedSnapshot)).toEqual({
+      profiles: [{ inboxId: "aabbccdd", name: "Codex" }],
+    });
+  });
+});

--- a/packages/core/src/convos/__tests__/profile-state.test.ts
+++ b/packages/core/src/convos/__tests__/profile-state.test.ts
@@ -94,4 +94,31 @@ describe("profile-state", () => {
       profiles: [{ inboxId: "aabbccdd", name: "Codex" }],
     });
   });
+
+  test("ignores malformed snapshot entries instead of throwing", () => {
+    const messages = [
+      makeMessage({
+        messageId: "profile-snapshot",
+        senderInboxId: "host",
+        contentType: "profile_snapshot",
+        content: {
+          profiles: [{}, { inboxId: "inbox-b", name: "Other Member" }],
+        },
+      }),
+    ];
+
+    expect(() =>
+      resolveProfilesFromMessages(messages, ["inbox-a", "inbox-b"]),
+    ).not.toThrow();
+
+    const resolved = resolveProfilesFromMessages(messages, [
+      "inbox-a",
+      "inbox-b",
+    ]);
+    expect(resolved.get("inbox-a")).toBeUndefined();
+    expect(resolved.get("inbox-b")).toEqual({
+      inboxId: "inbox-b",
+      name: "Other Member",
+    });
+  });
 });

--- a/packages/core/src/convos/codecs.ts
+++ b/packages/core/src/convos/codecs.ts
@@ -1,0 +1,13 @@
+import { JoinRequestCodec } from "./join-request-content.js";
+import {
+  ProfileSnapshotCodec,
+  ProfileUpdateCodec,
+} from "./profile-messages.js";
+
+export function createConvosCodecs(): unknown[] {
+  return [
+    new ProfileUpdateCodec(),
+    new ProfileSnapshotCodec(),
+    new JoinRequestCodec(),
+  ];
+}

--- a/packages/core/src/convos/codecs.ts
+++ b/packages/core/src/convos/codecs.ts
@@ -1,4 +1,5 @@
 import { JoinRequestCodec } from "./join-request-content.js";
+import { InviteJoinErrorCodec } from "./invite-join-error.js";
 import {
   ProfileSnapshotCodec,
   ProfileUpdateCodec,
@@ -9,5 +10,6 @@ export function createConvosCodecs(): unknown[] {
     new ProfileUpdateCodec(),
     new ProfileSnapshotCodec(),
     new JoinRequestCodec(),
+    new InviteJoinErrorCodec(),
   ];
 }

--- a/packages/core/src/convos/codecs.ts
+++ b/packages/core/src/convos/codecs.ts
@@ -1,3 +1,4 @@
+import type { Client as NodeSdkClient } from "@xmtp/node-sdk";
 import { JoinRequestCodec } from "./join-request-content.js";
 import { InviteJoinErrorCodec } from "./invite-join-error.js";
 import {
@@ -5,8 +6,12 @@ import {
   ProfileUpdateCodec,
 } from "./profile-messages.js";
 
+type NodeSdkCodecs = NonNullable<
+  NonNullable<Parameters<typeof NodeSdkClient.create>[1]>["codecs"]
+>;
+
 /** Returns the Convos custom-content codecs that Signet should register. */
-export function createConvosCodecs(): unknown[] {
+export function createConvosCodecs(): NodeSdkCodecs {
   return [
     new ProfileUpdateCodec(),
     new ProfileSnapshotCodec(),

--- a/packages/core/src/convos/codecs.ts
+++ b/packages/core/src/convos/codecs.ts
@@ -5,6 +5,7 @@ import {
   ProfileUpdateCodec,
 } from "./profile-messages.js";
 
+/** Returns the Convos custom-content codecs that Signet should register. */
 export function createConvosCodecs(): unknown[] {
   return [
     new ProfileUpdateCodec(),

--- a/packages/core/src/convos/invite-host.ts
+++ b/packages/core/src/convos/invite-host.ts
@@ -7,6 +7,7 @@ import {
   type IncomingJoinMessage,
   type JoinRequestResult,
 } from "./process-join-requests.js";
+import { extractJoinRequestContent } from "./join-request-content.js";
 
 /** Dependencies for the invite host listener. */
 export interface InviteHostDeps {
@@ -36,17 +37,16 @@ export async function tryProcessJoinRequest(
   deps: InviteHostDeps,
   event: RawMessageEvent,
 ): Promise<Result<JoinRequestResult, SignetError> | null> {
-  // Only process text content
-  if (typeof event.content !== "string") return null;
-
-  // Quick heuristic: invite slugs/URLs are always long single-token strings.
-  // Short messages or multi-word text are clearly not invites.
-  const text = event.content.trim();
-  if (text.length < 50 || text.includes(" ")) return null;
+  const joinRequest = extractJoinRequestContent(event.content);
+  const text =
+    typeof event.content === "string" ? event.content.trim() : undefined;
+  const looksLikeSlug =
+    text !== undefined && text.length >= 50 && !text.includes(" ");
+  if (!joinRequest && !looksLikeSlug) return null;
 
   const message: IncomingJoinMessage = {
     senderInboxId: event.senderInboxId,
-    messageText: text,
+    content: joinRequest ?? text ?? event.content,
   };
 
   return processJoinRequest(

--- a/packages/core/src/convos/invite-join-error.ts
+++ b/packages/core/src/convos/invite-join-error.ts
@@ -1,0 +1,148 @@
+import type {
+  ConvosContentTypeId,
+  EncodedConvosContent,
+} from "./join-request-content.js";
+import { isEncodedConvosContent } from "./join-request-content.js";
+
+export enum InviteJoinErrorType {
+  ConversationExpired = "conversationExpired",
+  GenericFailure = "genericFailure",
+  Unknown = "unknown",
+}
+
+export interface InviteJoinError {
+  readonly errorType: InviteJoinErrorType;
+  readonly inviteTag: string;
+  readonly timestamp: Date;
+}
+
+export const ContentTypeInviteJoinError: ConvosContentTypeId = {
+  authorityId: "convos.app",
+  typeId: "inviteJoinError",
+  versionMajor: 1,
+  versionMinor: 0,
+};
+
+export function encodeInviteJoinError(
+  error: InviteJoinError,
+): EncodedConvosContent {
+  return {
+    type: ContentTypeInviteJoinError,
+    parameters: {},
+    content: new TextEncoder().encode(
+      JSON.stringify({
+        errorType: error.errorType,
+        inviteTag: error.inviteTag,
+        timestamp: error.timestamp.toISOString(),
+      }),
+    ),
+    fallback: getInviteJoinErrorMessage(error),
+  };
+}
+
+export function decodeInviteJoinError(
+  encoded: Pick<EncodedConvosContent, "content">,
+): InviteJoinError {
+  const parsed = JSON.parse(
+    new TextDecoder().decode(encoded.content),
+  ) as Record<string, unknown>;
+  const errorType = Object.values(InviteJoinErrorType).includes(
+    parsed["errorType"] as InviteJoinErrorType,
+  )
+    ? (parsed["errorType"] as InviteJoinErrorType)
+    : InviteJoinErrorType.Unknown;
+
+  return {
+    errorType,
+    inviteTag:
+      typeof parsed["inviteTag"] === "string" ? parsed["inviteTag"] : "",
+    timestamp:
+      typeof parsed["timestamp"] === "string"
+        ? new Date(parsed["timestamp"])
+        : new Date(0),
+  };
+}
+
+export function extractInviteJoinError(
+  value: unknown,
+): InviteJoinError | undefined {
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "errorType" in value &&
+    "inviteTag" in value &&
+    "timestamp" in value
+  ) {
+    const error = value as Record<string, unknown>;
+    const timestamp = error["timestamp"];
+    return {
+      errorType: Object.values(InviteJoinErrorType).includes(
+        error["errorType"] as InviteJoinErrorType,
+      )
+        ? (error["errorType"] as InviteJoinErrorType)
+        : InviteJoinErrorType.Unknown,
+      inviteTag:
+        typeof error["inviteTag"] === "string" ? error["inviteTag"] : "",
+      timestamp:
+        timestamp instanceof Date
+          ? timestamp
+          : typeof timestamp === "string"
+            ? new Date(timestamp)
+            : new Date(0),
+    };
+  }
+
+  if (isEncodedConvosContent(value)) {
+    try {
+      return decodeInviteJoinError(value);
+    } catch {
+      return undefined;
+    }
+  }
+
+  return undefined;
+}
+
+export function isInviteJoinErrorContentType(
+  contentType: string | undefined,
+): boolean {
+  return (
+    contentType === "inviteJoinError" ||
+    contentType === "convos.app/inviteJoinError:1.0" ||
+    contentType === "convos.org/invite_join_error:1.0" ||
+    contentType === "invite_join_error"
+  );
+}
+
+export function getInviteJoinErrorMessage(error: InviteJoinError): string {
+  switch (error.errorType) {
+    case InviteJoinErrorType.ConversationExpired:
+      return "This conversation is no longer available";
+    case InviteJoinErrorType.GenericFailure:
+    case InviteJoinErrorType.Unknown:
+    default:
+      return "Failed to join conversation";
+  }
+}
+
+export class InviteJoinErrorCodec {
+  get contentType(): ConvosContentTypeId {
+    return ContentTypeInviteJoinError;
+  }
+
+  encode(content: InviteJoinError): EncodedConvosContent {
+    return encodeInviteJoinError(content);
+  }
+
+  decode(content: EncodedConvosContent): InviteJoinError {
+    return decodeInviteJoinError(content);
+  }
+
+  fallback(content: InviteJoinError): string {
+    return getInviteJoinErrorMessage(content);
+  }
+
+  shouldPush(): boolean {
+    return true;
+  }
+}

--- a/packages/core/src/convos/invite-join-error.ts
+++ b/packages/core/src/convos/invite-join-error.ts
@@ -4,18 +4,21 @@ import type {
 } from "./join-request-content.js";
 import { isEncodedConvosContent } from "./join-request-content.js";
 
+/** Error types surfaced by the Convos invite-join failure content. */
 export enum InviteJoinErrorType {
   ConversationExpired = "conversationExpired",
   GenericFailure = "genericFailure",
   Unknown = "unknown",
 }
 
+/** Structured payload describing why an invite join failed. */
 export interface InviteJoinError {
   readonly errorType: InviteJoinErrorType;
   readonly inviteTag: string;
   readonly timestamp: Date;
 }
 
+/** Content type descriptor for Convos invite-join errors. */
 export const ContentTypeInviteJoinError: ConvosContentTypeId = {
   authorityId: "convos.app",
   typeId: "inviteJoinError",
@@ -23,6 +26,7 @@ export const ContentTypeInviteJoinError: ConvosContentTypeId = {
   versionMinor: 0,
 };
 
+/** Encodes an invite-join error for transport over XMTP custom content. */
 export function encodeInviteJoinError(
   error: InviteJoinError,
 ): EncodedConvosContent {
@@ -40,6 +44,7 @@ export function encodeInviteJoinError(
   };
 }
 
+/** Decodes an invite-join error from the XMTP custom-content envelope. */
 export function decodeInviteJoinError(
   encoded: Pick<EncodedConvosContent, "content">,
 ): InviteJoinError {
@@ -63,6 +68,7 @@ export function decodeInviteJoinError(
   };
 }
 
+/** Extracts an invite-join error from decoded JSON or encoded Convos content. */
 export function extractInviteJoinError(
   value: unknown,
 ): InviteJoinError | undefined {
@@ -103,6 +109,7 @@ export function extractInviteJoinError(
   return undefined;
 }
 
+/** Matches legacy and fully qualified content-type labels for join failures. */
 export function isInviteJoinErrorContentType(
   contentType: string | undefined,
 ): boolean {
@@ -114,6 +121,7 @@ export function isInviteJoinErrorContentType(
   );
 }
 
+/** Returns the human-readable fallback string for an invite-join error. */
 export function getInviteJoinErrorMessage(error: InviteJoinError): string {
   switch (error.errorType) {
     case InviteJoinErrorType.ConversationExpired:
@@ -125,6 +133,7 @@ export function getInviteJoinErrorMessage(error: InviteJoinError): string {
   }
 }
 
+/** Codec that round-trips Convos invite-join errors through XMTP custom content. */
 export class InviteJoinErrorCodec {
   get contentType(): ConvosContentTypeId {
     return ContentTypeInviteJoinError;

--- a/packages/core/src/convos/join-request-content.ts
+++ b/packages/core/src/convos/join-request-content.ts
@@ -31,7 +31,9 @@ export interface JoinRequestContent {
   readonly metadata?: Record<string, string>;
 }
 
-function isEncodedConvosContent(value: unknown): value is EncodedConvosContent {
+export function isEncodedConvosContent(
+  value: unknown,
+): value is EncodedConvosContent {
   if (typeof value !== "object" || value === null) return false;
 
   const candidate = value as Record<string, unknown>;

--- a/packages/core/src/convos/join-request-content.ts
+++ b/packages/core/src/convos/join-request-content.ts
@@ -1,0 +1,121 @@
+export interface ConvosContentTypeId {
+  readonly authorityId: string;
+  readonly typeId: string;
+  readonly versionMajor: number;
+  readonly versionMinor: number;
+}
+
+export interface EncodedConvosContent {
+  readonly type: ConvosContentTypeId;
+  readonly parameters: Record<string, string>;
+  readonly content: Uint8Array;
+  readonly fallback?: string;
+}
+
+export const ContentTypeJoinRequest: ConvosContentTypeId = {
+  authorityId: "convos.org",
+  typeId: "join_request",
+  versionMajor: 1,
+  versionMinor: 0,
+};
+
+export interface JoinRequestProfile {
+  readonly name?: string;
+  readonly imageURL?: string;
+  readonly memberKind?: string;
+}
+
+export interface JoinRequestContent {
+  readonly inviteSlug: string;
+  readonly profile?: JoinRequestProfile;
+  readonly metadata?: Record<string, string>;
+}
+
+function isEncodedConvosContent(value: unknown): value is EncodedConvosContent {
+  if (typeof value !== "object" || value === null) return false;
+
+  const candidate = value as Record<string, unknown>;
+  const type = candidate["type"];
+  const content = candidate["content"];
+
+  return (
+    typeof type === "object" &&
+    type !== null &&
+    content instanceof Uint8Array &&
+    typeof (type as Record<string, unknown>)["authorityId"] === "string" &&
+    typeof (type as Record<string, unknown>)["typeId"] === "string"
+  );
+}
+
+function isJoinRequestShape(value: unknown): value is JoinRequestContent {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as Record<string, unknown>)["inviteSlug"] === "string"
+  );
+}
+
+export function decodeJoinRequest(
+  encoded: Pick<EncodedConvosContent, "content">,
+): JoinRequestContent {
+  const json = new TextDecoder().decode(encoded.content);
+  const parsed = JSON.parse(json) as unknown;
+  if (!isJoinRequestShape(parsed)) {
+    throw new Error("Missing inviteSlug in JoinRequest");
+  }
+  return parsed;
+}
+
+export function extractJoinRequestContent(
+  value: unknown,
+): JoinRequestContent | undefined {
+  if (isJoinRequestShape(value)) {
+    return value;
+  }
+
+  if (isEncodedConvosContent(value)) {
+    try {
+      return decodeJoinRequest(value);
+    } catch {
+      return undefined;
+    }
+  }
+
+  return undefined;
+}
+
+export function isJoinRequestContentType(
+  contentType: string | undefined,
+): boolean {
+  return (
+    contentType === "join_request" ||
+    contentType === "convos.org/join_request:1.0"
+  );
+}
+
+export class JoinRequestCodec {
+  get contentType(): ConvosContentTypeId {
+    return ContentTypeJoinRequest;
+  }
+
+  encode(content: JoinRequestContent): EncodedConvosContent {
+    return {
+      type: ContentTypeJoinRequest,
+      parameters: {},
+      content: new TextEncoder().encode(JSON.stringify(content)),
+      fallback: content.inviteSlug,
+    };
+  }
+
+  decode(content: EncodedConvosContent): JoinRequestContent {
+    return decodeJoinRequest(content);
+  }
+
+  fallback(content: JoinRequestContent): string {
+    return content.inviteSlug;
+  }
+
+  shouldPush(_content: JoinRequestContent): boolean {
+    return true;
+  }
+}

--- a/packages/core/src/convos/join-request-content.ts
+++ b/packages/core/src/convos/join-request-content.ts
@@ -127,7 +127,7 @@ export class JoinRequestCodec {
     return content.inviteSlug;
   }
 
-  shouldPush(_content: JoinRequestContent): boolean {
+  shouldPush(_content: unknown): boolean {
     return true;
   }
 }

--- a/packages/core/src/convos/join-request-content.ts
+++ b/packages/core/src/convos/join-request-content.ts
@@ -1,3 +1,4 @@
+/** Canonical identifier for a Convos custom content type. */
 export interface ConvosContentTypeId {
   readonly authorityId: string;
   readonly typeId: string;
@@ -5,6 +6,7 @@ export interface ConvosContentTypeId {
   readonly versionMinor: number;
 }
 
+/** Decoded XMTP payload for a Convos custom content message. */
 export interface EncodedConvosContent {
   readonly type: ConvosContentTypeId;
   readonly parameters: Record<string, string>;
@@ -12,6 +14,7 @@ export interface EncodedConvosContent {
   readonly fallback?: string;
 }
 
+/** Content type descriptor for Convos join requests. */
 export const ContentTypeJoinRequest: ConvosContentTypeId = {
   authorityId: "convos.org",
   typeId: "join_request",
@@ -19,18 +22,21 @@ export const ContentTypeJoinRequest: ConvosContentTypeId = {
   versionMinor: 0,
 };
 
+/** Optional profile fields a joiner can include with a join request. */
 export interface JoinRequestProfile {
   readonly name?: string;
   readonly imageURL?: string;
   readonly memberKind?: string;
 }
 
+/** Structured join-request payload sent to a Convos invite host. */
 export interface JoinRequestContent {
   readonly inviteSlug: string;
   readonly profile?: JoinRequestProfile;
   readonly metadata?: Record<string, string>;
 }
 
+/** Returns true when a decoded XMTP payload matches the Convos content shape. */
 export function isEncodedConvosContent(
   value: unknown,
 ): value is EncodedConvosContent {
@@ -57,6 +63,7 @@ function isJoinRequestShape(value: unknown): value is JoinRequestContent {
   );
 }
 
+/** Decodes a serialized Convos join request from its binary payload. */
 export function decodeJoinRequest(
   encoded: Pick<EncodedConvosContent, "content">,
 ): JoinRequestContent {
@@ -68,6 +75,7 @@ export function decodeJoinRequest(
   return parsed;
 }
 
+/** Extracts a join request from decoded JSON or encoded Convos content. */
 export function extractJoinRequestContent(
   value: unknown,
 ): JoinRequestContent | undefined {
@@ -86,6 +94,7 @@ export function extractJoinRequestContent(
   return undefined;
 }
 
+/** Matches the legacy and fully qualified content-type labels for join requests. */
 export function isJoinRequestContentType(
   contentType: string | undefined,
 ): boolean {
@@ -95,6 +104,7 @@ export function isJoinRequestContentType(
   );
 }
 
+/** Codec that round-trips Convos join requests through XMTP custom content. */
 export class JoinRequestCodec {
   get contentType(): ConvosContentTypeId {
     return ContentTypeJoinRequest;

--- a/packages/core/src/convos/join.ts
+++ b/packages/core/src/convos/join.ts
@@ -7,6 +7,7 @@ import type { XmtpEnv, SignetCoreConfig } from "../config.js";
 import type { SignerProviderFactory } from "../identity-registration.js";
 import { registerIdentity } from "../identity-registration.js";
 import { parseConvosInviteUrl, verifyConvosInvite } from "./invite-parser.js";
+import type { JoinRequestContent } from "./join-request-content.js";
 
 /** Dependencies injected into the join orchestrator. */
 export interface JoinConversationDeps {
@@ -70,7 +71,7 @@ function extractSlugForDm(input: string): string {
  * 2. Check expiration
  * 3. Create a new per-conversation identity and XMTP client
  * 4. Create a DM with the creator's inbox ID
- * 5. Send the invite slug as a join request
+ * 5. Send the structured join request and text fallback via DM
  * 6. Poll for group discovery (creator adds joiner to the group)
  * 7. Return the joined group info
  *
@@ -162,6 +163,20 @@ export async function joinConversation(
   }
 
   const slug = extractSlugForDm(inviteUrl);
+  const joinRequest: JoinRequestContent = {
+    inviteSlug: slug,
+    profile: { memberKind: "agent" },
+  };
+  const structuredSendResult = await client.sendMessage(
+    dmResult.value.dmId,
+    joinRequest,
+    "convos.org/join_request:1.0",
+  );
+  if (!structuredSendResult.isOk()) {
+    await identityStore.remove(identityId);
+    return structuredSendResult;
+  }
+
   const sendResult = await client.sendDmMessage(dmResult.value.dmId, slug);
   if (!sendResult.isOk()) {
     await identityStore.remove(identityId);

--- a/packages/core/src/convos/join.ts
+++ b/packages/core/src/convos/join.ts
@@ -6,6 +6,11 @@ import type { XmtpClientFactory } from "../xmtp-client-factory.js";
 import type { XmtpEnv, SignetCoreConfig } from "../config.js";
 import type { SignerProviderFactory } from "../identity-registration.js";
 import { registerIdentity } from "../identity-registration.js";
+import {
+  extractInviteJoinError,
+  getInviteJoinErrorMessage,
+  isInviteJoinErrorContentType,
+} from "./invite-join-error.js";
 import { parseConvosInviteUrl, verifyConvosInvite } from "./invite-parser.js";
 import type { JoinRequestContent } from "./join-request-content.js";
 
@@ -61,6 +66,39 @@ function extractSlugForDm(input: string): string {
     // Raw slug
   }
   return trimmed;
+}
+
+function findInviteJoinErrorReply(
+  messages: readonly {
+    senderInboxId: string;
+    contentType: string;
+    content: unknown;
+  }[],
+  creatorInboxId: string,
+  inviteTag: string,
+): string | undefined {
+  const normalizedCreatorInboxId = creatorInboxId.toLowerCase();
+
+  for (const message of messages) {
+    if (message.senderInboxId.toLowerCase() !== normalizedCreatorInboxId) {
+      continue;
+    }
+    if (!isInviteJoinErrorContentType(message.contentType)) {
+      continue;
+    }
+
+    const inviteJoinError = extractInviteJoinError(message.content);
+    if (!inviteJoinError) {
+      continue;
+    }
+    if (inviteJoinError.inviteTag !== inviteTag) {
+      continue;
+    }
+
+    return getInviteJoinErrorMessage(inviteJoinError);
+  }
+
+  return undefined;
 }
 
 /**
@@ -167,6 +205,7 @@ export async function joinConversation(
     inviteSlug: slug,
     profile: { memberKind: "agent" },
   };
+  const joinRequestSentAfter = new Date().toISOString();
   const structuredSendResult = await client.sendMessage(
     dmResult.value.dmId,
     joinRequest,
@@ -210,6 +249,28 @@ export async function joinConversation(
           groupName: group.name || invite.name,
           creatorInboxId: invite.creatorInboxId,
         });
+      }
+    }
+
+    const rejectionMessagesResult = await client.listMessages(
+      dmResult.value.dmId,
+      {
+        limit: 20,
+        after: joinRequestSentAfter,
+        direction: "descending",
+      },
+    );
+    if (rejectionMessagesResult.isOk()) {
+      const rejectionMessage = findInviteJoinErrorReply(
+        rejectionMessagesResult.value,
+        invite.creatorInboxId,
+        invite.tag,
+      );
+      if (rejectionMessage !== undefined) {
+        await identityStore.remove(identityId);
+        return Result.err(
+          ValidationError.create("inviteUrl", rejectionMessage),
+        );
       }
     }
 

--- a/packages/core/src/convos/join.ts
+++ b/packages/core/src/convos/join.ts
@@ -179,8 +179,9 @@ export async function joinConversation(
 
   const sendResult = await client.sendDmMessage(dmResult.value.dmId, slug);
   if (!sendResult.isOk()) {
-    await identityStore.remove(identityId);
-    return sendResult;
+    // Keep polling after the structured request succeeds. Modern Convos hosts
+    // can accept the join without the plain-text fallback, so treating this as
+    // fatal creates a false local failure and encourages duplicate retries.
   }
 
   // Step 6: Poll for group discovery

--- a/packages/core/src/convos/join.ts
+++ b/packages/core/src/convos/join.ts
@@ -205,7 +205,6 @@ export async function joinConversation(
     inviteSlug: slug,
     profile: { memberKind: "agent" },
   };
-  const joinRequestSentAfter = new Date().toISOString();
   const structuredSendResult = await client.sendMessage(
     dmResult.value.dmId,
     joinRequest,
@@ -256,7 +255,6 @@ export async function joinConversation(
       dmResult.value.dmId,
       {
         limit: 20,
-        after: joinRequestSentAfter,
         direction: "descending",
       },
     );

--- a/packages/core/src/convos/process-join-requests.ts
+++ b/packages/core/src/convos/process-join-requests.ts
@@ -5,6 +5,7 @@ import { secp256k1 } from "@noble/curves/secp256k1";
 import { sha256 } from "@noble/hashes/sha256";
 import { parseConvosInviteUrl } from "./invite-parser.js";
 import { decryptConversationToken } from "./invite-generator.js";
+import { extractJoinRequestContent } from "./join-request-content.js";
 
 // --- Types ---
 
@@ -29,8 +30,8 @@ export interface ProcessJoinRequestDeps {
 export interface IncomingJoinMessage {
   /** Inbox ID of the message sender (the requester). */
   readonly senderInboxId: string;
-  /** The text content of the DM. */
-  readonly messageText: string;
+  /** The decoded DM content. */
+  readonly content: unknown;
 }
 
 /** Result of successfully processing a join request. */
@@ -105,8 +106,22 @@ export async function processJoinRequest(
   deps: ProcessJoinRequestDeps,
   message: IncomingJoinMessage,
 ): Promise<Result<JoinRequestResult, SignetError>> {
+  const joinRequest = extractJoinRequestContent(message.content);
+  const inviteText =
+    joinRequest?.inviteSlug ??
+    (typeof message.content === "string" ? message.content : undefined);
+
+  if (!inviteText) {
+    return Result.err(
+      ValidationError.create(
+        "invite",
+        "Join request does not contain an invite",
+      ),
+    );
+  }
+
   // Step 1: Parse the message as an invite slug
-  const parseResult = parseConvosInviteUrl(message.messageText);
+  const parseResult = parseConvosInviteUrl(inviteText);
   if (!parseResult.isOk()) return parseResult;
 
   const invite = parseResult.value;

--- a/packages/core/src/convos/profile-messages.ts
+++ b/packages/core/src/convos/profile-messages.ts
@@ -1,0 +1,406 @@
+import protobuf from "protobufjs";
+import type {
+  ConvosContentTypeId,
+  EncodedConvosContent,
+} from "./join-request-content.js";
+
+const root = new protobuf.Root();
+
+const MemberKindEnum = new protobuf.Enum("MemberKind")
+  .add("MEMBER_KIND_UNSPECIFIED", 0)
+  .add("MEMBER_KIND_AGENT", 1);
+
+const MetadataValueType = new protobuf.Type("MetadataValue")
+  .add(
+    new protobuf.OneOf("value", ["string_value", "number_value", "bool_value"]),
+  )
+  .add(new protobuf.Field("string_value", 1, "string", "optional"))
+  .add(new protobuf.Field("number_value", 2, "double", "optional"))
+  .add(new protobuf.Field("bool_value", 3, "bool", "optional"));
+
+const EncryptedProfileImageRefType = new protobuf.Type(
+  "EncryptedProfileImageRef",
+)
+  .add(new protobuf.Field("url", 1, "string"))
+  .add(new protobuf.Field("salt", 2, "bytes"))
+  .add(new protobuf.Field("nonce", 3, "bytes"));
+
+const ProfileUpdateType = new protobuf.Type("ProfileUpdate")
+  .add(new protobuf.Field("name", 1, "string", "optional"))
+  .add(
+    new protobuf.Field(
+      "encrypted_image",
+      2,
+      "EncryptedProfileImageRef",
+      "optional",
+    ),
+  )
+  .add(new protobuf.Field("member_kind", 3, "MemberKind", "optional"))
+  .add(new protobuf.MapField("metadata", 4, "string", "MetadataValue"));
+
+const MemberProfileType = new protobuf.Type("MemberProfile")
+  .add(new protobuf.Field("inbox_id", 1, "bytes"))
+  .add(new protobuf.Field("name", 2, "string", "optional"))
+  .add(
+    new protobuf.Field(
+      "encrypted_image",
+      3,
+      "EncryptedProfileImageRef",
+      "optional",
+    ),
+  )
+  .add(new protobuf.Field("member_kind", 4, "MemberKind", "optional"))
+  .add(new protobuf.MapField("metadata", 5, "string", "MetadataValue"));
+
+const ProfileSnapshotType = new protobuf.Type("ProfileSnapshot").add(
+  new protobuf.Field("profiles", 1, "MemberProfile", "repeated"),
+);
+
+root.add(MemberKindEnum);
+root.add(MetadataValueType);
+root.add(EncryptedProfileImageRefType);
+root.add(ProfileUpdateType);
+root.add(MemberProfileType);
+root.add(ProfileSnapshotType);
+
+export const ContentTypeProfileUpdate: ConvosContentTypeId = {
+  authorityId: "convos.org",
+  typeId: "profile_update",
+  versionMajor: 1,
+  versionMinor: 0,
+};
+
+export const ContentTypeProfileSnapshot: ConvosContentTypeId = {
+  authorityId: "convos.org",
+  typeId: "profile_snapshot",
+  versionMajor: 1,
+  versionMinor: 0,
+};
+
+export enum MemberKind {
+  Unspecified = 0,
+  Agent = 1,
+}
+
+export interface EncryptedProfileImageRef {
+  readonly url: string;
+  readonly salt: Uint8Array;
+  readonly nonce: Uint8Array;
+}
+
+export type ProfileMetadataValue =
+  | { readonly type: "string"; readonly value: string }
+  | { readonly type: "number"; readonly value: number }
+  | { readonly type: "bool"; readonly value: boolean };
+
+export type ProfileMetadata = Record<string, ProfileMetadataValue>;
+
+export interface ProfileUpdateContent {
+  readonly name?: string;
+  readonly encryptedImage?: EncryptedProfileImageRef;
+  readonly memberKind?: MemberKind;
+  readonly metadata?: ProfileMetadata;
+}
+
+export interface MemberProfileEntry {
+  readonly inboxId: string;
+  readonly name?: string;
+  readonly encryptedImage?: EncryptedProfileImageRef;
+  readonly memberKind?: MemberKind;
+  readonly metadata?: ProfileMetadata;
+}
+
+export interface ProfileSnapshotContent {
+  readonly profiles: readonly MemberProfileEntry[];
+}
+
+interface RawMetadataValue {
+  readonly string_value?: string;
+  readonly number_value?: number;
+  readonly bool_value?: boolean;
+  readonly value?: "string_value" | "number_value" | "bool_value";
+}
+
+function metadataToProto(
+  metadata: ProfileMetadata,
+): Record<string, RawMetadataValue> {
+  const result: Record<string, RawMetadataValue> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    switch (value.type) {
+      case "string":
+        result[key] = { string_value: value.value };
+        break;
+      case "number":
+        result[key] = { number_value: value.value };
+        break;
+      case "bool":
+        result[key] = { bool_value: value.value };
+        break;
+    }
+  }
+  return result;
+}
+
+function metadataFromProto(
+  raw: Record<string, RawMetadataValue> | undefined,
+): ProfileMetadata | undefined {
+  if (!raw || Object.keys(raw).length === 0) return undefined;
+
+  const result: ProfileMetadata = {};
+  for (const [key, value] of Object.entries(raw)) {
+    switch (value.value) {
+      case "string_value":
+        result[key] = { type: "string", value: value.string_value ?? "" };
+        break;
+      case "number_value":
+        result[key] = { type: "number", value: value.number_value ?? 0 };
+        break;
+      case "bool_value":
+        result[key] = { type: "bool", value: value.bool_value ?? false };
+        break;
+      default:
+        if (value.string_value !== undefined) {
+          result[key] = { type: "string", value: value.string_value };
+        } else if (value.number_value !== undefined) {
+          result[key] = { type: "number", value: value.number_value };
+        } else if (value.bool_value !== undefined) {
+          result[key] = { type: "bool", value: value.bool_value };
+        }
+        break;
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  return Buffer.from(clean, "hex");
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("hex");
+}
+
+export function encodeProfileUpdate(
+  update: ProfileUpdateContent,
+): EncodedConvosContent {
+  const raw: Record<string, unknown> = {};
+
+  if (update.name !== undefined) {
+    raw["name"] = update.name;
+  }
+  if (update.encryptedImage !== undefined) {
+    raw["encrypted_image"] = {
+      url: update.encryptedImage.url,
+      salt: update.encryptedImage.salt,
+      nonce: update.encryptedImage.nonce,
+    };
+  }
+  if (
+    update.memberKind !== undefined &&
+    update.memberKind !== MemberKind.Unspecified
+  ) {
+    raw["member_kind"] = update.memberKind;
+  }
+  if (update.metadata && Object.keys(update.metadata).length > 0) {
+    raw["metadata"] = metadataToProto(update.metadata);
+  }
+
+  const error = ProfileUpdateType.verify(raw);
+  if (error) {
+    throw new Error(`Invalid ProfileUpdate: ${error}`);
+  }
+
+  return {
+    type: ContentTypeProfileUpdate,
+    parameters: {},
+    content: Buffer.from(
+      ProfileUpdateType.encode(ProfileUpdateType.create(raw)).finish(),
+    ),
+  };
+}
+
+export function decodeProfileUpdate(
+  encoded: Pick<EncodedConvosContent, "content">,
+): ProfileUpdateContent {
+  const decoded = ProfileUpdateType.decode(encoded.content);
+  const object = ProfileUpdateType.toObject(decoded, {
+    longs: Number,
+    bytes: Uint8Array,
+    defaults: false,
+    arrays: true,
+    objects: true,
+  }) as Record<string, unknown>;
+
+  const encryptedImage = object["encrypted_image"] as
+    | {
+        readonly url?: string;
+        readonly salt?: Uint8Array;
+        readonly nonce?: Uint8Array;
+      }
+    | undefined;
+  const metadata = metadataFromProto(
+    object["metadata"] as Record<string, RawMetadataValue> | undefined,
+  );
+
+  return {
+    ...(typeof object["name"] === "string" ? { name: object["name"] } : {}),
+    ...(encryptedImage
+      ? {
+          encryptedImage: {
+            url: encryptedImage.url ?? "",
+            salt: encryptedImage.salt ?? new Uint8Array(),
+            nonce: encryptedImage.nonce ?? new Uint8Array(),
+          },
+        }
+      : {}),
+    ...(typeof object["member_kind"] === "number"
+      ? { memberKind: object["member_kind"] as MemberKind }
+      : {}),
+    ...(metadata ? { metadata } : {}),
+  };
+}
+
+export function encodeProfileSnapshot(
+  snapshot: ProfileSnapshotContent,
+): EncodedConvosContent {
+  const raw = {
+    profiles: snapshot.profiles.map((profile) => {
+      const entry: Record<string, unknown> = {
+        inbox_id: hexToBytes(profile.inboxId),
+      };
+
+      if (profile.name !== undefined) {
+        entry["name"] = profile.name;
+      }
+      if (profile.encryptedImage !== undefined) {
+        entry["encrypted_image"] = {
+          url: profile.encryptedImage.url,
+          salt: profile.encryptedImage.salt,
+          nonce: profile.encryptedImage.nonce,
+        };
+      }
+      if (
+        profile.memberKind !== undefined &&
+        profile.memberKind !== MemberKind.Unspecified
+      ) {
+        entry["member_kind"] = profile.memberKind;
+      }
+      if (profile.metadata && Object.keys(profile.metadata).length > 0) {
+        entry["metadata"] = metadataToProto(profile.metadata);
+      }
+
+      return entry;
+    }),
+  };
+
+  const error = ProfileSnapshotType.verify(raw);
+  if (error) {
+    throw new Error(`Invalid ProfileSnapshot: ${error}`);
+  }
+
+  return {
+    type: ContentTypeProfileSnapshot,
+    parameters: {},
+    content: Buffer.from(
+      ProfileSnapshotType.encode(ProfileSnapshotType.create(raw)).finish(),
+    ),
+  };
+}
+
+export function decodeProfileSnapshot(
+  encoded: Pick<EncodedConvosContent, "content">,
+): ProfileSnapshotContent {
+  const decoded = ProfileSnapshotType.decode(encoded.content);
+  const object = ProfileSnapshotType.toObject(decoded, {
+    longs: Number,
+    bytes: Uint8Array,
+    defaults: false,
+    arrays: true,
+    objects: true,
+  }) as {
+    profiles?: ReadonlyArray<Record<string, unknown>>;
+  };
+
+  return {
+    profiles: (object.profiles ?? []).map((profile) => {
+      const encryptedImage = profile["encrypted_image"] as
+        | {
+            readonly url?: string;
+            readonly salt?: Uint8Array;
+            readonly nonce?: Uint8Array;
+          }
+        | undefined;
+      const metadata = metadataFromProto(
+        profile["metadata"] as Record<string, RawMetadataValue> | undefined,
+      );
+
+      return {
+        inboxId: bytesToHex(
+          (profile["inbox_id"] as Uint8Array) ?? new Uint8Array(),
+        ),
+        ...(typeof profile["name"] === "string"
+          ? { name: profile["name"] as string }
+          : {}),
+        ...(encryptedImage
+          ? {
+              encryptedImage: {
+                url: encryptedImage.url ?? "",
+                salt: encryptedImage.salt ?? new Uint8Array(),
+                nonce: encryptedImage.nonce ?? new Uint8Array(),
+              },
+            }
+          : {}),
+        ...(typeof profile["member_kind"] === "number"
+          ? { memberKind: profile["member_kind"] as MemberKind }
+          : {}),
+        ...(metadata ? { metadata } : {}),
+      };
+    }),
+  };
+}
+
+export class ProfileUpdateCodec {
+  get contentType(): ConvosContentTypeId {
+    return ContentTypeProfileUpdate;
+  }
+
+  encode(content: ProfileUpdateContent): EncodedConvosContent {
+    return encodeProfileUpdate(content);
+  }
+
+  decode(content: EncodedConvosContent): ProfileUpdateContent {
+    return decodeProfileUpdate(content);
+  }
+
+  fallback(): undefined {
+    return undefined;
+  }
+
+  shouldPush(): boolean {
+    return false;
+  }
+}
+
+export class ProfileSnapshotCodec {
+  get contentType(): ConvosContentTypeId {
+    return ContentTypeProfileSnapshot;
+  }
+
+  encode(content: ProfileSnapshotContent): EncodedConvosContent {
+    return encodeProfileSnapshot(content);
+  }
+
+  decode(content: EncodedConvosContent): ProfileSnapshotContent {
+    return decodeProfileSnapshot(content);
+  }
+
+  fallback(): undefined {
+    return undefined;
+  }
+
+  shouldPush(): boolean {
+    return false;
+  }
+}

--- a/packages/core/src/convos/profile-messages.ts
+++ b/packages/core/src/convos/profile-messages.ts
@@ -63,6 +63,7 @@ root.add(ProfileUpdateType);
 root.add(MemberProfileType);
 root.add(ProfileSnapshotType);
 
+/** Content type descriptor for Convos profile updates. */
 export const ContentTypeProfileUpdate: ConvosContentTypeId = {
   authorityId: "convos.org",
   typeId: "profile_update",
@@ -70,6 +71,7 @@ export const ContentTypeProfileUpdate: ConvosContentTypeId = {
   versionMinor: 0,
 };
 
+/** Content type descriptor for Convos profile snapshots. */
 export const ContentTypeProfileSnapshot: ConvosContentTypeId = {
   authorityId: "convos.org",
   typeId: "profile_snapshot",
@@ -77,24 +79,29 @@ export const ContentTypeProfileSnapshot: ConvosContentTypeId = {
   versionMinor: 0,
 };
 
+/** Member kinds currently surfaced by the Convos profile protocol. */
 export enum MemberKind {
   Unspecified = 0,
   Agent = 1,
 }
 
+/** Reference to an encrypted profile image published through Convos metadata. */
 export interface EncryptedProfileImageRef {
   readonly url: string;
   readonly salt: Uint8Array;
   readonly nonce: Uint8Array;
 }
 
+/** Supported metadata value variants for Convos profile payloads. */
 export type ProfileMetadataValue =
   | { readonly type: "string"; readonly value: string }
   | { readonly type: "number"; readonly value: number }
   | { readonly type: "bool"; readonly value: boolean };
 
+/** Arbitrary key-value metadata attached to a Convos profile payload. */
 export type ProfileMetadata = Record<string, ProfileMetadataValue>;
 
+/** Structured payload for a member's latest Convos profile update. */
 export interface ProfileUpdateContent {
   readonly name?: string;
   readonly encryptedImage?: EncryptedProfileImageRef;
@@ -102,6 +109,7 @@ export interface ProfileUpdateContent {
   readonly metadata?: ProfileMetadata;
 }
 
+/** Resolved profile fields for a single inbox inside a profile snapshot. */
 export interface MemberProfileEntry {
   readonly inboxId: string;
   readonly name?: string;
@@ -110,6 +118,7 @@ export interface MemberProfileEntry {
   readonly metadata?: ProfileMetadata;
 }
 
+/** Snapshot of the member profiles a host wants to publish for a conversation. */
 export interface ProfileSnapshotContent {
   readonly profiles: readonly MemberProfileEntry[];
 }
@@ -182,6 +191,7 @@ function bytesToHex(bytes: Uint8Array): string {
   return Buffer.from(bytes).toString("hex");
 }
 
+/** Encodes a profile update into the XMTP custom-content envelope Convos expects. */
 export function encodeProfileUpdate(
   update: ProfileUpdateContent,
 ): EncodedConvosContent {
@@ -221,6 +231,7 @@ export function encodeProfileUpdate(
   };
 }
 
+/** Decodes a profile update from the XMTP custom-content envelope. */
 export function decodeProfileUpdate(
   encoded: Pick<EncodedConvosContent, "content">,
 ): ProfileUpdateContent {
@@ -262,6 +273,7 @@ export function decodeProfileUpdate(
   };
 }
 
+/** Encodes a profile snapshot into the XMTP custom-content envelope. */
 export function encodeProfileSnapshot(
   snapshot: ProfileSnapshotContent,
 ): EncodedConvosContent {
@@ -309,6 +321,7 @@ export function encodeProfileSnapshot(
   };
 }
 
+/** Decodes a profile snapshot from the XMTP custom-content envelope. */
 export function decodeProfileSnapshot(
   encoded: Pick<EncodedConvosContent, "content">,
 ): ProfileSnapshotContent {
@@ -361,6 +374,7 @@ export function decodeProfileSnapshot(
   };
 }
 
+/** Codec that round-trips Convos profile updates through XMTP custom content. */
 export class ProfileUpdateCodec {
   get contentType(): ConvosContentTypeId {
     return ContentTypeProfileUpdate;
@@ -383,6 +397,7 @@ export class ProfileUpdateCodec {
   }
 }
 
+/** Codec that round-trips Convos profile snapshots through XMTP custom content. */
 export class ProfileSnapshotCodec {
   get contentType(): ConvosContentTypeId {
     return ContentTypeProfileSnapshot;

--- a/packages/core/src/convos/profile-state.ts
+++ b/packages/core/src/convos/profile-state.ts
@@ -1,0 +1,175 @@
+import type { XmtpDecodedMessage } from "../xmtp-client-factory.js";
+import { isEncodedConvosContent } from "./join-request-content.js";
+import {
+  ContentTypeProfileSnapshot,
+  ContentTypeProfileUpdate,
+  decodeProfileSnapshot,
+  decodeProfileUpdate,
+  type MemberProfileEntry,
+  type ProfileSnapshotContent,
+  type ProfileUpdateContent,
+} from "./profile-messages.js";
+
+export interface ResolvedProfile extends MemberProfileEntry {}
+
+function isContentTypeMatch(
+  contentType: string | undefined,
+  target: { authorityId: string; typeId: string },
+): boolean {
+  return (
+    contentType === target.typeId ||
+    contentType === `${target.authorityId}/${target.typeId}:1.0`
+  );
+}
+
+export function isProfileUpdateContentType(
+  contentType: string | undefined,
+): boolean {
+  return isContentTypeMatch(contentType, ContentTypeProfileUpdate);
+}
+
+export function isProfileSnapshotContentType(
+  contentType: string | undefined,
+): boolean {
+  return isContentTypeMatch(contentType, ContentTypeProfileSnapshot);
+}
+
+export function extractProfileUpdateContent(
+  content: unknown,
+): ProfileUpdateContent | undefined {
+  if (isEncodedConvosContent(content)) {
+    try {
+      return decodeProfileUpdate(content);
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (typeof content === "object" && content !== null) {
+    return content as ProfileUpdateContent;
+  }
+
+  return undefined;
+}
+
+export function extractProfileSnapshotContent(
+  content: unknown,
+): ProfileSnapshotContent | undefined {
+  if (isEncodedConvosContent(content)) {
+    try {
+      return decodeProfileSnapshot(content);
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (
+    typeof content === "object" &&
+    content !== null &&
+    "profiles" in content &&
+    Array.isArray((content as { profiles?: unknown }).profiles)
+  ) {
+    return content as ProfileSnapshotContent;
+  }
+
+  return undefined;
+}
+
+export function resolveProfilesFromMessages(
+  messages: readonly XmtpDecodedMessage[],
+  memberInboxIds?: readonly string[],
+): Map<string, ResolvedProfile> {
+  const profilesByInboxId = new Map<string, ResolvedProfile>();
+  let latestSnapshotProfiles: Map<string, MemberProfileEntry> | undefined;
+
+  const orderedMessages = [...messages].sort((left, right) =>
+    right.sentAt.localeCompare(left.sentAt),
+  );
+
+  for (const message of orderedMessages) {
+    if (isProfileUpdateContentType(message.contentType)) {
+      const senderInboxId = message.senderInboxId.toLowerCase();
+      if (!profilesByInboxId.has(senderInboxId)) {
+        const update = extractProfileUpdateContent(message.content);
+        if (!update) continue;
+        profilesByInboxId.set(senderInboxId, {
+          inboxId: message.senderInboxId,
+          ...(update.name !== undefined ? { name: update.name } : {}),
+          ...(update.encryptedImage !== undefined
+            ? { encryptedImage: update.encryptedImage }
+            : {}),
+          ...(update.memberKind !== undefined
+            ? { memberKind: update.memberKind }
+            : {}),
+          ...(update.metadata !== undefined
+            ? { metadata: update.metadata }
+            : {}),
+        });
+      }
+    } else if (
+      isProfileSnapshotContentType(message.contentType) &&
+      latestSnapshotProfiles === undefined
+    ) {
+      const snapshot = extractProfileSnapshotContent(message.content);
+      if (!snapshot) continue;
+      latestSnapshotProfiles = new Map(
+        snapshot.profiles
+          .filter((profile) => profile.inboxId.length > 0)
+          .map((profile) => [profile.inboxId.toLowerCase(), profile]),
+      );
+    }
+
+    if (
+      memberInboxIds &&
+      memberInboxIds.every((inboxId) =>
+        profilesByInboxId.has(inboxId.toLowerCase()),
+      )
+    ) {
+      break;
+    }
+  }
+
+  if (latestSnapshotProfiles) {
+    for (const [inboxId, profile] of latestSnapshotProfiles.entries()) {
+      if (!profilesByInboxId.has(inboxId)) {
+        profilesByInboxId.set(inboxId, {
+          inboxId: profile.inboxId,
+          ...(profile.name !== undefined ? { name: profile.name } : {}),
+          ...(profile.encryptedImage !== undefined
+            ? { encryptedImage: profile.encryptedImage }
+            : {}),
+          ...(profile.memberKind !== undefined
+            ? { memberKind: profile.memberKind }
+            : {}),
+          ...(profile.metadata !== undefined
+            ? { metadata: profile.metadata }
+            : {}),
+        });
+      }
+    }
+  }
+
+  return profilesByInboxId;
+}
+
+export function buildProfileSnapshotFromMessages(
+  messages: readonly XmtpDecodedMessage[],
+  memberInboxIds: readonly string[],
+  options?: { readonly includeFallbackEntries?: boolean },
+): ProfileSnapshotContent {
+  const resolved = resolveProfilesFromMessages(messages, memberInboxIds);
+  const includeFallbackEntries = options?.includeFallbackEntries ?? false;
+
+  return {
+    profiles: memberInboxIds.flatMap((inboxId) => {
+      const profile = resolved.get(inboxId.toLowerCase());
+      if (profile) {
+        return [profile];
+      }
+      if (includeFallbackEntries) {
+        return [{ inboxId }];
+      }
+      return [];
+    }),
+  };
+}

--- a/packages/core/src/convos/profile-state.ts
+++ b/packages/core/src/convos/profile-state.ts
@@ -10,6 +10,7 @@ import {
   type ProfileUpdateContent,
 } from "./profile-messages.js";
 
+/** Resolved profile fields for a member after combining updates and snapshots. */
 export interface ResolvedProfile extends MemberProfileEntry {}
 
 function isContentTypeMatch(
@@ -22,18 +23,21 @@ function isContentTypeMatch(
   );
 }
 
+/** Returns true when a content type identifies a Convos profile update. */
 export function isProfileUpdateContentType(
   contentType: string | undefined,
 ): boolean {
   return isContentTypeMatch(contentType, ContentTypeProfileUpdate);
 }
 
+/** Returns true when a content type identifies a Convos profile snapshot. */
 export function isProfileSnapshotContentType(
   contentType: string | undefined,
 ): boolean {
   return isContentTypeMatch(contentType, ContentTypeProfileSnapshot);
 }
 
+/** Extracts a profile update from decoded JSON or encoded Convos content. */
 export function extractProfileUpdateContent(
   content: unknown,
 ): ProfileUpdateContent | undefined {
@@ -52,6 +56,7 @@ export function extractProfileUpdateContent(
   return undefined;
 }
 
+/** Extracts a profile snapshot from decoded JSON or encoded Convos content. */
 export function extractProfileSnapshotContent(
   content: unknown,
 ): ProfileSnapshotContent | undefined {
@@ -75,6 +80,7 @@ export function extractProfileSnapshotContent(
   return undefined;
 }
 
+/** Resolves the latest known member profiles from a conversation's message history. */
 export function resolveProfilesFromMessages(
   messages: readonly XmtpDecodedMessage[],
   memberInboxIds?: readonly string[],
@@ -152,6 +158,10 @@ export function resolveProfilesFromMessages(
   return profilesByInboxId;
 }
 
+/**
+ * Builds a profile snapshot for the given members using known profile messages,
+ * optionally falling back to bare inbox entries when no profile is available.
+ */
 export function buildProfileSnapshotFromMessages(
   messages: readonly XmtpDecodedMessage[],
   memberInboxIds: readonly string[],

--- a/packages/core/src/convos/profile-state.ts
+++ b/packages/core/src/convos/profile-state.ts
@@ -13,6 +13,16 @@ import {
 /** Resolved profile fields for a member after combining updates and snapshots. */
 export interface ResolvedProfile extends MemberProfileEntry {}
 
+function isSnapshotProfileEntry(value: unknown): value is MemberProfileEntry {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "inboxId" in value &&
+    typeof (value as { inboxId?: unknown }).inboxId === "string" &&
+    (value as { inboxId: string }).inboxId.length > 0
+  );
+}
+
 function isContentTypeMatch(
   contentType: string | undefined,
   target: { authorityId: string; typeId: string },
@@ -120,7 +130,7 @@ export function resolveProfilesFromMessages(
       if (!snapshot) continue;
       latestSnapshotProfiles = new Map(
         snapshot.profiles
-          .filter((profile) => profile.inboxId.length > 0)
+          .filter(isSnapshotProfileEntry)
           .map((profile) => [profile.inboxId.toLowerCase(), profile]),
       );
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -143,6 +143,38 @@ export type {
   IncomingJoinMessage,
   JoinRequestResult,
 } from "./convos/process-join-requests.js";
+export {
+  ContentTypeJoinRequest,
+  JoinRequestCodec,
+  decodeJoinRequest,
+  extractJoinRequestContent,
+  isJoinRequestContentType,
+} from "./convos/join-request-content.js";
+export type {
+  JoinRequestContent,
+  JoinRequestProfile,
+  EncodedConvosContent,
+  ConvosContentTypeId,
+} from "./convos/join-request-content.js";
+export {
+  ContentTypeProfileUpdate,
+  ContentTypeProfileSnapshot,
+  MemberKind,
+  ProfileUpdateCodec,
+  ProfileSnapshotCodec,
+  encodeProfileUpdate,
+  decodeProfileUpdate,
+  encodeProfileSnapshot,
+  decodeProfileSnapshot,
+} from "./convos/profile-messages.js";
+export type {
+  ProfileUpdateContent,
+  ProfileSnapshotContent,
+  MemberProfileEntry,
+  ProfileMetadata,
+  ProfileMetadataValue,
+  EncryptedProfileImageRef,
+} from "./convos/profile-messages.js";
 
 // Convos invite host (join request listener)
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -148,6 +148,7 @@ export {
   JoinRequestCodec,
   decodeJoinRequest,
   extractJoinRequestContent,
+  isEncodedConvosContent,
   isJoinRequestContentType,
 } from "./convos/join-request-content.js";
 export type {
@@ -156,6 +157,17 @@ export type {
   EncodedConvosContent,
   ConvosContentTypeId,
 } from "./convos/join-request-content.js";
+export {
+  ContentTypeInviteJoinError,
+  InviteJoinErrorCodec,
+  InviteJoinErrorType,
+  decodeInviteJoinError,
+  encodeInviteJoinError,
+  extractInviteJoinError,
+  getInviteJoinErrorMessage,
+  isInviteJoinErrorContentType,
+} from "./convos/invite-join-error.js";
+export type { InviteJoinError } from "./convos/invite-join-error.js";
 export {
   ContentTypeProfileUpdate,
   ContentTypeProfileSnapshot,
@@ -175,6 +187,15 @@ export type {
   ProfileMetadataValue,
   EncryptedProfileImageRef,
 } from "./convos/profile-messages.js";
+export {
+  buildProfileSnapshotFromMessages,
+  extractProfileSnapshotContent,
+  extractProfileUpdateContent,
+  isProfileSnapshotContentType,
+  isProfileUpdateContentType,
+  resolveProfilesFromMessages,
+} from "./convos/profile-state.js";
+export type { ResolvedProfile } from "./convos/profile-state.js";
 
 // Convos invite host (join request listener)
 export {

--- a/packages/core/src/sdk/sdk-client-factory.ts
+++ b/packages/core/src/sdk/sdk-client-factory.ts
@@ -10,6 +10,7 @@ import { createXmtpSigner } from "./signer-adapter.js";
 import type { SdkEoaSigner } from "./signer-adapter.js";
 import { createSdkClient } from "./sdk-client.js";
 import type { SdkClientShape } from "./sdk-types.js";
+import { createConvosCodecs } from "../convos/codecs.js";
 
 /**
  * A function that creates a native SDK client.
@@ -24,6 +25,7 @@ export type SdkCreateClientFn = (
     env: string;
     appVersion: string;
     disableDeviceSync: boolean;
+    codecs: unknown[];
   },
 ) => Promise<SdkClientShape>;
 
@@ -63,6 +65,7 @@ export function createSdkClientFactory(
           env: options.env,
           appVersion: options.appVersion,
           disableDeviceSync: true,
+          codecs: createConvosCodecs(),
         });
 
         const client = createSdkClient({
@@ -97,6 +100,7 @@ async function defaultSdkCreate(
     env: string;
     appVersion: string;
     disableDeviceSync: boolean;
+    codecs: unknown[];
   },
 ): Promise<SdkClientShape> {
   // Dynamic import so native binding errors surface at runtime, not import time
@@ -128,7 +132,10 @@ async function defaultSdkCreate(
     signMessage: (message: string) => signer.signMessage(message),
   };
 
-  const client = await Client.create(sdkSigner, options);
+  const client = await Client.create(
+    sdkSigner,
+    options as Parameters<typeof Client.create>[1],
+  );
   // The SDK Client is structurally compatible with SdkClientShape
   return client as unknown as SdkClientShape;
 }

--- a/packages/core/src/sdk/sdk-client-factory.ts
+++ b/packages/core/src/sdk/sdk-client-factory.ts
@@ -1,6 +1,7 @@
 import { Result } from "better-result";
 import type { SignetError } from "@xmtp/signet-schemas";
 import { InternalError } from "@xmtp/signet-schemas";
+import type { Client as NodeSdkClient } from "@xmtp/node-sdk";
 import type {
   XmtpClientFactory,
   XmtpClientCreateOptions,
@@ -25,7 +26,7 @@ export type SdkCreateClientFn = (
     env: string;
     appVersion: string;
     disableDeviceSync: boolean;
-    codecs: unknown[];
+    codecs: NodeSdkCodecs;
   },
 ) => Promise<SdkClientShape>;
 
@@ -36,6 +37,9 @@ export interface SdkClientFactoryOptions {
 }
 
 const DEFAULT_SYNC_TIMEOUT_MS = 30_000;
+type NodeSdkCreateOptions = Parameters<typeof NodeSdkClient.create>[1];
+type NodeSdkSigner = Parameters<typeof NodeSdkClient.create>[0];
+type NodeSdkCodecs = NonNullable<NonNullable<NodeSdkCreateOptions>["codecs"]>;
 
 /**
  * Creates a production XmtpClientFactory backed by @xmtp/node-sdk.
@@ -100,7 +104,7 @@ async function defaultSdkCreate(
     env: string;
     appVersion: string;
     disableDeviceSync: boolean;
-    codecs: unknown[];
+    codecs: NodeSdkCodecs;
   },
 ): Promise<SdkClientShape> {
   // Dynamic import so native binding errors surface at runtime, not import time
@@ -113,7 +117,7 @@ async function defaultSdkCreate(
     Ethereum: 0,
     Passkey: 1,
   };
-  const sdkSigner = {
+  const sdkSigner: NodeSdkSigner = {
     type: "EOA" as const,
     getIdentifier() {
       const id = signer.getIdentifier();
@@ -131,11 +135,9 @@ async function defaultSdkCreate(
     },
     signMessage: (message: string) => signer.signMessage(message),
   };
+  const clientOptions: NodeSdkCreateOptions = options;
 
-  const client = await Client.create(
-    sdkSigner,
-    options as Parameters<typeof Client.create>[1],
-  );
+  const client = await Client.create(sdkSigner, clientOptions);
   // The SDK Client is structurally compatible with SdkClientShape
   return client as unknown as SdkClientShape;
 }

--- a/packages/core/src/sdk/sdk-client.ts
+++ b/packages/core/src/sdk/sdk-client.ts
@@ -25,6 +25,7 @@ import {
   wrapDmStream,
   wrapGroupStream,
 } from "./stream-wrappers.js";
+import { isEncodedConvosContent } from "../convos/join-request-content.js";
 import type {
   SdkClientShape,
   SdkGroupShape,
@@ -134,6 +135,9 @@ export function createSdkClient(options: SdkClientOptions): XmtpClient {
 
       // For custom content types, use group.send() with encoded content
       if (contentType && contentType !== "xmtp.org/text:1.0") {
+        if (isEncodedConvosContent(content)) {
+          return wrapSdkCall(async () => group.send(content), "sendMessage");
+        }
         // Parse "authority/type:major.minor" format
         const slashIdx = contentType.indexOf("/");
         const colonIdx = contentType.indexOf(":");


### PR DESCRIPTION
## Summary
- add Convos protocol foundations for structured join requests and profile-related content types
- register codecs and profile state helpers used by host and join flows
- expand coverage for join request parsing, profile messages/state, and related protocol exports

## What Changed
- add structured `convos.org/join_request:1.0` support alongside the existing invite slug path
- add profile message/state helpers and codec registration for Convos-native content
- harden core join processing and SDK integration around the new protocol surface
- cover the new exports in docs/tests so the protocol layer is directly usable by later stack branches

## How To Test
- `bun test packages/core/src/convos/__tests__/join-request-content.test.ts`
- `bun test packages/core/src/convos/__tests__/profile-messages.test.ts`
- `bun test packages/core/src/convos/__tests__/profile-state.test.ts`
- `bun run check`

Closes #303
Closes #306
