### PR TITLE
feat(cli): add xs init posture presets

### DIFF
--- a/.claude/skills/libxmtp-dev/SKILL.md
+++ b/.claude/skills/libxmtp-dev/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: libxmtp-dev
+description: >
+  Understand and navigate the libxmtp Rust codebase — the core XMTP protocol
+  library that implements MLS-based messaging. Use this skill when analyzing
+  libxmtp's architecture, understanding how it maps to the JS/mobile/WASM SDKs,
+  identifying modularization opportunities, or tracing how a specific feature
+  flows through the crate structure. Reference material lives in
+  .reference/libxmtp/ (shallow clone).
+---
+
+# Working with libxmtp
+
+> libxmtp is a Rust workspace implementing the XMTP messaging protocol using
+> MLS (Messaging Layer Security). It produces bindings for mobile (Android/iOS
+> via uniffi), WebAssembly, and Node.js (via napi).
+
+## Reference location
+
+The libxmtp source lives at `.reference/libxmtp/` as a read-only shallow clone.
+**Do not modify files in this directory.**
+
+## Architecture
+
+```text
+┌──────────────────────────────────────────────────────────────────┐
+│                      LANGUAGE BINDINGS                           │
+│  bindings/mobile (uniffi)  │  bindings/wasm  │  bindings/node    │
+└──────────────────────────────┬───────────────────────────────────┘
+                               │
+                ┌──────────────▼──────────────┐
+                │      xmtp_mls (Client)      │
+                │  Groups, messages, sync     │
+                └──────────────┬──────────────┘
+        ┌──────────┬───────────┼───────────┬──────────┐
+        ▼          ▼           ▼           ▼          ▼
+   xmtp_api   xmtp_db     xmtp_id    xmtp_proto  xmtp_cryptography
+   (traits)   (storage)   (identity) (protobuf)  (crypto ops)
+        │
+        ├─► xmtp_api_grpc (gRPC implementation)
+        └─► xmtp_api_d14n (decentralized API)
+```
+
+## Crate inventory
+
+| Crate | Lines | Role |
+|---|---|---|
+| `xmtp_mls` | ~55K | **The core.** Client, groups, messages, sync, subscriptions, intents, identity, workers. This is the monolith that does most of the work. |
+| `xmtp_db` | ~25K | Storage layer. Diesel ORM over encrypted SQLite (SQLCipher). Migrations, encrypted store, OpenMLS key store provider. |
+| `xmtp_proto` | ~67K | Protobuf definitions (mostly generated). Wire format for all XMTP protocol messages. |
+| `xmtp_api_d14n` | ~15K | Decentralized API client. Connects to the XMTP d14n network (Broadcast Network + App Chain). |
+| `xmtp_id` | ~6.5K | Identity management. Inbox ID generation, key packages, associations (wallet ↔ inbox), SCW verification. |
+| `xmtp_content_types` | ~3K | Content type codecs. Text, reaction, reply, read-receipt, attachments, group-updated, etc. |
+| `xmtp_common` | ~3K | Shared utilities. Test macros, retry logic, time helpers, feature-gated platform abstractions. |
+| `xmtp_mls_common` | ~2.5K | Shared MLS types. Content types, group membership, permissions, metadata policies. |
+| `xmtp_api` | ~1.7K | API trait definitions. `XmtpApi` trait that `xmtp_api_grpc` and `xmtp_api_d14n` implement. |
+| `xmtp_api_grpc` | ~1.9K | Legacy gRPC API client implementation. |
+| `xmtp_cryptography` | ~1K | Crypto operations. Signature recovery, ECDSA utils. |
+| `xmtp_archive` | ~1K | Archive/backup functionality for device sync. |
+| `xmtp_configuration` | ~400 | Configuration and feature flags. |
+
+## Bindings
+
+| Target | Lines | Notes |
+|---|---|---|
+| `bindings/mobile` | ~16K | uniffi-based. Generates Swift and Kotlin bindings. |
+| `bindings/node` | ~6.3K | napi-rs based. Generates `@xmtp/node-bindings` npm package. |
+| `bindings/wasm` | ~6.3K | wasm-bindgen based. Generates `@xmtp/wasm-bindings`. |
+
+## Key patterns
+
+- **`Client<Context>`** — generic client parameterized by context (allows different API/DB combinations)
+- **`ClientBuilder`** — fluent builder for client construction with identity, API, and storage config
+- **`XmtpMlsLocalContext`** — centralizes dependencies (API, storage, identity, locks, events)
+- **Trait abstractions** — `XmtpApi`, `XmtpDb`, `InboxOwner` enable pluggable implementations
+- **Platform macros** — `if_native!` / `if_wasm!` for platform-specific code paths
+- **Intent system** — state machine for pending group changes with retry on epoch conflicts
+
+## Key modules in xmtp_mls
+
+- `client.rs` — the Client struct, creation, registration
+- `builder.rs` — ClientBuilder for fluent construction
+- `context.rs` — XmtpMlsLocalContext (dependency container)
+- `groups/` — group creation, membership, metadata, permissions, message sending/receiving
+- `identity/` — identity management, inbox state
+- `messages/` — message persistence, querying
+- `subscriptions/` — network subscriptions, streaming
+- `worker/` — background sync workers
+- `intents.rs` — intent state machine for group operations
+- `mls_store.rs` — MLS credential and key package store
+
+## Key modules in xmtp_db
+
+- `encrypted_store/` — Diesel-based encrypted SQLite store
+- `sql_key_store/` — OpenMLS `StorageProvider` implementation backed by SQLite
+- `traits.rs` — storage trait definitions
+
+## Navigating the code
+
+When tracing a feature:
+1. Start in `bindings/node/src/` to see the public API surface
+2. Follow into `crates/xmtp_mls/src/client.rs` or the relevant module
+3. Storage operations route through `crates/xmtp_db/`
+4. Network operations use traits from `crates/xmtp_api/`
+5. Identity operations live in `crates/xmtp_id/`
+
+## Relationship to the unified stack vision
+
+The existing codebase (xmtp-signet) consumes libxmtp through `@xmtp/node-sdk`
+(JS wrapper) → `@xmtp/node-bindings` (napi) → libxmtp. The `XmtpClient`
+interface in `packages/core/src/xmtp-client-factory.ts` is the abstraction
+boundary.
+
+The modularization exercise maps libxmtp crates to proposed stack layers:
+
+| libxmtp crate | Stack layer |
+|---|---|
+| `xmtp_mls` (MLS core) | Layer 4: MLS Processing |
+| `xmtp_db` | Layer 6: Application Layer (message/conversation storage) |
+| `xmtp_id` | Layer 6: Application Layer (participant awareness) |
+| `xmtp_content_types` | Layer 6: Application Layer (codecs) |
+| `xmtp_api` / `xmtp_api_d14n` | Layer 1-2: Gateway / Envelope Store |
+| `xmtp_cryptography` | Layer 5: Key Custody |
+| `xmtp_mls_common` | Shared types across layers |

