### PR TITLE
refactor(core): inject onboarding scheme into conversation actions

### DIFF
--- a/packages/cli/src/__tests__/action-surface-map.test.ts
+++ b/packages/cli/src/__tests__/action-surface-map.test.ts
@@ -6,6 +6,7 @@ import { InternalError } from "@xmtp/signet-schemas";
 import { createKeyActions, createWalletActions } from "@xmtp/signet-keys";
 import {
   createConsentActions,
+  createConvosOnboardingScheme,
   createConversationActions,
   createInboxActions,
   createMessageActions,
@@ -103,6 +104,7 @@ describe("action surface map", () => {
     }
 
     for (const spec of createConversationActions({
+      onboardingScheme: createConvosOnboardingScheme(),
       identityStore: {} as never,
       getManagedClient: () => undefined,
       getGroupInfo: async () => Result.err(InternalError.create("unused")),

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -27,6 +27,7 @@ import {
   SignetCoreConfigSchema,
   createSdkClientFactory,
   createConsentActions,
+  createConvosOnboardingScheme,
   createConversationActions,
   createInboxActions as createInboxActionSpecs,
   createLookupActions,
@@ -703,6 +704,7 @@ export function createProductionDeps(): SignetRuntimeDeps {
       }
 
       const actions = createConversationActions({
+        onboardingScheme: createConvosOnboardingScheme(),
         identityStore: core.identityStore,
         ...(operatorManagerRef ? { operatorManager: operatorManagerRef } : {}),
         getManagedClient: (id) => core.getManagedClient(id),

--- a/packages/core/src/__tests__/conversation-action-examples.test.ts
+++ b/packages/core/src/__tests__/conversation-action-examples.test.ts
@@ -12,6 +12,7 @@ import {
   createConversationActions,
   type ConversationActionDeps,
 } from "../conversation-actions.js";
+import { createConvosOnboardingScheme } from "../convos/onboarding-scheme.js";
 
 function stubCtx(): HandlerContext {
   return {
@@ -21,6 +22,7 @@ function stubCtx(): HandlerContext {
 }
 
 describe("conversation action examples", () => {
+  const onboardingScheme = createConvosOnboardingScheme();
   let identityStore: SqliteIdentityStore;
   let idMappings: IdMappingStore;
   let mappingDb: Database;
@@ -47,6 +49,7 @@ describe("conversation action examples", () => {
     );
 
     deps = {
+      onboardingScheme,
       identityStore,
       getManagedClient: (_id: string): ManagedClient | undefined => undefined,
       getGroupInfo: async (groupId: string) =>

--- a/packages/core/src/__tests__/conversation-actions.test.ts
+++ b/packages/core/src/__tests__/conversation-actions.test.ts
@@ -18,6 +18,7 @@ import {
   type ConversationActionDeps,
 } from "../conversation-actions.js";
 import { generateConvosInviteUrl } from "../convos/invite-generator.js";
+import { createConvosOnboardingScheme } from "../convos/onboarding-scheme.js";
 import { extractProfileUpdateContent } from "../convos/profile-state.js";
 
 /** Minimal handler context for tests. */
@@ -224,6 +225,7 @@ function createOperatorManager(
 }
 
 describe("conversation actions", () => {
+  const onboardingScheme = createConvosOnboardingScheme();
   let identityStore: SqliteIdentityStore;
   let idMappings: IdMappingStore;
   let mappingDb: Database;
@@ -250,6 +252,7 @@ describe("conversation actions", () => {
     operatorManager?: OperatorManager,
   ): void {
     deps = {
+      onboardingScheme,
       identityStore,
       ...(operatorManager ? { operatorManager } : {}),
       getManagedClient: (id) => managedClients.get(id),
@@ -452,6 +455,7 @@ describe("conversation actions", () => {
       };
 
       deps = {
+        onboardingScheme,
         identityStore,
         getManagedClient: (id) => managedClients.get(id),
         getManagedClientForGroup: (groupId) =>
@@ -504,6 +508,7 @@ describe("conversation actions", () => {
       };
 
       deps = {
+        onboardingScheme,
         identityStore,
         operatorManager: createOperatorManager({ op_codex: "Codex" }),
         getManagedClient: (id) => managedClients.get(id),
@@ -554,6 +559,7 @@ describe("conversation actions", () => {
       };
 
       deps = {
+        onboardingScheme,
         identityStore,
         getManagedClient: (id) => managedClients.get(id),
         getManagedClientForGroup: (groupId) =>

--- a/packages/core/src/conversation-actions.ts
+++ b/packages/core/src/conversation-actions.ts
@@ -16,9 +16,8 @@ import type {
 } from "./xmtp-client-factory.js";
 import type { SignetCoreConfig } from "./config.js";
 import { joinConversation } from "./convos/join.js";
-import { generateConvosInviteUrl } from "./convos/invite-generator.js";
-import { encodeProfileUpdate, MemberKind } from "./convos/profile-messages.js";
 import type { SignerProviderFactory } from "./identity-registration.js";
+import type { OnboardingScheme } from "./schemes/onboarding-scheme.js";
 
 const GroupInfoSchema = z.object({
   chatId: z.string().optional(),
@@ -54,6 +53,8 @@ const ProfileUpdateResultSchema = z.object({
 
 /** Dependencies used to build conversation-related action specs. */
 export interface ConversationActionDeps {
+  /** Onboarding scheme used for invite and profile lifecycle behavior. */
+  readonly onboardingScheme: OnboardingScheme;
   /** Identity store used to resolve conversation creators and viewers. */
   readonly identityStore: SqliteIdentityStore;
   /** Optional operator manager for defaulting human-facing Convos profile names. */
@@ -503,6 +504,7 @@ export function createConversationActions(
 
       const joinResult = await joinConversation(
         {
+          onboardingScheme: deps.onboardingScheme,
           identityStore: deps.identityStore,
           clientFactory: deps.clientFactory,
           signerProviderFactory: deps.signerProviderFactory,
@@ -620,20 +622,23 @@ export function createConversationActions(
         .join("")
         .slice(0, 10);
 
-      const env =
-        deps.config.env === "dev" || deps.config.env === "local"
-          ? (deps.config.env as "dev" | "local")
-          : ("production" as const);
-
-      const urlResult = await generateConvosInviteUrl({
-        conversationId: groupId,
-        creatorInboxId: managed.inboxId,
-        walletPrivateKeyHex,
-        inviteTag,
-        name: input.name ?? groupResult.value.name,
-        description: input.description ?? groupResult.value.description,
-        env,
-      });
+      const urlResult = await deps.onboardingScheme.generate(
+        {
+          groupId,
+        },
+        {
+          creatorInboxId: managed.inboxId,
+          walletPrivateKeyHex,
+        },
+        {
+          tag: inviteTag,
+          name: input.name ?? groupResult.value.name,
+          description: input.description ?? groupResult.value.description,
+        },
+        {
+          env: deps.config.env,
+        },
+      );
 
       if (Result.isError(urlResult)) return urlResult;
 
@@ -643,7 +648,7 @@ export function createConversationActions(
       }
 
       return Result.ok({
-        inviteUrl: urlResult.value,
+        inviteUrl: urlResult.value.url,
         chatId: input.chatId,
         groupId,
         groupName: groupResult.value.name,
@@ -840,11 +845,11 @@ export function createConversationActions(
 
       const updateResult = await managedResult.value.client.sendMessage(
         groupId,
-        encodeProfileUpdate({
+        deps.onboardingScheme.encodeProfileUpdate({
           name: profileSelection.profileName,
-          memberKind: MemberKind.Agent,
+          memberKind: "agent",
         }),
-        "convos.org/profile_update:1.0",
+        deps.onboardingScheme.profileUpdateContentType(),
       );
       if (Result.isError(updateResult)) return updateResult;
 

--- a/packages/core/src/conversation-actions.ts
+++ b/packages/core/src/conversation-actions.ts
@@ -15,7 +15,7 @@ import type {
   XmtpGroupInfo,
 } from "./xmtp-client-factory.js";
 import type { SignetCoreConfig } from "./config.js";
-import { joinConversation } from "./convos/join.js";
+import { joinConversation } from "./schemes/join.js";
 import type { SignerProviderFactory } from "./identity-registration.js";
 import type { OnboardingScheme } from "./schemes/onboarding-scheme.js";
 

--- a/packages/core/src/convos/__tests__/join.test.ts
+++ b/packages/core/src/convos/__tests__/join.test.ts
@@ -13,6 +13,7 @@ import type {
   SignerProviderLike,
 } from "../../xmtp-client-factory.js";
 import { InviteJoinErrorType } from "../invite-join-error.js";
+import { createConvosOnboardingScheme } from "../onboarding-scheme.js";
 import { joinConversation, type JoinConversationDeps } from "../join.js";
 import { extractProfileUpdateContent } from "../profile-state.js";
 
@@ -65,6 +66,7 @@ const TEST_CREATOR_INBOX_ID =
 const TEST_DB_KEY = new Uint8Array(32).fill(0xab);
 const TEST_SIGNER_KEY =
   "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" as const;
+const ONBOARDING_SCHEME = createConvosOnboardingScheme();
 
 function buildTestSlug(): string {
   const payloadBytes = InvitePayloadType.encode(
@@ -199,6 +201,7 @@ function createDeps(overrides?: {
     });
 
   return {
+    onboardingScheme: ONBOARDING_SCHEME,
     identityStore:
       overrides?.identityStore ?? new SqliteIdentityStore(":memory:"),
     clientFactory: createMockFactory(client),
@@ -523,6 +526,7 @@ describe("joinConversation", () => {
 
     const store = new SqliteIdentityStore(":memory:");
     const deps: JoinConversationDeps = {
+      onboardingScheme: ONBOARDING_SCHEME,
       identityStore: store,
       clientFactory: failingFactory,
       signerProviderFactory: () => createMockSignerProvider(),

--- a/packages/core/src/convos/join.ts
+++ b/packages/core/src/convos/join.ts
@@ -6,17 +6,17 @@ import type { XmtpClientFactory } from "../xmtp-client-factory.js";
 import type { XmtpEnv, SignetCoreConfig } from "../config.js";
 import type { SignerProviderFactory } from "../identity-registration.js";
 import { registerIdentity } from "../identity-registration.js";
+import type { OnboardingScheme } from "../schemes/onboarding-scheme.js";
 import {
   extractInviteJoinError,
   getInviteJoinErrorMessage,
   isInviteJoinErrorContentType,
 } from "./invite-join-error.js";
-import { encodeProfileUpdate, MemberKind } from "./profile-messages.js";
-import { parseConvosInviteUrl, verifyConvosInvite } from "./invite-parser.js";
 import type { JoinRequestContent } from "./join-request-content.js";
 
 /** Dependencies injected into the join orchestrator. */
 export interface JoinConversationDeps {
+  readonly onboardingScheme: OnboardingScheme;
   readonly identityStore: SqliteIdentityStore;
   readonly clientFactory: XmtpClientFactory;
   readonly signerProviderFactory: SignerProviderFactory;
@@ -127,18 +127,24 @@ export async function joinConversation(
   inviteUrl: string,
   options?: JoinConversationOptions,
 ): Promise<Result<JoinResult, SignetError>> {
-  const { identityStore, clientFactory, signerProviderFactory, config } = deps;
+  const {
+    onboardingScheme,
+    identityStore,
+    clientFactory,
+    signerProviderFactory,
+    config,
+  } = deps;
   const pollIntervalMs = options?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   const maxPollAttempts = options?.maxPollAttempts ?? DEFAULT_MAX_POLL_ATTEMPTS;
 
   // Step 1: Parse invite
-  const parseResult = parseConvosInviteUrl(inviteUrl);
+  const parseResult = onboardingScheme.parse(inviteUrl);
   if (!parseResult.isOk()) return parseResult;
 
   const invite = parseResult.value;
 
   // Step 2: Verify signature structure
-  const verifyResult = verifyConvosInvite(invite);
+  const verifyResult = onboardingScheme.verify(invite);
   if (!verifyResult.isOk()) return verifyResult;
 
   // Step 3: Check expiration
@@ -220,7 +226,7 @@ export async function joinConversation(
   const structuredSendResult = await client.sendMessage(
     dmResult.value.dmId,
     joinRequest,
-    "convos.org/join_request:1.0",
+    onboardingScheme.joinRequestContentType(),
   );
   if (!structuredSendResult.isOk()) {
     await identityStore.remove(identityId);
@@ -254,13 +260,13 @@ export async function joinConversation(
       if (group !== undefined) {
         const profileUpdateResult = await client.sendMessage(
           group.groupId,
-          encodeProfileUpdate({
-            memberKind: MemberKind.Agent,
+          onboardingScheme.encodeProfileUpdate({
+            memberKind: "agent",
             ...(options?.profileName !== undefined
               ? { name: options.profileName }
               : {}),
           }),
-          "convos.org/profile_update:1.0",
+          onboardingScheme.profileUpdateContentType(),
         );
 
         return Result.ok({

--- a/packages/core/src/schemes/join.ts
+++ b/packages/core/src/schemes/join.ts
@@ -1,0 +1,6 @@
+export type {
+  JoinConversationDeps,
+  JoinConversationOptions,
+  JoinResult,
+} from "../convos/join.js";
+export { joinConversation } from "../convos/join.js";


### PR DESCRIPTION
## Summary
- inject `OnboardingScheme` into conversation actions and join flows instead of importing Convos helpers directly
- keep behavior unchanged while moving invite parsing, verification, and profile publishing behind the scheme interface
- preserve the existing Convos defaults through the injected implementation

## Validation
- `bun run check` on `v1/onboarding-schemes-move`

Closes #323