### PR TITLE
refactor(core): source codecs from onboarding scheme

### DIFF
--- a/packages/core/src/__tests__/sdk-client-factory.test.ts
+++ b/packages/core/src/__tests__/sdk-client-factory.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { generatePrivateKey } from "viem/accounts";
+import { createConvosOnboardingScheme } from "../convos/onboarding-scheme.js";
 import { createSdkClientFactory } from "../sdk/sdk-client-factory.js";
 import { createMockSdkNativeClient } from "./sdk-fixtures.js";
 import type { XmtpClientCreateOptions } from "../xmtp-client-factory.js";
@@ -51,8 +52,14 @@ describe("createSdkClientFactory", () => {
   });
 
   test("passes options through to SDK create", async () => {
+    const baseScheme = createConvosOnboardingScheme();
+    const customCodecs = baseScheme.codecs().slice(0, 1);
     let capturedOptions: Record<string, unknown> = {};
     const factory = createSdkClientFactory({
+      onboardingScheme: {
+        ...baseScheme,
+        codecs: () => customCodecs,
+      },
       sdkCreateClient: async (_signer, options) => {
         capturedOptions = options as Record<string, unknown>;
         return createMockSdkNativeClient();
@@ -64,8 +71,7 @@ describe("createSdkClientFactory", () => {
     expect(capturedOptions["dbPath"]).toBe("/tmp/test.db3");
     expect(capturedOptions["env"]).toBe("local");
     expect(capturedOptions["appVersion"]).toBe("test/0.1.0");
-    expect(Array.isArray(capturedOptions["codecs"])).toBe(true);
-    expect(capturedOptions["codecs"] as unknown[]).toHaveLength(4);
+    expect(capturedOptions["codecs"]).toBe(customCodecs);
   });
 
   test("creates signer from signerPrivateKey in options", async () => {

--- a/packages/core/src/__tests__/sdk-client.test.ts
+++ b/packages/core/src/__tests__/sdk-client.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { encodeProfileSnapshot } from "../convos/profile-messages.js";
+import { createConvosOnboardingScheme } from "../convos/onboarding-scheme.js";
+import type { EncodedOnboardingContent } from "../schemes/onboarding-scheme.js";
 import { createSdkClient } from "../sdk/sdk-client.js";
 import {
   createMockSdkNativeClient,
@@ -70,6 +72,42 @@ describe("createSdkClient", () => {
         expect(result.value).toBe("msg-id-encoded");
       }
       expect(capturedPayload).toEqual(snapshot);
+    });
+
+    test("uses scheme-owned encoded content detection for custom onboarding types", async () => {
+      const baseScheme = createConvosOnboardingScheme();
+      const customType = "example.org/profile_snapshot:9.9";
+      const customEncoded = { custom: true };
+
+      let capturedPayload: unknown = null;
+      const group = createMockGroup({ id: "g1" });
+      group.send = async (encoded: unknown) => {
+        capturedPayload = encoded;
+        return "msg-id-custom";
+      };
+
+      const native = createMockSdkNativeClient({ groups: [group] });
+      const client = createSdkClient({
+        client: native,
+        syncTimeoutMs: 5000,
+        onboardingScheme: {
+          ...baseScheme,
+          isEncodedContent(value): value is EncodedOnboardingContent {
+            return value === customEncoded;
+          },
+          profileSnapshotContentType() {
+            return customType;
+          },
+        },
+      });
+
+      const result = await client.sendMessage("g1", customEncoded, customType);
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe("msg-id-custom");
+      }
+      expect(capturedPayload).toBe(customEncoded);
     });
   });
 

--- a/packages/core/src/sdk/sdk-client-factory.ts
+++ b/packages/core/src/sdk/sdk-client-factory.ts
@@ -11,7 +11,8 @@ import { createXmtpSigner } from "./signer-adapter.js";
 import type { SdkEoaSigner } from "./signer-adapter.js";
 import { createSdkClient } from "./sdk-client.js";
 import type { SdkClientShape } from "./sdk-types.js";
-import { createConvosCodecs } from "../convos/codecs.js";
+import { createConvosOnboardingScheme } from "../convos/onboarding-scheme.js";
+import type { OnboardingScheme } from "../schemes/onboarding-scheme.js";
 
 /**
  * A function that creates a native SDK client.
@@ -34,9 +35,12 @@ export type SdkCreateClientFn = (
 export interface SdkClientFactoryOptions {
   /** Override the SDK Client.create function (for testing). */
   readonly sdkCreateClient?: SdkCreateClientFn;
+  /** Onboarding scheme that owns custom codecs and content handling. */
+  readonly onboardingScheme?: OnboardingScheme;
 }
 
 const DEFAULT_SYNC_TIMEOUT_MS = 30_000;
+const DEFAULT_ONBOARDING_SCHEME = createConvosOnboardingScheme();
 type NodeSdkCreateOptions = Parameters<typeof NodeSdkClient.create>[1];
 type NodeSdkSigner = Parameters<typeof NodeSdkClient.create>[0];
 type NodeSdkCodecs = NonNullable<NonNullable<NodeSdkCreateOptions>["codecs"]>;
@@ -53,6 +57,8 @@ export function createSdkClientFactory(
   factoryOptions?: SdkClientFactoryOptions,
 ): XmtpClientFactory {
   const sdkCreate = factoryOptions?.sdkCreateClient ?? defaultSdkCreate;
+  const onboardingScheme =
+    factoryOptions?.onboardingScheme ?? DEFAULT_ONBOARDING_SCHEME;
 
   return {
     async create(
@@ -69,12 +75,13 @@ export function createSdkClientFactory(
           env: options.env,
           appVersion: options.appVersion,
           disableDeviceSync: true,
-          codecs: createConvosCodecs(),
+          codecs: onboardingScheme.codecs(),
         });
 
         const client = createSdkClient({
           client: nativeClient,
           syncTimeoutMs: DEFAULT_SYNC_TIMEOUT_MS,
+          onboardingScheme,
         });
 
         return Result.ok(client);

--- a/packages/core/src/sdk/sdk-client.ts
+++ b/packages/core/src/sdk/sdk-client.ts
@@ -25,7 +25,8 @@ import {
   wrapDmStream,
   wrapGroupStream,
 } from "./stream-wrappers.js";
-import { isEncodedConvosContent } from "../convos/join-request-content.js";
+import { createConvosOnboardingScheme } from "../convos/onboarding-scheme.js";
+import type { OnboardingScheme } from "../schemes/onboarding-scheme.js";
 import type {
   SdkClientShape,
   SdkGroupShape,
@@ -39,7 +40,11 @@ export interface SdkClientOptions {
   readonly client: SdkClientShape;
   /** Timeout for sync operations in milliseconds. */
   readonly syncTimeoutMs: number;
+  /** Onboarding scheme that owns custom content-type handling. */
+  readonly onboardingScheme?: OnboardingScheme;
 }
+
+const DEFAULT_ONBOARDING_SCHEME = createConvosOnboardingScheme();
 
 /**
  * Look up a group by ID, returning NotFoundError if missing.
@@ -117,7 +122,17 @@ function toSdkConsentState(state: "allowed" | "denied"): SdkConsentState {
  * Wraps every SDK call in try/catch, converting exceptions to Result errors.
  */
 export function createSdkClient(options: SdkClientOptions): XmtpClient {
-  const { client, syncTimeoutMs } = options;
+  const {
+    client,
+    syncTimeoutMs,
+    onboardingScheme = DEFAULT_ONBOARDING_SCHEME,
+  } = options;
+
+  const isOnboardingContentType = (contentType: string): boolean =>
+    contentType === onboardingScheme.joinRequestContentType() ||
+    contentType === onboardingScheme.errorContentType() ||
+    contentType === onboardingScheme.profileUpdateContentType() ||
+    contentType === onboardingScheme.profileSnapshotContentType();
 
   return {
     get inboxId(): string {
@@ -135,7 +150,10 @@ export function createSdkClient(options: SdkClientOptions): XmtpClient {
 
       // For custom content types, use group.send() with encoded content
       if (contentType && contentType !== "xmtp.org/text:1.0") {
-        if (isEncodedConvosContent(content)) {
+        if (
+          isOnboardingContentType(contentType) &&
+          onboardingScheme.isEncodedContent(content)
+        ) {
           return wrapSdkCall(async () => group.send(content), "sendMessage");
         }
         // Parse "authority/type:major.minor" format


### PR DESCRIPTION
## Summary
- source SDK codecs and content-type detection from the injected onboarding scheme
- remove hardcoded Convos codec lookups from the SDK client factory and client runtime
- preserve the existing Convos behavior by default while shifting ownership to the scheme interface

## Validation
- `bun run check` on `v1/onboarding-schemes-move`

Closes #324