### PR TITLE
docs(onboarding): add onboarding-scheme stack execution guide

### DIFF
--- a/.agents/plans/v1/onboarding-scheme-stack.md
+++ b/.agents/plans/v1/onboarding-scheme-stack.md
@@ -1,0 +1,80 @@
+# Onboarding Scheme Stack
+
+Status: active
+Last updated: 2026-04-17
+Parent issue: #318
+
+## Goal
+
+Implement the onboarding-scheme abstraction as a linear Graphite stack without
+changing Convos wire compatibility.
+
+## Stack invariants
+
+- one branch per issue, one commit per branch
+- keep the stack linear even where issue dependencies are parallel
+- preserve byte compatibility with existing Convos invite, join, and profile
+  flows throughout the stack
+- use `Refs #318` on the kickoff PR; do not close the epic until the subissue
+  stack is merged
+
+## Execution order
+
+| Order | Issue | Branch | Commit / PR title |
+|---|---:|---|---|
+| 0 | #318 | `v1/onboarding-kickoff` | `docs(onboarding): add onboarding-scheme stack execution guide` |
+| 1 | #319 | `v1/onboarding-scheme-contract` | `feat(core): define onboarding scheme contracts` |
+| 2 | #320 | `v1/invite-crypto` | `refactor(core): extract shared invite crypto` |
+| 3 | #321 | `v1/convos-onboarding-scheme` | `feat(core): implement convos onboarding scheme` |
+| 4 | #322 | `v1/onboarding-equivalence` | `test(core): add onboarding equivalence coverage` |
+| 5 | #323 | `v1/onboarding-conversation-di` | `refactor(core): inject onboarding scheme into conversation actions` |
+| 6 | #324 | `v1/onboarding-sdk-codecs` | `refactor(core): source codecs from onboarding scheme` |
+| 7 | #325 | `v1/onboarding-scheme-config` | `feat(cli): configure onboarding scheme resolution` |
+| 8 | #326 | `v1/onboarding-schemes-move` | `chore(core): move convos implementation under schemes` |
+
+## Branch intent
+
+### #318 kickoff
+
+- add tracked docs for the abstraction and execution order
+- no runtime code changes
+
+### #319-#321 foundation
+
+- define the `OnboardingScheme` surface in `packages/core`
+- extract shared crypto helpers
+- wrap current Convos behavior in a scheme implementation
+
+### #322 safety gate
+
+- add equivalence tests for invite generation, parsing, verification, profile
+  encoding, and host-side join processing
+- do not swap internal call sites before this branch is green
+
+### #323-#325 functional cutover
+
+- inject the scheme into conversation actions and join orchestration
+- source codecs from the resolved scheme in the SDK layer
+- add CLI config and resolve the scheme once at startup
+
+### #326 cleanup
+
+- move the Convos implementation under `packages/core/src/schemes/convos/`
+- remove remaining direct `convos/` import paths outside `schemes/`
+
+## Review and verification checkpoints
+
+- after `#322`: run targeted core tests plus a top-branch `bun run check`
+- after `#325`: run targeted core and CLI tests plus a top-branch `bun run check`
+- after `#326`: run import-path sweep and full top-branch `bun run check`
+- after each later-stack fix from `#322` onward: `gt absorb -a`, `gt restack`,
+  then re-run top-branch verification
+
+## Guardrails
+
+- do not change Convos content-type strings, protobuf layouts, salts, or
+  signature behavior
+- keep user-facing CLI help text Convos-specific where behavior is still
+  Convos-only in this stack
+- do not widen scope into plugin loading, multi-scheme selection, or identity
+  model redesign

--- a/docs/onboarding-scheme-abstraction.md
+++ b/docs/onboarding-scheme-abstraction.md
@@ -1,0 +1,96 @@
+# Onboarding Scheme Abstraction
+
+Status: proposed
+Last updated: 2026-04-17
+Parent issue: #318
+
+## Goal
+
+Decouple Signet's onboarding flow from the Convos-specific implementation so
+the signet runtime can support other invite, join, and profile schemes without
+changing the credential, policy, or seal model.
+
+This is an abstraction exercise, not a protocol rewrite. Convos remains the
+first and only scheme in this stack.
+
+## Hard compatibility guardrail
+
+The Convos wire protocol is fixed for interoperability. This stack must not
+change:
+
+- content type strings such as `convos.org/join_request:1.0`
+- protobuf field numbers or layouts
+- invite crypto defaults such as HKDF salt `"ConvosInviteV1"`
+- signature algorithm or verification behavior
+- invite tag storage or validation semantics
+- joiner-side slug extraction behavior from invite URLs
+
+The abstraction exists so a different scheme can coexist later. It does not
+make the Convos protocol itself configurable on the wire.
+
+## Proposed interface
+
+Add a single `OnboardingScheme` interface in `packages/core` that owns:
+
+- invite generation, parsing, and verification
+- host-side join request processing
+- profile update and snapshot encoding
+- profile resolution from message history
+- content codec registration and content-type accessors
+
+Convos remains one concrete implementation behind that interface.
+
+## Scope of change
+
+### Changes in this stack
+
+- define the `OnboardingScheme` contract and supporting types
+- extract shared invite crypto primitives into reusable utilities
+- wrap the current Convos behavior in `createConvosOnboardingScheme()`
+- inject the scheme into conversation actions, join orchestration, and SDK
+  codec registration
+- add `[onboarding] scheme = "convos"` to CLI config and resolve it at startup
+- move `packages/core/src/convos/` to `packages/core/src/schemes/convos/`
+
+### Explicit non-goals
+
+- no plugin loading or dynamic scheme discovery
+- no multi-scheme-per-signet support
+- no redesign of identity mode behavior
+- no user-facing CLI taxonomy change beyond onboarding config
+- no protocol migration for existing Convos messages or invites
+
+## Runtime model
+
+Each signet instance resolves exactly one onboarding scheme at startup:
+
+```toml
+[onboarding]
+scheme = "convos"
+```
+
+The runtime resolves the configured ID with a static switch and passes the
+resulting scheme object into the core seams that need it.
+
+## Integration points
+
+The scheme gets wired into these internal seams:
+
+- `createConversationActions(...)`
+- `joinConversation(...)`
+- `createSdkClientFactory(...)`
+- SDK content-type detection in `sdk-client.ts`
+- invite-host startup wiring in `packages/cli/src/start.ts`
+
+## Migration order
+
+1. Define the interface and types
+2. Extract shared crypto utilities
+3. Implement the Convos scheme wrapper
+4. Add equivalence tests proving byte-for-byte compatibility
+5. Swap internal call sites to the injected scheme
+6. Add config and runtime resolution
+7. Move files under `schemes/convos/`
+
+The equivalence suite is the main safety gate. No behavioral call-site swap
+should land before it passes.


### PR DESCRIPTION
## Summary
- promote the onboarding-scheme abstraction note into tracked repo docs
- add a tracked execution guide under `.agents/plans/v1/` for the full #318 stack
- record branch order, issue mapping, and the no-wire-change guardrail

## Validation
- `bun run check` on `v1/onboarding-schemes-move`

Refs #318