--- a/.claude/skills/libxmtp-dev/references/crate-inventory.md
+++ b/.claude/skills/libxmtp-dev/references/crate-inventory.md
@@ -1,0 +1,77 @@
+# libxmtp Crate Inventory
+
+Source: `.reference/libxmtp/`
+
+## Crates by size and role
+
+| Crate | Lines | Category | Role |
+|---|---|---|---|
+| `xmtp_proto` | ~67K | Foundation | Protobuf definitions (mostly generated). Defines `XmtpApi`, `XmtpMlsClient`, `XmtpIdentityClient`, `XmtpMlsStreams` traits. |
+| `xmtp_mls` | ~55K | Core | The monolith. Client, groups, messages, sync, subscriptions, intents, identity, workers. |
+| `xmtp_db` | ~25K | Storage | Diesel ORM over encrypted SQLite (SQLCipher). 22 tables. OpenMLS `StorageProvider` impl. |
+| `xmtp_api_d14n` | ~15K | Transport | Decentralized API client (Broadcast Network + App Chain). |
+| `xmtp_id` | ~6.5K | Identity | Inbox ID generation, associations (wallet ↔ inbox), key packages, SCW verification. |
+| `xmtp_content_types` | ~3K | Content | 17 content type codecs. |
+| `xmtp_common` | ~3K | Foundation | Retry, streams, logging, macros, time, platform abstractions. |
+| `xmtp_mls_common` | ~2.5K | Foundation | Shared MLS types: metadata, permissions, TLS collections. |
+| `xmtp_macro` | ~2.2K | Build | Proc macros for error codes, logging. |
+| `xmtp_api_grpc` | ~1.9K | Transport | Legacy gRPC API client. |
+| `xmtp_api` | ~1.7K | Transport | API trait definitions + wrapper types. |
+| `xmtp_archive` | ~1K | Application | Archive export/import for device sync. |
+| `xmtp_cryptography` | ~1K | Foundation | Ed25519 credentials, ECDSA utils, hashing. |
+| `xmtp_configuration` | ~400 | Foundation | Constants, timing, feature flags, environment configs. |
+
+## Bindings
+
+| Target | Lines | Technology |
+|---|---|---|
+| `bindings/mobile` | ~16K | uniffi (generates Swift + Kotlin) |
+| `bindings/node` | ~6.3K | napi-rs (generates `@xmtp/node-bindings`) |
+| `bindings/wasm` | ~6.3K | wasm-bindgen (generates `@xmtp/wasm-bindings`) |
+
+## SDKs (in-repo)
+
+- `sdks/android/` — Android SDK
+- `sdks/ios/` — iOS SDK (Swift, uses Package.swift at repo root)
+
+## xmtp_mls internal modules
+
+The core crate's internal structure:
+
+| Module | Lines (approx) | Category |
+|---|---|---|
+| `groups/mls_sync.rs` | ~5K (181KB) | MLS-protocol + application mixed. Publish intents, process messages, validate commits. THE monolith within the monolith. |
+| `groups/mod.rs` | ~2K | Application. Group creation, metadata, send message. |
+| `groups/intents.rs` | ~1.5K | Application. Intent data types for group operations. |
+| `groups/group_permissions.rs` | ~1.5K | Application. Permission policy system. |
+| `groups/validated_commit.rs` | ~1K | MLS-protocol. Commit validation logic. |
+| `groups/members.rs` | ~500 | Application. Member listing and queries. |
+| `groups/subscriptions.rs` | ~500 | Application. Per-group streaming. |
+| `groups/welcomes/` | ~800 | MLS-protocol. Welcome message processing. |
+| `groups/commit_log.rs` | ~400 | MLS-protocol. Commit integrity tracking. |
+| `messages/` | ~400 | Application. Message decoding, enrichment. |
+| `identity.rs` + `identity/` | ~600 | Identity. Installation keys, key packages. |
+| `identity_updates.rs` | ~500 | Identity. Association state management. |
+| `subscriptions/` | ~1K | Transport. Streaming subscriptions. |
+| `worker/` | ~2K+ | Infrastructure. Background sync, key rotation, disappearing messages. |
+| `client.rs` | ~800 | Application. Client struct, orchestration. |
+| `builder.rs` | ~690 | Application. ClientBuilder, worker registration. |
+| `context.rs` | ~375 | Infrastructure. `XmtpSharedContext` trait, DI. |
+
+## xmtp_db tables (22 total)
+
+**MLS-state tables** (must stay with MLS engine):
+- `openmls_key_store` — OpenMLS key-value store
+- `openmls_key_value` — OpenMLS epoch/tree state
+- `key_package_history` — key package rotation tracking
+
+**Application-data tables** (could move to application layer):
+- `groups` — group metadata, membership state, consent
+- `group_messages` — decoded messages with content, sender, timestamps
+- `group_intents` — pending group operation intents
+- `identity_updates` — cached association states
+- `consent_records` — per-entity consent (inbox, group, address)
+- `user_preferences` — synced preferences
+- `wallet_addresses` — known wallet associations
+- `association_state` — inbox-to-identity mappings
+- Plus ~10 more operational tables (cursors, sync state, events, etc.)

