### PR TITLE
feat: add convos post-accept parity

### DIFF
--- a/packages/cli/src/__tests__/invite-host-effects.test.ts
+++ b/packages/cli/src/__tests__/invite-host-effects.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import { decodeProfileSnapshot } from "@xmtp/signet-core";
+import { InternalError, ValidationError } from "@xmtp/signet-schemas";
+import { createInviteHostEffects } from "../invite-host-effects.js";
+import type {
+  ManagedInviteJoinAcceptance,
+  ManagedInviteJoinFailure,
+} from "../invite-host-listener.js";
+import type { AuditEntry } from "../audit/log.js";
+
+function makeAcceptance(): ManagedInviteJoinAcceptance {
+  return {
+    join: {
+      groupId: "group-1",
+      requesterInboxId: "eeff0011",
+      inviteTag: "tag-123",
+    },
+    hostIdentityId: "identity-host",
+    hostInboxId: "aabbccdd",
+    requestMessage: {
+      type: "raw.message",
+      messageId: "dm-msg-1",
+      groupId: "dm-1",
+      senderInboxId: "eeff0011",
+      contentType: "join_request",
+      content: {
+        inviteSlug: "slug",
+        profile: { name: "Codex", memberKind: "agent" },
+      },
+      sentAt: "2026-04-15T15:00:00.000Z",
+      threadId: null,
+      isHistorical: false,
+    },
+  };
+}
+
+function makeFailure(
+  error: ManagedInviteJoinFailure["error"],
+): ManagedInviteJoinFailure {
+  return {
+    error,
+    requestMessage: {
+      type: "raw.message",
+      messageId: "dm-msg-2",
+      groupId: "dm-2",
+      senderInboxId: "eeff0011",
+      contentType: "join_request",
+      content: { inviteSlug: "slug" },
+      sentAt: "2026-04-15T15:00:00.000Z",
+      threadId: null,
+      isHistorical: false,
+    },
+  };
+}
+
+describe("createInviteHostEffects", () => {
+  test("records accepted joins and emits a fallback profile snapshot", async () => {
+    const entries: AuditEntry[] = [];
+    const sentMessages: Array<{ content: unknown; contentType?: string }> = [];
+
+    const effects = createInviteHostEffects({
+      auditLog: {
+        path: ":memory:",
+        async append(entry) {
+          entries.push(entry);
+        },
+        async tail() {
+          return [];
+        },
+        async readAll() {
+          return [];
+        },
+      },
+      getManagedClientForGroup() {
+        return {
+          async getGroupInfo() {
+            return Result.ok({
+              groupId: "group-1",
+              name: "Hosted chat",
+              description: "",
+              memberInboxIds: ["aabbccdd", "eeff0011"],
+              createdAt: "2026-04-15T15:00:00.000Z",
+            });
+          },
+          async listMessages() {
+            return Result.ok([]);
+          },
+          async sendMessage(_groupId, content, contentType) {
+            sentMessages.push({ content, contentType });
+            return Result.ok("snapshot-msg-1");
+          },
+        };
+      },
+      resolveLocalChatId: () => "conv_local_1",
+      now: () => new Date("2026-04-15T15:00:00.000Z"),
+    });
+
+    await effects.onJoinAccepted(makeAcceptance());
+
+    expect(entries.map((entry) => entry.action)).toEqual([
+      "convos.join-request.accepted",
+      "convos.profile-snapshot.sent",
+    ]);
+    expect(entries[0]?.detail).toMatchObject({
+      groupId: "group-1",
+      localChatId: "conv_local_1",
+      inviteTag: "tag-123",
+      joinerInboxId: "eeff0011",
+      hostInboxId: "aabbccdd",
+      dmId: "dm-1",
+      requestMessageId: "dm-msg-1",
+    });
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0]?.contentType).toBe(
+      "convos.org/profile_snapshot:1.0",
+    );
+    expect(
+      decodeProfileSnapshot(
+        sentMessages[0]?.content as Parameters<typeof decodeProfileSnapshot>[0],
+      ),
+    ).toEqual({
+      profiles: [
+        { inboxId: "aabbccdd" },
+        { inboxId: "eeff0011", name: "Codex", memberKind: 1 },
+      ],
+    });
+  });
+
+  test("pages profile history so older member profiles survive a new snapshot", async () => {
+    const sentMessages: Array<{ content: unknown; contentType?: string }> = [];
+    const listCalls: Array<string | undefined> = [];
+
+    const fillerMessages = Array.from({ length: 500 }, (_, index) => ({
+      messageId: `filler-${index + 1}`,
+      groupId: "group-1",
+      senderInboxId: "noise",
+      contentType: "text",
+      content: `noise-${index + 1}`,
+      sentAt: new Date(
+        Date.UTC(2026, 3, 15, 15, 0, 0, 500 - index),
+      ).toISOString(),
+      threadId: null,
+    }));
+    const olderProfileMessage = {
+      messageId: "older-profile-msg-1",
+      groupId: "group-1",
+      senderInboxId: "11223344",
+      contentType: "convos.org/profile_update:1.0",
+      content: { name: "Existing member" },
+      sentAt: "2026-04-15T14:59:00.000Z",
+      threadId: null,
+    };
+
+    const effects = createInviteHostEffects({
+      auditLog: {
+        path: ":memory:",
+        async append() {},
+        async tail() {
+          return [];
+        },
+        async readAll() {
+          return [];
+        },
+      },
+      getManagedClientForGroup() {
+        return {
+          async getGroupInfo() {
+            return Result.ok({
+              groupId: "group-1",
+              name: "Hosted chat",
+              description: "",
+              memberInboxIds: ["aabbccdd", "11223344", "eeff0011"],
+              createdAt: "2026-04-15T15:00:00.000Z",
+            });
+          },
+          async listMessages(_groupId, options) {
+            listCalls.push(options?.before);
+            if (!options?.before) {
+              return Result.ok(fillerMessages);
+            }
+            return Result.ok([olderProfileMessage]);
+          },
+          async sendMessage(_groupId, content, contentType) {
+            sentMessages.push({ content, contentType });
+            return Result.ok("snapshot-msg-2");
+          },
+        };
+      },
+      now: () => new Date("2026-04-15T15:00:00.000Z"),
+    });
+
+    await effects.onJoinAccepted(makeAcceptance());
+
+    expect(listCalls).toHaveLength(2);
+    expect(
+      decodeProfileSnapshot(
+        sentMessages[0]?.content as Parameters<typeof decodeProfileSnapshot>[0],
+      ),
+    ).toEqual({
+      profiles: [
+        { inboxId: "aabbccdd" },
+        { inboxId: "11223344", name: "Existing member" },
+        { inboxId: "eeff0011", name: "Codex", memberKind: 1 },
+      ],
+    });
+  });
+
+  test("keeps paging past sparse snapshots to recover older member profiles", async () => {
+    const sentMessages: Array<{ content: unknown; contentType?: string }> = [];
+    const listCalls: Array<string | undefined> = [];
+
+    const fillerMessages = Array.from({ length: 499 }, (_, index) => ({
+      messageId: `sparse-filler-${index + 1}`,
+      groupId: "group-1",
+      senderInboxId: "noise",
+      contentType: "text",
+      content: `noise-${index + 1}`,
+      sentAt: new Date(
+        Date.UTC(2026, 3, 15, 14, 59, 59, 999 - index),
+      ).toISOString(),
+      threadId: null,
+    }));
+    const sparseSnapshotMessage = {
+      messageId: "sparse-snapshot-1",
+      groupId: "group-1",
+      senderInboxId: "aabbccdd",
+      contentType: "convos.org/profile_snapshot:1.0",
+      content: {
+        profiles: [
+          { inboxId: "aabbccdd" },
+          { inboxId: "11223344" },
+          { inboxId: "eeff0011" },
+        ],
+      },
+      sentAt: "2026-04-15T15:00:00.000Z",
+      threadId: null,
+    };
+    const olderProfileMessage = {
+      messageId: "older-profile-msg-2",
+      groupId: "group-1",
+      senderInboxId: "11223344",
+      contentType: "convos.org/profile_update:1.0",
+      content: { name: "Recovered member" },
+      sentAt: "2026-04-15T14:59:00.000Z",
+      threadId: null,
+    };
+
+    const effects = createInviteHostEffects({
+      auditLog: {
+        path: ":memory:",
+        async append() {},
+        async tail() {
+          return [];
+        },
+        async readAll() {
+          return [];
+        },
+      },
+      getManagedClientForGroup() {
+        return {
+          async getGroupInfo() {
+            return Result.ok({
+              groupId: "group-1",
+              name: "Hosted chat",
+              description: "",
+              memberInboxIds: ["aabbccdd", "11223344", "eeff0011"],
+              createdAt: "2026-04-15T15:00:00.000Z",
+            });
+          },
+          async listMessages(_groupId, options) {
+            listCalls.push(options?.before);
+            if (!options?.before) {
+              return Result.ok([sparseSnapshotMessage, ...fillerMessages]);
+            }
+            return Result.ok([olderProfileMessage]);
+          },
+          async sendMessage(_groupId, content, contentType) {
+            sentMessages.push({ content, contentType });
+            return Result.ok("snapshot-msg-3");
+          },
+        };
+      },
+      now: () => new Date("2026-04-15T15:00:00.000Z"),
+    });
+
+    await effects.onJoinAccepted(makeAcceptance());
+
+    expect(listCalls).toHaveLength(2);
+    expect(
+      decodeProfileSnapshot(
+        sentMessages[0]?.content as Parameters<typeof decodeProfileSnapshot>[0],
+      ),
+    ).toEqual({
+      profiles: [
+        { inboxId: "aabbccdd" },
+        { inboxId: "11223344", name: "Recovered member" },
+        { inboxId: "eeff0011", name: "Codex", memberKind: 1 },
+      ],
+    });
+  });
+
+  test("records validation failures as rejected joins", async () => {
+    const entries: AuditEntry[] = [];
+    const effects = createInviteHostEffects({
+      auditLog: {
+        path: ":memory:",
+        async append(entry) {
+          entries.push(entry);
+        },
+        async tail() {
+          return [];
+        },
+        async readAll() {
+          return [];
+        },
+      },
+      getManagedClientForGroup: () => undefined,
+      now: () => new Date("2026-04-15T15:00:00.000Z"),
+    });
+
+    await effects.onJoinRejected(
+      makeFailure(ValidationError.create("invite", "Invite tag did not match")),
+    );
+
+    expect(entries[0]?.action).toBe("convos.join-request.rejected");
+    expect(entries[0]?.detail).toMatchObject({
+      dmId: "dm-2",
+      joinerInboxId: "eeff0011",
+      errorCategory: "validation",
+    });
+  });
+
+  test("records transient failures separately from validation rejections", async () => {
+    const entries: AuditEntry[] = [];
+    const effects = createInviteHostEffects({
+      auditLog: {
+        path: ":memory:",
+        async append(entry) {
+          entries.push(entry);
+        },
+        async tail() {
+          return [];
+        },
+        async readAll() {
+          return [];
+        },
+      },
+      getManagedClientForGroup: () => undefined,
+      now: () => new Date("2026-04-15T15:00:00.000Z"),
+    });
+
+    await effects.onJoinRejected(
+      makeFailure(InternalError.create("temporary addMembers failure")),
+    );
+
+    expect(entries[0]?.action).toBe("convos.join-request.failed");
+    expect(entries[0]?.detail).toMatchObject({
+      errorCategory: "internal",
+    });
+  });
+});

