### PR TITLE
test(cli): add coverage for init preset env isolation and chat invite warning

### DIFF
--- a/packages/cli/src/__tests__/init-presets.test.ts
+++ b/packages/cli/src/__tests__/init-presets.test.ts
@@ -67,6 +67,74 @@ describe("init posture presets", () => {
     expect(config.credentials.maxConcurrentPerOperator).toBe(1);
   });
 
+  test("loadConfig with envOverrides: {} ignores process env vars", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "xmtp-signet-init-presets-"));
+    tempDirs.push(dir);
+    const configPath = join(dir, "config.toml");
+
+    const config = applyInitPreset(CliConfigSchema.parse({}), "recommended");
+    await writeConfig(configPath, config);
+
+    const original = process.env["XMTP_SIGNET_ENV"];
+    try {
+      process.env["XMTP_SIGNET_ENV"] = "production";
+
+      const withEmpty = await loadConfig({ configPath, envOverrides: {} });
+      expect(withEmpty.isOk()).toBe(true);
+      if (!withEmpty.isOk()) return;
+      expect(withEmpty.value.signet.env).toBe("dev");
+
+      const withDefault = await loadConfig({ configPath });
+      expect(withDefault.isOk()).toBe(true);
+      if (!withDefault.isOk()) return;
+      expect(withDefault.value.signet.env).toBe("production");
+    } finally {
+      if (original === undefined) {
+        delete process.env["XMTP_SIGNET_ENV"];
+      } else {
+        process.env["XMTP_SIGNET_ENV"] = original;
+      }
+    }
+  });
+
+  test("config round-trip with envOverrides: {} does not bake in env vars", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "xmtp-signet-init-presets-"));
+    tempDirs.push(dir);
+    const configPath = join(dir, "config.toml");
+
+    const original = process.env["XMTP_SIGNET_ENV"];
+    try {
+      process.env["XMTP_SIGNET_ENV"] = "production";
+
+      const loaded = await loadConfig({ configPath, envOverrides: {} });
+      expect(loaded.isOk()).toBe(true);
+      if (!loaded.isOk()) return;
+
+      const config = applyInitPreset(loaded.value, "recommended");
+      await writeConfig(configPath, config);
+
+      delete process.env["XMTP_SIGNET_ENV"];
+
+      const reloaded = await loadConfig({ configPath });
+      expect(reloaded.isOk()).toBe(true);
+      if (!reloaded.isOk()) return;
+      expect(reloaded.value.signet.env).toBe("dev");
+    } finally {
+      if (original === undefined) {
+        delete process.env["XMTP_SIGNET_ENV"];
+      } else {
+        process.env["XMTP_SIGNET_ENV"] = original;
+      }
+    }
+  });
+
+  test("rejects unknown preset names with a validation error", () => {
+    const result = resolveInitPreset("yolo");
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+    expect(result.error.category).toBe("validation");
+  });
+
   test("persists preset configs as parseable TOML", async () => {
     const dir = await mkdtemp(join(tmpdir(), "xmtp-signet-init-presets-"));
     tempDirs.push(dir);

--- a/packages/cli/src/__tests__/xs-chat-command-wiring.test.ts
+++ b/packages/cli/src/__tests__/xs-chat-command-wiring.test.ts
@@ -3,10 +3,60 @@ import { Result } from "better-result";
 import { InternalError, type SignetError } from "@xmtp/signet-schemas";
 import type { AdminClient } from "../admin/client.js";
 import { createChatCommands } from "../commands/xs-chat.js";
+import type { DaemonCommandContext } from "../commands/daemon-client.js";
+import type { CliConfig } from "../config/schema.js";
 
 interface RequestCall {
   readonly method: string;
   readonly params: Record<string, unknown> | undefined;
+}
+
+function stubConfig(profileNameDefault?: string): CliConfig {
+  return {
+    signet: {
+      env: "dev",
+      identityMode: "per-group",
+      dataDir: undefined,
+    },
+    defaults: {
+      profileName: profileNameDefault,
+    },
+    keys: {
+      rootKeyPolicy: "biometric",
+      operationalKeyPolicy: "open",
+      vaultKeyPolicy: "open",
+    },
+    biometricGating: {
+      rootKeyCreation: false,
+      operationalKeyRotation: false,
+      scopeExpansion: false,
+      egressExpansion: false,
+      agentCreation: false,
+      adminReadElevation: false,
+    },
+    ws: {
+      port: 8393,
+      host: "127.0.0.1",
+    },
+    http: {
+      enabled: false,
+      port: 8081,
+      host: "127.0.0.1",
+    },
+    admin: {
+      authMode: "admin-key",
+      socketPath: undefined,
+    },
+    credentials: {
+      defaultTtlSeconds: 3600,
+      maxConcurrentPerOperator: 3,
+      actionExpirySeconds: 300,
+    },
+    logging: {
+      level: "info",
+      auditLogPath: undefined,
+    },
+  };
 }
 
 function createHarness<T>(
@@ -43,57 +93,77 @@ function createHarness<T>(
         options: { configPath?: string | undefined },
         run: (
           adminClient: AdminClient,
+          context: DaemonCommandContext,
         ) => Promise<Result<TResult, SignetError>>,
       ): Promise<Result<TResult, SignetError>> {
         withDaemonCalls.push(options);
-        return run(client);
+        return run(client, {} as DaemonCommandContext);
       },
       async loadConfig() {
-        return Result.ok({
-          signet: {
-            env: "dev",
-            identityMode: "per-group",
-            dataDir: undefined,
-          },
-          defaults: {
-            profileName: options?.profileNameDefault,
-          },
-          keys: {
-            rootKeyPolicy: "biometric",
-            operationalKeyPolicy: "open",
-            vaultKeyPolicy: "open",
-          },
-          biometricGating: {
-            rootKeyCreation: false,
-            operationalKeyRotation: false,
-            scopeExpansion: false,
-            egressExpansion: false,
-            agentCreation: false,
-            adminReadElevation: false,
-          },
-          ws: {
-            port: 8393,
-            host: "127.0.0.1",
-          },
-          http: {
-            enabled: false,
-            port: 8081,
-            host: "127.0.0.1",
-          },
-          admin: {
-            authMode: "admin-key",
-            socketPath: undefined,
-          },
-          credentials: {
-            defaultTtlSeconds: 3600,
-            maxConcurrentPerOperator: 3,
-            actionExpirySeconds: 300,
-          },
-          logging: {
-            level: "info",
-            auditLogPath: undefined,
-          },
-        });
+        return Result.ok(stubConfig(options?.profileNameDefault));
+      },
+      writeStdout(message: string) {
+        stdout.push(message);
+      },
+      writeStderr(message: string) {
+        stderr.push(message);
+      },
+      exit(code: number) {
+        exitCode = code;
+      },
+    },
+    requestCalls,
+    withDaemonCalls,
+    stdout,
+    stderr,
+    get exitCode() {
+      return exitCode;
+    },
+  };
+}
+
+function createMixedHarness(
+  responses: readonly Result<unknown, SignetError>[],
+  options?: {
+    readonly profileNameDefault?: string | undefined;
+  },
+) {
+  const requestCalls: RequestCall[] = [];
+  const withDaemonCalls: Array<{ configPath?: string | undefined }> = [];
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let exitCode: number | undefined;
+  const queuedResponses = [...responses];
+
+  const client: AdminClient = {
+    async connect() {
+      return Result.ok(undefined);
+    },
+    async request<T>(method: string, params?: Record<string, unknown>) {
+      requestCalls.push({ method, params });
+      const next = queuedResponses.shift();
+      if (next === undefined) {
+        throw new Error(`No queued response left for ${method}`);
+      }
+      return next as Result<T, SignetError>;
+    },
+    async close() {},
+  };
+
+  return {
+    deps: {
+      async withDaemonClient<TResult>(
+        opts: { configPath?: string | undefined },
+        run: (
+          adminClient: AdminClient,
+          context: DaemonCommandContext,
+        ) => Promise<Result<TResult, SignetError>>,
+      ): Promise<Result<TResult, SignetError>> {
+        withDaemonCalls.push(opts);
+        return run(client, {} as DaemonCommandContext);
+      },
+      async loadConfig() {
+        return Result.ok(stubConfig(options?.profileNameDefault));
       },
       writeStdout(message: string) {
         stdout.push(message);
@@ -126,49 +196,7 @@ function createErrorHarness(error: SignetError) {
         return Result.err(error);
       },
       async loadConfig() {
-        return Result.ok({
-          signet: {
-            env: "dev",
-            identityMode: "per-group",
-            dataDir: undefined,
-          },
-          defaults: {},
-          keys: {
-            rootKeyPolicy: "biometric",
-            operationalKeyPolicy: "open",
-            vaultKeyPolicy: "open",
-          },
-          biometricGating: {
-            rootKeyCreation: false,
-            operationalKeyRotation: false,
-            scopeExpansion: false,
-            egressExpansion: false,
-            agentCreation: false,
-            adminReadElevation: false,
-          },
-          ws: {
-            port: 8393,
-            host: "127.0.0.1",
-          },
-          http: {
-            enabled: false,
-            port: 8081,
-            host: "127.0.0.1",
-          },
-          admin: {
-            authMode: "admin-key",
-            socketPath: undefined,
-          },
-          credentials: {
-            defaultTtlSeconds: 3600,
-            maxConcurrentPerOperator: 3,
-            actionExpirySeconds: 300,
-          },
-          logging: {
-            level: "info",
-            auditLogPath: undefined,
-          },
-        });
+        return Result.ok(stubConfig());
       },
       writeStdout(message: string) {
         stdout.push(message);
@@ -290,6 +318,27 @@ describe("xs chat join", () => {
       },
     ]);
   });
+
+  test("skips default profile name when --op is provided", async () => {
+    const harness = createHarness(
+      { groupId: "g1" },
+      { profileNameDefault: "DefaultProfile" },
+    );
+    const command = createChatCommands(harness.deps);
+
+    await command.parseAsync([
+      "node",
+      "chat",
+      "join",
+      "https://popup.convos.org/v2?i=test",
+      "--op",
+      "op_agent1",
+    ]);
+
+    expect(harness.requestCalls).toHaveLength(1);
+    expect(harness.requestCalls[0]?.method).toBe("chat.join");
+    expect(harness.requestCalls[0]?.params).not.toHaveProperty("profileName");
+  });
 });
 
 describe("xs chat invite", () => {
@@ -396,6 +445,60 @@ describe("xs chat create", () => {
     ]);
     expect(harness.stdout.join("")).toContain("inviteUrl:");
   });