--- a/.claude/skills/libxmtp-dev/references/modularization-seams.md
+++ b/.claude/skills/libxmtp-dev/references/modularization-seams.md
@@ -1,0 +1,80 @@
+# libxmtp Trait Boundaries and Internal Structure
+
+Factual inventory of existing trait abstractions and module organization.
+
+## Existing trait boundaries
+
+| Trait | Defined in | Purpose |
+|---|---|---|
+| `XmtpSharedContext` | `xmtp_mls/context.rs` | Central DI container. Associated types for `Db`, `ApiClient`, `MlsStorage`, `ContextReference`. Methods: `db()`, `api()`, `sync_api()`, `scw_verifier()`, `mls_provider()`, `identity()`, `mls_storage()`, `worker_events()`, `local_events()`, `mls_commit_lock()`, `mutexes()`. |
+| `XmtpApi` | `xmtp_proto` | Network API surface. Message publish, subscribe, query. Implemented by `xmtp_api_d14n` and `xmtp_api_grpc`. |
+| `XmtpDb` | `xmtp_db/traits.rs` | Storage access. Combined trait of 20+ sub-traits. Implemented by `EncryptedMessageStore`. |
+| `XmtpMlsStorageProvider` | `xmtp_db` | OpenMLS `StorageProvider` implementation for SQLite. Implemented by `SqlKeyStore`. |
+| `SmartContractSignatureVerifier` | `xmtp_id` | SCW signature verification. Has remote and local implementations. |
+| `Worker` | `xmtp_mls/worker.rs` | Background task interface. Implemented by SyncWorker, KeyPackagesCleaner, DisappearingMessages, PendingSelfRemove, CommitLogWorker, TaskWorker. |
+| `ContentCodec` | `xmtp_content_types` | Encode/decode for a content type. 17 built-in implementations. |
+| `DbQuery` | `xmtp_db` | Composite query trait (groups, messages, intents, consent, etc.). 20+ sub-traits. |
+| `XmtpQuery` | `xmtp_db` | Paginated query abstraction. |
+| `CursorStore` | `xmtp_mls` | Cursor persistence for sync position tracking. Implemented by `SqliteCursorStore`. |
+
+## xmtp_mls internal modules by category
+
+**MLS protocol operations:**
+- `groups/mls_sync.rs` (~5K lines, 181KB) — intent publishing, message receiving/decryption, commit validation/application, key package fetching, HMAC computation, welcome wrapping, fork detection, group membership resolution
+- `groups/validated_commit.rs` (~1K lines) — commit validation logic
+- `groups/welcomes/` (~800 lines) — welcome message processing
+- `groups/commit_log.rs` (~400 lines) — commit integrity tracking
+- `groups/group_membership.rs` — group membership state tracking
+- `groups/mls_ext/` — MLS extensions
+
+**Application logic:**
+- `client.rs` (~800 lines) — Client struct, orchestration (create group, create DM, conversations, inbox state, consent)
+- `builder.rs` (~690 lines) — ClientBuilder, worker registration
+- `groups/mod.rs` (~2K lines) — group creation, metadata, send message
+- `groups/intents.rs` (~1.5K lines) — intent data types for group operations
+- `groups/group_permissions.rs` (~1.5K lines) — permission policy system
+- `groups/members.rs` (~500 lines) — member listing and queries
+- `messages/` (~400 lines) — message decoding, enrichment
+
+**Identity:**
+- `identity.rs` + `identity/` (~600 lines) — installation identity, key packages, HPKE wrapper keys
+- `identity_updates.rs` (~500 lines) — association state management, installation diff tracking
+
+**Infrastructure:**
+- `context.rs` (~375 lines) — `XmtpSharedContext` trait, dependency injection
+- `subscriptions/` (~1K lines) — streaming subscriptions
+- `worker/` (~2K+ lines) — background sync, key rotation, disappearing messages, device sync
+- `cursor_store.rs` — sync cursor persistence
+
+## xmtp_db tables (22 total)
+
+**MLS-state tables:**
+- `openmls_key_store` — OpenMLS key-value store
+- `openmls_key_value` — OpenMLS epoch/tree state
+- `key_package_history` — key package rotation tracking
+
+**Application-data tables:**
+- `groups` — group metadata, membership state, consent, added_by_inbox_id, welcome_id, rotated_at
+- `group_messages` — decoded messages with content, sender, timestamps, delivery_status, content_type, version_major/minor, authority_id
+- `group_intents` — pending group operation intents with state machine (ToPublish, Published, Committed, Error)
+- `identity_updates` — cached association states
+- `consent_records` — per-entity consent (inbox_id, conversation_id, address)
+- `user_preferences` — synced HMAC keys
+- `wallet_addresses` — known wallet-to-inbox associations
+- `association_state` — inbox-to-identity state cache
+
+**Operational tables:**
+- `refresh_state` — per-entity sync cursors (conversation topics, welcome topics, consent, key packages)
+- `events` — local event log
+- `identity` — local installation identity (inbox_id, installation_keys, credential, rowid=1 singleton)
+- Plus additional tables for sync coordination, device sync state
+
+## Key structural observations
+
+- `mls_sync.rs` at 181KB / ~5K lines is the largest single file in the codebase
+- `XmtpSharedContext` is required by most operations — carries transitive dependency on database, API client, identity, MLS storage, and event channels
+- `DbQuery` requires implementing 20+ sub-traits; any code taking a `DbQuery` bound depends on the entire database schema
+- `xmtp_mls` directly depends on `xmtp_content_types` for message decoding in `decoded_message.rs` and content-type-specific logic in `groups/mod.rs` (reply references, reaction references, delete message references)
+- `Client<Context>` is generic over context — the trait-based DI pattern already enables pluggable implementations
+- Platform-specific code is gated by `if_native!` / `if_wasm!` macros in `xmtp_common`
+- The intent system in `groups/intents.rs` implements a state machine for pending group changes with retry on epoch conflicts

