### PR TITLE
feat(cli): configure onboarding scheme resolution

### DIFF
--- a/packages/cli/src/__tests__/config-loader.test.ts
+++ b/packages/cli/src/__tests__/config-loader.test.ts
@@ -22,6 +22,7 @@ describe("loadConfig", () => {
     expect(result.isOk()).toBe(true);
     if (!result.isOk()) return;
     const config = result.value;
+    expect(config.onboarding.scheme).toBe("convos");
     expect(config.signet.env).toBe("dev");
     expect(config.ws.port).toBe(8393);
     expect(config.logging.level).toBe("info");
@@ -31,7 +32,10 @@ describe("loadConfig", () => {
     const tomlPath = join(tempDir, "config.toml");
     await writeFile(
       tomlPath,
-      `[signet]
+      `[onboarding]
+scheme = "convos"
+
+[signet]
 env = "production"
 identityMode = "shared"
 
@@ -51,6 +55,7 @@ defaultTtlSeconds = 7200
     expect(result.isOk()).toBe(true);
     if (!result.isOk()) return;
     const config = result.value;
+    expect(config.onboarding.scheme).toBe("convos");
     expect(config.signet.env).toBe("production");
     expect(config.signet.identityMode).toBe("shared");
     expect(config.defaults.profileName).toBe("Codex");
@@ -188,6 +193,7 @@ level = "debug"
     expect(result.isOk()).toBe(true);
     if (!result.isOk()) return;
     const config = result.value;
+    expect(config.onboarding.scheme).toBe("convos");
     expect(config.logging.level).toBe("debug");
     expect(config.signet.env).toBe("dev");
     expect(config.ws.port).toBe(8393);

--- a/packages/cli/src/__tests__/config-schema.test.ts
+++ b/packages/cli/src/__tests__/config-schema.test.ts
@@ -8,6 +8,7 @@ describe("CliConfigSchema", () => {
     if (!result.success) return;
 
     const config = result.data;
+    expect(config.onboarding.scheme).toBe("convos");
     expect(config.signet.env).toBe("dev");
     expect(config.signet.identityMode).toBe("per-group");
     expect(config.signet.dataDir).toBeUndefined();
@@ -34,8 +35,18 @@ describe("CliConfigSchema", () => {
     });
     expect(result.success).toBe(true);
     if (!result.success) return;
+    expect(result.data.onboarding.scheme).toBe("convos");
     expect(result.data.signet.env).toBe("dev");
     expect(result.data.signet.identityMode).toBe("per-group");
+  });
+
+  test("onboarding section defaults correctly", () => {
+    const result = CliConfigSchema.safeParse({
+      onboarding: {},
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.onboarding.scheme).toBe("convos");
   });
 
   test("accepts a default Convos profile name", () => {

--- a/packages/cli/src/__tests__/daemon-command-wiring.test.ts
+++ b/packages/cli/src/__tests__/daemon-command-wiring.test.ts
@@ -176,6 +176,7 @@ describe("daemon-backed CLI command wiring", () => {
       uptime: 5,
       activeCredentials: 2,
       activeConnections: 1,
+      onboardingScheme: "convos" as const,
       xmtpEnv: "local" as const,
       identityMode: "per-group" as const,
       wsPort: 8393,

--- a/packages/cli/src/__tests__/dev-network.test.ts
+++ b/packages/cli/src/__tests__/dev-network.test.ts
@@ -214,6 +214,7 @@ describe.skipIf(!process.env["XMTP_NETWORK_TESTS"])(
       expect(typeof output["address"]).toBe("string");
       expect((output["address"] as string).startsWith("0x")).toBe(true);
       expect(output["env"]).toBe("dev");
+      expect(output["onboardingScheme"]).toBe("convos");
       expect(output["label"]).toBe("test-alice");
     });
 

--- a/packages/cli/src/__tests__/init-presets.test.ts
+++ b/packages/cli/src/__tests__/init-presets.test.ts
@@ -33,6 +33,7 @@ describe("init posture presets", () => {
     const config = applyInitPreset(base, "recommended");
 
     expect(config.signet.identityMode).toBe("per-group");
+    expect(config.onboarding.scheme).toBe("convos");
     expect(config.keys.rootKeyPolicy).toBe("biometric");
     expect(config.keys.vaultKeyPolicy).toBe("open");
     expect(config.biometricGating.adminReadElevation).toBe(true);
@@ -45,6 +46,7 @@ describe("init posture presets", () => {
     const config = applyInitPreset(base, "trusted-local");
 
     expect(config.signet.identityMode).toBe("shared");
+    expect(config.onboarding.scheme).toBe("convos");
     expect(config.keys.rootKeyPolicy).toBe("biometric");
     expect(config.keys.operationalKeyPolicy).toBe("open");
     expect(config.keys.vaultKeyPolicy).toBe("open");
@@ -57,6 +59,7 @@ describe("init posture presets", () => {
     const config = applyInitPreset(base, "hardened");
 
     expect(config.signet.identityMode).toBe("per-group");
+    expect(config.onboarding.scheme).toBe("convos");
     expect(config.keys.rootKeyPolicy).toBe("biometric");
     expect(config.keys.vaultKeyPolicy).toBe("passcode");
     expect(config.biometricGating.scopeExpansion).toBe(true);
@@ -145,6 +148,8 @@ describe("init posture presets", () => {
     await writeConfig(configPath, config);
 
     const raw = await readFile(configPath, "utf8");
+    expect(raw).toContain("[onboarding]");
+    expect(raw).toContain('scheme = "convos"');
     expect(raw).toContain("[signet]");
     expect(raw).toContain('identityMode = "per-group"');
     expect(raw).toContain("[biometricGating]");
@@ -152,6 +157,7 @@ describe("init posture presets", () => {
     const loaded = await loadConfig({ configPath });
     expect(loaded.isOk()).toBe(true);
     if (!loaded.isOk()) return;
+    expect(loaded.value.onboarding.scheme).toBe("convos");
     expect(loaded.value.defaults.profileName).toBe("Codex");
     expect(loaded.value.keys.vaultKeyPolicy).toBe("passcode");
     expect(loaded.value.biometricGating.adminReadElevation).toBe(true);

--- a/packages/cli/src/__tests__/invite-host-effects.test.ts
+++ b/packages/cli/src/__tests__/invite-host-effects.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { Result } from "better-result";
-import { decodeProfileSnapshot } from "@xmtp/signet-core";
+import {
+  createConvosOnboardingScheme,
+  decodeProfileSnapshot,
+} from "@xmtp/signet-core";
 import { InternalError, ValidationError } from "@xmtp/signet-schemas";
 import { createInviteHostEffects } from "../invite-host-effects.js";
 import type {
@@ -8,6 +11,8 @@ import type {
   ManagedInviteJoinFailure,
 } from "../invite-host-listener.js";
 import type { AuditEntry } from "../audit/log.js";
+
+const ONBOARDING_SCHEME = createConvosOnboardingScheme();
 
 function makeAcceptance(): ManagedInviteJoinAcceptance {
   return {
@@ -92,6 +97,7 @@ describe("createInviteHostEffects", () => {
           },
         };
       },
+      onboardingScheme: ONBOARDING_SCHEME,
       resolveLocalChatId: () => "conv_local_1",
       now: () => new Date("2026-04-15T15:00:00.000Z"),
     });
@@ -187,6 +193,7 @@ describe("createInviteHostEffects", () => {
           },
         };
       },
+      onboardingScheme: ONBOARDING_SCHEME,
       now: () => new Date("2026-04-15T15:00:00.000Z"),
     });
 
@@ -281,6 +288,7 @@ describe("createInviteHostEffects", () => {
           },
         };
       },
+      onboardingScheme: ONBOARDING_SCHEME,
       now: () => new Date("2026-04-15T15:00:00.000Z"),
     });
 
@@ -315,6 +323,7 @@ describe("createInviteHostEffects", () => {
           return [];
         },
       },
+      onboardingScheme: ONBOARDING_SCHEME,
       getManagedClientForGroup: () => undefined,
       now: () => new Date("2026-04-15T15:00:00.000Z"),
     });
@@ -346,6 +355,7 @@ describe("createInviteHostEffects", () => {
           return [];
         },
       },
+      onboardingScheme: ONBOARDING_SCHEME,
       getManagedClientForGroup: () => undefined,
       now: () => new Date("2026-04-15T15:00:00.000Z"),
     });

--- a/packages/cli/src/__tests__/invite-host-listener.test.ts
+++ b/packages/cli/src/__tests__/invite-host-listener.test.ts
@@ -1,12 +1,19 @@
 import { describe, expect, test } from "bun:test";
 import { Result } from "better-result";
-import { generateConvosInviteSlug, type CoreRawEvent } from "@xmtp/signet-core";
+import {
+  createConvosOnboardingScheme,
+  generateConvosInviteSlug,
+  type CoreRawEvent,
+} from "@xmtp/signet-core";
 import {
   InternalError,
   NotFoundError,
   type SignetError,
 } from "@xmtp/signet-schemas";
-import { startManagedInviteHostListener } from "../invite-host-listener.js";
+import {
+  startManagedInviteHostListener as startManagedInviteHostListenerBase,
+  type ManagedInviteHostListenerDeps,
+} from "../invite-host-listener.js";
 
 const WRONG_PRIVATE_KEY_HEX =
   "0000000000000000000000000000000000000000000000000000000000000002";
@@ -20,6 +27,16 @@ const RIGHT_CREATOR_INBOX_ID =
 
 const TEST_CONVERSATION_ID = "550e8400-e29b-41d4-a716-446655440000";
 const TEST_REQUESTER_INBOX_ID = "requester-inbox-id-abc123";
+const TEST_ONBOARDING_SCHEME = createConvosOnboardingScheme();
+
+function startManagedInviteHostListener(
+  deps: Omit<ManagedInviteHostListenerDeps, "onboardingScheme">,
+): () => void {
+  return startManagedInviteHostListenerBase({
+    onboardingScheme: TEST_ONBOARDING_SCHEME,
+    ...deps,
+  });
+}
 
 function makeRawMessageEvent(content: unknown): CoreRawEvent {
   return {

--- a/packages/cli/src/__tests__/smoke.test.ts
+++ b/packages/cli/src/__tests__/smoke.test.ts
@@ -233,10 +233,12 @@ describe("Phase 2B smoke tests", () => {
     ]);
     expect(statusResult.exitCode).toBe(0);
     const status = JSON.parse(statusResult.stdout) as {
+      onboardingScheme: string;
       state: string;
       wsPort: number;
     };
     expect(status).toMatchObject({
+      onboardingScheme: "convos",
       state: "running",
     });
     expect(status.wsPort).toBeGreaterThan(0);

--- a/packages/cli/src/__tests__/xs-chat-command-wiring.test.ts
+++ b/packages/cli/src/__tests__/xs-chat-command-wiring.test.ts
@@ -13,6 +13,9 @@ interface RequestCall {
 
 function stubConfig(profileNameDefault?: string): CliConfig {
   return {
+    onboarding: {
+      scheme: "convos",
+    },
     signet: {
       env: "dev",
       identityMode: "per-group",

--- a/packages/cli/src/commands/identity.ts
+++ b/packages/cli/src/commands/identity.ts
@@ -14,6 +14,7 @@ import { writeConfig } from "../config/writer.js";
 import { resolvePaths } from "../config/paths.js";
 import { formatOutput } from "../output/formatter.js";
 import { exitCodeFromCategory } from "../output/exit-codes.js";
+import { resolveOnboardingScheme } from "../onboarding-schemes.js";
 
 /**
  * Identity bootstrap and listing commands (direct mode, no daemon required).
@@ -207,6 +208,7 @@ export function createIdentityInitCommand(): Command {
           km,
           paths,
           env,
+          onboardingSchemeId: config.onboarding.scheme,
           label: typeof options.label === "string" ? options.label : "default",
           rootPublicKey,
           operationalKeyId: opKey.identityId,
@@ -231,6 +233,7 @@ export function createIdentityInitCommand(): Command {
           : {}),
         configPath,
         configWritten,
+        onboardingScheme: config.onboarding.scheme,
         rootPublicKey,
         operationalKeyId: opKey.identityId,
         adminKeyFingerprint,
@@ -273,6 +276,7 @@ async function registerXmtpIdentity(opts: {
   readonly km: KeyManager;
   readonly paths: ReturnType<typeof resolvePaths>;
   readonly env: "dev" | "production";
+  readonly onboardingSchemeId: "convos";
   readonly label: string;
   readonly rootPublicKey: string;
   readonly operationalKeyId: string;
@@ -288,6 +292,7 @@ async function registerXmtpIdentity(opts: {
     km,
     paths,
     env,
+    onboardingSchemeId,
     label,
     rootPublicKey,
     operationalKeyId,
@@ -312,7 +317,9 @@ async function registerXmtpIdentity(opts: {
   const identityStore = new SqliteIdentityStore(
     `${paths.dataDir}/identities.db`,
   );
-  const clientFactory = createSdkClientFactory();
+  const clientFactory = createSdkClientFactory({
+    onboardingScheme: resolveOnboardingScheme(onboardingSchemeId),
+  });
   const signerProviderFactory = (identityId: string) =>
     createSignerProviderFn(km, identityId);
 
@@ -349,6 +356,7 @@ async function registerXmtpIdentity(opts: {
       : {}),
     configPath,
     configWritten,
+    onboardingScheme: onboardingSchemeId,
     rootPublicKey,
     operationalKeyId,
     adminKeyFingerprint,

--- a/packages/cli/src/commands/lifecycle.ts
+++ b/packages/cli/src/commands/lifecycle.ts
@@ -117,7 +117,9 @@ export function createLifecycleCommands(
 
       const runtimeResult = await resolvedDeps.createSignetRuntime(
         config,
-        resolvedDeps.createProductionDeps(),
+        resolvedDeps.createProductionDeps({
+          onboardingSchemeId: config.onboarding.scheme,
+        }),
       );
 
       if (Result.isError(runtimeResult)) {

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -74,6 +74,18 @@ export const HttpServerConfigSchema: z.ZodType<
 
 // -- CLI config --
 
+export type OnboardingSchemeId = "convos";
+
+type OnboardingConfig = {
+  scheme: OnboardingSchemeId;
+};
+
+type OnboardingConfigInput =
+  | {
+      scheme?: OnboardingSchemeId | undefined;
+    }
+  | undefined;
+
 type SignetConfig = {
   env: "local" | "dev" | "production";
   identityMode: "per-group" | "shared";
@@ -90,6 +102,7 @@ type SignetConfigInput =
 
 /** Top-level CLI configuration. Parsed from TOML with env var overrides. */
 export type CliConfig = {
+  onboarding: OnboardingConfig;
   signet: SignetConfig;
   defaults: {
     profileName?: string | undefined;
@@ -118,6 +131,7 @@ export type CliConfig = {
 };
 
 type CliConfigInput = {
+  onboarding?: OnboardingConfigInput;
   signet?: SignetConfigInput;
   defaults?:
     | {
@@ -173,8 +187,22 @@ const SignetConfigSchema: z.ZodType<
   })
   .default({});
 
+const OnboardingConfigSchema: z.ZodType<
+  OnboardingConfig,
+  z.ZodTypeDef,
+  OnboardingConfigInput
+> = z
+  .object({
+    scheme: z
+      .literal("convos")
+      .default("convos")
+      .describe("Onboarding scheme used for invite and profile flows"),
+  })
+  .default({});
+
 const CliConfigBaseSchema = z
   .object({
+    onboarding: OnboardingConfigSchema,
     signet: SignetConfigSchema,
     defaults: z
       .object({

--- a/packages/cli/src/daemon/status.ts
+++ b/packages/cli/src/daemon/status.ts
@@ -9,6 +9,7 @@ export type DaemonStatus = {
   uptime: number;
   activeCredentials: number;
   activeConnections: number;
+  onboardingScheme: "convos";
   xmtpEnv: "local" | "dev" | "production";
   identityMode: "per-group" | "shared";
   wsPort: number;
@@ -50,6 +51,9 @@ export const DaemonStatusSchema: z.ZodType<DaemonStatus> = z
       .int()
       .nonnegative()
       .describe("Number of active WebSocket connections"),
+    onboardingScheme: z
+      .enum(["convos"])
+      .describe("Configured onboarding scheme"),
     xmtpEnv: z
       .enum(["local", "dev", "production"])
       .describe("XMTP network environment"),

--- a/packages/cli/src/invite-host-effects.ts
+++ b/packages/cli/src/invite-host-effects.ts
@@ -1,12 +1,10 @@
 import { Result } from "better-result";
 import {
-  buildProfileSnapshotFromMessages,
-  encodeProfileSnapshot,
   extractJoinRequestContent,
-  MemberKind,
   type ListMessagesOptions,
-  type ProfileSnapshotContent,
-  resolveProfilesFromMessages,
+  type MemberProfileData,
+  type OnboardingScheme,
+  type ResolvedOnboardingProfile,
   type XmtpDecodedMessage,
   type XmtpGroupInfo,
 } from "@xmtp/signet-core";
@@ -17,7 +15,6 @@ import type {
   ManagedInviteJoinFailure,
 } from "./invite-host-listener.js";
 
-const PROFILE_SNAPSHOT_CONTENT_TYPE = "convos.org/profile_snapshot:1.0";
 const PROFILE_SNAPSHOT_SCAN_OPTIONS = {
   limit: 500,
   direction: "descending",
@@ -44,6 +41,7 @@ export interface InviteHostEffectsDeps {
   readonly getManagedClientForGroup: (
     groupId: string,
   ) => InviteHostEffectsClient | undefined;
+  readonly onboardingScheme: OnboardingScheme;
   readonly resolveLocalChatId?: (groupId: string) => string | undefined;
   readonly now?: () => Date;
 }
@@ -104,58 +102,54 @@ async function appendSnapshotAudit(
 
 function applyAcceptedJoinProfile(
   acceptance: ManagedInviteJoinAcceptance,
-  snapshot: ProfileSnapshotContent,
-): ProfileSnapshotContent {
+  snapshotMembers: readonly MemberProfileData[],
+): readonly MemberProfileData[] {
   const requestedProfile = extractJoinRequestContent(
     acceptance.requestMessage.content,
   )?.profile;
   if (!requestedProfile) {
-    return snapshot;
+    return snapshotMembers;
   }
 
   const requestedMemberKind =
-    requestedProfile.memberKind === "agent" ? MemberKind.Agent : undefined;
+    requestedProfile.memberKind === "agent"
+      ? "agent"
+      : requestedProfile.memberKind === "human"
+        ? "human"
+        : undefined;
   const joinerInboxId = acceptance.join.requesterInboxId.toLowerCase();
 
-  return {
-    profiles: snapshot.profiles.map((profile) => {
-      if (profile.inboxId.toLowerCase() !== joinerInboxId) {
-        return profile;
-      }
+  return snapshotMembers.map((profile) => {
+    if (profile.inboxId.toLowerCase() !== joinerInboxId) {
+      return profile;
+    }
 
-      return {
-        ...profile,
-        ...(requestedProfile.name !== undefined
-          ? { name: requestedProfile.name }
-          : {}),
-        ...(requestedMemberKind !== undefined
-          ? { memberKind: requestedMemberKind }
-          : {}),
-      };
-    }),
-  };
+    return {
+      ...profile,
+      ...(requestedProfile.name !== undefined
+        ? { name: requestedProfile.name }
+        : {}),
+      ...(requestedMemberKind !== undefined
+        ? { memberKind: requestedMemberKind }
+        : {}),
+    };
+  });
 }
 
 function hasMaterializedProfile(
-  profile:
-    | {
-        readonly name?: unknown;
-        readonly encryptedImage?: unknown;
-        readonly memberKind?: unknown;
-        readonly metadata?: unknown;
-      }
-    | undefined,
+  profile: ResolvedOnboardingProfile | undefined,
 ): boolean {
   return (
     profile !== undefined &&
     (profile.name !== undefined ||
-      profile.encryptedImage !== undefined ||
+      profile.imageUrl !== undefined ||
       profile.memberKind !== undefined ||
       profile.metadata !== undefined)
   );
 }
 
 async function loadProfileSnapshotMessages(
+  deps: InviteHostEffectsDeps,
   managed: InviteHostEffectsClient,
   groupId: string,
   memberInboxIds: readonly string[],
@@ -178,7 +172,7 @@ async function loadProfileSnapshotMessages(
 
     collected.push(...messagesResult.value);
 
-    const resolvedProfiles = resolveProfilesFromMessages(
+    const resolvedProfiles = deps.onboardingScheme.resolveProfilesFromHistory(
       collected,
       memberInboxIds,
     );
@@ -260,6 +254,7 @@ export function createInviteHostEffects(deps: InviteHostEffectsDeps): {
       }
 
       const messagesResult = await loadProfileSnapshotMessages(
+        deps,
         managed,
         acceptance.join.groupId,
         groupInfoResult.value.memberInboxIds,
@@ -279,22 +274,27 @@ export function createInviteHostEffects(deps: InviteHostEffectsDeps): {
         return;
       }
 
-      const snapshot = applyAcceptedJoinProfile(
+      const resolvedProfiles = deps.onboardingScheme.resolveProfilesFromHistory(
+        messagesResult.value,
+        groupInfoResult.value.memberInboxIds,
+      );
+      const snapshotMembers = applyAcceptedJoinProfile(
         acceptance,
-        buildProfileSnapshotFromMessages(
-          messagesResult.value,
-          groupInfoResult.value.memberInboxIds,
-          { includeFallbackEntries: true },
+        groupInfoResult.value.memberInboxIds.map(
+          (inboxId) =>
+            resolvedProfiles.get(inboxId.toLowerCase()) ?? {
+              inboxId,
+            },
         ),
       );
-      if (snapshot.profiles.length === 0) {
+      if (snapshotMembers.length === 0) {
         return;
       }
 
       const sendResult = await managed.sendMessage(
         acceptance.join.groupId,
-        encodeProfileSnapshot(snapshot),
-        PROFILE_SNAPSHOT_CONTENT_TYPE,
+        deps.onboardingScheme.encodeProfileSnapshot(snapshotMembers),
+        deps.onboardingScheme.profileSnapshotContentType(),
       );
       if (Result.isError(sendResult)) {
         await appendSnapshotAudit(
@@ -305,7 +305,7 @@ export function createInviteHostEffects(deps: InviteHostEffectsDeps): {
           {
             errorCategory: sendResult.error.category,
             errorMessage: sendResult.error.message,
-            profileCount: snapshot.profiles.length,
+            profileCount: snapshotMembers.length,
             stage: "sendMessage",
           },
         );
@@ -319,7 +319,7 @@ export function createInviteHostEffects(deps: InviteHostEffectsDeps): {
         true,
         {
           messageId: sendResult.value,
-          profileCount: snapshot.profiles.length,
+          profileCount: snapshotMembers.length,
         },
       );
     },

--- a/packages/cli/src/invite-host-listener.ts
+++ b/packages/cli/src/invite-host-listener.ts
@@ -1,12 +1,12 @@
 import { Result } from "better-result";
 import {
+  createConvosOnboardingScheme,
   extractJoinRequestContent,
-  tryProcessJoinRequest,
-  isJoinRequestContentType,
   type CoreRawEvent,
-  type ListMessagesOptions,
-  type RawMessageEvent,
   type JoinRequestResult,
+  type ListMessagesOptions,
+  type OnboardingScheme,
+  type RawMessageEvent,
   type XmtpDecodedMessage,
 } from "@xmtp/signet-core";
 import type { SignetError } from "@xmtp/signet-schemas";
@@ -72,6 +72,8 @@ export interface ManagedInviteHostListenerDeps {
   readonly getGroupInviteTag: (
     groupId: string,
   ) => Promise<Result<string | undefined, SignetError>>;
+  /** Onboarding scheme used to detect and process invite joins. */
+  readonly onboardingScheme?: OnboardingScheme;
   /** Best-effort callback after a join request is accepted. */
   readonly onJoinAccepted?: (
     acceptance: ManagedInviteJoinAcceptance,
@@ -94,6 +96,7 @@ const RECENT_JOIN_SCAN_OPTIONS = {
 const DM_RECOVERY_RETRY_DELAY_MS = 250;
 const MAX_DM_RECOVERY_RETRIES = 3;
 const DEFAULT_PROCESSED_INVITE_KEY_TTL_MS = 5_000;
+const DEFAULT_ONBOARDING_SCHEME = createConvosOnboardingScheme();
 
 interface InviteRecoveryScanResult {
   readonly messages: readonly RawMessageEvent[];
@@ -115,11 +118,16 @@ function resolveInviteRequestKey(event: RawMessageEvent): string | null {
 function preferInviteCandidate(
   current: RawMessageEvent | undefined,
   candidate: RawMessageEvent,
+  onboardingScheme: OnboardingScheme,
 ): RawMessageEvent {
   if (!current) return candidate;
 
-  const currentStructured = isJoinRequestContentType(current.contentType);
-  const candidateStructured = isJoinRequestContentType(candidate.contentType);
+  const currentStructured = onboardingScheme.isJoinRequestContentType(
+    current.contentType,
+  );
+  const candidateStructured = onboardingScheme.isJoinRequestContentType(
+    candidate.contentType,
+  );
 
   if (candidateStructured && !currentStructured) {
     return candidate;
@@ -128,10 +136,13 @@ function preferInviteCandidate(
   return current;
 }
 
-function isInviteCandidate(event: CoreRawEvent): event is RawMessageEvent {
+function isInviteCandidate(
+  event: CoreRawEvent,
+  onboardingScheme: OnboardingScheme,
+): event is RawMessageEvent {
   if (event.type !== "raw.message") return false;
   if (event.isHistorical) return false;
-  if (isJoinRequestContentType(event.contentType)) {
+  if (onboardingScheme.isJoinRequestContentType(event.contentType)) {
     return true;
   }
   if (typeof event.content !== "string") return false;
@@ -174,7 +185,9 @@ export async function dispatchInviteJoinRequestAcrossManagedIdentities(
   deps: ManagedInviteHostListenerDeps,
   event: CoreRawEvent,
 ): Promise<ManagedInviteJoinDispatchOutcome> {
-  if (!isInviteCandidate(event)) {
+  const onboardingScheme = deps.onboardingScheme ?? DEFAULT_ONBOARDING_SCHEME;
+
+  if (!isInviteCandidate(event, onboardingScheme)) {
     return { result: null, shouldRetry: false };
   }
 
@@ -200,7 +213,7 @@ export async function dispatchInviteJoinRequestAcrossManagedIdentities(
       continue;
     }
 
-    const result = await tryProcessJoinRequest(
+    const result = await onboardingScheme.processJoinRequest(
       {
         walletPrivateKeyHex: normalizePrivateKeyHex(keyResult.value),
         creatorInboxId: identity.inboxId,
@@ -208,16 +221,19 @@ export async function dispatchInviteJoinRequestAcrossManagedIdentities(
           managed.addMembers(groupId, inboxIds),
         getGroupInviteTag: deps.getGroupInviteTag,
       },
-      event,
+      {
+        senderInboxId: event.senderInboxId,
+        content: event.content,
+      },
     );
-
-    if (result === null) {
-      return { result: null, shouldRetry };
-    }
     if (Result.isOk(result)) {
       return {
         result: Result.ok({
-          join: result.value,
+          join: {
+            groupId: result.value.groupId,
+            requesterInboxId: result.value.requesterInboxId,
+            inviteTag: result.value.inviteTag,
+          },
           hostIdentityId: identity.id,
           hostInboxId: identity.inboxId,
         }),
@@ -239,6 +255,7 @@ async function listRecentInviteCandidatesAcrossManagedIdentities(
   processedMessageIds: ReadonlySet<string>,
   processedInviteKeys: ReadonlySet<string>,
 ): Promise<InviteRecoveryScanResult> {
+  const onboardingScheme = deps.onboardingScheme ?? DEFAULT_ONBOARDING_SCHEME;
   const identities = await deps.listIdentities();
   const messages = new Map<string, RawMessageEvent>();
   let shouldRetry = false;
@@ -268,7 +285,7 @@ async function listRecentInviteCandidatesAcrossManagedIdentities(
 
       for (const message of [...listResult.value].reverse()) {
         const event = toRawMessageEvent(message);
-        if (!isInviteCandidate(event)) continue;
+        if (!isInviteCandidate(event, onboardingScheme)) continue;
         if (processedMessageIds.has(event.messageId)) continue;
         const requestKey = resolveInviteRequestKey(event);
         if (requestKey && processedInviteKeys.has(requestKey)) continue;
@@ -277,6 +294,7 @@ async function listRecentInviteCandidatesAcrossManagedIdentities(
           preferInviteCandidate(
             messages.get(requestKey ?? event.messageId),
             event,
+            onboardingScheme,
           ),
         );
       }
@@ -376,6 +394,7 @@ async function processInviteCandidate(
 export function startManagedInviteHostListener(
   deps: ManagedInviteHostListenerDeps,
 ): () => void {
+  const onboardingScheme = deps.onboardingScheme ?? DEFAULT_ONBOARDING_SCHEME;
   const processedMessageIds = new Set<string>();
   const processedInviteKeys = new Set<string>();
   const inflightMessageIds = new Set<string>();
@@ -469,7 +488,7 @@ export function startManagedInviteHostListener(
   const unsubscribe = deps.subscribe((event) => {
     void (async () => {
       if (event.type === "raw.message") {
-        if (!isInviteCandidate(event)) return;
+        if (!isInviteCandidate(event, onboardingScheme)) return;
         await processInviteCandidate(
           deps,
           event,

--- a/packages/cli/src/invite-host-listener.ts
+++ b/packages/cli/src/invite-host-listener.ts
@@ -1,6 +1,5 @@
 import { Result } from "better-result";
 import {
-  createConvosOnboardingScheme,
   extractJoinRequestContent,
   type CoreRawEvent,
   type JoinRequestResult,
@@ -73,7 +72,7 @@ export interface ManagedInviteHostListenerDeps {
     groupId: string,
   ) => Promise<Result<string | undefined, SignetError>>;
   /** Onboarding scheme used to detect and process invite joins. */
-  readonly onboardingScheme?: OnboardingScheme;
+  readonly onboardingScheme: OnboardingScheme;
   /** Best-effort callback after a join request is accepted. */
   readonly onJoinAccepted?: (
     acceptance: ManagedInviteJoinAcceptance,
@@ -96,7 +95,6 @@ const RECENT_JOIN_SCAN_OPTIONS = {
 const DM_RECOVERY_RETRY_DELAY_MS = 250;
 const MAX_DM_RECOVERY_RETRIES = 3;
 const DEFAULT_PROCESSED_INVITE_KEY_TTL_MS = 5_000;
-const DEFAULT_ONBOARDING_SCHEME = createConvosOnboardingScheme();
 
 interface InviteRecoveryScanResult {
   readonly messages: readonly RawMessageEvent[];
@@ -185,7 +183,7 @@ export async function dispatchInviteJoinRequestAcrossManagedIdentities(
   deps: ManagedInviteHostListenerDeps,
   event: CoreRawEvent,
 ): Promise<ManagedInviteJoinDispatchOutcome> {
-  const onboardingScheme = deps.onboardingScheme ?? DEFAULT_ONBOARDING_SCHEME;
+  const onboardingScheme = deps.onboardingScheme;
 
   if (!isInviteCandidate(event, onboardingScheme)) {
     return { result: null, shouldRetry: false };
@@ -255,7 +253,7 @@ async function listRecentInviteCandidatesAcrossManagedIdentities(
   processedMessageIds: ReadonlySet<string>,
   processedInviteKeys: ReadonlySet<string>,
 ): Promise<InviteRecoveryScanResult> {
-  const onboardingScheme = deps.onboardingScheme ?? DEFAULT_ONBOARDING_SCHEME;
+  const onboardingScheme = deps.onboardingScheme;
   const identities = await deps.listIdentities();
   const messages = new Map<string, RawMessageEvent>();
   let shouldRetry = false;
@@ -394,7 +392,7 @@ async function processInviteCandidate(
 export function startManagedInviteHostListener(
   deps: ManagedInviteHostListenerDeps,
 ): () => void {
-  const onboardingScheme = deps.onboardingScheme ?? DEFAULT_ONBOARDING_SCHEME;
+  const onboardingScheme = deps.onboardingScheme;
   const processedMessageIds = new Set<string>();
   const processedInviteKeys = new Set<string>();
   const inflightMessageIds = new Set<string>();

--- a/packages/cli/src/onboarding-schemes.ts
+++ b/packages/cli/src/onboarding-schemes.ts
@@ -1,0 +1,15 @@
+import {
+  createConvosOnboardingScheme,
+  type OnboardingScheme,
+} from "@xmtp/signet-core";
+import type { OnboardingSchemeId } from "./config/schema.js";
+
+/** Resolve a configured onboarding scheme ID to its runtime implementation. */
+export function resolveOnboardingScheme(
+  schemeId: OnboardingSchemeId,
+): OnboardingScheme {
+  switch (schemeId) {
+    case "convos":
+      return createConvosOnboardingScheme();
+  }
+}

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -546,6 +546,7 @@ export async function createSignetRuntime(
           ? credentialsResult.value.length
           : 0,
         activeConnections: wsServer.connectionCount,
+        onboardingScheme: config.onboarding.scheme,
         xmtpEnv: config.signet.env,
         identityMode: config.signet.identityMode,
         wsPort: boundWsPort,

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -868,6 +868,7 @@ export function createProductionDeps(options?: {
                 managed.client.sendMessage(targetGroupId, content, contentType),
             };
           },
+          onboardingScheme,
           resolveLocalChatId: (groupId) =>
             idMappingStoreRef?.resolve(groupId)?.localId,
         });

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -27,7 +27,6 @@ import {
   SignetCoreConfigSchema,
   createSdkClientFactory,
   createConsentActions,
-  createConvosOnboardingScheme,
   createConversationActions,
   createInboxActions as createInboxActionSpecs,
   createLookupActions,
@@ -61,7 +60,7 @@ import {
   type HttpServerConfig as HttpServerImplConfig,
   type HttpServerDeps,
 } from "./http/server.js";
-import type { AdminServerConfig } from "./config/schema.js";
+import type { AdminServerConfig, OnboardingSchemeId } from "./config/schema.js";
 import type { SignetRuntimeDeps } from "./runtime.js";
 import { createSealActions as createSealActionSpecs } from "./actions/seal-actions.js";
 import {
@@ -77,6 +76,7 @@ import { createEventProjector } from "./ws/event-projector.js";
 import { createPendingActionStore } from "@xmtp/signet-sessions";
 import { startManagedInviteHostListener } from "./invite-host-listener.js";
 import { createSealInputResolver } from "./seal-input-resolver.js";
+import { resolveOnboardingScheme } from "./onboarding-schemes.js";
 
 /** Map SignetCoreImpl states to the contract's CoreState. */
 function mapSignetState(state: SignetState): CoreState {
@@ -105,7 +105,13 @@ function mapSignetState(state: SignetState): CoreState {
  * createSignetRuntime -- the `unknown` params are narrowed here
  * to the concrete types each package expects.
  */
-export function createProductionDeps(): SignetRuntimeDeps {
+export function createProductionDeps(options?: {
+  onboardingSchemeId?: OnboardingSchemeId;
+}): SignetRuntimeDeps {
+  const onboardingScheme = resolveOnboardingScheme(
+    options?.onboardingSchemeId ?? "convos",
+  );
+
   // Hold references so downstream factories can access shared instances
   let keyManagerRef: KeyManager | null = null;
   let coreImplRef: SignetCoreImpl | null = null;
@@ -186,7 +192,7 @@ export function createProductionDeps(): SignetRuntimeDeps {
         return createSignerProvider(keyManagerRef, identityId);
       };
 
-      const clientFactory = createSdkClientFactory();
+      const clientFactory = createSdkClientFactory({ onboardingScheme });
 
       // Parse through schema so defaults (heartbeatIntervalMs, etc.) are applied
       const coreConfig = SignetCoreConfigSchema.parse({
@@ -704,14 +710,14 @@ export function createProductionDeps(): SignetRuntimeDeps {
       }
 
       const actions = createConversationActions({
-        onboardingScheme: createConvosOnboardingScheme(),
+        onboardingScheme,
         identityStore: core.identityStore,
         ...(operatorManagerRef ? { operatorManager: operatorManagerRef } : {}),
         getManagedClient: (id) => core.getManagedClient(id),
         getManagedClientForGroup: (groupId) =>
           core.getManagedClientForGroup(groupId),
         getGroupInfo: (groupId: string) => core.context.getGroupInfo(groupId),
-        clientFactory: createSdkClientFactory(),
+        clientFactory: createSdkClientFactory({ onboardingScheme }),
         signerProviderFactory,
         attachManagedIdentity: (identityId) =>
           core.attachPersistedIdentity(identityId),
@@ -866,6 +872,7 @@ export function createProductionDeps(): SignetRuntimeDeps {
             idMappingStoreRef?.resolve(groupId)?.localId,
         });
         inviteHostUnsub = startManagedInviteHostListener({
+          onboardingScheme,
           subscribe: (handler) => core.on(handler),
           listIdentities: () => core.identityStore.list(),
           getWalletPrivateKeyHex: async (identityId) => {


### PR DESCRIPTION
## Summary
- add CLI config support for `[onboarding] scheme = "convos"`
- resolve the onboarding scheme once in CLI startup and inject it into conversation actions, SDK creation, and invite hosting
- surface the configured scheme in init and runtime status without broadening the core config unnecessarily

## Validation
- `bun run check` on `v1/onboarding-schemes-move`

Closes #325