### PR TITLE
feat: add convos profile and invite ux

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,8 +190,8 @@ The `xs` command groups are:
 - `operator` — `create`, `list`, `info`, `rename`, `rm`
 - `cred` — `issue`, `list`, `info`, `revoke`, `update`
 - `chat` — `create`, `list`, `info`, `update`, `sync`, `join`, `invite`,
-  `leave`, `rm`, plus `members` subgroup (`list`, `add`, `rm`, `promote`,
-  `demote`)
+  `update-profile`, `leave`, `rm`, plus `members` subgroup (`list`, `add`,
+  `rm`, `promote`, `demote`)
 - `msg` — `send`, `reply`, `react`, `read`, `list`, `info`
 - `policy` — `create`, `list`, `info`, `update`, `rm`
 - `seal` _(deferred)_ — `list`, `info`, `verify`, `history`

--- a/packages/cli/src/__tests__/action-surface-map.test.ts
+++ b/packages/cli/src/__tests__/action-surface-map.test.ts
@@ -233,7 +233,7 @@ describe("action surface map", () => {
 
     expect(surfaceMap.entries.length).toBeGreaterThan(0);
     expect(hash).toBe(
-      "64b8424f690eb164190a8d0cb3c936811a0c01d671dd6b98d8476dfada9964ff",
+      "bba9c300f4efb2cde7e5859789b848be5d5487485a5d4cd77d2bce644e17d723",
     );
   });
 });

--- a/packages/cli/src/__tests__/xs-chat-command-wiring.test.ts
+++ b/packages/cli/src/__tests__/xs-chat-command-wiring.test.ts
@@ -122,6 +122,125 @@ describe("xs chat update", () => {
   });
 });
 