--- a/README.md
+++ b/README.md
@@ -98,8 +98,14 @@ bun run check
 ### Run the signet
 
 ```bash
-# Create a local XMTP identity and key hierarchy
+# Create a local XMTP identity and key hierarchy with the recommended posture
 xs init --env dev --label owner
+
+# Use the lower-ceremony trusted local posture for smoke testing
+xs init trusted-local --env dev --label owner
+
+# Use the stricter hardened posture for shorter-lived defaults and explicit approval gates
+xs init hardened --env production --label owner
 
 # Start the daemon
 xs daemon start
@@ -129,6 +135,20 @@ xs policy create --label chatty --allow send,reply
 
 `xs cred ...` is the canonical v1 lifecycle surface. Credential metadata
 includes the scoped conversations and effective allow/deny sets directly.
+
+### `xs init` posture presets
+
+`xs init` now supports a small set of onboarding postures so first-run setup can
+stay simple without collapsing the custody boundary:
+
+| Command                 | Posture                                                                                |
+| ----------------------- | -------------------------------------------------------------------------------------- |
+| `xs init`               | Recommended default: per-chat isolation with owner-gated sensitive reads               |
+| `xs init trusted-local` | Trusted local testing: shared identity mode and lower ceremony                         |
+| `xs init hardened`      | Stricter approval defaults, shorter-lived credentials, stronger operational boundaries |
+
+All three presets keep the signet as the real XMTP client. They do not hand raw
+keys, raw databases, or direct XMTP SDK access to the harness.
 
 See [docs/development.md](docs/development.md) for the development workflow and
 package layout.

--- a/packages/cli/src/__tests__/init-presets.test.ts
+++ b/packages/cli/src/__tests__/init-presets.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadConfig } from "../config/loader.js";
+import { applyInitPreset, resolveInitPreset } from "../config/init-presets.js";
+import { CliConfigSchema } from "../config/schema.js";
+import { writeConfig } from "../config/writer.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) =>
+      rm(dir, {
+        recursive: true,
+        force: true,
+      }),
+    ),
+  );
+});
+
+describe("init posture presets", () => {
+  test("defaults to the recommended posture when no preset is provided", () => {
+    const result = resolveInitPreset(undefined);
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    expect(result.value).toBe("recommended");
+  });
+
+  test("recommended posture preserves per-group isolation and owner-gated reads", () => {
+    const base = CliConfigSchema.parse({});
+    const config = applyInitPreset(base, "recommended");
+
+    expect(config.signet.identityMode).toBe("per-group");
+    expect(config.keys.rootKeyPolicy).toBe("biometric");
+    expect(config.keys.vaultKeyPolicy).toBe("open");
+    expect(config.biometricGating.adminReadElevation).toBe(true);
+    expect(config.biometricGating.scopeExpansion).toBe(false);
+    expect(config.credentials.defaultTtlSeconds).toBe(3600);
+  });
+
+  test("trusted-local posture flattens ceremony without breaking custody defaults", () => {
+    const base = CliConfigSchema.parse({});
+    const config = applyInitPreset(base, "trusted-local");
+
+    expect(config.signet.identityMode).toBe("shared");
+    expect(config.keys.rootKeyPolicy).toBe("biometric");
+    expect(config.keys.operationalKeyPolicy).toBe("open");
+    expect(config.keys.vaultKeyPolicy).toBe("open");
+    expect(config.biometricGating.adminReadElevation).toBe(false);
+    expect(config.credentials.defaultTtlSeconds).toBe(43_200);
+  });
+
+  test("hardened posture enables approval gates and shorter-lived defaults", () => {
+    const base = CliConfigSchema.parse({});
+    const config = applyInitPreset(base, "hardened");
+
+    expect(config.signet.identityMode).toBe("per-group");
+    expect(config.keys.rootKeyPolicy).toBe("biometric");
+    expect(config.keys.vaultKeyPolicy).toBe("passcode");
+    expect(config.biometricGating.scopeExpansion).toBe(true);
+    expect(config.biometricGating.egressExpansion).toBe(true);
+    expect(config.biometricGating.agentCreation).toBe(true);
+    expect(config.biometricGating.adminReadElevation).toBe(true);
+    expect(config.credentials.defaultTtlSeconds).toBe(900);
+    expect(config.credentials.maxConcurrentPerOperator).toBe(1);
+  });
+
+  test("persists preset configs as parseable TOML", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "xmtp-signet-init-presets-"));
+    tempDirs.push(dir);
+    const configPath = join(dir, "config.toml");
+
+    const config = applyInitPreset(CliConfigSchema.parse({}), "hardened");
+    await writeConfig(configPath, config);
+
+    const raw = await readFile(configPath, "utf8");
+    expect(raw).toContain("[signet]");
+    expect(raw).toContain('identityMode = "per-group"');
+    expect(raw).toContain("[biometricGating]");
+
+    const loaded = await loadConfig({ configPath });
+    expect(loaded.isOk()).toBe(true);
+    if (!loaded.isOk()) return;
+    expect(loaded.value.keys.vaultKeyPolicy).toBe("passcode");
+    expect(loaded.value.biometricGating.adminReadElevation).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/identity.ts
+++ b/packages/cli/src/commands/identity.ts
@@ -1,9 +1,16 @@
 import { Command } from "commander";
 import { Result } from "better-result";
-import { mkdirSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import { createKeyManager } from "@xmtp/signet-keys";
 import type { KeyManager } from "@xmtp/signet-keys";
-import { loadConfig } from "../config/loader.js";
+import { loadConfig, defaultConfigPath } from "../config/loader.js";
+import {
+  applyInitPreset,
+  describeInitPreset,
+  resolveInitPreset,
+  type InitPreset,
+} from "../config/init-presets.js";
+import { writeConfig } from "../config/writer.js";
 import { resolvePaths } from "../config/paths.js";
 import { formatOutput } from "../output/formatter.js";
 import { exitCodeFromCategory } from "../output/exit-codes.js";
@@ -66,28 +73,68 @@ export function createIdentityCommands(): Command {
 /** Create the direct-mode identity bootstrap command used by `identity init` and `xs init`. */
 export function createIdentityInitCommand(): Command {
   return new Command("init")
-    .description("Create a new XMTP identity and key hierarchy")
+    .description(
+      "Create a new XMTP identity and key hierarchy, optionally applying a posture preset",
+    )
+    .argument(
+      "[preset]",
+      "Initialization posture: recommended, trusted-local, or hardened",
+    )
     .option("--config <path>", "Path to config file")
     .option("--json", "JSON output")
     .option("--env <env>", "XMTP environment (local|dev|production)")
     .option("--label <name>", "Human-readable label for this identity")
-    .action(async (options) => {
+    .action(async (presetArg: string | undefined, options) => {
       const json = Boolean(options.json);
       const print = (data: unknown) =>
         process.stdout.write(formatOutput(data, { json }) + "\n");
       const printErr = (data: unknown) =>
         process.stderr.write(formatOutput(data, { json }) + "\n");
 
-      const configResult = await loadConfig(
+      const presetResult = resolveInitPreset(presetArg);
+      if (presetResult.isErr()) {
+        printErr({
+          error: presetResult.error.message,
+          ...(presetResult.error.context !== null
+            ? { context: presetResult.error.context }
+            : {}),
+        });
+        process.exit(exitCodeFromCategory(presetResult.error.category));
+      }
+      const preset = presetResult.value;
+      const configPath =
         typeof options.config === "string"
-          ? { configPath: options.config }
-          : {},
-      );
+          ? options.config
+          : defaultConfigPath();
+      const configExists = existsSync(configPath);
+
+      const configResult = await loadConfig({
+        configPath,
+        envOverrides: {},
+      });
       if (configResult.isErr()) {
         printErr({ error: configResult.error.message });
         process.exit(exitCodeFromCategory(configResult.error.category));
       }
-      const config = configResult.value;
+      let config =
+        !configExists || presetArg !== undefined
+          ? applyInitPreset(configResult.value, preset)
+          : configResult.value;
+      const env = resolveEnv(options.env, config.signet.env);
+      if (config.signet.env !== env) {
+        config = {
+          ...config,
+          signet: {
+            ...config.signet,
+            env,
+          },
+        };
+      }
+
+      const configWritten = !configExists || presetArg !== undefined;
+      if (configWritten) {
+        await writeConfig(configPath, config);
+      }
       const paths = resolvePaths(config);
 
       mkdirSync(paths.dataDir, { recursive: true });
@@ -141,7 +188,6 @@ export function createIdentityInitCommand(): Command {
         adminKeyFingerprint = adminResult.value.fingerprint;
       }
 
-      const env = resolveEnv(options.env, config.signet.env);
       if (env !== "local") {
         await registerXmtpIdentity({
           km,
@@ -152,6 +198,9 @@ export function createIdentityInitCommand(): Command {
           operationalKeyId: opKey.identityId,
           adminKeyFingerprint,
           platform: km.platform,
+          configPath,
+          configWritten,
+          ...(configWritten ? { preset } : {}),
           print,
           printErr,
         });
@@ -160,6 +209,14 @@ export function createIdentityInitCommand(): Command {
 
       print({
         initialized: true,
+        ...(configWritten
+          ? {
+              preset,
+              presetDescription: describeInitPreset(preset),
+            }
+          : {}),
+        configPath,
+        configWritten,
         rootPublicKey,
         operationalKeyId: opKey.identityId,
         adminKeyFingerprint,
@@ -207,6 +264,9 @@ async function registerXmtpIdentity(opts: {
   readonly operationalKeyId: string;
   readonly adminKeyFingerprint: string;
   readonly platform: string;
+  readonly configPath: string;
+  readonly configWritten: boolean;
+  readonly preset?: InitPreset;
   readonly print: (data: unknown) => void;
   readonly printErr: (data: unknown) => void;
 }): Promise<void> {
@@ -219,6 +279,9 @@ async function registerXmtpIdentity(opts: {
     operationalKeyId,
     adminKeyFingerprint,
     platform,
+    configPath,
+    configWritten,
+    preset,
     print,
     printErr,
   } = opts;
@@ -264,6 +327,14 @@ async function registerXmtpIdentity(opts: {
 
   print({
     initialized: true,
+    ...(preset !== undefined
+      ? {
+          preset,
+          presetDescription: describeInitPreset(preset),
+        }
+      : {}),
+    configPath,
+    configWritten,
     rootPublicKey,
     operationalKeyId,
     adminKeyFingerprint,

--- a/packages/cli/src/config/init-presets.ts
+++ b/packages/cli/src/config/init-presets.ts
@@ -1,0 +1,112 @@
+import { Result } from "better-result";
+import { z } from "zod";
+import { ValidationError } from "@xmtp/signet-schemas";
+import { CliConfigSchema } from "./schema.js";
+import type { CliConfig } from "./schema.js";
+
+/** Named first-run postures supported by `xs init`. */
+export const InitPresetSchema: z.ZodEnum<
+  ["recommended", "trusted-local", "hardened"]
+> = z.enum(["recommended", "trusted-local", "hardened"]);
+
+/** Supported initialization posture label. */
+export type InitPreset = z.infer<typeof InitPresetSchema>;
+
+/**
+ * Parse the optional `xs init` preset argument.
+ *
+ * Omitted input maps to the recommended posture.
+ */
+export function resolveInitPreset(
+  input: string | undefined,
+): Result<InitPreset, ValidationError> {
+  if (input === undefined) {
+    return Result.ok("recommended");
+  }
+
+  const parsed = InitPresetSchema.safeParse(input);
+  if (!parsed.success) {
+    return Result.err(
+      ValidationError.create(
+        "preset",
+        "Expected one of: recommended, trusted-local, hardened",
+        { received: input },
+      ),
+    );
+  }
+
+  return Result.ok(parsed.data);
+}
+
+/** Human-readable one-line summary used in CLI output and docs. */
+export function describeInitPreset(preset: InitPreset): string {
+  switch (preset) {
+    case "recommended":
+      return "Per-chat isolation with owner-gated sensitive reads.";
+    case "trusted-local":
+      return "Trusted local testing with shared identity mode and lower ceremony.";
+    case "hardened":
+      return "Per-chat isolation with stricter approval and shorter-lived defaults.";
+  }
+}
+
+/**
+ * Apply a named posture preset on top of an existing parsed CLI config.
+ *
+ * The preset only touches the fields that define the onboarding posture and
+ * preserves environment, dataDir, ports, and other local overrides.
+ */
+export function applyInitPreset(
+  baseConfig: CliConfig,
+  preset: InitPreset,
+): CliConfig {
+  const config = structuredClone(baseConfig);
+
+  switch (preset) {
+    case "recommended":
+      config.signet.identityMode = "per-group";
+      config.keys.rootKeyPolicy = "biometric";
+      config.keys.operationalKeyPolicy = "open";
+      config.keys.vaultKeyPolicy = "open";
+      config.biometricGating.rootKeyCreation = false;
+      config.biometricGating.operationalKeyRotation = false;
+      config.biometricGating.scopeExpansion = false;
+      config.biometricGating.egressExpansion = false;
+      config.biometricGating.agentCreation = false;
+      config.biometricGating.adminReadElevation = true;
+      config.credentials.defaultTtlSeconds = 3600;
+      config.credentials.maxConcurrentPerOperator = 3;
+      config.credentials.actionExpirySeconds = 300;
+      return CliConfigSchema.parse(config);
+    case "trusted-local":
+      config.signet.identityMode = "shared";
+      config.keys.rootKeyPolicy = "biometric";
+      config.keys.operationalKeyPolicy = "open";
+      config.keys.vaultKeyPolicy = "open";
+      config.biometricGating.rootKeyCreation = false;
+      config.biometricGating.operationalKeyRotation = false;
+      config.biometricGating.scopeExpansion = false;
+      config.biometricGating.egressExpansion = false;
+      config.biometricGating.agentCreation = false;
+      config.biometricGating.adminReadElevation = false;
+      config.credentials.defaultTtlSeconds = 43_200;
+      config.credentials.maxConcurrentPerOperator = 6;
+      config.credentials.actionExpirySeconds = 1_800;
+      return CliConfigSchema.parse(config);
+    case "hardened":
+      config.signet.identityMode = "per-group";
+      config.keys.rootKeyPolicy = "biometric";
+      config.keys.operationalKeyPolicy = "open";
+      config.keys.vaultKeyPolicy = "passcode";
+      config.biometricGating.rootKeyCreation = true;
+      config.biometricGating.operationalKeyRotation = true;
+      config.biometricGating.scopeExpansion = true;
+      config.biometricGating.egressExpansion = true;
+      config.biometricGating.agentCreation = true;
+      config.biometricGating.adminReadElevation = true;
+      config.credentials.defaultTtlSeconds = 900;
+      config.credentials.maxConcurrentPerOperator = 1;
+      config.credentials.actionExpirySeconds = 120;
+      return CliConfigSchema.parse(config);
+  }
+}

--- a/packages/cli/src/config/loader.ts
+++ b/packages/cli/src/config/loader.ts
@@ -62,7 +62,10 @@ export async function loadConfig(options?: {
   return Result.ok(parseResult.data);
 }
 
-function defaultConfigPath(): string {
+/**
+ * Returns the default CLI configuration path for the current environment.
+ */
+export function defaultConfigPath(): string {
   const defaults = resolvePaths(CliConfigSchema.parse({}));
   return defaults.configFile;
 }

--- a/packages/cli/src/config/writer.ts
+++ b/packages/cli/src/config/writer.ts
@@ -1,0 +1,16 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { stringify as stringifyToml } from "smol-toml";
+import type { CliConfig } from "./schema.js";
+
+/**
+ * Persist a parsed CLI config as TOML, creating the parent directory when
+ * needed so first-run `xs init` can materialize the recommended setup.
+ */
+export async function writeConfig(
+  configPath: string,
+  config: CliConfig,
+): Promise<void> {
+  await mkdir(dirname(configPath), { recursive: true });
+  await writeFile(configPath, stringifyToml(config) + "\n", "utf8");
+}


### PR DESCRIPTION
## Summary
- add posture presets for `xs init`: recommended, `trusted-local`, and `hardened`
- persist preset-backed CLI config defaults so first-run setup leaves the repo in a usable state
- seed the default Convos profile name from the init label when one is provided

## Why
- gives new users a secure recommended path while still offering explicit posture shortcuts for trusted local testing and stricter setups
- makes the secure-default story concrete at the very first CLI touchpoint

## What Changed
- added preset resolution and config-writing helpers for CLI init
- taught `xs init [preset]` to write tuned identity, key-policy, gating, and credential defaults
- added regression coverage for preset persistence and config loading
- updated README onboarding docs for the new init modes

## How To Test
- run `xs init`
- run `xs init trusted-local`
- run `xs init hardened`
- run `bun test packages/cli/src/__tests__/init-presets.test.ts packages/cli/src/__tests__/config-loader.test.ts packages/cli/src/__tests__/config-schema.test.ts`
- run `bun run typecheck`

Closes #312