### PR TITLE
feat(cli): streamline chat onboarding defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ bun run check
 ### Run the signet
 
 ```bash
-# Create a local XMTP identity and key hierarchy with the recommended posture
+# Create a local XMTP identity and key hierarchy with the recommended posture.
+# The label also becomes the default Convos profile name for chat join/invite flows.
 xs init --env dev --label owner
 
 # Use the lower-ceremony trusted local posture for smoke testing
@@ -126,6 +127,9 @@ xs cred info cred_b2c1
 # Create a conversation
 xs chat create --name "Design Team"
 
+# Create a conversation and immediately get a Convos QR/link
+xs chat create --name "Device Test" --invite
+
 # Send a message
 xs msg send "Hello from the signet" --to conv_9e2d1a4b8c3f7e60
 
@@ -150,24 +154,29 @@ stay simple without collapsing the custody boundary:
 All three presets keep the signet as the real XMTP client. They do not hand raw
 keys, raw databases, or direct XMTP SDK access to the harness.
 
+When `xs init` writes the config, it also stores the init label as the default
+Convos profile name. That means common flows like `xs chat join <invite>` and
+`xs chat create --invite` can publish a human-facing profile without requiring
+extra `--profile-name` ceremony every time.
+
 See [docs/development.md](docs/development.md) for the development workflow and
 package layout.
 
 ## CLI commands
 
-| Group                 | Commands                                                                    |
-| --------------------- | --------------------------------------------------------------------------- |
-| top-level             | `init`, `status`, `reset`, `logs`, `lookup`, `search`, `consent`            |
-| `daemon`              | `start`, `stop`, `status`                                                   |
-| `operator`            | `create`, `list`, `info`, `rename`, `rm`                                    |
-| `cred`                | `issue`, `list`, `info`, `revoke`, `update`                                 |
-| `chat`                | `create`, `list`, `info`, `update`, `sync`, `join`, `invite`, `leave`, `rm` |
-| `chat ... member`     | `list`, `add`, `rm`, `promote`, `demote`                                    |
-| `msg`                 | `send`, `reply`, `react`, `read`, `list`, `info`                            |
-| `policy`              | `create`, `list`, `info`, `update`, `rm`                                    |
-| `seal` _(deferred)_   | `list`, `info`, `verify`, `history`                                         |
-| `wallet` _(deferred)_ | `list`, `info`, `provider set`, `provider list`                             |
-| `key` _(deferred)_    | `init`, `rotate`, `list`, `info`                                            |
+| Group                 | Commands                                                                                      |
+| --------------------- | --------------------------------------------------------------------------------------------- |
+| top-level             | `init`, `status`, `reset`, `logs`, `lookup`, `search`, `consent`                              |
+| `daemon`              | `start`, `stop`, `status`                                                                     |
+| `operator`            | `create`, `list`, `info`, `rename`, `rm`                                                      |
+| `cred`                | `issue`, `list`, `info`, `revoke`, `update`                                                   |
+| `chat`                | `create`, `list`, `info`, `update`, `sync`, `join`, `invite`, `update-profile`, `leave`, `rm` |
+| `chat ... member`     | `list`, `add`, `rm`, `promote`, `demote`                                                      |
+| `msg`                 | `send`, `reply`, `react`, `read`, `list`, `info`                                              |
+| `policy`              | `create`, `list`, `info`, `update`, `rm`                                                      |
+| `seal` _(deferred)_   | `list`, `info`, `verify`, `history`                                                           |
+| `wallet` _(deferred)_ | `list`, `info`, `provider set`, `provider list`                                               |
+| `key` _(deferred)_    | `init`, `rotate`, `list`, `info`                                                              |
 
 ## What's working
 

--- a/packages/cli/src/__tests__/config-loader.test.ts
+++ b/packages/cli/src/__tests__/config-loader.test.ts
@@ -35,6 +35,9 @@ describe("loadConfig", () => {
 env = "production"
 identityMode = "shared"
 
+[defaults]
+profileName = "Codex"
+
 [ws]
 port = 9000
 host = "0.0.0.0"
@@ -50,6 +53,7 @@ defaultTtlSeconds = 7200
     const config = result.value;
     expect(config.signet.env).toBe("production");
     expect(config.signet.identityMode).toBe("shared");
+    expect(config.defaults.profileName).toBe("Codex");
     expect(config.ws.port).toBe(9000);
     expect(config.ws.host).toBe("0.0.0.0");
     expect(config.credentials.defaultTtlSeconds).toBe(7200);

--- a/packages/cli/src/__tests__/config-schema.test.ts
+++ b/packages/cli/src/__tests__/config-schema.test.ts
@@ -11,6 +11,7 @@ describe("CliConfigSchema", () => {
     expect(config.signet.env).toBe("dev");
     expect(config.signet.identityMode).toBe("per-group");
     expect(config.signet.dataDir).toBeUndefined();
+    expect(config.defaults.profileName).toBeUndefined();
     expect(config.keys.rootKeyPolicy).toBe("biometric");
     expect(config.keys.operationalKeyPolicy).toBe("open");
     expect(config.keys.vaultKeyPolicy).toBe("open");
@@ -35,6 +36,15 @@ describe("CliConfigSchema", () => {
     if (!result.success) return;
     expect(result.data.signet.env).toBe("dev");
     expect(result.data.signet.identityMode).toBe("per-group");
+  });
+
+  test("accepts a default Convos profile name", () => {
+    const result = CliConfigSchema.safeParse({
+      defaults: { profileName: "Codex" },
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.defaults.profileName).toBe("Codex");
   });
 
   test("rejects unknown legacy section", () => {

--- a/packages/cli/src/__tests__/init-presets.test.ts
+++ b/packages/cli/src/__tests__/init-presets.test.ts
@@ -73,6 +73,7 @@ describe("init posture presets", () => {
     const configPath = join(dir, "config.toml");
 
     const config = applyInitPreset(CliConfigSchema.parse({}), "hardened");
+    config.defaults.profileName = "Codex";
     await writeConfig(configPath, config);
 
     const raw = await readFile(configPath, "utf8");
@@ -83,6 +84,7 @@ describe("init posture presets", () => {
     const loaded = await loadConfig({ configPath });
     expect(loaded.isOk()).toBe(true);
     if (!loaded.isOk()) return;
+    expect(loaded.value.defaults.profileName).toBe("Codex");
     expect(loaded.value.keys.vaultKeyPolicy).toBe("passcode");
     expect(loaded.value.biometricGating.adminReadElevation).toBe(true);
   });

--- a/packages/cli/src/__tests__/xs-chat-command-wiring.test.ts
+++ b/packages/cli/src/__tests__/xs-chat-command-wiring.test.ts
@@ -9,12 +9,18 @@ interface RequestCall {
   readonly params: Record<string, unknown> | undefined;
 }
 
-function createHarness<T>(response: T) {
+function createHarness<T>(
+  response: T | readonly T[],
+  options?: {
+    readonly profileNameDefault?: string | undefined;
+  },
+) {
   const requestCalls: RequestCall[] = [];
   const withDaemonCalls: Array<{ configPath?: string | undefined }> = [];
   const stdout: string[] = [];
   const stderr: string[] = [];
   let exitCode: number | undefined;
+  const queuedResponses = Array.isArray(response) ? [...response] : [response];
 
   const client: AdminClient = {
     async connect() {
@@ -22,7 +28,11 @@ function createHarness<T>(response: T) {
     },
     async request(method, params) {
       requestCalls.push({ method, params });
-      return Result.ok(response);
+      const next = queuedResponses.shift();
+      if (next === undefined) {
+        throw new Error(`No queued response left for ${method}`);
+      }
+      return Result.ok(next);
     },
     async close() {},
   };
@@ -37,6 +47,53 @@ function createHarness<T>(response: T) {
       ): Promise<Result<TResult, SignetError>> {
         withDaemonCalls.push(options);
         return run(client);
+      },
+      async loadConfig() {
+        return Result.ok({
+          signet: {
+            env: "dev",
+            identityMode: "per-group",
+            dataDir: undefined,
+          },
+          defaults: {
+            profileName: options?.profileNameDefault,
+          },
+          keys: {
+            rootKeyPolicy: "biometric",
+            operationalKeyPolicy: "open",
+            vaultKeyPolicy: "open",
+          },
+          biometricGating: {
+            rootKeyCreation: false,
+            operationalKeyRotation: false,
+            scopeExpansion: false,
+            egressExpansion: false,
+            agentCreation: false,
+            adminReadElevation: false,
+          },
+          ws: {
+            port: 8393,
+            host: "127.0.0.1",
+          },
+          http: {
+            enabled: false,
+            port: 8081,
+            host: "127.0.0.1",
+          },
+          admin: {
+            authMode: "admin-key",
+            socketPath: undefined,
+          },
+          credentials: {
+            defaultTtlSeconds: 3600,
+            maxConcurrentPerOperator: 3,
+            actionExpirySeconds: 300,
+          },
+          logging: {
+            level: "info",
+            auditLogPath: undefined,
+          },
+        });
       },
       writeStdout(message: string) {
         stdout.push(message);
@@ -67,6 +124,51 @@ function createErrorHarness(error: SignetError) {
     deps: {
       async withDaemonClient<TResult>(): Promise<Result<TResult, SignetError>> {
         return Result.err(error);
+      },
+      async loadConfig() {
+        return Result.ok({
+          signet: {
+            env: "dev",
+            identityMode: "per-group",
+            dataDir: undefined,
+          },
+          defaults: {},
+          keys: {
+            rootKeyPolicy: "biometric",
+            operationalKeyPolicy: "open",
+            vaultKeyPolicy: "open",
+          },
+          biometricGating: {
+            rootKeyCreation: false,
+            operationalKeyRotation: false,
+            scopeExpansion: false,
+            egressExpansion: false,
+            agentCreation: false,
+            adminReadElevation: false,
+          },
+          ws: {
+            port: 8393,
+            host: "127.0.0.1",
+          },
+          http: {
+            enabled: false,
+            port: 8081,
+            host: "127.0.0.1",
+          },
+          admin: {
+            authMode: "admin-key",
+            socketPath: undefined,
+          },
+          credentials: {
+            defaultTtlSeconds: 3600,
+            maxConcurrentPerOperator: 3,
+            actionExpirySeconds: 300,
+          },
+          logging: {
+            level: "info",
+            auditLogPath: undefined,
+          },
+        });
       },
       writeStdout(message: string) {
         stdout.push(message);
@@ -158,6 +260,36 @@ describe("xs chat join", () => {
       },
     ]);
   });
+
+  test("falls back to the configured default profile name when none is passed", async () => {
+    const harness = createHarness(
+      { groupId: "g1", profileName: "Codex" },
+      { profileNameDefault: "Codex" },
+    );
+    const command = createChatCommands(harness.deps);
+
+    await command.parseAsync([
+      "node",
+      "chat",
+      "join",
+      "https://popup.convos.org/v2?i=test",
+      "--timeout",
+      "45",
+      "--config",
+      "/tmp/test.toml",
+    ]);
+
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "chat.join",
+        params: {
+          inviteUrl: "https://popup.convos.org/v2?i=test",
+          profileName: "Codex",
+          timeoutSeconds: 45,
+        },
+      },
+    ]);
+  });
 });
 
 describe("xs chat invite", () => {
@@ -209,6 +341,63 @@ describe("xs chat invite", () => {
   });
 });
 
+describe("xs chat create", () => {
+  test("can create, publish a profile, and invite in one flow", async () => {
+    const harness = createHarness([
+      { chatId: "conv_new", groupId: "g1", name: "Codex Group" },
+      { profileApplied: true, profileName: "Codex" },
+      {
+        inviteUrl: "https://popup.convos.org/v2?i=test",
+        groupName: "Codex Group",
+        groupId: "g1",
+      },
+    ]);
+    const command = createChatCommands(harness.deps);
+
+    await command.parseAsync([
+      "node",
+      "chat",
+      "create",
+      "--name",
+      "Codex Group",
+      "--invite",
+      "--profile-name",
+      "Codex",
+      "--invite-description",
+      "Join this test chat",
+      "--format",
+      "link",
+      "--config",
+      "/tmp/test.toml",
+    ]);
+
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "chat.create",
+        params: {
+          name: "Codex Group",
+          memberInboxIds: [],
+        },
+      },
+      {
+        method: "chat.update-profile",
+        params: {
+          chatId: "conv_new",
+          profileName: "Codex",
+        },
+      },
+      {
+        method: "chat.invite",
+        params: {
+          chatId: "conv_new",
+          description: "Join this test chat",
+        },
+      },
+    ]);
+    expect(harness.stdout.join("")).toContain("inviteUrl:");
+  });
+});
+
 describe("xs chat update-profile", () => {
   test("routes identity and operator-backed defaults through the daemon client", async () => {
     const harness = createHarness({ profileApplied: true });
@@ -235,6 +424,33 @@ describe("xs chat update-profile", () => {
           chatId: "conv_abc",
           identityLabel: "joiner",
           operatorId: "op_codex",
+        },
+      },
+    ]);
+  });
+
+  test("uses the configured default profile name when no explicit override is provided", async () => {
+    const harness = createHarness(
+      { profileApplied: true, profileName: "Codex" },
+      { profileNameDefault: "Codex" },
+    );
+    const command = createChatCommands(harness.deps);
+
+    await command.parseAsync([
+      "node",
+      "chat",
+      "update-profile",
+      "conv_abc",
+      "--config",
+      "/tmp/test.toml",
+    ]);
+
+    expect(harness.requestCalls).toEqual([
+      {
+        method: "chat.update-profile",
+        params: {
+          chatId: "conv_abc",
+          profileName: "Codex",
         },
       },
     ]);
@@ -339,7 +555,7 @@ describe("xs chat member admin commands", () => {
   });
 
   test("routes member promote and demote", async () => {
-    const harness = createHarness({ role: "admin" });
+    const harness = createHarness([{ role: "admin" }, { role: "member" }]);
     const command = createChatCommands(harness.deps);
 
     await command.parseAsync([

--- a/packages/cli/src/commands/identity.ts
+++ b/packages/cli/src/commands/identity.ts
@@ -131,6 +131,20 @@ export function createIdentityInitCommand(): Command {
         };
       }
 
+      if (
+        typeof options.label === "string" &&
+        options.label.trim().length > 0 &&
+        config.defaults.profileName === undefined
+      ) {
+        config = {
+          ...config,
+          defaults: {
+            ...config.defaults,
+            profileName: options.label.trim(),
+          },
+        };
+      }
+
       const configWritten = !configExists || presetArg !== undefined;
       if (configWritten) {
         await writeConfig(configPath, config);

--- a/packages/cli/src/commands/xs-chat.ts
+++ b/packages/cli/src/commands/xs-chat.ts
@@ -80,10 +80,15 @@ async function resolveProfileNameOverride(
   options: {
     readonly configPath?: string | undefined;
     readonly explicitProfileName?: string | undefined;
+    readonly hasOperatorId?: boolean;
   },
 ): Promise<Result<string | undefined, SignetError>> {
   if (options.explicitProfileName !== undefined) {
     return Result.ok(options.explicitProfileName);
+  }
+
+  if (options.hasOperatorId === true) {
+    return Result.ok(undefined);
   }
 
   const configResult = await deps.loadConfig(
@@ -194,6 +199,7 @@ export function createChatCommands(
           ? await resolveProfileNameOverride(resolvedDeps, {
               configPath: opts.config,
               explicitProfileName: opts.profileName,
+              hasOperatorId: opts.op !== undefined,
             })
           : Result.ok(undefined);
         if (profileNameResult.isErr()) {
@@ -267,7 +273,15 @@ export function createChatCommands(
                 : {}),
             });
             if (invite.isErr()) {
-              return invite;
+              return Result.ok({
+                ...createdValue,
+                ...(profile ? { profile } : {}),
+                ...(profileWarning ? { profileWarning } : {}),
+                inviteWarning: {
+                  category: invite.error.category,
+                  message: invite.error.message,
+                },
+              });
             }
 
             return Result.ok({
@@ -286,30 +300,41 @@ export function createChatCommands(
 
         if (opts.invite === true) {
           const output = result.value as Record<string, unknown>;
-          const invite = output["invite"] as Record<string, unknown>;
+          const invite = output["invite"] as
+            | Record<string, unknown>
+            | undefined;
           const profileWarning = output["profileWarning"] as
+            | { category: string; message: string }
+            | undefined;
+          const inviteWarning = output["inviteWarning"] as
             | { category: string; message: string }
             | undefined;
 
           if (json) {
-            const { renderQrToDataUrl } = await import("../invite/qr.js");
-            const inviteUrl =
-              typeof invite["inviteUrl"] === "string"
-                ? invite["inviteUrl"]
-                : "";
-            const qrDataUrl = await renderQrToDataUrl(inviteUrl);
-            resolvedDeps.writeStdout(
-              formatOutput(
-                {
-                  ...output,
-                  invite: {
-                    ...invite,
-                    qrDataUrl,
+            if (invite !== undefined) {
+              const { renderQrToDataUrl } = await import("../invite/qr.js");
+              const inviteUrl =
+                typeof invite["inviteUrl"] === "string"
+                  ? invite["inviteUrl"]
+                  : "";
+              const qrDataUrl = await renderQrToDataUrl(inviteUrl);
+              resolvedDeps.writeStdout(
+                formatOutput(
+                  {
+                    ...output,
+                    invite: {
+                      ...invite,
+                      qrDataUrl,
+                    },
                   },
-                },
-                { json: true },
-              ) + "\n",
-            );
+                  { json: true },
+                ) + "\n",
+              );
+            } else {
+              resolvedDeps.writeStdout(
+                formatOutput(output, { json: true }) + "\n",
+              );
+            }
             return;
           }
 
@@ -326,10 +351,17 @@ export function createChatCommands(
               `warning: profile update failed (${profileWarning.category}): ${profileWarning.message}\n`,
             );
           }
-          await writeInviteOutput(resolvedDeps, invite, {
-            json: false,
-            format,
-          });
+          if (inviteWarning) {
+            resolvedDeps.writeStderr(
+              `warning: invite failed (${inviteWarning.category}): ${inviteWarning.message}\n`,
+            );
+          }
+          if (invite !== undefined) {
+            await writeInviteOutput(resolvedDeps, invite, {
+              json: false,
+              format,
+            });
+          }
           return;
         }
 
@@ -484,6 +516,7 @@ export function createChatCommands(
           {
             configPath: opts.config,
             explicitProfileName: opts.profileName,
+            hasOperatorId: opts.op !== undefined,
           },
         );
         if (profileNameResult.isErr()) {
@@ -589,6 +622,7 @@ export function createChatCommands(
           {
             configPath: opts.config,
             explicitProfileName: opts.profileName,
+            hasOperatorId: opts.op !== undefined,
           },
         );
         if (profileNameResult.isErr()) {

--- a/packages/cli/src/commands/xs-chat.ts
+++ b/packages/cli/src/commands/xs-chat.ts
@@ -10,7 +10,10 @@
  */
 
 import { Command } from "commander";
-import type { SignetError } from "@xmtp/signet-schemas";
+import { Result } from "better-result";
+import { InternalError, type SignetError } from "@xmtp/signet-schemas";
+import { loadConfig } from "../config/loader.js";
+import type { CliConfig } from "../config/schema.js";
 import { requireForce } from "../output/confirm.js";
 import { exitCodeFromCategory } from "../output/exit-codes.js";
 import { formatOutput } from "../output/formatter.js";
@@ -22,6 +25,10 @@ import {
 /** Dependencies for v1 chat commands. */
 export interface XsChatCommandDeps {
   readonly withDaemonClient: WithDaemonClient;
+  readonly loadConfig: (options?: {
+    configPath?: string;
+    envOverrides?: Record<string, string>;
+  }) => Promise<Result<CliConfig, SignetError>>;
   readonly writeStdout: (message: string) => void;
   readonly writeStderr: (message: string) => void;
   readonly exit: (code: number) => void;
@@ -29,6 +36,7 @@ export interface XsChatCommandDeps {
 
 const defaultDeps: XsChatCommandDeps = {
   withDaemonClient: createWithDaemonClient(),
+  loadConfig: (options) => loadConfig(options),
   writeStdout(message) {
     process.stdout.write(message);
   },
@@ -65,6 +73,29 @@ function normalizeInviteFormat(format: string | undefined): InviteFormat {
   return format === "link" || format === "qr" || format === "both"
     ? format
     : "both";
+}
+
+async function resolveProfileNameOverride(
+  deps: XsChatCommandDeps,
+  options: {
+    readonly configPath?: string | undefined;
+    readonly explicitProfileName?: string | undefined;
+  },
+): Promise<Result<string | undefined, SignetError>> {
+  if (options.explicitProfileName !== undefined) {
+    return Result.ok(options.explicitProfileName);
+  }
+
+  const configResult = await deps.loadConfig(
+    options.configPath !== undefined
+      ? { configPath: options.configPath }
+      : undefined,
+  );
+  if (configResult.isErr()) {
+    return configResult;
+  }
+
+  return Result.ok(configResult.value.defaults.profileName);
 }
 
 async function writeInviteOutput(
@@ -108,12 +139,25 @@ export function createChatCommands(
 
   cmd
     .command("create")
-    .description("Create a conversation")
+    .description(
+      "Create a conversation, optionally publishing a profile and invite in one flow",
+    )
     .option("--config <path>", "Path to config file")
     .requiredOption("--name <name>", "Conversation name")
     .option("--members <inboxIds>", "Member inbox IDs (comma-separated)")
     .option("--as <inbox>", "Inbox ID to act as")
     .option("--op <operator>", "Operator ID")
+    .option(
+      "--invite",
+      "Generate a Convos invite immediately after creating the chat",
+    )
+    .option(
+      "--profile-name <name>",
+      "Convos profile name to publish after create (or before invite output)",
+    )
+    .option("--invite-name <name>", "Invite display name override")
+    .option("--invite-description <desc>", "Invite description override")
+    .option("--format <type>", "Output format: link, qr, or both", "both")
     .option("--json", "JSON output")
     .action(
       async (opts: {
@@ -122,9 +166,15 @@ export function createChatCommands(
         members?: string;
         as?: string;
         op?: string;
+        invite?: true;
+        profileName?: string;
+        inviteName?: string;
+        inviteDescription?: string;
+        format?: string;
         json?: true;
       }) => {
         const json = opts.json === true;
+        const format = normalizeInviteFormat(opts.format);
         const payload: Record<string, unknown> = {
           name: opts.name,
           memberInboxIds:
@@ -138,13 +188,148 @@ export function createChatCommands(
         if (opts.as !== undefined) payload["creatorIdentityLabel"] = opts.as;
         if (opts.op !== undefined) payload["operatorId"] = opts.op;
 
+        const shouldResolveProfile =
+          opts.profileName !== undefined || opts.invite === true;
+        const profileNameResult = shouldResolveProfile
+          ? await resolveProfileNameOverride(resolvedDeps, {
+              configPath: opts.config,
+              explicitProfileName: opts.profileName,
+            })
+          : Result.ok(undefined);
+        if (profileNameResult.isErr()) {
+          writeError(resolvedDeps, profileNameResult.error, json);
+          return;
+        }
+
         const result = await resolvedDeps.withDaemonClient(
           { configPath: opts.config },
-          (client) => client.request("chat.create", payload),
+          async (client) => {
+            const created = await client.request("chat.create", payload);
+            if (created.isErr()) {
+              return created;
+            }
+
+            const createdValue = created.value as Record<string, unknown>;
+            const chatId =
+              typeof createdValue["chatId"] === "string"
+                ? createdValue["chatId"]
+                : typeof createdValue["groupId"] === "string"
+                  ? createdValue["groupId"]
+                  : undefined;
+            if (chatId === undefined) {
+              return Result.err(
+                InternalError.create(
+                  "chat.create response did not include chatId or groupId",
+                ) as SignetError,
+              );
+            }
+
+            let profile: Record<string, unknown> | undefined;
+            let profileWarning:
+              | { category: string; message: string }
+              | undefined;
+            if (profileNameResult.value !== undefined) {
+              const profileResult = await client.request(
+                "chat.update-profile",
+                {
+                  chatId,
+                  ...(opts.as !== undefined ? { identityLabel: opts.as } : {}),
+                  ...(opts.op !== undefined ? { operatorId: opts.op } : {}),
+                  profileName: profileNameResult.value,
+                },
+              );
+              if (profileResult.isErr()) {
+                profileWarning = {
+                  category: profileResult.error.category,
+                  message: profileResult.error.message,
+                };
+              } else {
+                profile = profileResult.value as Record<string, unknown>;
+              }
+            }
+
+            if (opts.invite !== true) {
+              return Result.ok({
+                ...createdValue,
+                ...(profile ? { profile } : {}),
+                ...(profileWarning ? { profileWarning } : {}),
+              });
+            }
+
+            const invite = await client.request("chat.invite", {
+              chatId,
+              ...(opts.as !== undefined ? { identityLabel: opts.as } : {}),
+              ...(opts.inviteName !== undefined
+                ? { name: opts.inviteName }
+                : {}),
+              ...(opts.inviteDescription !== undefined
+                ? { description: opts.inviteDescription }
+                : {}),
+            });
+            if (invite.isErr()) {
+              return invite;
+            }
+
+            return Result.ok({
+              ...createdValue,
+              ...(profile ? { profile } : {}),
+              ...(profileWarning ? { profileWarning } : {}),
+              invite: invite.value,
+            });
+          },
         );
 
         if (result.isErr()) {
           writeError(resolvedDeps, result.error, json);
+          return;
+        }
+
+        if (opts.invite === true) {
+          const output = result.value as Record<string, unknown>;
+          const invite = output["invite"] as Record<string, unknown>;
+          const profileWarning = output["profileWarning"] as
+            | { category: string; message: string }
+            | undefined;
+
+          if (json) {
+            const { renderQrToDataUrl } = await import("../invite/qr.js");
+            const inviteUrl =
+              typeof invite["inviteUrl"] === "string"
+                ? invite["inviteUrl"]
+                : "";
+            const qrDataUrl = await renderQrToDataUrl(inviteUrl);
+            resolvedDeps.writeStdout(
+              formatOutput(
+                {
+                  ...output,
+                  invite: {
+                    ...invite,
+                    qrDataUrl,
+                  },
+                },
+                { json: true },
+              ) + "\n",
+            );
+            return;
+          }
+
+          resolvedDeps.writeStdout(
+            formatOutput(
+              Object.fromEntries(
+                Object.entries(output).filter(([key]) => key !== "invite"),
+              ),
+              { json: false },
+            ) + "\n",
+          );
+          if (profileWarning) {
+            resolvedDeps.writeStderr(
+              `warning: profile update failed (${profileWarning.category}): ${profileWarning.message}\n`,
+            );
+          }
+          await writeInviteOutput(resolvedDeps, invite, {
+            json: false,
+            format,
+          });
           return;
         }
 
@@ -294,8 +479,19 @@ export function createChatCommands(
         const payload: Record<string, unknown> = { inviteUrl: url };
         if (opts.as !== undefined) payload["label"] = opts.as;
         if (opts.op !== undefined) payload["operatorId"] = opts.op;
-        if (opts.profileName !== undefined) {
-          payload["profileName"] = opts.profileName;
+        const profileNameResult = await resolveProfileNameOverride(
+          resolvedDeps,
+          {
+            configPath: opts.config,
+            explicitProfileName: opts.profileName,
+          },
+        );
+        if (profileNameResult.isErr()) {
+          writeError(resolvedDeps, profileNameResult.error, json);
+          return;
+        }
+        if (profileNameResult.value !== undefined) {
+          payload["profileName"] = profileNameResult.value;
         }
         if (opts.timeout !== undefined) {
           payload["timeoutSeconds"] = Number.parseInt(opts.timeout, 10);
@@ -388,8 +584,19 @@ export function createChatCommands(
         const payload: Record<string, unknown> = { chatId: id };
         if (opts.as !== undefined) payload["identityLabel"] = opts.as;
         if (opts.op !== undefined) payload["operatorId"] = opts.op;
-        if (opts.profileName !== undefined) {
-          payload["profileName"] = opts.profileName;
+        const profileNameResult = await resolveProfileNameOverride(
+          resolvedDeps,
+          {
+            configPath: opts.config,
+            explicitProfileName: opts.profileName,
+          },
+        );
+        if (profileNameResult.isErr()) {
+          writeError(resolvedDeps, profileNameResult.error, json);
+          return;
+        }
+        if (profileNameResult.value !== undefined) {
+          payload["profileName"] = profileNameResult.value;
         }
 
         const result = await resolvedDeps.withDaemonClient(

--- a/packages/cli/src/config/loader.ts
+++ b/packages/cli/src/config/loader.ts
@@ -62,9 +62,7 @@ export async function loadConfig(options?: {
   return Result.ok(parseResult.data);
 }
 
-/**
- * Returns the default CLI configuration path for the current environment.
- */
+/** Resolve the default CLI config file path from schema defaults and XDG rules. */
 export function defaultConfigPath(): string {
   const defaults = resolvePaths(CliConfigSchema.parse({}));
   return defaults.configFile;

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -91,6 +91,9 @@ type SignetConfigInput =
 /** Top-level CLI configuration. Parsed from TOML with env var overrides. */
 export type CliConfig = {
   signet: SignetConfig;
+  defaults: {
+    profileName?: string | undefined;
+  };
   keys: {
     rootKeyPolicy: "biometric" | "passcode" | "open";
     operationalKeyPolicy: "biometric" | "passcode" | "open";
@@ -116,6 +119,11 @@ export type CliConfig = {
 
 type CliConfigInput = {
   signet?: SignetConfigInput;
+  defaults?:
+    | {
+        profileName?: string | undefined;
+      }
+    | undefined;
   keys?:
     | {
         rootKeyPolicy?: "biometric" | "passcode" | "open" | undefined;
@@ -168,6 +176,14 @@ const SignetConfigSchema: z.ZodType<
 const CliConfigBaseSchema = z
   .object({
     signet: SignetConfigSchema,
+    defaults: z
+      .object({
+        profileName: z
+          .string()
+          .optional()
+          .describe("Default human-facing profile name for Convos flows"),
+      })
+      .default({}),
     keys: z
       .object({
         rootKeyPolicy: z


### PR DESCRIPTION
## Summary
- add a streamlined `xs chat create --invite` flow for new chat onboarding
- let `xs chat join` and `xs chat update-profile` fall back to the configured default profile name
- keep existing invite generation for existing chats while making the first-run Convos flow much smoother

## Why
- turns the init-time defaults from #315 into a practical chat onboarding path instead of making users re-specify profile context on every command
- keeps the ergonomics the same across more secure and more relaxed local setups

## What Changed
- added config-backed profile-name resolution for chat join and profile update flows
- extended `xs chat create` with an optional immediate invite flow and matching output paths
- expanded CLI wiring tests to cover default-profile and create-plus-invite behavior
- updated README onboarding examples and command-surface docs

## How To Test
- run `xs init --label Codex`
- run `xs chat create --name "Device Test" --invite`
- run `xs chat join "<invite-url>"`
- run `bun test packages/cli/src/__tests__/xs-chat-command-wiring.test.ts packages/cli/src/__tests__/config-schema.test.ts packages/cli/src/__tests__/config-loader.test.ts packages/cli/src/__tests__/init-presets.test.ts`
- run `bun run lint`
- run `bun run docs:check`

Addresses #313