+describe("xs chat join", () => {
+  test("routes operator and explicit profile options through the daemon client", async () => {
+    const harness = createHarness({ groupId: "g1", profileName: "Codex" });
+    const command = createChatCommands(harness.deps);
+
+    await command.parseAsync([
+      "node",
+      "chat",
+      "join",
+      "https://popup.convos.org/v2?i=test",
+      "--as",
+      "joiner",
+      "--op",
+      "op_codex",
+      "--profile-name",
+      "Codex",
+      "--timeout",
+      "45",
+      "--config",
+      "/tmp/test.toml",
+    ]);
+
+    expect(harness.withDaemonCalls).toEqual([{ configPath: "/tmp/test.toml" }]);
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "chat.join",
+        params: {
+          inviteUrl: "https://popup.convos.org/v2?i=test",
+          label: "joiner",
+          operatorId: "op_codex",
+          profileName: "Codex",
+          timeoutSeconds: 45,
+        },
+      },
+    ]);
+  });
+});
+
+describe("xs chat invite", () => {
+  test("renders the link-friendly output format without falling back to key-value text", async () => {
+    const harness = createHarness({
+      inviteUrl: "https://popup.convos.org/v2?i=test",
+      groupName: "Codex Group",
+      groupId: "g1",
+    });
+    const command = createChatCommands(harness.deps);
+
+    await command.parseAsync([
+      "node",
+      "chat",
+      "invite",
+      "conv_abc",
+      "--format",
+      "link",
+    ]);
+
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "chat.invite",
+        params: {
+          chatId: "conv_abc",
+        },
+      },
+    ]);
+    expect(harness.stdout.join("")).toContain("Group: Codex Group (conv_abc)");
+    expect(harness.stdout.join("")).toContain(
+      "https://popup.convos.org/v2?i=test",
+    );
+    expect(harness.stdout.join("")).not.toContain("inviteUrl:");
+  });
+
+  test("includes a QR data URL in JSON output", async () => {
+    const harness = createHarness({
+      inviteUrl: "https://popup.convos.org/v2?i=test",
+      groupName: "Codex Group",
+      groupId: "g1",
+    });
+    const command = createChatCommands(harness.deps);
+
+    await command.parseAsync(["node", "chat", "invite", "conv_abc", "--json"]);
+
+    const parsed = JSON.parse(harness.stdout.join(""));
+    expect(parsed.inviteUrl).toBe("https://popup.convos.org/v2?i=test");
+    expect(parsed.qrDataUrl).toMatch(/^data:image\/png;base64,/);
+  });
+});
+
+describe("xs chat update-profile", () => {
+  test("routes identity and operator-backed defaults through the daemon client", async () => {
+    const harness = createHarness({ profileApplied: true });
+    const command = createChatCommands(harness.deps);
+
+    await command.parseAsync([
+      "node",
+      "chat",
+      "update-profile",
+      "conv_abc",
+      "--as",
+      "joiner",
+      "--op",
+      "op_codex",
+      "--config",
+      "/tmp/test.toml",
+    ]);
+
+    expect(harness.withDaemonCalls).toEqual([{ configPath: "/tmp/test.toml" }]);
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "chat.update-profile",
+        params: {
+          chatId: "conv_abc",
+          identityLabel: "joiner",
+          operatorId: "op_codex",
+        },
+      },
+    ]);
+  });
+});
+
 describe("xs chat leave", () => {
   test("without --force prints dry-run message and does not dispatch", async () => {
     const harness = createHarness({ leftGroup: true });

--- a/packages/cli/src/__tests__/xs-chat-command-wiring.test.ts
+++ b/packages/cli/src/__tests__/xs-chat-command-wiring.test.ts
@@ -161,7 +161,7 @@ describe("xs chat join", () => {
 });
 
 describe("xs chat invite", () => {
-  test("renders the link-friendly output format without falling back to key-value text", async () => {
+  test("preserves the legacy key-value output for non-JSON invite consumers", async () => {
     const harness = createHarness({
       inviteUrl: "https://popup.convos.org/v2?i=test",
       groupName: "Codex Group",
@@ -186,11 +186,11 @@ describe("xs chat invite", () => {
         },
       },
     ]);
-    expect(harness.stdout.join("")).toContain("Group: Codex Group (conv_abc)");
+    expect(harness.stdout.join("")).toContain("groupName: Codex Group");
     expect(harness.stdout.join("")).toContain(
       "https://popup.convos.org/v2?i=test",
     );
-    expect(harness.stdout.join("")).not.toContain("inviteUrl:");
+    expect(harness.stdout.join("")).toContain("inviteUrl:");
   });
 
   test("includes a QR data URL in JSON output", async () => {

--- a/packages/cli/src/__tests__/xs-chat-msg-commands.test.ts
+++ b/packages/cli/src/__tests__/xs-chat-msg-commands.test.ts
@@ -197,9 +197,9 @@ describe("chat commands", () => {
 
   // -- total count --
 
-  test("has 10 direct subcommands (including member group)", async () => {
+  test("has 11 direct subcommands (including member group)", async () => {
     const cmd = await load();
-    expect(cmd.commands.length).toBe(10);
+    expect(cmd.commands.length).toBe(11);
   });
 });
 

--- a/packages/cli/src/commands/xs-chat.ts
+++ b/packages/cli/src/commands/xs-chat.ts
@@ -40,6 +40,8 @@ const defaultDeps: XsChatCommandDeps = {
   },
 };
 
+type InviteFormat = "link" | "qr" | "both";
+
 function writeError(
   deps: XsChatCommandDeps,
   error: SignetError,
@@ -57,6 +59,49 @@ function writeError(
     ) + "\n",
   );
   deps.exit(exitCodeFromCategory(error.category));
+}
+
+function normalizeInviteFormat(format: string | undefined): InviteFormat {
+  return format === "link" || format === "qr" || format === "both"
+    ? format
+    : "both";
+}
+
+async function writeInviteOutput(
+  deps: XsChatCommandDeps,
+  inviteResult: Record<string, unknown>,
+  chatId: string,
+  options: { readonly json: boolean; readonly format: InviteFormat },
+): Promise<void> {
+  const inviteUrl =
+    typeof inviteResult["inviteUrl"] === "string"
+      ? inviteResult["inviteUrl"]
+      : "";
+  const groupName =
+    typeof inviteResult["groupName"] === "string"
+      ? inviteResult["groupName"]
+      : "unnamed";
+
+  if (options.json) {
+    const { renderQrToDataUrl } = await import("../invite/qr.js");
+    const qrDataUrl = await renderQrToDataUrl(inviteUrl);
+    deps.writeStdout(
+      formatOutput({ ...inviteResult, qrDataUrl }, { json: true }) + "\n",
+    );
+    return;
+  }
+
+  deps.writeStdout(`Group: ${groupName} (${chatId})\n`);
+
+  if (options.format === "link" || options.format === "both") {
+    deps.writeStdout(`\nInvite URL:\n${inviteUrl}\n`);
+  }
+
+  if (options.format === "qr" || options.format === "both") {
+    const { renderQrToTerminal } = await import("../invite/qr.js");
+    const qr = await renderQrToTerminal(inviteUrl);
+    deps.writeStdout(`\n${qr}`);
+  }
 }
 
 /**
@@ -237,17 +282,30 @@ export function createChatCommands(
     .description("Join a conversation via invite link")
     .argument("<url>", "Invite URL")
     .option("--config <path>", "Path to config file")
-    .option("--as <inbox>", "Inbox ID to act as")
+    .option("--as <label>", "Label for the new joined identity")
+    .option("--op <operator>", "Operator ID for profile defaults")
+    .option("--profile-name <name>", "Explicit Convos profile name")
     .option("--timeout <seconds>", "Timeout in seconds")
     .option("--json", "JSON output")
     .action(
       async (
         url: string,
-        opts: { config?: string; as?: string; timeout?: string; json?: true },
+        opts: {
+          config?: string;
+          as?: string;
+          op?: string;
+          profileName?: string;
+          timeout?: string;
+          json?: true;
+        },
       ) => {
         const json = opts.json === true;
         const payload: Record<string, unknown> = { inviteUrl: url };
         if (opts.as !== undefined) payload["label"] = opts.as;
+        if (opts.op !== undefined) payload["operatorId"] = opts.op;
+        if (opts.profileName !== undefined) {
+          payload["profileName"] = opts.profileName;
+        }
         if (opts.timeout !== undefined) {
           payload["timeoutSeconds"] = Number.parseInt(opts.timeout, 10);
         }
@@ -274,6 +332,7 @@ export function createChatCommands(
     .option("--as <inbox>", "Inbox ID to act as")
     .option("--name <name>", "Invite display name")
     .option("--description <desc>", "Invite description")
+    .option("--format <type>", "Output format: link, qr, or both", "both")
     .option("--json", "JSON output")
     .action(
       async (
@@ -283,10 +342,12 @@ export function createChatCommands(
           as?: string;
           name?: string;
           description?: string;
+          format?: string;
           json?: true;
         },
       ) => {
         const json = opts.json === true;
+        const format = normalizeInviteFormat(opts.format);
         const payload: Record<string, unknown> = { chatId: id };
         if (opts.as !== undefined) payload["identityLabel"] = opts.as;
         if (opts.name !== undefined) payload["name"] = opts.name;
@@ -297,6 +358,53 @@ export function createChatCommands(
         const result = await resolvedDeps.withDaemonClient(
           { configPath: opts.config },
           (client) => client.request("chat.invite", payload),
+        );
+
+        if (result.isErr()) {
+          writeError(resolvedDeps, result.error, json);
+          return;
+        }
+
+        await writeInviteOutput(
+          resolvedDeps,
+          result.value as Record<string, unknown>,
+          id,
+          { json, format },
+        );
+      },
+    );
+
+  cmd
+    .command("update-profile")
+    .description("Publish a Convos profile update")
+    .argument("<id>", "Conversation ID")
+    .option("--config <path>", "Path to config file")
+    .option("--as <identity>", "Identity label to act as")
+    .option("--op <operator>", "Operator ID for profile defaults")
+    .option("--profile-name <name>", "Explicit Convos profile name")
+    .option("--json", "JSON output")
+    .action(
+      async (
+        id: string,
+        opts: {
+          config?: string;
+          as?: string;
+          op?: string;
+          profileName?: string;
+          json?: true;
+        },
+      ) => {
+        const json = opts.json === true;
+        const payload: Record<string, unknown> = { chatId: id };
+        if (opts.as !== undefined) payload["identityLabel"] = opts.as;
+        if (opts.op !== undefined) payload["operatorId"] = opts.op;
+        if (opts.profileName !== undefined) {
+          payload["profileName"] = opts.profileName;
+        }
+
+        const result = await resolvedDeps.withDaemonClient(
+          { configPath: opts.config },
+          (client) => client.request("chat.update-profile", payload),
         );
 
         if (result.isErr()) {

--- a/packages/cli/src/commands/xs-chat.ts
+++ b/packages/cli/src/commands/xs-chat.ts
@@ -70,17 +70,12 @@ function normalizeInviteFormat(format: string | undefined): InviteFormat {
 async function writeInviteOutput(
   deps: XsChatCommandDeps,
   inviteResult: Record<string, unknown>,
-  chatId: string,
   options: { readonly json: boolean; readonly format: InviteFormat },
 ): Promise<void> {
   const inviteUrl =
     typeof inviteResult["inviteUrl"] === "string"
       ? inviteResult["inviteUrl"]
       : "";
-  const groupName =
-    typeof inviteResult["groupName"] === "string"
-      ? inviteResult["groupName"]
-      : "unnamed";
 
   if (options.json) {
     const { renderQrToDataUrl } = await import("../invite/qr.js");
@@ -91,11 +86,7 @@ async function writeInviteOutput(
     return;
   }
 
-  deps.writeStdout(`Group: ${groupName} (${chatId})\n`);
-
-  if (options.format === "link" || options.format === "both") {
-    deps.writeStdout(`\nInvite URL:\n${inviteUrl}\n`);
-  }
+  deps.writeStdout(formatOutput(inviteResult, { json: false }) + "\n");
 
   if (options.format === "qr" || options.format === "both") {
     const { renderQrToTerminal } = await import("../invite/qr.js");
@@ -368,7 +359,6 @@ export function createChatCommands(
         await writeInviteOutput(
           resolvedDeps,
           result.value as Record<string, unknown>,
-          id,
           { json, format },
         );
       },

--- a/packages/cli/src/commands/xs-chat.ts
+++ b/packages/cli/src/commands/xs-chat.ts
@@ -107,7 +107,7 @@ async function writeInviteOutput(
 /**
  * Create the `chat` subcommand group.
  *
- * Subcommands: create, list, info, update, sync, join, invite, leave, rm, member.
+ * Subcommands: create, list, info, update, sync, join, invite, update-profile, leave, rm, members.
  */
 export function createChatCommands(
   deps: Partial<XsChatCommandDeps> = {},

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -704,6 +704,7 @@ export function createProductionDeps(): SignetRuntimeDeps {
 
       const actions = createConversationActions({
         identityStore: core.identityStore,
+        ...(operatorManagerRef ? { operatorManager: operatorManagerRef } : {}),
         getManagedClient: (id) => core.getManagedClient(id),
         getManagedClientForGroup: (groupId) =>
           core.getManagedClientForGroup(groupId),

--- a/packages/core/src/__tests__/conversation-actions.test.ts
+++ b/packages/core/src/__tests__/conversation-actions.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { Database } from "bun:sqlite";
 import { Result } from "better-result";
-import { NotFoundError } from "@xmtp/signet-schemas";
+import { InternalError, NotFoundError } from "@xmtp/signet-schemas";
 import type { SignetError, IdMappingStore } from "@xmtp/signet-schemas";
-import type { HandlerContext } from "@xmtp/signet-contracts";
+import type { HandlerContext, OperatorManager } from "@xmtp/signet-contracts";
 import { SqliteIdentityStore } from "../identity-store.js";
 import { createSqliteIdMappingStore } from "../id-mapping-store.js";
 import type { ManagedClient } from "../client-registry.js";
@@ -18,6 +18,7 @@ import {
   type ConversationActionDeps,
 } from "../conversation-actions.js";
 import { generateConvosInviteUrl } from "../convos/invite-generator.js";
+import { extractProfileUpdateContent } from "../convos/profile-state.js";
 
 /** Minimal handler context for tests. */
 function stubCtx(): HandlerContext {
@@ -191,6 +192,37 @@ function createJoinMockClient(): XmtpClient {
   };
 }
 
+function createOperatorManager(
+  labels: Record<string, string>,
+): OperatorManager {
+  return {
+    create: async () => Result.err(InternalError.create("not implemented")),
+    list: async () => Result.err(InternalError.create("not implemented")),
+    lookup: async (operatorId) => {
+      const label = labels[operatorId];
+      if (!label) {
+        return Result.err(
+          NotFoundError.create("operator", operatorId) as SignetError,
+        );
+      }
+      return Result.ok({
+        id: operatorId,
+        config: {
+          label,
+          role: "operator",
+          scopeMode: "per-chat",
+          provider: "internal",
+        },
+        createdAt: new Date().toISOString(),
+        createdBy: "owner",
+        status: "active",
+      });
+    },
+    update: async () => Result.err(InternalError.create("not implemented")),
+    remove: async () => Result.err(InternalError.create("not implemented")),
+  };
+}
+
 describe("conversation actions", () => {
   let identityStore: SqliteIdentityStore;
   let idMappings: IdMappingStore;
@@ -215,9 +247,11 @@ describe("conversation actions", () => {
       groupId: string,
     ) => Promise<Result<XmtpGroupInfo, SignetError>>,
     cleanupLocalState?: ConversationActionDeps["cleanupLocalState"],
+    operatorManager?: OperatorManager,
   ): void {
     deps = {
       identityStore,
+      ...(operatorManager ? { operatorManager } : {}),
       getManagedClient: (id) => managedClients.get(id),
       getManagedClientForGroup: (groupId) =>
         [...managedClients.values()].find((managed) =>
@@ -243,6 +277,9 @@ describe("conversation actions", () => {
     const updateAction = actions.find((a) => a.id === "chat.update");
     const leaveAction = actions.find((a) => a.id === "chat.leave");
     const rmAction = actions.find((a) => a.id === "chat.rm");
+    const updateProfileAction = actions.find(
+      (a) => a.id === "chat.update-profile",
+    );
     const removeMemberAction = actions.find(
       (a) => a.id === "chat.remove-member",
     );
@@ -266,6 +303,9 @@ describe("conversation actions", () => {
 
     expect(updateAction?.intent).toBe("write");
     expect(updateAction?.http?.auth).toBe("admin");
+
+    expect(updateProfileAction?.intent).toBe("write");
+    expect(updateProfileAction?.http?.auth).toBe("admin");
 
     expect(leaveAction?.intent).toBe("write");
     expect(leaveAction?.http?.auth).toBe("admin");
@@ -455,6 +495,56 @@ describe("conversation actions", () => {
       expect(attachedIdentityIds).toEqual([result.value.identityId]);
     });
 
+    test("defaults the profile name from the operator label when requested", async () => {
+      const inviteUrl = await buildJoinInviteUrl();
+      const joinClient = createJoinMockClient();
+      const joinClientFactory: XmtpClientFactory = {
+        create: async () => Result.ok(joinClient),
+      };
+
+      deps = {
+        identityStore,
+        operatorManager: createOperatorManager({ op_codex: "Codex" }),
+        getManagedClient: (id) => managedClients.get(id),
+        getManagedClientForGroup: (groupId) =>
+          [...managedClients.values()].find((managed) =>
+            managed.groupIds.has(groupId),
+          ),
+        getGroupInfo: async (groupId) =>
+          Result.err(NotFoundError.create("group", groupId) as SignetError),
+        idMappings,
+        clientFactory: joinClientFactory,
+        signerProviderFactory: () => createJoinMockSignerProvider(),
+        config: {
+          dataDir: ":memory:",
+          env: "dev",
+          appVersion: "xmtp-signet/test",
+        },
+      };
+
+      const actions = createConversationActions(deps);
+      const joinAction = actions.find((a) => a.id === "chat.join");
+      expect(joinAction).toBeDefined();
+      if (!joinAction) return;
+
+      const result = await joinAction.handler(
+        {
+          inviteUrl,
+          label: "joiner",
+          operatorId: "op_codex",
+          timeoutSeconds: 2,
+        },
+        stubCtx(),
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+
+      expect(result.value.profileName).toBe("Codex");
+      expect(result.value.profileSource).toBe("operator-default");
+      expect(result.value.profileApplied).toBe(true);
+    });
+
     test("returns success even when live attach fails after the durable join completes", async () => {
       const inviteUrl = await buildJoinInviteUrl();
       const joinClient = createJoinMockClient();
@@ -501,6 +591,112 @@ describe("conversation actions", () => {
       if (!result.isOk()) return;
 
       expect(result.value.groupId).toBe("joined-group-1");
+    });
+  });
+
+  describe("chat.update-profile", () => {
+    test("publishes a profile update with an explicit name", async () => {
+      const managed = await seedIdentity("profile-updater");
+      managed.groupIds.add("g-profile");
+      const sent: Array<{
+        groupId: string;
+        content: unknown;
+        contentType: string | undefined;
+      }> = [];
+      const trackedClient: XmtpClient = {
+        ...createMockClient({ inboxId: managed.inboxId }),
+        sendMessage: async (groupId, content, contentType) => {
+          sent.push({ groupId, content, contentType });
+          return Result.ok("profile-msg-1");
+        },
+      };
+      managedClients.set(managed.identityId, {
+        ...managed,
+        client: trackedClient,
+      });
+      setupDeps();
+
+      const actions = createConversationActions(deps);
+      const updateProfileAction = actions.find(
+        (a) => a.id === "chat.update-profile",
+      );
+      expect(updateProfileAction).toBeDefined();
+      if (!updateProfileAction) return;
+
+      const result = await updateProfileAction.handler(
+        {
+          chatId: "g-profile",
+          identityLabel: "profile-updater",
+          profileName: "Codex",
+        },
+        stubCtx(),
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+
+      expect(result.value).toEqual({
+        chatId: "g-profile",
+        groupId: "g-profile",
+        profileName: "Codex",
+        profileSource: "explicit",
+        profileApplied: true,
+      });
+      expect(sent).toHaveLength(1);
+      expect(sent[0]?.groupId).toBe("g-profile");
+      expect(sent[0]?.contentType).toBe("convos.org/profile_update:1.0");
+      expect(extractProfileUpdateContent(sent[0]?.content)).toEqual({
+        name: "Codex",
+        memberKind: 1,
+      });
+    });
+
+    test("defaults the profile name from the operator label", async () => {
+      const managed = await seedIdentity("profile-updater");
+      managed.groupIds.add("g-profile");
+      const sent: Array<{ content: unknown }> = [];
+      const trackedClient: XmtpClient = {
+        ...createMockClient({ inboxId: managed.inboxId }),
+        sendMessage: async (_groupId, content) => {
+          sent.push({ content });
+          return Result.ok("profile-msg-2");
+        },
+      };
+      managedClients.set(managed.identityId, {
+        ...managed,
+        client: trackedClient,
+      });
+      setupDeps(
+        undefined,
+        undefined,
+        createOperatorManager({ op_codex: "Codex" }),
+      );
+
+      const actions = createConversationActions(deps);
+      const updateProfileAction = actions.find(
+        (a) => a.id === "chat.update-profile",
+      );
+      expect(updateProfileAction).toBeDefined();
+      if (!updateProfileAction) return;
+
+      const result = await updateProfileAction.handler(
+        {
+          chatId: "g-profile",
+          operatorId: "op_codex",
+        },
+        stubCtx(),
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) return;
+
+      expect(result.value.profileName).toBe("Codex");
+      expect(result.value.profileSource).toBe("operator-default");
+      expect(sent).toHaveLength(1);
+      expect(extractProfileUpdateContent(sent[0]?.content)).toEqual({
+        name: "Codex",
+        memberKind: 1,
+      });
     });
   });
 

--- a/packages/core/src/__tests__/conversation-actions.test.ts
+++ b/packages/core/src/__tests__/conversation-actions.test.ts
@@ -492,6 +492,7 @@ describe("conversation actions", () => {
       if (!result.isOk()) return;
 
       expect(result.value.groupId).toBe("joined-group-1");
+      expect(result.value.profileApplied).toBe(true);
       expect(attachedIdentityIds).toEqual([result.value.identityId]);
     });
 
@@ -591,6 +592,7 @@ describe("conversation actions", () => {
       if (!result.isOk()) return;
 
       expect(result.value.groupId).toBe("joined-group-1");
+      expect(result.value.profileApplied).toBe(true);
     });
   });
 

--- a/packages/core/src/conversation-actions.ts
+++ b/packages/core/src/conversation-actions.ts
@@ -1,7 +1,12 @@
 import { Result } from "better-result";
 import { z } from "zod";
-import type { ActionSpec } from "@xmtp/signet-contracts";
-import { NotFoundError, createResourceId } from "@xmtp/signet-schemas";
+import type { ActionSpec, OperatorManager } from "@xmtp/signet-contracts";
+import {
+  InternalError,
+  NotFoundError,
+  ValidationError,
+  createResourceId,
+} from "@xmtp/signet-schemas";
 import type { SignetError, IdMappingStore } from "@xmtp/signet-schemas";
 import type { SqliteIdentityStore } from "./identity-store.js";
 import type { ManagedClient } from "./client-registry.js";
@@ -12,6 +17,7 @@ import type {
 import type { SignetCoreConfig } from "./config.js";
 import { joinConversation } from "./convos/join.js";
 import { generateConvosInviteUrl } from "./convos/invite-generator.js";
+import { encodeProfileUpdate, MemberKind } from "./convos/profile-messages.js";
 import type { SignerProviderFactory } from "./identity-registration.js";
 
 const GroupInfoSchema = z.object({
@@ -36,10 +42,22 @@ const CleanupResultSchema = z.object({
   actions: z.array(z.string()),
 });
 
+const ProfileSourceSchema = z.enum(["explicit", "operator-default"]);
+
+const ProfileUpdateResultSchema = z.object({
+  chatId: z.string().optional(),
+  groupId: z.string(),
+  profileName: z.string(),
+  profileSource: ProfileSourceSchema,
+  profileApplied: z.literal(true),
+});
+
 /** Dependencies used to build conversation-related action specs. */
 export interface ConversationActionDeps {
   /** Identity store used to resolve conversation creators and viewers. */
   readonly identityStore: SqliteIdentityStore;
+  /** Optional operator manager for defaulting human-facing Convos profile names. */
+  readonly operatorManager?: OperatorManager;
   /** Lookup for the managed client tied to a signet identity. */
   readonly getManagedClient: (identityId: string) => ManagedClient | undefined;
   /** Optional lookup for the managed client currently responsible for a group. */
@@ -145,6 +163,48 @@ function ensureLocalId(
   const localId = createResourceId("conversation");
   idMappings.set(groupId, localId, "conversation");
   return localId;
+}
+
+type ProfileSelectionSource = z.infer<typeof ProfileSourceSchema>;
+
+interface ProfileSelection {
+  readonly profileName: string;
+  readonly profileSource: ProfileSelectionSource;
+}
+
+async function resolveProfileSelection(
+  operatorManager: OperatorManager | undefined,
+  input: {
+    readonly operatorId?: string | undefined;
+    readonly profileName?: string | undefined;
+  },
+): Promise<Result<ProfileSelection | null, SignetError>> {
+  if (input.profileName !== undefined) {
+    return Result.ok({
+      profileName: input.profileName,
+      profileSource: "explicit",
+    });
+  }
+
+  if (input.operatorId === undefined) {
+    return Result.ok(null);
+  }
+
+  if (!operatorManager) {
+    return Result.err(
+      InternalError.create(
+        "OperatorManager not initialized before resolving profile defaults",
+      ) as SignetError,
+    );
+  }
+
+  const operatorResult = await operatorManager.lookup(input.operatorId);
+  if (Result.isError(operatorResult)) return operatorResult;
+
+  return Result.ok({
+    profileName: operatorResult.value.config.label,
+    profileSource: "operator-default",
+  });
 }
 
 async function resolveManagedClientForGroup(
@@ -381,6 +441,8 @@ export function createConversationActions(
     {
       inviteUrl: string;
       label?: string | undefined;
+      operatorId?: string | undefined;
+      profileName?: string | undefined;
       timeoutSeconds?: number | undefined;
     },
     {
@@ -391,6 +453,9 @@ export function createConversationActions(
       inviteTag: string;
       groupName: string | undefined;
       creatorInboxId: string;
+      profileName?: string | undefined;
+      profileSource?: ProfileSelectionSource | undefined;
+      profileApplied?: boolean | undefined;
     },
     SignetError
   > = {
@@ -400,6 +465,8 @@ export function createConversationActions(
     input: z.object({
       inviteUrl: z.string(),
       label: z.string().optional(),
+      operatorId: z.string().optional(),
+      profileName: z.string().optional(),
       timeoutSeconds: z.number().positive().optional(),
     }),
     handler: async (input) => {
@@ -415,14 +482,24 @@ export function createConversationActions(
       const maxPollAttempts = input.timeoutSeconds
         ? Math.ceil((input.timeoutSeconds * 1000) / 2000)
         : undefined;
+      const profileSelectionResult = await resolveProfileSelection(
+        deps.operatorManager,
+        input,
+      );
+      if (Result.isError(profileSelectionResult)) return profileSelectionResult;
+      const profileSelection = profileSelectionResult.value;
 
       const joinOptions: {
         label?: string;
         maxPollAttempts?: number;
+        profileName?: string;
       } = {};
       if (input.label !== undefined) joinOptions.label = input.label;
       if (maxPollAttempts !== undefined)
         joinOptions.maxPollAttempts = maxPollAttempts;
+      if (profileSelection) {
+        joinOptions.profileName = profileSelection.profileName;
+      }
 
       const joinResult = await joinConversation(
         {
@@ -448,7 +525,13 @@ export function createConversationActions(
       }
 
       const chatId = ensureLocalId(deps.idMappings, joinResult.value.groupId);
-      return Result.ok({ ...joinResult.value, chatId });
+      return Result.ok({
+        ...joinResult.value,
+        chatId,
+        ...(profileSelection
+          ? { profileSource: profileSelection.profileSource }
+          : {}),
+      });
     },
     cli: {
       command: "chat:join",
@@ -688,6 +771,93 @@ export function createConversationActions(
     },
     cli: {
       command: "chat:update",
+    },
+    mcp: {},
+    http: {
+      auth: "admin",
+    },
+  };
+
+  const updateProfile: ActionSpec<
+    {
+      chatId: string;
+      identityLabel?: string | undefined;
+      operatorId?: string | undefined;
+      profileName?: string | undefined;
+    },
+    {
+      chatId?: string | undefined;
+      groupId: string;
+      profileName: string;
+      profileSource: ProfileSelectionSource;
+      profileApplied: true;
+    },
+    SignetError
+  > = {
+    id: "chat.update-profile",
+    description: "Publish a Convos profile update for a group identity",
+    intent: "write",
+    input: z
+      .object({
+        chatId: z.string(),
+        identityLabel: z.string().optional(),
+        operatorId: z.string().optional(),
+        profileName: z.string().optional(),
+      })
+      .refine(
+        (value) =>
+          value.profileName !== undefined || value.operatorId !== undefined,
+        {
+          message: "Provide a profile name or operator ID",
+          path: ["chatId"],
+        },
+      ),
+    output: ProfileUpdateResultSchema,
+    handler: async (input) => {
+      const groupId = resolveGroupId(deps.idMappings, input.chatId);
+      const managedResult = await resolveManagedClientForGroup(
+        deps,
+        groupId,
+        input.identityLabel,
+      );
+      if (Result.isError(managedResult)) return managedResult;
+
+      const profileSelectionResult = await resolveProfileSelection(
+        deps.operatorManager,
+        input,
+      );
+      if (Result.isError(profileSelectionResult)) return profileSelectionResult;
+
+      const profileSelection = profileSelectionResult.value;
+      if (!profileSelection) {
+        return Result.err(
+          ValidationError.create(
+            "profileName",
+            "A profile name or operator default is required",
+          ) as SignetError,
+        );
+      }
+
+      const updateResult = await managedResult.value.client.sendMessage(
+        groupId,
+        encodeProfileUpdate({
+          name: profileSelection.profileName,
+          memberKind: MemberKind.Agent,
+        }),
+        "convos.org/profile_update:1.0",
+      );
+      if (Result.isError(updateResult)) return updateResult;
+
+      return Result.ok({
+        chatId: input.chatId,
+        groupId,
+        profileName: profileSelection.profileName,
+        profileSource: profileSelection.profileSource,
+        profileApplied: true,
+      });
+    },
+    cli: {
+      command: "chat:update-profile",
     },
     mcp: {},
     http: {
@@ -1015,6 +1185,7 @@ export function createConversationActions(
     list,
     info,
     update,
+    updateProfile,
     join,
     invite,
     leave,

--- a/packages/core/src/convos/__tests__/join.test.ts
+++ b/packages/core/src/convos/__tests__/join.test.ts
@@ -14,6 +14,7 @@ import type {
 } from "../../xmtp-client-factory.js";
 import { InviteJoinErrorType } from "../invite-join-error.js";
 import { joinConversation, type JoinConversationDeps } from "../join.js";
+import { extractProfileUpdateContent } from "../profile-state.js";
 
 // --- Protobuf setup (same as invite-parser tests) ---
 
@@ -275,6 +276,62 @@ describe("joinConversation", () => {
     const identities = await deps.identityStore.list();
     expect(identities).toHaveLength(1);
     expect(identities[0]?.inboxId).toBe("joiner-inbox-123");
+  });
+
+  test("includes the selected profile name and publishes a post-join profile update", async () => {
+    const structuredCalls: Array<{
+      conversationId: string;
+      content: unknown;
+      contentType: string | undefined;
+    }> = [];
+
+    const client = createMockClient({
+      onSendMessage: (conversationId, content, contentType) =>
+        structuredCalls.push({ conversationId, content, contentType }),
+      groupsAfterSync: [
+        {
+          groupId: "joined-group-1",
+          name: "Test Group",
+          description: "",
+          memberInboxIds: ["joiner-inbox-123", TEST_CREATOR_INBOX_ID],
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    const result = await joinConversation(
+      createDeps({ client }),
+      buildTestUrl(),
+      {
+        label: "codex",
+        profileName: "Codex",
+        pollIntervalMs: 10,
+        maxPollAttempts: 3,
+      },
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.profileName).toBe("Codex");
+    expect(result.value.profileApplied).toBe(true);
+    expect(structuredCalls).toHaveLength(2);
+    expect(structuredCalls[0]).toEqual({
+      conversationId: "dm-1",
+      content: {
+        inviteSlug: buildTestSlug(),
+        profile: { name: "Codex", memberKind: "agent" },
+      },
+      contentType: "convos.org/join_request:1.0",
+    });
+    expect(structuredCalls[1]?.conversationId).toBe("joined-group-1");
+    expect(structuredCalls[1]?.contentType).toBe(
+      "convos.org/profile_update:1.0",
+    );
+    expect(extractProfileUpdateContent(structuredCalls[1]?.content)).toEqual({
+      name: "Codex",
+      memberKind: 1,
+    });
   });
 
   test("returns error when invite URL is invalid", async () => {

--- a/packages/core/src/convos/__tests__/join.test.ts
+++ b/packages/core/src/convos/__tests__/join.test.ts
@@ -4,7 +4,7 @@ import protobuf from "protobufjs";
 import Long from "long";
 import { secp256k1 } from "@noble/curves/secp256k1";
 import { sha256 } from "@noble/hashes/sha256";
-import { InternalError } from "@xmtp/signet-schemas";
+import { InternalError, type SignetError } from "@xmtp/signet-schemas";
 import { SqliteIdentityStore } from "../../identity-store.js";
 import type {
   XmtpClient,
@@ -111,7 +111,7 @@ function createMockClient(options?: {
   inboxId?: string;
   onCreateDm?: (peerInboxId: string) => void;
   onSendDm?: (dmId: string, text: string) => void;
-  sendDmResult?: Result<string, InternalError>;
+  sendDmResult?: Result<string, SignetError>;
   onSendMessage?: (
     conversationId: string,
     content: unknown,
@@ -332,6 +332,55 @@ describe("joinConversation", () => {
       name: "Codex",
       memberKind: 1,
     });
+  });
+
+  test("continues polling when the plain-text fallback fails after a structured join request", async () => {
+    const structuredCalls: Array<{
+      conversationId: string;
+      content: unknown;
+      contentType: string | undefined;
+    }> = [];
+
+    const client = createMockClient({
+      sendDmResult: Result.err(
+        InternalError.create("temporary DM fallback failure"),
+      ),
+      onSendMessage: (conversationId, content, contentType) =>
+        structuredCalls.push({ conversationId, content, contentType }),
+      groupsAfterSync: [
+        {
+          groupId: "joined-group-1",
+          name: "Test Group",
+          description: "",
+          memberInboxIds: ["joiner-inbox-123", TEST_CREATOR_INBOX_ID],
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    const deps = createDeps({ client });
+    const result = await joinConversation(deps, buildTestUrl(), {
+      pollIntervalMs: 10,
+      maxPollAttempts: 3,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.groupId).toBe("joined-group-1");
+    expect(structuredCalls).toHaveLength(1);
+    expect(structuredCalls[0]).toEqual({
+      conversationId: "dm-1",
+      content: {
+        inviteSlug: buildTestSlug(),
+        profile: { memberKind: "agent" },
+      },
+      contentType: "convos.org/join_request:1.0",
+    });
+
+    const identities = await deps.identityStore.list();
+    expect(identities).toHaveLength(1);
+    expect(identities[0]?.inboxId).toBe("joiner-inbox-123");
   });
 
   test("returns error when invite URL is invalid", async () => {

--- a/packages/core/src/convos/__tests__/join.test.ts
+++ b/packages/core/src/convos/__tests__/join.test.ts
@@ -251,21 +251,28 @@ describe("joinConversation", () => {
 
     expect(result.value.groupId).toBe("joined-group-1");
     expect(result.value.identityId).toBeDefined();
+    expect(result.value.profileApplied).toBe(true);
 
     // Verify DM was sent to creator
     expect(dmCalls).toHaveLength(1);
     expect(dmCalls[0]?.peerInboxId).toBe(TEST_CREATOR_INBOX_ID);
 
-    expect(structuredCalls).toEqual([
-      {
-        conversationId: "dm-1",
-        content: {
-          inviteSlug: buildTestSlug(),
-          profile: { memberKind: "agent" },
-        },
-        contentType: "convos.org/join_request:1.0",
+    expect(structuredCalls).toHaveLength(2);
+    expect(structuredCalls[0]).toEqual({
+      conversationId: "dm-1",
+      content: {
+        inviteSlug: buildTestSlug(),
+        profile: { memberKind: "agent" },
       },
-    ]);
+      contentType: "convos.org/join_request:1.0",
+    });
+    expect(structuredCalls[1]?.conversationId).toBe("joined-group-1");
+    expect(structuredCalls[1]?.contentType).toBe(
+      "convos.org/profile_update:1.0",
+    );
+    expect(extractProfileUpdateContent(structuredCalls[1]?.content)).toEqual({
+      memberKind: 1,
+    });
 
     // Verify slug was sent as DM text
     expect(sendCalls).toHaveLength(1);
@@ -368,7 +375,8 @@ describe("joinConversation", () => {
     if (!result.isOk()) return;
 
     expect(result.value.groupId).toBe("joined-group-1");
-    expect(structuredCalls).toHaveLength(1);
+    expect(result.value.profileApplied).toBe(true);
+    expect(structuredCalls).toHaveLength(2);
     expect(structuredCalls[0]).toEqual({
       conversationId: "dm-1",
       content: {
@@ -376,6 +384,13 @@ describe("joinConversation", () => {
         profile: { memberKind: "agent" },
       },
       contentType: "convos.org/join_request:1.0",
+    });
+    expect(structuredCalls[1]?.conversationId).toBe("joined-group-1");
+    expect(structuredCalls[1]?.contentType).toBe(
+      "convos.org/profile_update:1.0",
+    );
+    expect(extractProfileUpdateContent(structuredCalls[1]?.content)).toEqual({
+      memberKind: 1,
     });
 
     const identities = await deps.identityStore.list();

--- a/packages/core/src/convos/join.ts
+++ b/packages/core/src/convos/join.ts
@@ -11,6 +11,7 @@ import {
   getInviteJoinErrorMessage,
   isInviteJoinErrorContentType,
 } from "./invite-join-error.js";
+import { encodeProfileUpdate, MemberKind } from "./profile-messages.js";
 import { parseConvosInviteUrl, verifyConvosInvite } from "./invite-parser.js";
 import type { JoinRequestContent } from "./join-request-content.js";
 
@@ -26,6 +27,8 @@ export interface JoinConversationDeps {
 export interface JoinConversationOptions {
   /** Human-readable label for the new identity. */
   readonly label?: string;
+  /** Optional Convos profile name to publish for the joined identity. */
+  readonly profileName?: string;
   /** Milliseconds between poll attempts for group discovery. */
   readonly pollIntervalMs?: number;
   /** Maximum number of poll attempts before timing out. */
@@ -46,6 +49,10 @@ export interface JoinResult {
   readonly groupName: string | undefined;
   /** The creator's inbox ID. */
   readonly creatorInboxId: string;
+  /** The profile name selected for this join, if any. */
+  readonly profileName?: string;
+  /** Whether the best-effort profile update succeeded after the join. */
+  readonly profileApplied?: boolean;
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 2000;
@@ -203,7 +210,12 @@ export async function joinConversation(
   const slug = extractSlugForDm(inviteUrl);
   const joinRequest: JoinRequestContent = {
     inviteSlug: slug,
-    profile: { memberKind: "agent" },
+    profile: {
+      memberKind: "agent",
+      ...(options?.profileName !== undefined
+        ? { name: options.profileName }
+        : {}),
+    },
   };
   const structuredSendResult = await client.sendMessage(
     dmResult.value.dmId,
@@ -240,6 +252,28 @@ export async function joinConversation(
     if (groups.length > 0) {
       const group = groups[0];
       if (group !== undefined) {
+        if (options?.profileName !== undefined) {
+          const profileUpdateResult = await client.sendMessage(
+            group.groupId,
+            encodeProfileUpdate({
+              name: options.profileName,
+              memberKind: MemberKind.Agent,
+            }),
+            "convos.org/profile_update:1.0",
+          );
+
+          return Result.ok({
+            identityId,
+            inboxId,
+            groupId: group.groupId,
+            inviteTag: invite.tag,
+            groupName: group.name || invite.name,
+            creatorInboxId: invite.creatorInboxId,
+            profileName: options.profileName,
+            profileApplied: profileUpdateResult.isOk(),
+          });
+        }
+
         return Result.ok({
           identityId,
           inboxId,

--- a/packages/core/src/convos/join.ts
+++ b/packages/core/src/convos/join.ts
@@ -252,27 +252,16 @@ export async function joinConversation(
     if (groups.length > 0) {
       const group = groups[0];
       if (group !== undefined) {
-        if (options?.profileName !== undefined) {
-          const profileUpdateResult = await client.sendMessage(
-            group.groupId,
-            encodeProfileUpdate({
-              name: options.profileName,
-              memberKind: MemberKind.Agent,
-            }),
-            "convos.org/profile_update:1.0",
-          );
-
-          return Result.ok({
-            identityId,
-            inboxId,
-            groupId: group.groupId,
-            inviteTag: invite.tag,
-            groupName: group.name || invite.name,
-            creatorInboxId: invite.creatorInboxId,
-            profileName: options.profileName,
-            profileApplied: profileUpdateResult.isOk(),
-          });
-        }
+        const profileUpdateResult = await client.sendMessage(
+          group.groupId,
+          encodeProfileUpdate({
+            memberKind: MemberKind.Agent,
+            ...(options?.profileName !== undefined
+              ? { name: options.profileName }
+              : {}),
+          }),
+          "convos.org/profile_update:1.0",
+        );
 
         return Result.ok({
           identityId,
@@ -281,6 +270,10 @@ export async function joinConversation(
           inviteTag: invite.tag,
           groupName: group.name || invite.name,
           creatorInboxId: invite.creatorInboxId,
+          ...(options?.profileName !== undefined
+            ? { profileName: options.profileName }
+            : {}),
+          profileApplied: profileUpdateResult.isOk(),
         });
       }
     }


### PR DESCRIPTION
## Summary
- add first-class Convos profile support in the join/update flows
- default profile names from the operator label when no explicit override is provided
- improve `xs chat invite` output for real-device Convos testing

## What Changed
- extend `chat.join` to carry optional Convos profile data and tolerate best-effort fallback send failures
- add `chat.update-profile` plus runtime/operator-label defaults for profile naming
- add CLI support for `xs chat join --profile-name`, `xs chat update-profile`, and richer invite output formats
- expose QR-friendly invite output so device handoff is easier during manual Convos testing
- refresh command wiring and action-surface tests for the new CLI/runtime behavior

## How To Test
- `bun test packages/core/src/convos/__tests__/join.test.ts`
- `bun test packages/core/src/__tests__/conversation-actions.test.ts`
- `bun test packages/cli/src/__tests__/xs-chat-command-wiring.test.ts`
- `bun run check`

Closes #305
Closes #307