--- a/packages/cli/src/__tests__/invite-host-listener.test.ts
+++ b/packages/cli/src/__tests__/invite-host-listener.test.ts
@@ -231,7 +231,7 @@ describe("startManagedInviteHostListener", () => {
     ]);
   });
 
-  test("processes structured join requests alongside plain slug fallback", async () => {
+  test("deduplicates structured join requests and plain slug fallback", async () => {
     const slug = await buildValidSlug();
 
     const addedByIdentity: string[] = [];
@@ -265,15 +265,80 @@ describe("startManagedInviteHostListener", () => {
     capturedHandler?.({
       ...makeRawMessageEvent({
         inviteSlug: slug,
-        profile: { memberKind: "agent" },
+        profile: { name: "Codex", memberKind: "agent" },
       }),
       messageId: "structured-join-request-1",
       contentType: "join_request",
+    });
+    capturedHandler?.({
+      ...makeRawMessageEvent(slug),
+      messageId: "fallback-join-request-1",
+      contentType: "text",
     });
     await new Promise((resolve) => setTimeout(resolve, 100));
 
     expect(addedByIdentity).toEqual([
       `${TEST_CONVERSATION_ID}:${TEST_REQUESTER_INBOX_ID}`,
+    ]);
+  });
+
+  test("notifies acceptance callbacks with host identity context", async () => {
+    const slug = await buildValidSlug();
+
+    const accepted: Array<{
+      hostIdentityId: string;
+      hostInboxId: string;
+      requesterInboxId: string;
+      groupId: string;
+      messageId: string;
+    }> = [];
+    let capturedHandler: ((event: CoreRawEvent) => void) | null = null;
+
+    startManagedInviteHostListener({
+      subscribe(handler) {
+        capturedHandler = handler;
+        return () => {};
+      },
+      async listIdentities() {
+        return [{ id: "right", inboxId: RIGHT_CREATOR_INBOX_ID }];
+      },
+      async getWalletPrivateKeyHex() {
+        return Result.ok(RIGHT_PRIVATE_KEY_HEX);
+      },
+      getManagedClient() {
+        return {
+          addMembers: async () => Result.ok(undefined),
+          listMessages: async () => Result.ok([]),
+        };
+      },
+      async getGroupInviteTag() {
+        return Result.ok("host-test-tag");
+      },
+      async onJoinAccepted(acceptance) {
+        accepted.push({
+          hostIdentityId: acceptance.hostIdentityId,
+          hostInboxId: acceptance.hostInboxId,
+          requesterInboxId: acceptance.join.requesterInboxId,
+          groupId: acceptance.join.groupId,
+          messageId: acceptance.requestMessage.messageId,
+        });
+      },
+    });
+
+    capturedHandler?.({
+      ...makeRawMessageEvent(slug),
+      messageId: "accepted-join-msg-1",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(accepted).toEqual([
+      {
+        hostIdentityId: "right",
+        hostInboxId: RIGHT_CREATOR_INBOX_ID,
+        requesterInboxId: TEST_REQUESTER_INBOX_ID,
+        groupId: TEST_CONVERSATION_ID,
+        messageId: "accepted-join-msg-1",
+      },
     ]);
   });
 
@@ -442,6 +507,52 @@ describe("startManagedInviteHostListener", () => {
     expect(addMemberCalls).toBe(2);
   });
 
+  test("allows a same-inbox rejoin after the logical dedupe window expires", async () => {
+    const slug = await buildValidSlug();
+
+    let addMemberCalls = 0;
+    let capturedHandler: ((event: CoreRawEvent) => void) | null = null;
+
+    startManagedInviteHostListener({
+      subscribe(handler) {
+        capturedHandler = handler;
+        return () => {};
+      },
+      async listIdentities() {
+        return [{ id: "creator", inboxId: RIGHT_CREATOR_INBOX_ID }];
+      },
+      async getWalletPrivateKeyHex() {
+        return Result.ok(RIGHT_PRIVATE_KEY_HEX);
+      },
+      getManagedClient() {
+        return {
+          addMembers: async () => {
+            addMemberCalls += 1;
+            return Result.ok(undefined);
+          },
+        };
+      },
+      async getGroupInviteTag() {
+        return Result.ok("host-test-tag");
+      },
+      processedInviteKeyTtlMs: 20,
+    });
+
+    capturedHandler?.({
+      ...makeRawMessageEvent(slug),
+      messageId: "rejoin-msg-1",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    capturedHandler?.({
+      ...makeRawMessageEvent(slug),
+      messageId: "rejoin-msg-2",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(addMemberCalls).toBe(2);
+  });
+
   test("retries DM recovery after a transient history lookup failure", async () => {
     const slug = await buildValidSlug();
 
@@ -555,6 +666,188 @@ describe("startManagedInviteHostListener", () => {
 
     expect(listMessageCalls).toBeGreaterThanOrEqual(2);
     expect(addMemberCalls).toBe(2);
+  });
+
+  test("retries DM recovery when host key lookup is not ready yet", async () => {
+    const slug = await buildValidSlug();
+
+    let addMemberCalls = 0;
+    let keyLookupCalls = 0;
+    let listMessageCalls = 0;
+    let capturedHandler: ((event: CoreRawEvent) => void) | null = null;
+
+    startManagedInviteHostListener({
+      subscribe(handler) {
+        capturedHandler = handler;
+        return () => {};
+      },
+      async listIdentities() {
+        return [{ id: "creator", inboxId: RIGHT_CREATOR_INBOX_ID }];
+      },
+      async getWalletPrivateKeyHex() {
+        keyLookupCalls += 1;
+        if (keyLookupCalls === 1) {
+          return Result.err(
+            InternalError.create("identity key not loaded yet"),
+          );
+        }
+        return Result.ok(RIGHT_PRIVATE_KEY_HEX);
+      },
+      getManagedClient() {
+        return {
+          addMembers: async () => {
+            addMemberCalls += 1;
+            return Result.ok(undefined);
+          },
+          listMessages: async (groupId) => {
+            listMessageCalls += 1;
+            return Result.ok([
+              {
+                messageId: "dm-key-retry-msg-1",
+                groupId,
+                senderInboxId: TEST_REQUESTER_INBOX_ID,
+                contentType: "text",
+                content: slug,
+                sentAt: new Date().toISOString(),
+                threadId: null,
+              },
+            ]);
+          },
+        };
+      },
+      async getGroupInviteTag() {
+        return Result.ok("host-test-tag");
+      },
+    });
+
+    capturedHandler?.(makeRawDmJoinedEvent("dm-join-key-retry"));
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    expect(keyLookupCalls).toBeGreaterThanOrEqual(2);
+    expect(listMessageCalls).toBeGreaterThanOrEqual(2);
+    expect(addMemberCalls).toBe(1);
+  });
+
+  test("retries DM recovery when transient identity setup is mixed with validation misses", async () => {
+    const slug = await buildValidSlug();
+
+    let addMemberCalls = 0;
+    let rightKeyLookupCalls = 0;
+    const failures: string[] = [];
+    let capturedHandler: ((event: CoreRawEvent) => void) | null = null;
+
+    startManagedInviteHostListener({
+      subscribe(handler) {
+        capturedHandler = handler;
+        return () => {};
+      },
+      async listIdentities() {
+        return [
+          { id: "wrong", inboxId: WRONG_CREATOR_INBOX_ID },
+          { id: "right", inboxId: RIGHT_CREATOR_INBOX_ID },
+        ];
+      },
+      async getWalletPrivateKeyHex(identityId) {
+        if (identityId === "wrong") {
+          return Result.ok(WRONG_PRIVATE_KEY_HEX);
+        }
+
+        rightKeyLookupCalls += 1;
+        if (rightKeyLookupCalls === 1) {
+          return Result.err(
+            InternalError.create("managed identity still attaching"),
+          );
+        }
+        return Result.ok(RIGHT_PRIVATE_KEY_HEX);
+      },
+      getManagedClient(identityId) {
+        return {
+          addMembers: async () => {
+            if (identityId === "right") {
+              addMemberCalls += 1;
+            }
+            return Result.ok(undefined);
+          },
+          listMessages: async (groupId) =>
+            Result.ok([
+              {
+                messageId: "dm-mixed-retry-msg-1",
+                groupId,
+                senderInboxId: TEST_REQUESTER_INBOX_ID,
+                contentType: "text",
+                content: slug,
+                sentAt: new Date().toISOString(),
+                threadId: null,
+              },
+            ]),
+        };
+      },
+      async getGroupInviteTag() {
+        return Result.ok("host-test-tag");
+      },
+      async onJoinRejected(failure) {
+        failures.push(failure.error.category);
+      },
+    });
+
+    capturedHandler?.(makeRawDmJoinedEvent("dm-join-mixed-retry"));
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    expect(rightKeyLookupCalls).toBeGreaterThanOrEqual(2);
+    expect(addMemberCalls).toBe(1);
+    expect(failures).toEqual([]);
+  });
+
+  test("does not retry recovered invites after a validation failure", async () => {
+    const slug = await buildValidSlug();
+
+    let listMessageCalls = 0;
+    const failures: string[] = [];
+    let capturedHandler: ((event: CoreRawEvent) => void) | null = null;
+
+    startManagedInviteHostListener({
+      subscribe(handler) {
+        capturedHandler = handler;
+        return () => {};
+      },
+      async listIdentities() {
+        return [{ id: "creator", inboxId: RIGHT_CREATOR_INBOX_ID }];
+      },
+      async getWalletPrivateKeyHex() {
+        return Result.ok(RIGHT_PRIVATE_KEY_HEX);
+      },
+      getManagedClient() {
+        return {
+          addMembers: async () => Result.ok(undefined),
+          listMessages: async (groupId) => {
+            listMessageCalls += 1;
+            return Result.ok([
+              {
+                messageId: "dm-validation-failure-msg-1",
+                groupId,
+                senderInboxId: TEST_REQUESTER_INBOX_ID,
+                contentType: "text",
+                content: slug,
+                sentAt: new Date().toISOString(),
+                threadId: null,
+              },
+            ]);
+          },
+        };
+      },
+      async getGroupInviteTag() {
+        return Result.ok("wrong-host-tag");
+      },
+      async onJoinRejected(failure) {
+        failures.push(failure.error.category);
+      },
+    });
+
+    capturedHandler?.(makeRawDmJoinedEvent("dm-validation-failure"));
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    expect(listMessageCalls).toBe(1);
+    expect(failures).toEqual(["validation"]);
   });
 
   test("does not retry DM recovery for identities that do not own the DM", async () => {

--- a/packages/cli/src/__tests__/runtime.test.ts
+++ b/packages/cli/src/__tests__/runtime.test.ts
@@ -448,6 +448,23 @@ describe("createSignetRuntime", () => {
     expect(runtime.paths.auditLog).toBe(join(tempDir, "audit.jsonl"));
   });
 
+  test("passes the runtime audit log into conversation action wiring", async () => {
+    const tracker = createCallTracker();
+    const config = makeConfig(tempDir);
+    const deps = makeMockDeps(tracker);
+    let conversationAuditLogPath: string | undefined;
+
+    deps.createConversationActions = ({ auditLog }) => {
+      conversationAuditLogPath = auditLog.path;
+      return [];
+    };
+
+    const result = await createSignetRuntime(config, deps);
+    expect(Result.isOk(result)).toBe(true);
+
+    expect(conversationAuditLogPath).toBe(join(tempDir, "audit.jsonl"));
+  });
+
   test("status() reports actual bound port, not config port", async () => {
     const tracker = createCallTracker();
     // Config with port 0 (dynamic allocation)

--- a/packages/cli/src/invite-host-effects.ts
+++ b/packages/cli/src/invite-host-effects.ts
@@ -1,0 +1,345 @@
+import { Result } from "better-result";
+import {
+  buildProfileSnapshotFromMessages,
+  encodeProfileSnapshot,
+  extractJoinRequestContent,
+  MemberKind,
+  type ListMessagesOptions,
+  type ProfileSnapshotContent,
+  resolveProfilesFromMessages,
+  type XmtpDecodedMessage,
+  type XmtpGroupInfo,
+} from "@xmtp/signet-core";
+import type { SignetError } from "@xmtp/signet-schemas";
+import type { AuditEntry, AuditLog } from "./audit/log.js";
+import type {
+  ManagedInviteJoinAcceptance,
+  ManagedInviteJoinFailure,
+} from "./invite-host-listener.js";
+
+const PROFILE_SNAPSHOT_CONTENT_TYPE = "convos.org/profile_snapshot:1.0";
+const PROFILE_SNAPSHOT_SCAN_OPTIONS = {
+  limit: 500,
+  direction: "descending",
+} satisfies ListMessagesOptions;
+
+interface InviteHostEffectsClient {
+  readonly getGroupInfo: (
+    groupId: string,
+  ) => Promise<Result<XmtpGroupInfo, SignetError>>;
+  readonly listMessages: (
+    groupId: string,
+    options?: ListMessagesOptions,
+  ) => Promise<Result<readonly XmtpDecodedMessage[], SignetError>>;
+  readonly sendMessage: (
+    groupId: string,
+    content: unknown,
+    contentType?: string,
+  ) => Promise<Result<string, SignetError>>;
+}
+
+/** Dependencies for audit and profile-side effects after invite handling. */
+export interface InviteHostEffectsDeps {
+  readonly auditLog: AuditLog;
+  readonly getManagedClientForGroup: (
+    groupId: string,
+  ) => InviteHostEffectsClient | undefined;
+  readonly resolveLocalChatId?: (groupId: string) => string | undefined;
+  readonly now?: () => Date;
+}
+
+function entryTimestamp(deps: InviteHostEffectsDeps): string {
+  return (deps.now ?? (() => new Date()))().toISOString();
+}
+
+function joinFailureAction(
+  category: SignetError["category"],
+): "convos.join-request.rejected" | "convos.join-request.failed" {
+  switch (category) {
+    case "validation":
+    case "permission":
+    case "auth":
+      return "convos.join-request.rejected";
+    case "internal":
+    case "timeout":
+    case "cancelled":
+    default:
+      return "convos.join-request.failed";
+  }
+}
+
+async function appendAudit(
+  deps: InviteHostEffectsDeps,
+  entry: AuditEntry,
+): Promise<void> {
+  await deps.auditLog.append(entry);
+}
+
+async function appendSnapshotAudit(
+  deps: InviteHostEffectsDeps,
+  acceptance: ManagedInviteJoinAcceptance,
+  action: "convos.profile-snapshot.sent" | "convos.profile-snapshot.failed",
+  success: boolean,
+  detail: Record<string, unknown>,
+): Promise<void> {
+  await appendAudit(deps, {
+    timestamp: entryTimestamp(deps),
+    action,
+    actor: "system",
+    target: acceptance.join.groupId,
+    success,
+    detail: {
+      groupId: acceptance.join.groupId,
+      localChatId: deps.resolveLocalChatId?.(acceptance.join.groupId),
+      inviteTag: acceptance.join.inviteTag,
+      joinerInboxId: acceptance.join.requesterInboxId,
+      hostIdentityId: acceptance.hostIdentityId,
+      hostInboxId: acceptance.hostInboxId,
+      dmId: acceptance.requestMessage.groupId,
+      requestMessageId: acceptance.requestMessage.messageId,
+      ...detail,
+    },
+  });
+}
+
+function applyAcceptedJoinProfile(
+  acceptance: ManagedInviteJoinAcceptance,
+  snapshot: ProfileSnapshotContent,
+): ProfileSnapshotContent {
+  const requestedProfile = extractJoinRequestContent(
+    acceptance.requestMessage.content,
+  )?.profile;
+  if (!requestedProfile) {
+    return snapshot;
+  }
+
+  const requestedMemberKind =
+    requestedProfile.memberKind === "agent" ? MemberKind.Agent : undefined;
+  const joinerInboxId = acceptance.join.requesterInboxId.toLowerCase();
+
+  return {
+    profiles: snapshot.profiles.map((profile) => {
+      if (profile.inboxId.toLowerCase() !== joinerInboxId) {
+        return profile;
+      }
+
+      return {
+        ...profile,
+        ...(requestedProfile.name !== undefined
+          ? { name: requestedProfile.name }
+          : {}),
+        ...(requestedMemberKind !== undefined
+          ? { memberKind: requestedMemberKind }
+          : {}),
+      };
+    }),
+  };
+}
+
+function hasMaterializedProfile(
+  profile:
+    | {
+        readonly name?: unknown;
+        readonly encryptedImage?: unknown;
+        readonly memberKind?: unknown;
+        readonly metadata?: unknown;
+      }
+    | undefined,
+): boolean {
+  return (
+    profile !== undefined &&
+    (profile.name !== undefined ||
+      profile.encryptedImage !== undefined ||
+      profile.memberKind !== undefined ||
+      profile.metadata !== undefined)
+  );
+}
+
+async function loadProfileSnapshotMessages(
+  managed: InviteHostEffectsClient,
+  groupId: string,
+  memberInboxIds: readonly string[],
+): Promise<Result<readonly XmtpDecodedMessage[], SignetError>> {
+  const collected: XmtpDecodedMessage[] = [];
+  let before: string | undefined;
+
+  while (true) {
+    const listOptions = before
+      ? { ...PROFILE_SNAPSHOT_SCAN_OPTIONS, before }
+      : PROFILE_SNAPSHOT_SCAN_OPTIONS;
+    const messagesResult = await managed.listMessages(groupId, listOptions);
+    if (Result.isError(messagesResult)) {
+      return messagesResult;
+    }
+
+    if (messagesResult.value.length === 0) {
+      return Result.ok(collected);
+    }
+
+    collected.push(...messagesResult.value);
+
+    const resolvedProfiles = resolveProfilesFromMessages(
+      collected,
+      memberInboxIds,
+    );
+    if (
+      memberInboxIds.every((inboxId) =>
+        hasMaterializedProfile(resolvedProfiles.get(inboxId.toLowerCase())),
+      )
+    ) {
+      return Result.ok(collected);
+    }
+
+    if (messagesResult.value.length < PROFILE_SNAPSHOT_SCAN_OPTIONS.limit) {
+      return Result.ok(collected);
+    }
+
+    const oldestMessage = messagesResult.value[messagesResult.value.length - 1];
+    before = oldestMessage?.sentAt;
+    if (!before) {
+      return Result.ok(collected);
+    }
+  }
+}
+
+/** Creates best-effort audit and profile side effects for hosted invite flows. */
+export function createInviteHostEffects(deps: InviteHostEffectsDeps): {
+  readonly onJoinAccepted: (
+    acceptance: ManagedInviteJoinAcceptance,
+  ) => Promise<void>;
+  readonly onJoinRejected: (failure: ManagedInviteJoinFailure) => Promise<void>;
+} {
+  return {
+    async onJoinAccepted(acceptance): Promise<void> {
+      await appendAudit(deps, {
+        timestamp: entryTimestamp(deps),
+        action: "convos.join-request.accepted",
+        actor: "system",
+        target: acceptance.join.groupId,
+        success: true,
+        detail: {
+          groupId: acceptance.join.groupId,
+          localChatId: deps.resolveLocalChatId?.(acceptance.join.groupId),
+          inviteTag: acceptance.join.inviteTag,
+          joinerInboxId: acceptance.join.requesterInboxId,
+          hostIdentityId: acceptance.hostIdentityId,
+          hostInboxId: acceptance.hostInboxId,
+          dmId: acceptance.requestMessage.groupId,
+          requestMessageId: acceptance.requestMessage.messageId,
+        },
+      });
+
+      const managed = deps.getManagedClientForGroup(acceptance.join.groupId);
+      if (!managed) {
+        await appendSnapshotAudit(
+          deps,
+          acceptance,
+          "convos.profile-snapshot.failed",
+          false,
+          { errorMessage: "Managed client unavailable for accepted group" },
+        );
+        return;
+      }
+
+      const groupInfoResult = await managed.getGroupInfo(
+        acceptance.join.groupId,
+      );
+      if (Result.isError(groupInfoResult)) {
+        await appendSnapshotAudit(
+          deps,
+          acceptance,
+          "convos.profile-snapshot.failed",
+          false,
+          {
+            errorCategory: groupInfoResult.error.category,
+            errorMessage: groupInfoResult.error.message,
+            stage: "groupInfo",
+          },
+        );
+        return;
+      }
+
+      const messagesResult = await loadProfileSnapshotMessages(
+        managed,
+        acceptance.join.groupId,
+        groupInfoResult.value.memberInboxIds,
+      );
+      if (Result.isError(messagesResult)) {
+        await appendSnapshotAudit(
+          deps,
+          acceptance,
+          "convos.profile-snapshot.failed",
+          false,
+          {
+            errorCategory: messagesResult.error.category,
+            errorMessage: messagesResult.error.message,
+            stage: "listMessages",
+          },
+        );
+        return;
+      }
+
+      const snapshot = applyAcceptedJoinProfile(
+        acceptance,
+        buildProfileSnapshotFromMessages(
+          messagesResult.value,
+          groupInfoResult.value.memberInboxIds,
+          { includeFallbackEntries: true },
+        ),
+      );
+      if (snapshot.profiles.length === 0) {
+        return;
+      }
+
+      const sendResult = await managed.sendMessage(
+        acceptance.join.groupId,
+        encodeProfileSnapshot(snapshot),
+        PROFILE_SNAPSHOT_CONTENT_TYPE,
+      );
+      if (Result.isError(sendResult)) {
+        await appendSnapshotAudit(
+          deps,
+          acceptance,
+          "convos.profile-snapshot.failed",
+          false,
+          {
+            errorCategory: sendResult.error.category,
+            errorMessage: sendResult.error.message,
+            profileCount: snapshot.profiles.length,
+            stage: "sendMessage",
+          },
+        );
+        return;
+      }
+
+      await appendSnapshotAudit(
+        deps,
+        acceptance,
+        "convos.profile-snapshot.sent",
+        true,
+        {
+          messageId: sendResult.value,
+          profileCount: snapshot.profiles.length,
+        },
+      );
+    },
+
+    async onJoinRejected(failure): Promise<void> {
+      await appendAudit(deps, {
+        timestamp: entryTimestamp(deps),
+        action: joinFailureAction(failure.error.category),
+        actor: "system",
+        target: failure.requestMessage.groupId,
+        success: false,
+        detail: {
+          dmId: failure.requestMessage.groupId,
+          requestMessageId: failure.requestMessage.messageId,
+          joinerInboxId: failure.requestMessage.senderInboxId,
+          contentType: failure.requestMessage.contentType,
+          errorCategory: failure.error.category,
+          errorMessage: failure.error.message,
+        },
+      });
+    },
+  };
+}

--- a/packages/cli/src/invite-host-listener.ts
+++ b/packages/cli/src/invite-host-listener.ts
@@ -1,5 +1,6 @@
 import { Result } from "better-result";
 import {
+  extractJoinRequestContent,
   tryProcessJoinRequest,
   isJoinRequestContentType,
   type CoreRawEvent,
@@ -26,6 +27,33 @@ interface ManagedInviteHostIdentity {
   readonly inboxId: string | null;
 }
 
+interface ManagedInviteJoinResolution {
+  readonly join: JoinRequestResult;
+  readonly hostIdentityId: string;
+  readonly hostInboxId: string;
+}
+
+interface ManagedInviteJoinDispatchOutcome {
+  readonly result: Result<ManagedInviteJoinResolution, SignetError> | null;
+  readonly shouldRetry: boolean;
+}
+
+/** Successful join resolution plus the raw request message that triggered it. */
+export interface ManagedInviteJoinAcceptance extends ManagedInviteJoinResolution {
+  readonly requestMessage: RawMessageEvent;
+}
+
+/** Failed join processing plus the raw request message that failed. */
+export interface ManagedInviteJoinFailure {
+  readonly error: SignetError;
+  readonly requestMessage: RawMessageEvent;
+}
+
+interface InviteCandidateProcessResult {
+  readonly accepted: boolean;
+  readonly shouldRetry: boolean;
+}
+
 /** Dependencies required to resolve the correct managed identity for an invite. */
 export interface ManagedInviteHostListenerDeps {
   /** Subscribe to raw core events and return an unsubscribe callback. */
@@ -44,6 +72,19 @@ export interface ManagedInviteHostListenerDeps {
   readonly getGroupInviteTag: (
     groupId: string,
   ) => Promise<Result<string | undefined, SignetError>>;
+  /** Best-effort callback after a join request is accepted. */
+  readonly onJoinAccepted?: (
+    acceptance: ManagedInviteJoinAcceptance,
+  ) => Promise<void>;
+  /** Best-effort callback after a structured join request fails. */
+  readonly onJoinRejected?: (
+    failure: ManagedInviteJoinFailure,
+  ) => Promise<void>;
+  /**
+   * Milliseconds to retain logical invite dedupe keys after a successful join.
+   * This only needs to cover the structured/fallback catch-up window.
+   */
+  readonly processedInviteKeyTtlMs?: number;
 }
 
 const RECENT_JOIN_SCAN_OPTIONS = {
@@ -52,10 +93,39 @@ const RECENT_JOIN_SCAN_OPTIONS = {
 } satisfies ListMessagesOptions;
 const DM_RECOVERY_RETRY_DELAY_MS = 250;
 const MAX_DM_RECOVERY_RETRIES = 3;
+const DEFAULT_PROCESSED_INVITE_KEY_TTL_MS = 5_000;
 
 interface InviteRecoveryScanResult {
   readonly messages: readonly RawMessageEvent[];
   readonly shouldRetry: boolean;
+}
+
+function resolveInviteRequestKey(event: RawMessageEvent): string | null {
+  const inviteSlug =
+    extractJoinRequestContent(event.content)?.inviteSlug ??
+    (typeof event.content === "string" ? event.content.trim() : undefined);
+
+  if (!inviteSlug || inviteSlug.length === 0) {
+    return null;
+  }
+
+  return `${event.senderInboxId.toLowerCase()}:${inviteSlug}`;
+}
+
+function preferInviteCandidate(
+  current: RawMessageEvent | undefined,
+  candidate: RawMessageEvent,
+): RawMessageEvent {
+  if (!current) return candidate;
+
+  const currentStructured = isJoinRequestContentType(current.contentType);
+  const candidateStructured = isJoinRequestContentType(candidate.contentType);
+
+  if (candidateStructured && !currentStructured) {
+    return candidate;
+  }
+
+  return current;
 }
 
 function isInviteCandidate(event: CoreRawEvent): event is RawMessageEvent {
@@ -72,6 +142,14 @@ function isInviteCandidate(event: CoreRawEvent): event is RawMessageEvent {
 
 function normalizePrivateKeyHex(value: string): string {
   return value.startsWith("0x") ? value.slice(2) : value;
+}
+
+function isRetryableInviteError(error: SignetError): boolean {
+  return (
+    error.category !== "validation" &&
+    error.category !== "permission" &&
+    error.category !== "auth"
+  );
 }
 
 function toRawMessageEvent(message: XmtpDecodedMessage): RawMessageEvent {
@@ -95,20 +173,32 @@ function toRawMessageEvent(message: XmtpDecodedMessage): RawMessageEvent {
 export async function dispatchInviteJoinRequestAcrossManagedIdentities(
   deps: ManagedInviteHostListenerDeps,
   event: CoreRawEvent,
-): Promise<Result<JoinRequestResult, SignetError> | null> {
-  if (!isInviteCandidate(event)) return null;
+): Promise<ManagedInviteJoinDispatchOutcome> {
+  if (!isInviteCandidate(event)) {
+    return { result: null, shouldRetry: false };
+  }
 
   const identities = await deps.listIdentities();
   let lastError: SignetError | null = null;
+  let shouldRetry = false;
 
   for (const identity of identities) {
-    if (!identity.inboxId) continue;
+    if (!identity.inboxId) {
+      shouldRetry = true;
+      continue;
+    }
 
     const managed = deps.getManagedClient(identity.id);
-    if (!managed) continue;
+    if (!managed) {
+      shouldRetry = true;
+      continue;
+    }
 
     const keyResult = await deps.getWalletPrivateKeyHex(identity.id);
-    if (Result.isError(keyResult)) continue;
+    if (Result.isError(keyResult)) {
+      shouldRetry = true;
+      continue;
+    }
 
     const result = await tryProcessJoinRequest(
       {
@@ -121,18 +211,33 @@ export async function dispatchInviteJoinRequestAcrossManagedIdentities(
       event,
     );
 
-    if (result === null) return null;
-    if (Result.isOk(result)) return result;
+    if (result === null) {
+      return { result: null, shouldRetry };
+    }
+    if (Result.isOk(result)) {
+      return {
+        result: Result.ok({
+          join: result.value,
+          hostIdentityId: identity.id,
+          hostInboxId: identity.inboxId,
+        }),
+        shouldRetry: false,
+      };
+    }
     lastError = result.error;
+    if (isRetryableInviteError(result.error)) {
+      shouldRetry = true;
+    }
   }
 
-  return lastError ? Result.err(lastError) : null;
+  return { result: lastError ? Result.err(lastError) : null, shouldRetry };
 }
 
 async function listRecentInviteCandidatesAcrossManagedIdentities(
   deps: ManagedInviteHostListenerDeps,
   conversationId: string,
   processedMessageIds: ReadonlySet<string>,
+  processedInviteKeys: ReadonlySet<string>,
 ): Promise<InviteRecoveryScanResult> {
   const identities = await deps.listIdentities();
   const messages = new Map<string, RawMessageEvent>();
@@ -165,7 +270,15 @@ async function listRecentInviteCandidatesAcrossManagedIdentities(
         const event = toRawMessageEvent(message);
         if (!isInviteCandidate(event)) continue;
         if (processedMessageIds.has(event.messageId)) continue;
-        messages.set(event.messageId, event);
+        const requestKey = resolveInviteRequestKey(event);
+        if (requestKey && processedInviteKeys.has(requestKey)) continue;
+        messages.set(
+          requestKey ?? event.messageId,
+          preferInviteCandidate(
+            messages.get(requestKey ?? event.messageId),
+            event,
+          ),
+        );
       }
 
       if (listResult.value.length < RECENT_JOIN_SCAN_OPTIONS.limit) break;
@@ -186,25 +299,73 @@ async function processInviteCandidate(
   deps: ManagedInviteHostListenerDeps,
   event: RawMessageEvent,
   processedMessageIds: Set<string>,
+  processedInviteKeys: Set<string>,
   inflightMessageIds: Set<string>,
-): Promise<boolean> {
-  if (processedMessageIds.has(event.messageId)) return true;
-  if (inflightMessageIds.has(event.messageId)) return true;
+  inflightInviteKeys: Set<string>,
+  markInviteKeyProcessed: (requestKey: string) => void,
+): Promise<InviteCandidateProcessResult> {
+  const requestKey = resolveInviteRequestKey(event);
+  if (processedMessageIds.has(event.messageId)) {
+    return { accepted: true, shouldRetry: false };
+  }
+  if (requestKey && processedInviteKeys.has(requestKey)) {
+    return { accepted: true, shouldRetry: false };
+  }
+  if (inflightMessageIds.has(event.messageId)) {
+    return { accepted: true, shouldRetry: false };
+  }
+  if (requestKey && inflightInviteKeys.has(requestKey)) {
+    return { accepted: true, shouldRetry: false };
+  }
 
   inflightMessageIds.add(event.messageId);
+  if (requestKey) {
+    inflightInviteKeys.add(requestKey);
+  }
 
   try {
-    const result = await dispatchInviteJoinRequestAcrossManagedIdentities(
-      deps,
-      event,
-    );
-    if (result !== null && Result.isOk(result)) {
-      processedMessageIds.add(event.messageId);
-      return true;
+    const dispatchOutcome =
+      await dispatchInviteJoinRequestAcrossManagedIdentities(deps, event);
+    if (dispatchOutcome.result === null) {
+      return { accepted: false, shouldRetry: dispatchOutcome.shouldRetry };
     }
-    return false;
+
+    if (Result.isOk(dispatchOutcome.result)) {
+      processedMessageIds.add(event.messageId);
+      if (requestKey) {
+        markInviteKeyProcessed(requestKey);
+      }
+      try {
+        await deps.onJoinAccepted?.({
+          ...dispatchOutcome.result.value,
+          requestMessage: event,
+        });
+      } catch {
+        // Acceptance already succeeded; keep the invite marked processed.
+      }
+      return { accepted: true, shouldRetry: false };
+    }
+
+    if (!dispatchOutcome.shouldRetry) {
+      try {
+        await deps.onJoinRejected?.({
+          error: dispatchOutcome.result.error,
+          requestMessage: event,
+        });
+      } catch {
+        // Ignore audit/telemetry failures and preserve retry behavior below.
+      }
+    }
+
+    return {
+      accepted: false,
+      shouldRetry: dispatchOutcome.shouldRetry,
+    };
   } finally {
     inflightMessageIds.delete(event.messageId);
+    if (requestKey) {
+      inflightInviteKeys.delete(requestKey);
+    }
   }
 }
 
@@ -216,14 +377,29 @@ export function startManagedInviteHostListener(
   deps: ManagedInviteHostListenerDeps,
 ): () => void {
   const processedMessageIds = new Set<string>();
+  const processedInviteKeys = new Set<string>();
   const inflightMessageIds = new Set<string>();
+  const inflightInviteKeys = new Set<string>();
   const recoveryRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const processedInviteKeyTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
+  const processedInviteKeyTtlMs =
+    deps.processedInviteKeyTtlMs ?? DEFAULT_PROCESSED_INVITE_KEY_TTL_MS;
 
   function clearRecoveryRetryTimer(dmId: string): void {
     const timer = recoveryRetryTimers.get(dmId);
     if (timer === undefined) return;
     clearTimeout(timer);
     recoveryRetryTimers.delete(dmId);
+  }
+
+  function clearProcessedInviteKeyTimer(requestKey: string): void {
+    const timer = processedInviteKeyTimers.get(requestKey);
+    if (timer === undefined) return;
+    clearTimeout(timer);
+    processedInviteKeyTimers.delete(requestKey);
   }
 
   function unrefTimer(timer: ReturnType<typeof setTimeout>): void {
@@ -236,6 +412,17 @@ export function startManagedInviteHostListener(
     }
   }
 
+  function markInviteKeyProcessed(requestKey: string): void {
+    processedInviteKeys.add(requestKey);
+    clearProcessedInviteKeyTimer(requestKey);
+    const timer = setTimeout(() => {
+      processedInviteKeys.delete(requestKey);
+      processedInviteKeyTimers.delete(requestKey);
+    }, processedInviteKeyTtlMs);
+    unrefTimer(timer);
+    processedInviteKeyTimers.set(requestKey, timer);
+  }
+
   async function recoverInviteCandidatesFromDm(
     dmId: string,
     retryCount = 0,
@@ -244,17 +431,21 @@ export function startManagedInviteHostListener(
       deps,
       dmId,
       processedMessageIds,
+      processedInviteKeys,
     );
     let shouldRetry = scanResult.shouldRetry;
 
     for (const message of scanResult.messages) {
-      const processed = await processInviteCandidate(
+      const outcome = await processInviteCandidate(
         deps,
         message,
         processedMessageIds,
+        processedInviteKeys,
         inflightMessageIds,
+        inflightInviteKeys,
+        markInviteKeyProcessed,
       );
-      if (!processed) {
+      if (!outcome.accepted && outcome.shouldRetry) {
         shouldRetry = true;
       }
     }
@@ -283,7 +474,10 @@ export function startManagedInviteHostListener(
           deps,
           event,
           processedMessageIds,
+          processedInviteKeys,
           inflightMessageIds,
+          inflightInviteKeys,
+          markInviteKeyProcessed,
         );
         return;
       }
@@ -299,6 +493,9 @@ export function startManagedInviteHostListener(
   return () => {
     for (const dmId of recoveryRetryTimers.keys()) {
       clearRecoveryRetryTimer(dmId);
+    }
+    for (const requestKey of processedInviteKeyTimers.keys()) {
+      clearProcessedInviteKeyTimer(requestKey);
     }
     unsubscribe();
   };

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -104,7 +104,9 @@ export interface SignetRuntimeDeps {
 
   /** Optional factory for conversation action specs, wired in production by start.ts. */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  createConversationActions?: () => ActionSpec<any, any, SignetError>[];
+  createConversationActions?: (deps: {
+    auditLog: AuditLog;
+  }) => ActionSpec<any, any, SignetError>[];
 
   /** Optional factory for inbox action specs, wired in production by start.ts. */
   createInboxActions?: () => ActionSpec<unknown, unknown, SignetError>[];
@@ -430,7 +432,7 @@ export async function createSignetRuntime(
   }
 
   if (deps.createConversationActions) {
-    for (const spec of deps.createConversationActions()) {
+    for (const spec of deps.createConversationActions({ auditLog })) {
       registry.register(spec);
     }
   }

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -69,6 +69,7 @@ import {
 } from "./admin/read-elevation.js";
 import { createAdminReadDisclosureStore } from "./admin/read-disclosure-store.js";
 import { createReadDisclosureRollbackTracker } from "./admin/read-disclosure-rollback-tracker.js";
+import { createInviteHostEffects } from "./invite-host-effects.js";
 import { createWsRequestHandler } from "./ws/request-handler.js";
 import { createLazyCoreUpgrade } from "./ws/core-upgrade.js";
 import { createEventProjector } from "./ws/event-projector.js";
@@ -675,7 +676,7 @@ export function createProductionDeps(): SignetRuntimeDeps {
       return createInboxActionSpecs(inboxActionDeps);
     },
 
-    createConversationActions() {
+    createConversationActions(deps) {
       if (coreImplRef === null) {
         throw new Error(
           "SignetCoreImpl not initialized before conversation actions",
@@ -844,6 +845,23 @@ export function createProductionDeps(): SignetRuntimeDeps {
       if (!inviteHostUnsub) {
         const core = coreImplRef;
         const spf = signerProviderFactory;
+        const inviteHostEffects = createInviteHostEffects({
+          auditLog: deps.auditLog,
+          getManagedClientForGroup: (groupId) => {
+            const managed = core.getManagedClientForGroup(groupId);
+            if (!managed) return undefined;
+            return {
+              getGroupInfo: (targetGroupId) =>
+                managed.client.getGroupInfo(targetGroupId),
+              listMessages: (targetGroupId, options) =>
+                managed.client.listMessages(targetGroupId, options),
+              sendMessage: (targetGroupId, content, contentType) =>
+                managed.client.sendMessage(targetGroupId, content, contentType),
+            };
+          },
+          resolveLocalChatId: (groupId) =>
+            idMappingStoreRef?.resolve(groupId)?.localId,
+        });
         inviteHostUnsub = startManagedInviteHostListener({
           subscribe: (handler) => core.on(handler),
           listIdentities: () => core.identityStore.list(),
@@ -865,6 +883,8 @@ export function createProductionDeps(): SignetRuntimeDeps {
           },
           getGroupInviteTag: async (groupId) =>
             Result.ok(inviteTagStore.get(groupId)),
+          onJoinAccepted: inviteHostEffects.onJoinAccepted,
+          onJoinRejected: inviteHostEffects.onJoinRejected,
         });
       }
 


### PR DESCRIPTION
## Summary
- add host-side Convos parity after invite acceptance
- emit explicit acceptance effects and preserve profile state when new members join
- harden invite listener recovery, dedupe, and rejoin behavior

## What Changed
- add invite-host effects that record acceptance outcomes and emit post-accept profile snapshot/state
- update the invite host listener to dedupe logical joins correctly across structured and fallback requests
- keep same-inbox rejoins working by expiring logical dedupe keys instead of pinning them for daemon lifetime
- page group history when rebuilding profile snapshots so older member names/member kinds are not erased in busy groups
- expand CLI-side host parity tests around acceptance, recovery, and snapshot behavior

## How To Test
- `bun test packages/cli/src/__tests__/invite-host-listener.test.ts`
- `bun test packages/cli/src/__tests__/invite-host-effects.test.ts`
- `bun run check`

Closes #302
Closes #304