+
+  test("converts invite failure to a non-fatal warning preserving chatId", async () => {
+    const harness = createMixedHarness([
+      Result.ok({ chatId: "conv_new", name: "Test" }),
+      Result.ok({ profileApplied: true }),
+      Result.err(
+        InternalError.create("invite service unavailable") as SignetError,
+      ),
+    ]);
+    const command = createChatCommands(harness.deps);
+
+    await command.parseAsync([
+      "node",
+      "chat",
+      "create",
+      "--name",
+      "Test",
+      "--invite",
+      "--profile-name",
+      "Codex",
+      "--format",
+      "link",
+    ]);
+
+    expect(harness.requestCalls).toHaveLength(3);
+    expect(harness.requestCalls[0]?.method).toBe("chat.create");
+    expect(harness.requestCalls[1]?.method).toBe("chat.update-profile");
+    expect(harness.requestCalls[2]?.method).toBe("chat.invite");
+    expect(harness.stdout.join("")).toContain("conv_new");
+    expect(harness.stderr.join("")).toContain("warning: invite failed");
+    expect(harness.exitCode).toBeUndefined();
+  });
+
+  test("skips default profile name when --op is provided", async () => {
+    const harness = createHarness(
+      { chatId: "conv_new", name: "Op Chat" },
+      { profileNameDefault: "DefaultProfile" },
+    );
+    const command = createChatCommands(harness.deps);
+
+    await command.parseAsync([
+      "node",
+      "chat",
+      "create",
+      "--name",
+      "Op Chat",
+      "--op",
+      "op_agent1",
+    ]);
+
+    expect(harness.requestCalls).toHaveLength(1);
+    expect(harness.requestCalls[0]?.method).toBe("chat.create");
+    expect(harness.requestCalls[0]?.params).not.toHaveProperty("profileName");
+  });
 });
 
 describe("xs chat update-profile", () => {
@@ -454,6 +557,27 @@ describe("xs chat update-profile", () => {
         },
       },
     ]);
