### PR TITLE
refactor(core): extract shared invite crypto

### DIFF
--- a/packages/core/src/convos/invite-generator.ts
+++ b/packages/core/src/convos/invite-generator.ts
@@ -1,12 +1,8 @@
-import { deflateSync } from "node:zlib";
 import { Result } from "better-result";
 import protobuf from "protobufjs";
 import { InternalError } from "@xmtp/signet-schemas";
 import type { SignetError } from "@xmtp/signet-schemas";
-import { chacha20poly1305 } from "@noble/ciphers/chacha.js";
-import { hkdf } from "@noble/hashes/hkdf";
-import { sha256 as nobleSha256 } from "@noble/hashes/sha256";
-import { secp256k1 } from "@noble/curves/secp256k1";
+import { createInviteCrypto } from "../schemes/invite-crypto.js";
 
 // --- Protobuf schema definitions (must match invite-parser.ts) ---
 
@@ -31,10 +27,11 @@ new protobuf.Root().add(InvitePayloadType).add(SignedInviteType);
 
 // --- Constants ---
 
-const FORMAT_VERSION = 1;
-const HKDF_SALT = new TextEncoder().encode("ConvosInviteV1");
-const COMPRESSION_MARKER = 0x1f;
 const SEPARATOR_INTERVAL = 300;
+
+const convosInviteCrypto = createInviteCrypto({
+  salt: "ConvosInviteV1",
+});
 
 // --- Types ---
 
