### PR TITLE
feat(core): implement convos onboarding scheme

### DIFF
--- a/packages/core/src/convos/__tests__/onboarding-scheme.test.ts
+++ b/packages/core/src/convos/__tests__/onboarding-scheme.test.ts
@@ -9,6 +9,39 @@ const TEST_CREATOR_INBOX_ID =
 
 const TEST_CONVERSATION_ID = "550e8400-e29b-41d4-a716-446655440000";
 
+async function withFixedRandomValues<T>(
+  seed: Uint8Array,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const original = globalThis.crypto.getRandomValues.bind(globalThis.crypto);
+
+  Object.defineProperty(globalThis.crypto, "getRandomValues", {
+    configurable: true,
+    value<TArray extends ArrayBufferView | null>(array: TArray): TArray {
+      if (array === null) {
+        return array;
+      }
+
+      const bytes = new Uint8Array(
+        array.buffer,
+        array.byteOffset,
+        array.byteLength,
+      );
+      bytes.set(seed.slice(0, bytes.length));
+      return array;
+    },
+  });
+
+  try {
+    return await fn();
+  } finally {
+    Object.defineProperty(globalThis.crypto, "getRandomValues", {
+      configurable: true,
+      value: original,
+    });
+  }
+}
+
 describe("createConvosOnboardingScheme", () => {
   test("roundtrips a generated invite through parse and verify", async () => {
     const scheme = createConvosOnboardingScheme();
@@ -51,5 +84,39 @@ describe("createConvosOnboardingScheme", () => {
       "convos.org/profile_snapshot:1.0",
     );
     expect(scheme.errorContentType()).toBe("convos.app/inviteJoinError:1.0");
+  });
+
+  test("honors the conversation format hint for UUID-shaped ids", async () => {
+    await withFixedRandomValues(
+      Uint8Array.from({ length: 12 }, (_, i) => i),
+      async () => {
+        const scheme = createConvosOnboardingScheme();
+        const creator = {
+          creatorInboxId: TEST_CREATOR_INBOX_ID,
+          walletPrivateKeyHex: TEST_PRIVATE_KEY_HEX,
+        };
+        const metadata = { tag: "format-hint" };
+        const options = { env: "production" as const };
+
+        const uuidEncoded = await scheme.generate(
+          { groupId: TEST_CONVERSATION_ID, format: "uuid" },
+          creator,
+          metadata,
+          options,
+        );
+        const stringEncoded = await scheme.generate(
+          { groupId: TEST_CONVERSATION_ID, format: "string" },
+          creator,
+          metadata,
+          options,
+        );
+
+        expect(uuidEncoded.isOk()).toBe(true);
+        expect(stringEncoded.isOk()).toBe(true);
+        if (!uuidEncoded.isOk() || !stringEncoded.isOk()) return;
+
+        expect(uuidEncoded.value.slug).not.toBe(stringEncoded.value.slug);
+      },
+    );
   });
 });

--- a/packages/core/src/convos/__tests__/onboarding-scheme.test.ts
+++ b/packages/core/src/convos/__tests__/onboarding-scheme.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { createConvosOnboardingScheme } from "../onboarding-scheme.js";
+
+const TEST_PRIVATE_KEY_HEX =
+  "0000000000000000000000000000000000000000000000000000000000000001";
+
+const TEST_CREATOR_INBOX_ID =
+  "aabbccddee1122334455667788990011aabbccddee1122334455667788990011";
+
+const TEST_CONVERSATION_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("createConvosOnboardingScheme", () => {
+  test("roundtrips a generated invite through parse and verify", async () => {
+    const scheme = createConvosOnboardingScheme();
+
+    const generated = await scheme.generate(
+      { groupId: TEST_CONVERSATION_ID, format: "uuid" },
+      {
+        creatorInboxId: TEST_CREATOR_INBOX_ID,
+        walletPrivateKeyHex: TEST_PRIVATE_KEY_HEX,
+      },
+      {
+        tag: "scheme-test-tag",
+        name: "Scheme Test",
+      },
+      { env: "production" },
+    );
+
+    expect(generated.isOk()).toBe(true);
+    if (!generated.isOk()) return;
+
+    const parsed = scheme.parse(generated.value.url);
+    expect(parsed.isOk()).toBe(true);
+    if (!parsed.isOk()) return;
+
+    expect(parsed.value.schemeId).toBe("convos");
+    expect(parsed.value.tag).toBe("scheme-test-tag");
+
+    const verified = scheme.verify(parsed.value);
+    expect(verified.isOk()).toBe(true);
+  });
+
+  test("surfaces canonical content-type labels", () => {
+    const scheme = createConvosOnboardingScheme();
+
+    expect(scheme.joinRequestContentType()).toBe("convos.org/join_request:1.0");
+    expect(scheme.profileUpdateContentType()).toBe(
+      "convos.org/profile_update:1.0",
+    );
+    expect(scheme.profileSnapshotContentType()).toBe(
+      "convos.org/profile_snapshot:1.0",
+    );
+    expect(scheme.errorContentType()).toBe("convos.app/inviteJoinError:1.0");
+  });
+});

--- a/packages/core/src/convos/__tests__/onboarding-scheme.test.ts
+++ b/packages/core/src/convos/__tests__/onboarding-scheme.test.ts
@@ -119,4 +119,58 @@ describe("createConvosOnboardingScheme", () => {
       },
     );
   });