+  });
+
+  test("skips default profile name when --op is provided", async () => {
+    const harness = createHarness(
+      { profileApplied: true },
+      { profileNameDefault: "DefaultProfile" },
+    );
+    const command = createChatCommands(harness.deps);
+
+    await command.parseAsync([
+      "node",
+      "chat",
+      "update-profile",
+      "conv_abc",
+      "--op",
+      "op_agent1",
+    ]);
+
+    expect(harness.requestCalls).toHaveLength(1);
+    expect(harness.requestCalls[0]?.method).toBe("chat.update-profile");
+    expect(harness.requestCalls[0]?.params).not.toHaveProperty("profileName");
   });
 });
 


### PR DESCRIPTION
## Summary

Adds test coverage for the init preset and chat onboarding fixes merged in #315 and #316.

**Init presets** (3 new tests):
- `envOverrides: {}` prevents process env vars from leaking into persisted config
- Config round-trip with `envOverrides: {}` doesn't bake in env var values
- Invalid preset names rejected with validation error

**Chat command wiring** (5 new tests):
- Invite failure converted to non-fatal `inviteWarning` preserving chatId
- `--op` flag skips default profile name in `chat create`, `chat join`, and `chat update-profile`

Also refactored the test harnesses: extracted `stubConfig()` helper and fixed `WithDaemonClient` type signature to match the two-arg `(client, context)` contract.

## Test plan

- [x] `bun test src/__tests__/init-presets.test.ts` — 8/8 pass
- [x] `bun test src/__tests__/xs-chat-command-wiring.test.ts` — 19/19 pass
- [x] `bun run check` — 48/48 tasks, 0 failures