@@ -64,16 +61,6 @@ export interface GenerateInviteSlugOptions {
 export interface GenerateInviteUrlOptions extends GenerateInviteSlugOptions {
   /** XMTP environment: "production" or "dev". Defaults to "production". */
   readonly env?: "production" | "dev" | "local";
-}
-
-// --- Key derivation ---
-
-function deriveTokenKey(
-  privateKeyBytes: Uint8Array,
-  inboxId: string,
-): Uint8Array {
-  const info = new TextEncoder().encode(`inbox:${inboxId}`);
-  return hkdf(nobleSha256, privateKeyBytes, HKDF_SALT, info, 32);
 }
 
 // --- Conversation ID packing ---
@@ -152,20 +139,11 @@ function encryptConversationToken(
   creatorInboxId: string,
   privateKeyBytes: Uint8Array,
 ): Uint8Array {
-  const key = deriveTokenKey(privateKeyBytes, creatorInboxId);
-  const plaintext = packConversationId(conversationId);
-  const nonce = crypto.getRandomValues(new Uint8Array(12));
-  const aad = new TextEncoder().encode(creatorInboxId);
-
-  const cipher = chacha20poly1305(key, nonce, aad);
-  const ciphertext = cipher.encrypt(plaintext);
-
-  // Token format: [version=0x01][12-byte nonce][ciphertext+authTag]
-  const token = new Uint8Array(1 + 12 + ciphertext.length);
-  token[0] = FORMAT_VERSION;
-  token.set(nonce, 1);
-  token.set(ciphertext, 13);
-  return token;
+  return convosInviteCrypto.encryptToken(
+    packConversationId(conversationId),
+    creatorInboxId,
+    privateKeyBytes,
+  );
 }
 
 /**
@@ -177,17 +155,13 @@ export function decryptConversationToken(
   creatorInboxId: string,
   privateKeyBytes: Uint8Array,
 ): string {
-  if (tokenBytes[0] !== FORMAT_VERSION) {
-    throw new Error(`Unsupported token version: ${tokenBytes[0]}`);
-  }
-  const nonce = tokenBytes.slice(1, 13);
-  const ciphertextWithTag = tokenBytes.slice(13);
-  const key = deriveTokenKey(privateKeyBytes, creatorInboxId);
-  const aad = new TextEncoder().encode(creatorInboxId);
-
-  const cipher = chacha20poly1305(key, nonce, aad);
-  const plaintext = cipher.decrypt(ciphertextWithTag);
-  return unpackConversationId(plaintext);
+  return unpackConversationId(
+    convosInviteCrypto.decryptToken(
+      tokenBytes,
+      creatorInboxId,
+      privateKeyBytes,
+    ),
+  );
 }
 
 // --- Hex helpers ---
@@ -205,46 +179,10 @@ function bytesToHex(bytes: Uint8Array): string {
   return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-// --- secp256k1 signing ---
-
-/**
- * Sign a message hash with secp256k1 and produce a 65-byte recoverable
- * signature (r:32 + s:32 + recovery:1).
- */
-function signWithRecovery(
-  messageHash: Uint8Array,
-  privateKeyBytes: Uint8Array,
-): Uint8Array {
-  const sig = secp256k1.sign(messageHash, privateKeyBytes);
-  const compact = sig.toCompactRawBytes();
-  const result = new Uint8Array(65);
-  result.set(compact, 0);
-  result[64] = sig.recovery;
-  return result;
-}
-
 // --- Base64URL ---
 
 function base64UrlEncode(data: Uint8Array): string {
   return Buffer.from(data).toString("base64url");
-}
-
-// --- Compression ---
-
-function compressIfSmaller(data: Uint8Array): Uint8Array {
-  if (data.length <= 100) return data;
-  const compressed = deflateSync(data);
-  if (compressed.length + 5 < data.length) {
-    const result = new Uint8Array(compressed.length + 5);
-    result[0] = COMPRESSION_MARKER;
-    result[1] = (data.length >>> 24) & 0xff;
-    result[2] = (data.length >>> 16) & 0xff;
-    result[3] = (data.length >>> 8) & 0xff;
-    result[4] = data.length & 0xff;
-    result.set(new Uint8Array(compressed), 5);
-    return result;
-  }
-  return data;
 }
 
 // --- iMessage compatibility ---
@@ -312,8 +250,7 @@ export async function generateConvosInviteSlug(
     ).finish();
 
     // Step 3: Sign SHA256(payload) with secp256k1
-    const messageHash = nobleSha256(payloadBytes);
-    const signature = signWithRecovery(messageHash, privateKeyBytes);
+    const signature = convosInviteCrypto.sign(payloadBytes, privateKeyBytes);
 
     // Step 4: Wrap in SignedInvite
     const signedInviteBytes = SignedInviteType.encode(
@@ -324,7 +261,7 @@ export async function generateConvosInviteSlug(
     ).finish();
 
     // Compress if beneficial
-    const compressed = compressIfSmaller(signedInviteBytes);
+    const compressed = convosInviteCrypto.compress(signedInviteBytes);
 
     // Step 5: Base64url encode and insert separators
     const encoded = base64UrlEncode(compressed);

--- a/packages/core/src/convos/invite-parser.ts
+++ b/packages/core/src/convos/invite-parser.ts
@@ -1,11 +1,9 @@
-import { inflateSync } from "node:zlib";
 import { Result } from "better-result";
 import { ValidationError } from "@xmtp/signet-schemas";
 import type { SignetError } from "@xmtp/signet-schemas";
 import protobuf from "protobufjs";
 import Long from "long";
-import { secp256k1 } from "@noble/curves/secp256k1";
-import { sha256 } from "@noble/hashes/sha256";
+import { createInviteCrypto } from "../schemes/invite-crypto.js";
 
 // --- Protobuf schema definitions (programmatic, matching Convos format) ---
 
@@ -38,10 +36,9 @@ new protobuf.Root().add(InvitePayloadType).add(SignedInviteType);
  * Format: [0x1f marker][4-byte BE original size][zlib deflate data]
  * Matches the iOS and CLI implementations.
  */
-const COMPRESSION_MARKER = 0x1f;
-
-/** Maximum decompressed size (1 MB) to prevent decompression bombs. */
-const MAX_DECOMPRESSED_SIZE = 1024 * 1024;
+const convosInviteCrypto = createInviteCrypto({
+  salt: "ConvosInviteV1",
+});
 
 // --- Types ---
 
@@ -101,27 +98,6 @@ function base64UrlDecode(str: string): Uint8Array {
   const padLength = (4 - (base64.length % 4)) % 4;
   base64 += "=".repeat(padLength);
   return new Uint8Array(Buffer.from(base64, "base64"));
-}
-
-function decompress(data: Uint8Array): Result<Uint8Array, SignetError> {
-  if (data.length === 0 || data[0] !== COMPRESSION_MARKER) {
-    return Result.ok(data);
-  }
-
-  // Skip 5-byte header: [marker][4-byte BE original size]
-  const compressed = data.slice(5);
-  const decompressed = inflateSync(compressed);
-
-  if (decompressed.length > MAX_DECOMPRESSED_SIZE) {
-    return Result.err(
-      ValidationError.create(
-        "inviteUrl",
-        `Decompressed size exceeds maximum: ${decompressed.length}`,
-      ),
-    );
-  }
-
-  return Result.ok(new Uint8Array(decompressed));
 }
 
 /**
@@ -192,7 +168,9 @@ export function parseConvosInviteUrl(
     }
 
     // Step 4: Decompress
-    const decompressResult = decompress(decoded);
+    const decompressResult = convosInviteCrypto.decompress(decoded, {
+      errorField: "inviteUrl",
+    });
     if (decompressResult.isErr()) return decompressResult;
     const decompressed = decompressResult.value;
 
@@ -307,23 +285,10 @@ export function verifyConvosInvite(
       );
     }
 
-    const messageHash = sha256(signedInvitePayloadBytes);
-    const compactSig = signedInviteSignature.slice(0, 64);
-    const recoveryBit = signedInviteSignature[64];
-
-    if (recoveryBit === undefined || recoveryBit > 3) {
-      return Result.err(
-        ValidationError.create(
-          "inviteSignature",
-          `Invalid recovery bit: ${recoveryBit}`,
-        ),
-      );
-    }
-
-    // Attempt to recover public key -- will throw if signature is invalid
-    const sig =
-      secp256k1.Signature.fromCompact(compactSig).addRecoveryBit(recoveryBit);
-    sig.recoverPublicKey(messageHash);
+    convosInviteCrypto.recoverPublicKey(
+      signedInvitePayloadBytes,
+      signedInviteSignature,
+    );
 
     return Result.ok();
   } catch (cause) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -109,6 +109,11 @@ export type {
   ProfileData,
   ResolvedOnboardingProfile,
 } from "./schemes/onboarding-scheme.js";
+export {
+  createInviteCrypto,
+  type InviteCrypto,
+  type InviteCryptoConfig,
+} from "./schemes/invite-crypto.js";
 
 // Message actions
 export { createMessageActions } from "./message-actions.js";

--- a/packages/core/src/schemes/__tests__/invite-crypto.test.ts
+++ b/packages/core/src/schemes/__tests__/invite-crypto.test.ts
@@ -18,6 +18,24 @@ function buildCompressedPayload(
 }
 
 describe("createInviteCrypto", () => {
+  test("rejects a format version outside the byte range", () => {
+    expect(() =>
+      createInviteCrypto({
+        salt: "TestInviteCrypto",
+        formatVersion: 256,
+      }),
+    ).toThrow(/formatVersion must be an integer between 0 and 255/);
+  });
+
+  test("rejects a compression marker outside the byte range", () => {
+    expect(() =>
+      createInviteCrypto({
+        salt: "TestInviteCrypto",
+        compressionMarker: -1,
+      }),
+    ).toThrow(/compressionMarker must be an integer between 0 and 255/);
+  });
+
   test("rejects compressed payloads whose declared size exceeds the configured maximum", () => {
     const crypto = createInviteCrypto({
       salt: "TestInviteCrypto",

--- a/packages/core/src/schemes/__tests__/invite-crypto.test.ts
+++ b/packages/core/src/schemes/__tests__/invite-crypto.test.ts
@@ -1,0 +1,56 @@
+import { deflateSync } from "node:zlib";
+import { describe, expect, test } from "bun:test";
+import { createInviteCrypto } from "../invite-crypto.js";
+
+function buildCompressedPayload(
+  plaintext: Uint8Array,
+  declaredSize: number = plaintext.length,
+): Uint8Array {
+  const compressed = new Uint8Array(deflateSync(plaintext));
+  const result = new Uint8Array(compressed.length + 5);
+  result[0] = 0x1f;
+  result[1] = (declaredSize >>> 24) & 0xff;
+  result[2] = (declaredSize >>> 16) & 0xff;
+  result[3] = (declaredSize >>> 8) & 0xff;
+  result[4] = declaredSize & 0xff;
+  result.set(compressed, 5);
+  return result;
+}
+
+describe("createInviteCrypto", () => {
+  test("rejects compressed payloads whose declared size exceeds the configured maximum", () => {
+    const crypto = createInviteCrypto({
+      salt: "TestInviteCrypto",
+      maxDecompressedSize: 64,
+    });
+
+    const payload = buildCompressedPayload(
+      new TextEncoder().encode("tiny"),
+      65,
+    );
+    const result = crypto.decompress(payload, { errorField: "inviteUrl" });
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+
+    expect(result.error.message).toContain("Decompressed size exceeds maximum");
+  });
+
+  test("returns a validation error when compressed data expands beyond maxOutputLength", () => {
+    const crypto = createInviteCrypto({
+      salt: "TestInviteCrypto",
+      maxDecompressedSize: 64,
+    });
+
+    const payload = buildCompressedPayload(
+      new TextEncoder().encode("A".repeat(1024)),
+      1,
+    );
+    const result = crypto.decompress(payload, { errorField: "inviteUrl" });
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+
+    expect(result.error.message).toContain("Failed to decompress invite data");
+  });
+});

--- a/packages/core/src/schemes/invite-crypto.ts
+++ b/packages/core/src/schemes/invite-crypto.ts
@@ -182,17 +182,48 @@ export function createInviteCrypto(config: InviteCryptoConfig): InviteCrypto {
         return BetterResult.ok(data);
       }
 
-      const decompressed = inflateSync(data.slice(5));
-      if (decompressed.length > maxDecompressedSize) {
+      if (data.length < 5) {
         return BetterResult.err(
           ValidationError.create(
             options?.errorField ?? "inviteData",
-            `Decompressed size exceeds maximum: ${decompressed.length}`,
+            "Compressed invite data is truncated",
           ),
         );
       }
 
-      return BetterResult.ok(new Uint8Array(decompressed));
+      const declaredSize =
+        data[1]! * 0x1000000 + data[2]! * 0x10000 + data[3]! * 0x100 + data[4]!;
+      if (declaredSize > maxDecompressedSize) {
+        return BetterResult.err(
+          ValidationError.create(
+            options?.errorField ?? "inviteData",
+            `Decompressed size exceeds maximum: ${declaredSize}`,
+          ),
+        );
+      }
+
+      try {
+        const decompressed = inflateSync(data.slice(5), {
+          maxOutputLength: maxDecompressedSize,
+        });
+        if (decompressed.length > maxDecompressedSize) {
+          return BetterResult.err(
+            ValidationError.create(
+              options?.errorField ?? "inviteData",
+              `Decompressed size exceeds maximum: ${decompressed.length}`,
+            ),
+          );
+        }
+
+        return BetterResult.ok(new Uint8Array(decompressed));
+      } catch (cause) {
+        return BetterResult.err(
+          ValidationError.create(
+            options?.errorField ?? "inviteData",
+            `Failed to decompress invite data: ${cause instanceof Error ? cause.message : String(cause)}`,
+          ),
+        );
+      }
     },
   };
 }

--- a/packages/core/src/schemes/invite-crypto.ts
+++ b/packages/core/src/schemes/invite-crypto.ts
@@ -75,13 +75,28 @@ function createDeriveTokenKey(saltBytes: Uint8Array) {
   };
 }
 
+function requireByteConfig(field: string, value: number): number {
+  if (!Number.isInteger(value) || value < 0 || value > 0xff) {
+    throw new RangeError(
+      `${field} must be an integer between 0 and 255, received ${value}`,
+    );
+  }
+
+  return value;
+}
+
 /** Create the shared invite crypto implementation for one scheme. */
 export function createInviteCrypto(config: InviteCryptoConfig): InviteCrypto {
   const saltBytes = new TextEncoder().encode(config.salt);
   const deriveTokenKey = createDeriveTokenKey(saltBytes);
-  const formatVersion = config.formatVersion ?? DEFAULT_FORMAT_VERSION;
-  const compressionMarker =
-    config.compressionMarker ?? DEFAULT_COMPRESSION_MARKER;
+  const formatVersion = requireByteConfig(
+    "formatVersion",
+    config.formatVersion ?? DEFAULT_FORMAT_VERSION,
+  );
+  const compressionMarker = requireByteConfig(
+    "compressionMarker",
+    config.compressionMarker ?? DEFAULT_COMPRESSION_MARKER,
+  );
   const compressionThresholdBytes =
     config.compressionThresholdBytes ?? DEFAULT_COMPRESSION_THRESHOLD_BYTES;
   const maxDecompressedSize =

--- a/packages/core/src/schemes/invite-crypto.ts
+++ b/packages/core/src/schemes/invite-crypto.ts
@@ -1,0 +1,198 @@
+import { deflateSync, inflateSync } from "node:zlib";
+import type { Result } from "better-result";
+import { Result as BetterResult } from "better-result";
+import { ValidationError } from "@xmtp/signet-schemas";
+import type { SignetError } from "@xmtp/signet-schemas";
+import { chacha20poly1305 } from "@noble/ciphers/chacha.js";
+import { secp256k1 } from "@noble/curves/secp256k1";
+import { hkdf } from "@noble/hashes/hkdf";
+import { sha256 } from "@noble/hashes/sha256";
+
+const DEFAULT_FORMAT_VERSION = 1;
+const DEFAULT_COMPRESSION_MARKER = 0x1f;
+const DEFAULT_COMPRESSION_THRESHOLD_BYTES = 100;
+const DEFAULT_MAX_DECOMPRESSED_SIZE = 1024 * 1024;
+
+/** Configuration for a concrete onboarding scheme's invite crypto behavior. */
+export interface InviteCryptoConfig {
+  /** HKDF salt string used for token key derivation. */
+  readonly salt: string;
+  /** Token format version byte. Defaults to `1`. */
+  readonly formatVersion?: number;
+  /** Compression marker byte. Defaults to `0x1f`. */
+  readonly compressionMarker?: number;
+  /** Minimum payload size before compression is attempted. Defaults to `100`. */
+  readonly compressionThresholdBytes?: number;
+  /**
+   * Maximum allowed decompressed size to prevent decompression bombs.
+   * Defaults to `1 MiB`.
+   */
+  readonly maxDecompressedSize?: number;
+}
+
+/** Shared invite crypto primitives used by onboarding schemes. */
+export interface InviteCrypto {
+  /** Encrypt an opaque token payload for transport inside an invite. */
+  encryptToken(
+    plaintext: Uint8Array,
+    inboxId: string,
+    privateKeyBytes: Uint8Array,
+  ): Uint8Array;
+
+  /** Decrypt an opaque token payload carried inside an invite. */
+  decryptToken(
+    tokenBytes: Uint8Array,
+    inboxId: string,
+    privateKeyBytes: Uint8Array,
+  ): Uint8Array;
+
+  /** Sign payload bytes with a recoverable secp256k1 signature. */
+  sign(payloadBytes: Uint8Array, privateKeyBytes: Uint8Array): Uint8Array;
+
+  /** Recover the signer's public key from a recoverable invite signature. */
+  recoverPublicKey(
+    payloadBytes: Uint8Array,
+    signatureBytes: Uint8Array,
+  ): Uint8Array;
+
+  /** Conditionally compress payload bytes when it materially helps. */
+  compress(data: Uint8Array): Uint8Array;
+
+  /** Decompress payload bytes when the configured marker is present. */
+  decompress(
+    data: Uint8Array,
+    options?: { readonly errorField?: string },
+  ): Result<Uint8Array, SignetError>;
+}
+
+function createDeriveTokenKey(saltBytes: Uint8Array) {
+  return function deriveTokenKey(
+    privateKeyBytes: Uint8Array,
+    inboxId: string,
+  ): Uint8Array {
+    const info = new TextEncoder().encode(`inbox:${inboxId}`);
+    return hkdf(sha256, privateKeyBytes, saltBytes, info, 32);
+  };
+}
+
+/** Create the shared invite crypto implementation for one scheme. */
+export function createInviteCrypto(config: InviteCryptoConfig): InviteCrypto {
+  const saltBytes = new TextEncoder().encode(config.salt);
+  const deriveTokenKey = createDeriveTokenKey(saltBytes);
+  const formatVersion = config.formatVersion ?? DEFAULT_FORMAT_VERSION;
+  const compressionMarker =
+    config.compressionMarker ?? DEFAULT_COMPRESSION_MARKER;
+  const compressionThresholdBytes =
+    config.compressionThresholdBytes ?? DEFAULT_COMPRESSION_THRESHOLD_BYTES;
+  const maxDecompressedSize =
+    config.maxDecompressedSize ?? DEFAULT_MAX_DECOMPRESSED_SIZE;
+
+  return {
+    encryptToken(
+      plaintext: Uint8Array,
+      inboxId: string,
+      privateKeyBytes: Uint8Array,
+    ): Uint8Array {
+      const key = deriveTokenKey(privateKeyBytes, inboxId);
+      const nonce = crypto.getRandomValues(new Uint8Array(12));
+      const aad = new TextEncoder().encode(inboxId);
+      const cipher = chacha20poly1305(key, nonce, aad);
+      const ciphertext = cipher.encrypt(plaintext);
+
+      const token = new Uint8Array(1 + nonce.length + ciphertext.length);
+      token[0] = formatVersion;
+      token.set(nonce, 1);
+      token.set(ciphertext, 1 + nonce.length);
+      return token;
+    },
+
+    decryptToken(
+      tokenBytes: Uint8Array,
+      inboxId: string,
+      privateKeyBytes: Uint8Array,
+    ): Uint8Array {
+      if (tokenBytes[0] !== formatVersion) {
+        throw new Error(`Unsupported token version: ${tokenBytes[0]}`);
+      }
+
+      const nonce = tokenBytes.slice(1, 13);
+      const ciphertextWithTag = tokenBytes.slice(13);
+      const key = deriveTokenKey(privateKeyBytes, inboxId);
+      const aad = new TextEncoder().encode(inboxId);
+      const cipher = chacha20poly1305(key, nonce, aad);
+      return cipher.decrypt(ciphertextWithTag);
+    },
+
+    sign(payloadBytes: Uint8Array, privateKeyBytes: Uint8Array): Uint8Array {
+      const sig = secp256k1.sign(sha256(payloadBytes), privateKeyBytes);
+      const compact = sig.toCompactRawBytes();
+      const result = new Uint8Array(65);
+      result.set(compact, 0);
+      result[64] = sig.recovery;
+      return result;
+    },
+
+    recoverPublicKey(
+      payloadBytes: Uint8Array,
+      signatureBytes: Uint8Array,
+    ): Uint8Array {
+      if (signatureBytes.length !== 65) {
+        throw new Error(
+          `Invalid signature length: expected 65 bytes, got ${signatureBytes.length}`,
+        );
+      }
+
+      const compactSig = signatureBytes.slice(0, 64);
+      const recoveryBit = signatureBytes[64];
+
+      if (recoveryBit === undefined || recoveryBit > 3) {
+        throw new Error(`Invalid recovery bit: ${recoveryBit}`);
+      }
+
+      const sig =
+        secp256k1.Signature.fromCompact(compactSig).addRecoveryBit(recoveryBit);
+      return sig.recoverPublicKey(sha256(payloadBytes)).toRawBytes(false);
+    },
+
+    compress(data: Uint8Array): Uint8Array {
+      if (data.length <= compressionThresholdBytes) {
+        return data;
+      }
+
+      const compressed = deflateSync(data);
+      if (compressed.length + 5 < data.length) {
+        const result = new Uint8Array(compressed.length + 5);
+        result[0] = compressionMarker;
+        result[1] = (data.length >>> 24) & 0xff;
+        result[2] = (data.length >>> 16) & 0xff;
+        result[3] = (data.length >>> 8) & 0xff;
+        result[4] = data.length & 0xff;
+        result.set(new Uint8Array(compressed), 5);
+        return result;
+      }
+
+      return data;
+    },
+
+    decompress(
+      data: Uint8Array,
+      options?: { readonly errorField?: string },
+    ): Result<Uint8Array, SignetError> {
+      if (data.length === 0 || data[0] !== compressionMarker) {
+        return BetterResult.ok(data);
+      }
+
+      const decompressed = inflateSync(data.slice(5));
+      if (decompressed.length > maxDecompressedSize) {
+        return BetterResult.err(
+          ValidationError.create(
+            options?.errorField ?? "inviteData",
+            `Decompressed size exceeds maximum: ${decompressed.length}`,
+          ),
+        );
+      }
+
+      return BetterResult.ok(new Uint8Array(decompressed));
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- extract shared invite cryptography helpers into `packages/core/src/schemes/invite-crypto.ts`
- refactor Convos invite generation and parsing to use the shared helpers with the existing `ConvosInviteV1` salt
- preserve existing invite bytes and public behavior while introducing the reusable seam

## Validation
- `bun run check` on `v1/onboarding-schemes-move`

Closes #320