+
+  test("rejects plain image URLs when encoding a profile update", () => {
+    const scheme = createConvosOnboardingScheme();
+
+    expect(() =>
+      scheme.encodeProfileUpdate({
+        name: "Codex",
+        imageUrl: "https://example.com/avatar.png",
+      }),
+    ).toThrow("imageUrl");
+  });
+
+  test("rejects plain image URLs when encoding a profile snapshot", () => {
+    const scheme = createConvosOnboardingScheme();
+
+    expect(() =>
+      scheme.encodeProfileSnapshot([
+        {
+          inboxId: "inbox-a",
+          name: "Codex",
+          imageUrl: "https://example.com/avatar.png",
+        },
+      ]),
+    ).toThrow("imageUrl");
+  });
+
+  test("surfaces encrypted image URLs when resolving profile history", () => {
+    const scheme = createConvosOnboardingScheme();
+
+    const resolved = scheme.resolveProfilesFromHistory([
+      {
+        messageId: "msg-1",
+        groupId: "group-1",
+        senderInboxId: "inbox-a",
+        contentType: scheme.profileUpdateContentType(),
+        content: {
+          name: "Codex",
+          encryptedImage: {
+            url: "https://example.com/avatar.png",
+            salt: new Uint8Array([1, 2, 3]),
+            nonce: new Uint8Array([4, 5, 6]),
+          },
+        },
+        sentAt: "2026-04-18T03:00:00.000Z",
+        threadId: null,
+      },
+    ]);
+
+    expect(resolved.get("inbox-a")).toEqual({
+      inboxId: "inbox-a",
+      name: "Codex",
+      imageUrl: "https://example.com/avatar.png",
+    });
+  });
 });

--- a/packages/core/src/convos/invite-generator.ts
+++ b/packages/core/src/convos/invite-generator.ts
@@ -35,10 +35,18 @@ const convosInviteCrypto = createInviteCrypto({
 
 // --- Types ---
 
+/** Preferred packing strategy for a conversation ID in a Convos invite. */
+export type ConversationIdFormat = "uuid" | "string";
+
 /** Options for generating a Convos invite slug. */
 export interface GenerateInviteSlugOptions {
   /** The conversation/group ID to encrypt into the invite. */
   readonly conversationId: string;
+  /**
+   * Optional packing hint for UUID-shaped IDs that should still be encoded
+   * as plain strings.
+   */
+  readonly conversationIdFormat?: ConversationIdFormat;
   /** Hex-encoded creator inbox ID. */
   readonly creatorInboxId: string;
   /** Hex-encoded secp256k1 private key (without 0x prefix). */
@@ -65,11 +73,23 @@ export interface GenerateInviteUrlOptions extends GenerateInviteSlugOptions {
 
 // --- Conversation ID packing ---
 
-function packConversationId(conversationId: string): Uint8Array {
+function packConversationId(
+  conversationId: string,
+  format?: ConversationIdFormat,
+): Uint8Array {
   const uuidMatch = conversationId.match(
     /^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})$/i,
   );
-  if (uuidMatch) {
+  const shouldUseUuidEncoding =
+    format === "uuid" ? true : format === "string" ? false : uuidMatch !== null;
+
+  if (shouldUseUuidEncoding) {
+    if (!uuidMatch) {
+      throw new Error(
+        `Conversation ID format "uuid" requires a canonical UUID: ${conversationId}`,
+      );
+    }
+
     const hex = uuidMatch.slice(1).join("");
     const uuidBytes = hexToBytes(hex);
     const result = new Uint8Array(1 + uuidBytes.length);
@@ -136,11 +156,12 @@ export function unpackConversationId(data: Uint8Array): string {
 
 function encryptConversationToken(
   conversationId: string,
+  conversationIdFormat: ConversationIdFormat | undefined,
   creatorInboxId: string,
   privateKeyBytes: Uint8Array,
 ): Uint8Array {
   return convosInviteCrypto.encryptToken(
-    packConversationId(conversationId),
+    packConversationId(conversationId, conversationIdFormat),
     creatorInboxId,
     privateKeyBytes,
   );
@@ -217,6 +238,7 @@ export async function generateConvosInviteSlug(
     // Step 1: Encrypt conversation ID
     const conversationToken = encryptConversationToken(
       opts.conversationId,
+      opts.conversationIdFormat,
       opts.creatorInboxId,
       privateKeyBytes,
     );

--- a/packages/core/src/convos/onboarding-scheme.ts
+++ b/packages/core/src/convos/onboarding-scheme.ts
@@ -54,12 +54,16 @@ function resolveInviteBaseUrl(env: InviteOptions["env"]): string {
 
 function toGenerateInviteSlugOptions(
   conversationId: string,
+  conversationFormat: "uuid" | "string" | undefined,
   creator: CreatorContext,
   metadata: InviteMetadata,
   options: InviteOptions,
 ): GenerateInviteSlugOptions {
   return {
     conversationId,
+    ...(conversationFormat !== undefined
+      ? { conversationIdFormat: conversationFormat }
+      : {}),
     creatorInboxId: creator.creatorInboxId,
     walletPrivateKeyHex: creator.walletPrivateKeyHex,
     inviteTag: metadata.tag,
@@ -231,6 +235,7 @@ export function createConvosOnboardingScheme(): OnboardingScheme {
       const slugResult = await generateConvosInviteSlug(
         toGenerateInviteSlugOptions(
           conversation.groupId,
+          conversation.format,
           creator,
           metadata,
           options,

--- a/packages/core/src/convos/onboarding-scheme.ts
+++ b/packages/core/src/convos/onboarding-scheme.ts
@@ -135,7 +135,19 @@ function fromConvosMemberKind(
   return undefined;
 }
 
+function assertNoPlainProfileImageUrl(
+  profile: Pick<ProfileData, "imageUrl">,
+): void {
+  if (profile.imageUrl !== undefined) {
+    throw ValidationError.create(
+      "imageUrl",
+      "Convos profile messages require encrypted image metadata; raw image URLs are not supported",
+    );
+  }
+}
+
 function toProfileUpdateContent(profile: ProfileData): ProfileUpdateContent {
+  assertNoPlainProfileImageUrl(profile);
   const memberKind = toConvosMemberKind(profile.memberKind);
   const metadata = toConvosProfileMetadata(profile.metadata);
 
@@ -147,6 +159,7 @@ function toProfileUpdateContent(profile: ProfileData): ProfileUpdateContent {
 }
 
 function toMemberProfileEntry(profile: MemberProfileData): MemberProfileEntry {
+  assertNoPlainProfileImageUrl(profile);
   const memberKind = toConvosMemberKind(profile.memberKind);
   const metadata = toConvosProfileMetadata(profile.metadata);
 
@@ -216,6 +229,9 @@ function toResolvedProfile(
   return {
     inboxId: profile.inboxId,
     ...(profile.name !== undefined ? { name: profile.name } : {}),
+    ...(profile.encryptedImage !== undefined
+      ? { imageUrl: profile.encryptedImage.url }
+      : {}),
     ...(memberKind !== undefined ? { memberKind } : {}),
     ...(metadata !== undefined ? { metadata } : {}),
   };

--- a/packages/core/src/convos/onboarding-scheme.ts
+++ b/packages/core/src/convos/onboarding-scheme.ts
@@ -1,0 +1,332 @@
+import { Result } from "better-result";
+import { ValidationError } from "@xmtp/signet-schemas";
+import type { SignetError } from "@xmtp/signet-schemas";
+import type {
+  CreatorContext,
+  EncodedOnboardingContent,
+  IncomingJoinRequestMessage,
+  InviteMetadata,
+  InviteOptions,
+  MemberProfileData,
+  OnboardingContentTypeId,
+  OnboardingScheme,
+  ParsedInvite,
+  ProcessedJoinRequest,
+  ProfileData,
+  ResolvedOnboardingProfile,
+} from "../schemes/onboarding-scheme.js";
+import { createConvosCodecs } from "./codecs.js";
+import {
+  generateConvosInviteSlug,
+  type GenerateInviteSlugOptions,
+} from "./invite-generator.js";
+import { ContentTypeInviteJoinError } from "./invite-join-error.js";
+import {
+  ContentTypeJoinRequest,
+  isEncodedConvosContent,
+  isJoinRequestContentType,
+} from "./join-request-content.js";
+import { parseConvosInviteUrl, verifyConvosInvite } from "./invite-parser.js";
+import {
+  ContentTypeProfileSnapshot,
+  ContentTypeProfileUpdate,
+  encodeProfileSnapshot,
+  encodeProfileUpdate,
+  MemberKind,
+  type MemberProfileEntry,
+  type ProfileMetadata,
+  type ProfileMetadataValue,
+  type ProfileSnapshotContent,
+  type ProfileUpdateContent,
+} from "./profile-messages.js";
+import { resolveProfilesFromMessages } from "./profile-state.js";
+import { processJoinRequest } from "./process-join-requests.js";
+
+function formatContentType(contentType: OnboardingContentTypeId): string {
+  return `${contentType.authorityId}/${contentType.typeId}:${contentType.versionMajor}.${contentType.versionMinor}`;
+}
+
+function resolveInviteBaseUrl(env: InviteOptions["env"]): string {
+  return env === "dev" || env === "local"
+    ? "https://dev.convos.org/v2"
+    : "https://popup.convos.org/v2";
+}
+
+function toGenerateInviteSlugOptions(
+  conversationId: string,
+  creator: CreatorContext,
+  metadata: InviteMetadata,
+  options: InviteOptions,
+): GenerateInviteSlugOptions {
+  return {
+    conversationId,
+    creatorInboxId: creator.creatorInboxId,
+    walletPrivateKeyHex: creator.walletPrivateKeyHex,
+    inviteTag: metadata.tag,
+    ...(metadata.name !== undefined ? { name: metadata.name } : {}),
+    ...(metadata.description !== undefined
+      ? { description: metadata.description }
+      : {}),
+    ...(metadata.imageUrl !== undefined ? { imageUrl: metadata.imageUrl } : {}),
+    ...(options.expiresAt !== undefined
+      ? { expiresAt: options.expiresAt }
+      : {}),
+    ...(options.expiresAfterUse !== undefined
+      ? { expiresAfterUse: options.expiresAfterUse }
+      : {}),
+  };
+}
+
+function toConvosProfileMetadata(
+  metadata: ProfileData["metadata"],
+): ProfileMetadata | undefined {
+  if (!metadata) return undefined;
+
+  const converted: ProfileMetadata = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    const entry: ProfileMetadataValue =
+      typeof value === "string"
+        ? { type: "string", value }
+        : typeof value === "number"
+          ? { type: "number", value }
+          : { type: "bool", value };
+    converted[key] = entry;
+  }
+
+  return Object.keys(converted).length > 0 ? converted : undefined;
+}
+
+function fromConvosProfileMetadata(
+  metadata: ProfileMetadata | undefined,
+): ProfileData["metadata"] | undefined {
+  if (!metadata) return undefined;
+
+  const converted: ProfileData["metadata"] = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    converted[key] = value.value;
+  }
+
+  return Object.keys(converted).length > 0 ? converted : undefined;
+}
+
+function toConvosMemberKind(
+  memberKind: ProfileData["memberKind"],
+): MemberKind | undefined {
+  switch (memberKind) {
+    case "agent":
+      return MemberKind.Agent;
+    case "human":
+    case undefined:
+    default:
+      return undefined;
+  }
+}
+
+function fromConvosMemberKind(
+  memberKind: MemberKind | undefined,
+): ProfileData["memberKind"] | undefined {
+  if (memberKind === MemberKind.Agent) {
+    return "agent";
+  }
+  return undefined;
+}
+
+function toProfileUpdateContent(profile: ProfileData): ProfileUpdateContent {
+  const memberKind = toConvosMemberKind(profile.memberKind);
+  const metadata = toConvosProfileMetadata(profile.metadata);
+
+  return {
+    ...(profile.name !== undefined ? { name: profile.name } : {}),
+    ...(memberKind !== undefined ? { memberKind } : {}),
+    ...(metadata !== undefined ? { metadata } : {}),
+  };
+}
+
+function toMemberProfileEntry(profile: MemberProfileData): MemberProfileEntry {
+  const memberKind = toConvosMemberKind(profile.memberKind);
+  const metadata = toConvosProfileMetadata(profile.metadata);
+
+  return {
+    inboxId: profile.inboxId,
+    ...(profile.name !== undefined ? { name: profile.name } : {}),
+    ...(memberKind !== undefined ? { memberKind } : {}),
+    ...(metadata !== undefined ? { metadata } : {}),
+  };
+}
+
+function toParsedInvite(invite: ReturnType<typeof parseConvosInviteUrl>) {
+  if (invite.isErr()) return invite;
+  return Result.ok<ParsedInvite, SignetError>({
+    schemeId: "convos",
+    signedPayloadBytes: invite.value.signedInvitePayloadBytes,
+    signatureBytes: invite.value.signedInviteSignature,
+    conversationToken: invite.value.conversationToken,
+    creatorInboxId: invite.value.creatorInboxId,
+    tag: invite.value.tag,
+    ...(invite.value.name !== undefined ? { name: invite.value.name } : {}),
+    ...(invite.value.description !== undefined
+      ? { description: invite.value.description }
+      : {}),
+    ...(invite.value.imageUrl !== undefined
+      ? { imageUrl: invite.value.imageUrl }
+      : {}),
+    isExpired: invite.value.isExpired,
+    isConversationExpired: invite.value.isConversationExpired,
+    expiresAfterUse: invite.value.expiresAfterUse,
+  });
+}
+
+function toConvosParsedInvite(
+  invite: ParsedInvite,
+): Result<Parameters<typeof verifyConvosInvite>[0], SignetError> {
+  if (invite.schemeId !== "convos") {
+    return Result.err(
+      ValidationError.create(
+        "inviteScheme",
+        `Expected convos invite, received ${invite.schemeId}`,
+      ),
+    );
+  }
+
+  return Result.ok({
+    signedInvitePayloadBytes: invite.signedPayloadBytes,
+    signedInviteSignature: invite.signatureBytes,
+    conversationToken: invite.conversationToken,
+    creatorInboxId: invite.creatorInboxId,
+    tag: invite.tag,
+    name: invite.name,
+    description: invite.description,
+    imageUrl: invite.imageUrl,
+    isExpired: invite.isExpired,
+    isConversationExpired: invite.isConversationExpired,
+    expiresAfterUse: invite.expiresAfterUse,
+  });
+}
+
+function toResolvedProfile(
+  profile: MemberProfileEntry,
+): ResolvedOnboardingProfile {
+  const memberKind = fromConvosMemberKind(profile.memberKind);
+  const metadata = fromConvosProfileMetadata(profile.metadata);
+
+  return {
+    inboxId: profile.inboxId,
+    ...(profile.name !== undefined ? { name: profile.name } : {}),
+    ...(memberKind !== undefined ? { memberKind } : {}),
+    ...(metadata !== undefined ? { metadata } : {}),
+  };
+}
+
+/**
+ * Create the Convos implementation of the shared onboarding-scheme contract.
+ *
+ * This is a thin wrapper around the existing Convos invite, join, profile, and
+ * codec modules; it intentionally does not change any wire behavior.
+ */
+export function createConvosOnboardingScheme(): OnboardingScheme {
+  return {
+    id: "convos",
+
+    async generate(conversation, creator, metadata, options) {
+      const slugResult = await generateConvosInviteSlug(
+        toGenerateInviteSlugOptions(
+          conversation.groupId,
+          creator,
+          metadata,
+          options,
+        ),
+      );
+      if (slugResult.isErr()) return slugResult;
+
+      const baseUrl = resolveInviteBaseUrl(options.env);
+      const slug = slugResult.value;
+      return Result.ok({
+        url: `${baseUrl}?i=${encodeURIComponent(slug)}`,
+        slug,
+      });
+    },
+
+    parse(input) {
+      return toParsedInvite(parseConvosInviteUrl(input));
+    },
+
+    verify(invite) {
+      const convosInvite = toConvosParsedInvite(invite);
+      if (convosInvite.isErr()) return convosInvite;
+      return verifyConvosInvite(convosInvite.value);
+    },
+
+    async processJoinRequest(host, message) {
+      const result = await processJoinRequest(
+        {
+          walletPrivateKeyHex: host.walletPrivateKeyHex,
+          creatorInboxId: host.creatorInboxId,
+          addMembersToGroup: host.addMembersToGroup,
+          getGroupInviteTag: host.getGroupInviteTag,
+        },
+        {
+          senderInboxId: message.senderInboxId,
+          content: message.content,
+        } satisfies IncomingJoinRequestMessage,
+      );
+      if (result.isErr()) return result;
+
+      return Result.ok<ProcessedJoinRequest, SignetError>({
+        groupId: result.value.groupId,
+        requesterInboxId: result.value.requesterInboxId,
+        inviteTag: result.value.inviteTag,
+      });
+    },
+
+    encodeProfileUpdate(profile) {
+      return encodeProfileUpdate(
+        toProfileUpdateContent(profile),
+      ) as EncodedOnboardingContent;
+    },
+
+    encodeProfileSnapshot(members) {
+      const snapshot: ProfileSnapshotContent = {
+        profiles: members.map(toMemberProfileEntry),
+      };
+      return encodeProfileSnapshot(snapshot) as EncodedOnboardingContent;
+    },
+
+    resolveProfilesFromHistory(messages, memberInboxIds) {
+      const resolved = resolveProfilesFromMessages(messages, memberInboxIds);
+      return new Map(
+        Array.from(resolved.entries(), ([inboxId, profile]) => [
+          inboxId,
+          toResolvedProfile(profile),
+        ]),
+      );
+    },
+
+    codecs() {
+      return createConvosCodecs();
+    },
+
+    isEncodedContent(value): value is EncodedOnboardingContent {
+      return isEncodedConvosContent(value);
+    },
+
+    isJoinRequestContentType(contentType) {
+      return isJoinRequestContentType(contentType);
+    },
+
+    joinRequestContentType() {
+      return formatContentType(ContentTypeJoinRequest);
+    },
+
+    errorContentType() {
+      return formatContentType(ContentTypeInviteJoinError);
+    },
+
+    profileUpdateContentType() {
+      return formatContentType(ContentTypeProfileUpdate);
+    },
+
+    profileSnapshotContentType() {
+      return formatContentType(ContentTypeProfileSnapshot);
+    },
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -226,6 +226,7 @@ export {
   startInviteHostListener,
 } from "./convos/invite-host.js";
 export type { InviteHostDeps } from "./convos/invite-host.js";
+export { createConvosOnboardingScheme } from "./convos/onboarding-scheme.js";
 
 // SDK integration (production XmtpClientFactory implementation)
 export {


### PR DESCRIPTION
## Summary
- add `createConvosOnboardingScheme()` and the concrete Convos-backed onboarding implementation
- wrap the existing invite, join, profile, and codec behavior behind the new scheme contract
- keep all call sites unchanged so this branch only establishes the implementation seam

## Validation
- `bun run check` on `v1/onboarding-schemes-move`

Closes #321