### PR TITLE
docs: expand docstring coverage across runtime and signer

### DIFF
--- a/packages/cli/src/commands/daemon-client.ts
+++ b/packages/cli/src/commands/daemon-client.ts
@@ -21,16 +21,21 @@ export interface DaemonCommandContext {
 
 /** Dependencies for commands that connect to the running daemon. */
 export interface DaemonCommandDeps {
+  /** Load the effective CLI config before deriving admin connection details. */
   readonly loadConfig: typeof loadConfig;
+  /** Resolve filesystem/socket paths from the parsed config. */
   readonly resolvePaths: typeof resolvePaths;
+  /** Open the local key manager so the command can mint an admin JWT. */
   readonly createKeyManager: (
     config: Parameters<typeof createKeyManager>[0],
   ) => Promise<Result<RpcKeyManager, SignetError>>;
+  /** Create the admin RPC client bound to the resolved Unix socket path. */
   readonly createAdminClient: (socketPath: string) => AdminClient;
 }
 
 /** Common option bag for commands that can target a config file. */
 export interface DaemonCommandOptions {
+  /** Override the default config path for one-off command invocations. */
   readonly configPath?: string | undefined;
 }
 

--- a/packages/cli/src/config/paths.ts
+++ b/packages/cli/src/config/paths.ts
@@ -9,11 +9,17 @@ const APP_NAME = "xmtp-signet";
  * All paths are absolute with tilde and XDG variables resolved.
  */
 export interface ResolvedPaths {
+  /** Location of the CLI config file that `xs` reads and writes. */
   readonly configFile: string;
+  /** Persistent runtime data directory shared across daemon restarts. */
   readonly dataDir: string;
+  /** PID file used to advertise and inspect the active daemon process. */
   readonly pidFile: string;
+  /** Unix socket path for owner-admin RPC traffic. */
   readonly adminSocket: string;
+  /** JSONL audit log path for security-sensitive actions and approvals. */
   readonly auditLog: string;
+  /** Vault database path that backs local identity and key material. */
   readonly identityKeyFile: string;
 }
 

--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -74,6 +74,7 @@ export const HttpServerConfigSchema: z.ZodType<
 
 // -- CLI config --
 
+/** Supported onboarding scheme IDs for invite, profile, and first-run flows. */
 export type OnboardingSchemeId = "convos";
 
 type OnboardingConfig = {

--- a/packages/cli/src/daemon/status.ts
+++ b/packages/cli/src/daemon/status.ts
@@ -3,19 +3,29 @@ import { z } from "zod";
 
 /** Daemon status as returned by `status` and admin `ping()`. */
 export type DaemonStatus = {
+  /** High-level daemon process lifecycle state. */
   state: "running" | "draining" | "stopped";
+  /** Current XMTP core readiness state projected into the public contract. */
   coreState: CoreState;
   pid: number;
   uptime: number;
+  /** Count of credentials that are currently issued and not revoked. */
   activeCredentials: number;
+  /** Number of live harness/admin transport connections. */
   activeConnections: number;
+  /** Active onboarding flow family used for invite/profile orchestration. */
   onboardingScheme: "convos";
+  /** XMTP environment the daemon is currently connected to. */
   xmtpEnv: "local" | "dev" | "production";
+  /** Identity isolation posture chosen for this runtime. */
   identityMode: "per-group" | "shared";
   wsPort: number;
   version: string;
+  /** Number of local identities currently registered in the runtime store. */
   identityCount: number;
+  /** Whether the core has reached a live network-connected state. */
   networkState: "disconnected" | "connected";
+  /** Inbox IDs that the current runtime has actively connected for syncing. */
   connectedInboxIds: readonly string[];
 };
 

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -44,15 +44,25 @@ import {
 
 /** The fully wired signet runtime returned by the composition root. */
 export interface SignetRuntime {
+  /** XMTP lifecycle facade used by the transports and status APIs. */
   readonly core: SignetCore;
+  /** Credential issuance, lookup, and revocation surface for the daemon. */
   readonly credentialManager: CredentialManager;
+  /** Seal publisher/lookup surface coupled to credential changes. */
   readonly sealManager: SealManager;
+  /** Local key custody layer for owner/admin and operational keys. */
   readonly keyManager: KeyManager;
+  /** Harness-facing WebSocket transport. */
   readonly wsServer: WsServer;
+  /** Owner-admin RPC transport. */
   readonly adminServer: AdminServer;
+  /** Optional HTTP admin surface when enabled in config. */
   readonly httpServer: HttpServer | null;
+  /** Audit log sink for approvals and sensitive operations. */
   readonly auditLog: AuditLog;
+  /** Parsed runtime config used to create this composition. */
   readonly config: CliConfig;
+  /** Resolved filesystem locations derived from the runtime config. */
   readonly paths: ResolvedPaths;
 
   /** Start all services in dependency order. */
@@ -73,26 +83,33 @@ export interface SignetRuntime {
  * Tests provide mocks here; production uses real implementations.
  */
 export interface SignetRuntimeDeps {
+  /** Create the platform-specific key custody layer before other services. */
   createKeyManager: (
     config: unknown,
   ) => Promise<Result<KeyManager, SignetError>>;
 
+  /** Create the XMTP core runtime and state machine. */
   createSignetCore: (
     config: unknown,
     signerFactory: unknown,
     clientFactory: unknown,
   ) => SignetCore;
 
+  /** Create the credential manager responsible for issue/revoke flows. */
   createCredentialManager: (
     config: unknown,
     keyManager: KeyManager,
   ) => CredentialManager;
+  /** Create the seal manager that tracks public authorization state. */
   createSealManager: (deps: unknown) => SealManager;
 
+  /** Create the harness-facing WebSocket transport. */
   createWsServer: (config: unknown, deps: unknown) => WsServer;
 
+  /** Create the admin RPC transport used by `xs` owner commands. */
   createAdminServer: (config: unknown, deps: unknown) => AdminServer;
 
+  /** Create the optional HTTP transport that mirrors selected admin flows. */
   createHttpServer?: (config: unknown, deps: unknown) => HttpServer;
 
   /** Optional factory for the shared admin read-elevation manager. */

--- a/packages/contracts/src/action-derive.ts
+++ b/packages/contracts/src/action-derive.ts
@@ -15,6 +15,7 @@ export interface McpAnnotations {
   readonly [key: string]: unknown;
 }
 
+/** Minimal action shape needed by the transport-derivation helpers. */
 type ActionLike = Pick<
   ActionSpec<unknown, unknown>,
   "cli" | "description" | "http" | "id" | "idempotent" | "intent" | "mcp"
@@ -22,6 +23,10 @@ type ActionLike = Pick<
 
 const DEFAULT_HTTP_BASE_PATH = "/v1/actions";
 
+/**
+ * Normalizes the configured HTTP base path so derived routes can join onto it
+ * without introducing double slashes or a dangling trailing slash.
+ */
 const normalizeBasePath = (basePath: string): string => {
   const trimmed = basePath.trim();
   if (trimmed === "" || trimmed === "/") {
@@ -32,6 +37,10 @@ const normalizeBasePath = (basePath: string): string => {
   return withLeadingSlash.replace(/\/+$/, "");
 };
 
+/**
+ * Normalizes an override path into the canonical route form used by the
+ * derived HTTP surface.
+ */
 const normalizePath = (path: string): string => {
   const trimmed = path.trim();
   if (trimmed === "") {

--- a/packages/contracts/src/action-surface-map.ts
+++ b/packages/contracts/src/action-surface-map.ts
@@ -50,6 +50,10 @@ export interface ActionSurfaceMapEntry {
   };
 }
 
+/**
+ * Recursively sorts object keys so hashes and snapshots stay stable even when
+ * source objects were assembled in different insertion orders.
+ */
 const deepSortKeys = (value: unknown): unknown => {
   if (Array.isArray(value)) {
     return value.map(deepSortKeys);
@@ -66,6 +70,11 @@ const deepSortKeys = (value: unknown): unknown => {
   return value;
 };
 
+/**
+ * Determines whether a surface should appear in the public map. HTTP is
+ * special because specs can opt out with `expose: false` while still carrying
+ * route metadata internally.
+ */
 const isSurfaceExposed = (
   spec: AnyActionSpec,
   surface: ActionSurface,
@@ -77,11 +86,16 @@ const isSurfaceExposed = (
   return spec[surface] !== undefined;
 };
 
+/** Returns the sorted list of exposed surfaces for a spec. */
 const getSurfaces = (spec: AnyActionSpec): ActionSurface[] =>
   ACTION_SURFACES.filter((surface) =>
     isSurfaceExposed(spec, surface),
   ).toSorted();
 
+/**
+ * Projects an action spec into its deterministic, transport-normalized summary
+ * shape before hashing or publishing the surface map.
+ */
 const toEntry = (spec: AnyActionSpec): ActionSurfaceMapEntry => {
   const entry: Record<string, unknown> = {
     exampleCount: spec.examples?.length ?? 0,

--- a/packages/core/src/convos/join.ts
+++ b/packages/core/src/convos/join.ts
@@ -75,6 +75,10 @@ function extractSlugForDm(input: string): string {
   return trimmed;
 }
 
+/**
+ * Scan recent DM replies for a host-authored invite failure that matches the
+ * current invite tag so we can surface a precise error instead of timing out.
+ */
 function findInviteJoinErrorReply(
   messages: readonly {
     senderInboxId: string;

--- a/packages/core/src/convos/onboarding-scheme.ts
+++ b/packages/core/src/convos/onboarding-scheme.ts
@@ -42,16 +42,23 @@ import {
 import { resolveProfilesFromMessages } from "./profile-state.js";
 import { processJoinRequest } from "./process-join-requests.js";
 
+/** Render a fully qualified content-type label from the shared scheme shape. */
 function formatContentType(contentType: OnboardingContentTypeId): string {
   return `${contentType.authorityId}/${contentType.typeId}:${contentType.versionMajor}.${contentType.versionMinor}`;
 }
 
+/** Choose the public Convos invite host that matches the current XMTP env. */
 function resolveInviteBaseUrl(env: InviteOptions["env"]): string {
   return env === "dev" || env === "local"
     ? "https://dev.convos.org/v2"
     : "https://popup.convos.org/v2";
 }
 
+/**
+ * Adapt the shared invite-generation contract into the exact option bag the
+ * Convos slug generator expects, omitting optional fields when absent so we do
+ * not change wire defaults.
+ */
 function toGenerateInviteSlugOptions(
   conversationId: string,
   conversationFormat: "uuid" | "string" | undefined,
@@ -81,6 +88,7 @@ function toGenerateInviteSlugOptions(
   };
 }
 
+/** Convert the scheme's flat metadata map into Convos' typed metadata union. */
 function toConvosProfileMetadata(
   metadata: ProfileData["metadata"],
 ): ProfileMetadata | undefined {
@@ -100,6 +108,7 @@ function toConvosProfileMetadata(
   return Object.keys(converted).length > 0 ? converted : undefined;
 }
 
+/** Collapse Convos metadata values back to the generic primitive map. */
 function fromConvosProfileMetadata(
   metadata: ProfileMetadata | undefined,
 ): ProfileData["metadata"] | undefined {
@@ -135,6 +144,11 @@ function fromConvosMemberKind(
   return undefined;
 }
 
+/**
+ * Guard the generic scheme contract against raw image URLs. Convos profile
+ * messages only carry encrypted image descriptors, so accepting a plain URL
+ * here would silently promise behavior the codec cannot preserve.
+ */
 function assertNoPlainProfileImageUrl(
   profile: Pick<ProfileData, "imageUrl">,
 ): void {
@@ -171,6 +185,7 @@ function toMemberProfileEntry(profile: MemberProfileData): MemberProfileEntry {
   };
 }
 
+/** Convert a Convos-specific parsed invite into the shared scheme shape. */
 function toParsedInvite(invite: ReturnType<typeof parseConvosInviteUrl>) {
   if (invite.isErr()) return invite;
   return Result.ok<ParsedInvite, SignetError>({
@@ -193,6 +208,10 @@ function toParsedInvite(invite: ReturnType<typeof parseConvosInviteUrl>) {
   });
 }
 
+/**
+ * Narrow a shared parsed invite back to the Convos wire shape before running
+ * Convos-specific verification logic.
+ */
 function toConvosParsedInvite(
   invite: ParsedInvite,
 ): Result<Parameters<typeof verifyConvosInvite>[0], SignetError> {
@@ -220,6 +239,7 @@ function toConvosParsedInvite(
   });
 }
 
+/** Project a Convos member profile back into the generic onboarding view. */
 function toResolvedProfile(
   profile: MemberProfileEntry,
 ): ResolvedOnboardingProfile {

--- a/packages/core/src/convos/profile-state.ts
+++ b/packages/core/src/convos/profile-state.ts
@@ -13,6 +13,7 @@ import {
 /** Resolved profile fields for a member after combining updates and snapshots. */
 export interface ResolvedProfile extends MemberProfileEntry {}
 
+/** Narrow arbitrary snapshot entries before we trust them as member profiles. */
 function isSnapshotProfileEntry(value: unknown): value is MemberProfileEntry {
   return (
     typeof value === "object" &&
@@ -23,6 +24,7 @@ function isSnapshotProfileEntry(value: unknown): value is MemberProfileEntry {
   );
 }
 
+/** Match both short legacy labels and fully qualified Convos content types. */
 function isContentTypeMatch(
   contentType: string | undefined,
   target: { authorityId: string; typeId: string },
@@ -98,6 +100,8 @@ export function resolveProfilesFromMessages(
   const profilesByInboxId = new Map<string, ResolvedProfile>();
   let latestSnapshotProfiles: Map<string, MemberProfileEntry> | undefined;
 
+  // Walk newest-first so the first update we see for an inbox wins, then use
+  // the latest snapshot only as a backfill for members without a newer update.
   const orderedMessages = [...messages].sort((left, right) =>
     right.sentAt.localeCompare(left.sentAt),
   );

--- a/packages/core/src/schemes/invite-crypto.ts
+++ b/packages/core/src/schemes/invite-crypto.ts
@@ -65,6 +65,7 @@ export interface InviteCrypto {
   ): Result<Uint8Array, SignetError>;
 }
 
+/** Pre-bind the scheme salt so token encryption and decryption share one KDF. */
 function createDeriveTokenKey(saltBytes: Uint8Array) {
   return function deriveTokenKey(
     privateKeyBytes: Uint8Array,
@@ -75,6 +76,7 @@ function createDeriveTokenKey(saltBytes: Uint8Array) {
   };
 }
 
+/** Validate config values that must fit into a single serialized byte. */
 function requireByteConfig(field: string, value: number): number {
   if (!Number.isInteger(value) || value < 0 || value > 0xff) {
     throw new RangeError(

--- a/packages/mcp/src/call-handler.ts
+++ b/packages/mcp/src/call-handler.ts
@@ -83,6 +83,7 @@ export async function handleCallTool(
 // Internal helpers
 // ---------------------------------------------------------------------------
 
+/** Build per-request action metadata for the result envelope. */
 function buildMeta(requestId: string, startTime: number): ActionResultMeta {
   return {
     requestId,
@@ -91,6 +92,7 @@ function buildMeta(requestId: string, startTime: number): ActionResultMeta {
   };
 }
 
+/** Resolve the MCP tool name back to its registered action spec. */
 function findSpecByToolName(
   toolName: string,
   registry: ActionRegistry,
@@ -99,6 +101,7 @@ function findSpecByToolName(
   return mcpSpecs.find((spec) => deriveMcpToolName(spec) === toolName);
 }
 
+/** Translate an unknown tool request into the standard action-result envelope. */
 function formatNotFound(
   toolName: string,
   startTime: number,
@@ -111,6 +114,7 @@ function formatNotFound(
   return formatActionResult(result);
 }
 
+/** Collapse Zod validation details into the shared validation error shape. */
 function formatValidationError(
   zodError: {
     issues: ReadonlyArray<{
@@ -133,6 +137,7 @@ function formatValidationError(
   return formatActionResult(result);
 }
 
+/** Guard the MCP adapter against unexpected handler throws. */
 function formatInternalError(
   error: unknown,
   startTime: number,

--- a/packages/policy/src/materiality.ts
+++ b/packages/policy/src/materiality.ts
@@ -1,11 +1,13 @@
 import type { PolicyDelta } from "@xmtp/signet-contracts";
 
+/** Narrow a single-or-array input into the array form used internally. */
 function isDeltaArray(
   deltas: PolicyDelta | readonly PolicyDelta[],
 ): deltas is readonly PolicyDelta[] {
   return Array.isArray(deltas);
 }
 
+/** Normalize single-delta callers onto the shared batch evaluation path. */
 function normalizeDeltas(
   deltas: PolicyDelta | readonly PolicyDelta[],
 ): readonly PolicyDelta[] {
@@ -26,6 +28,7 @@ export function isMaterialChange(
   return normalizeDeltas(deltas).some((delta) => isSingleDeltaMaterial(delta));
 }
 
+/** Any added, removed, or flipped scope is material because the seal changes. */
 function isSingleDeltaMaterial(delta: PolicyDelta): boolean {
   return (
     delta.added.length > 0 ||
@@ -46,6 +49,10 @@ export function requiresReauthorization(
   );
 }
 
+/**
+ * Reauthorization is only required when privileges expand: newly added scopes
+ * or deny-to-allow flips. Pure restriction changes stay silent.
+ */
 function isSingleDeltaEscalation(delta: PolicyDelta): boolean {
   return (
     delta.added.length > 0 ||

--- a/packages/seals/src/manager.ts
+++ b/packages/seals/src/manager.ts
@@ -377,10 +377,12 @@ function hasInputChanges(previous: SealInput, next: SealInput): boolean {
   );
 }
 
+/** Canonical serialization for structural equality checks on nested metadata. */
 function stableSerialize(value: unknown): string {
   return new TextDecoder().decode(canonicalize(value));
 }
 
+/** Apply the optional list filters used by the public seal listing API. */
 function matchesFilter(
   envelope: SealEnvelopeType,
   filter: SealListFilter,
@@ -402,6 +404,7 @@ function matchesFilter(
   return true;
 }
 
+/** Sort helper that keeps the most recently issued seal first. */
 function compareNewestFirst(
   left: SealEnvelopeType,
   right: SealEnvelopeType,
@@ -412,6 +415,10 @@ function compareNewestFirst(
   );
 }
 
+/**
+ * Finds the current head of a seal chain by looking for the only envelope that
+ * is not referenced as another envelope's predecessor.
+ */
 function findHistoryHead(
   envelopes: readonly SealEnvelopeType[],
 ): SealEnvelopeType | undefined {

--- a/scripts/check-doc-coverage.ts
+++ b/scripts/check-doc-coverage.ts
@@ -13,6 +13,10 @@ type PackageStats = {
   documented: number;
 };
 
+/**
+ * Recursively collect source files from each package source tree, skipping
+ * generated and test directories so coverage only reflects shipped surfaces.
+ */
 function walkSourceFiles(dir: string, acc: string[] = []): string[] {
   for (const entry of readdirSync(dir)) {
     const fullPath = join(dir, entry);
@@ -35,10 +39,12 @@ function walkSourceFiles(dir: string, acc: string[] = []): string[] {
   return acc;
 }
 
+/** Return the stable modifier list for a node across TypeScript versions. */
 function getModifiers(node: ts.Node): readonly ts.ModifierLike[] {
   return ts.getModifiers?.(node) ?? node.modifiers ?? [];
 }
 
+/** Detect whether a top-level declaration contributes to the export surface. */
 function isExported(node: ts.Node): boolean {
   const modifiers = getModifiers(node);
 
@@ -49,6 +55,12 @@ function isExported(node: ts.Node): boolean {
   );
 }
 
+/**
+ * Determine whether a declaration has a usable TSDoc/JSDoc comment.
+ *
+ * We accept either parsed JSDoc nodes with real content or a raw leading `/**`
+ * block so the script stays tolerant of the formatter and compiler API quirks.
+ */
 function hasDocComment(node: ts.Node, sourceFile: ts.SourceFile): boolean {
   const jsDocs = ts.getJSDocCommentsAndTags(node);
 
@@ -69,6 +81,7 @@ function hasDocComment(node: ts.Node, sourceFile: ts.SourceFile): boolean {
   );
 }
 
+/** Best-effort human-readable name used in failure output. */
 function getNodeName(
   node: ts.Node | undefined,
   sourceFile: ts.SourceFile,
@@ -82,11 +95,13 @@ function getNodeName(
   }
 }
 
+/** Format percentages with the single decimal place used in coverage output. */
 function formatPercent(numerator: number, denominator: number): string {
   if (denominator === 0) return "100.0";
   return ((numerator / denominator) * 100).toFixed(1);
 }
 
+/** Print the repo-wide and per-package coverage table. */
 function printSummary(
   byPackage: ReadonlyArray<[string, PackageStats]>,
   total: number,

--- a/signet-signer/Sources/SignetCore/Models.swift
+++ b/signet-signer/Sources/SignetCore/Models.swift
@@ -9,6 +9,7 @@ public enum KeyPolicy: String, Codable, CaseIterable, Sendable {
 
 // MARK: - Error Types
 
+/// Domain-specific failures returned by the Secure Enclave helper layer.
 public enum SignetError: Error, CustomStringConvertible {
     case seUnavailable
     case creationFailed(String)
@@ -18,6 +19,7 @@ public enum SignetError: Error, CustomStringConvertible {
     case decryptionFailed(String)
     case authCancelled
 
+    /// Human-readable description surfaced by the CLI.
     public var description: String {
         switch self {
         case .seUnavailable:
@@ -37,6 +39,7 @@ public enum SignetError: Error, CustomStringConvertible {
         }
     }
 
+    /// Process exit code used by the CLI wrapper.
     public var exitCode: Int32 {
         switch self {
         case .seUnavailable: return 1
@@ -52,12 +55,14 @@ public enum SignetError: Error, CustomStringConvertible {
 
 // MARK: - JSON Response Types
 
+/// Response payload for the `create` command.
 public struct CreateResponse: Codable {
     public let keyRef: String
     public let publicKey: String
     public let policy: String
     public let label: String
 
+    /// Create a JSON-encodable response for a newly created SE key.
     public init(keyRef: String, publicKey: String, policy: String, label: String) {
         self.keyRef = keyRef
         self.publicKey = publicKey
@@ -66,19 +71,23 @@ public struct CreateResponse: Codable {
     }
 }
 
+/// Response payload for the `sign` command.
 public struct SignResponse: Codable {
     public let signature: String
 
+    /// Create a JSON-encodable signature response.
     public init(signature: String) {
         self.signature = signature
     }
 }
 
+/// Response payload for system and availability inspection.
 public struct SystemInfoResponse: Codable {
     public let available: Bool
     public let chip: String?
     public let macOS: String?
 
+    /// Create a JSON-encodable system information response.
     public init(available: Bool, chip: String?, macOS: String?) {
         self.available = available
         self.chip = chip
@@ -86,17 +95,21 @@ public struct SystemInfoResponse: Codable {
     }
 }
 
+/// Response payload for the ECIES decrypt path.
 public struct DecryptResponse: Codable {
     public let plaintext: String
 
+    /// Create a JSON-encodable decrypt response.
     public init(plaintext: String) {
         self.plaintext = plaintext
     }
 }
 
+/// Response payload for existence checks against persisted key references.
 public struct KeyInfoResponse: Codable {
     public let exists: Bool
 
+    /// Create a JSON-encodable key lookup response.
     public init(exists: Bool) {
         self.exists = exists
     }

--- a/signet-signer/Sources/SignetCore/SecureEnclaveManager.swift
+++ b/signet-signer/Sources/SignetCore/SecureEnclaveManager.swift
@@ -2,8 +2,10 @@ import Foundation
 import CryptoKit
 import Security
 
+/// High-level wrapper around CryptoKit and Security framework Secure Enclave operations.
 public class SecureEnclaveManager {
 
+    /// Create a new manager instance.
     public init() {}
 
     /// Purpose of the SE key — determines CryptoKit key type.
@@ -14,6 +16,7 @@ public class SecureEnclaveManager {
 
     // MARK: - Key Creation
 
+    /// Create a new Secure Enclave-backed P-256 key and return its opaque handle plus public key.
     public func createKey(policy: KeyPolicy, purpose: KeyPurpose = .signing) throws -> (dataRepresentation: Data, publicKey: Data) {
         guard SecureEnclave.isAvailable else {
             throw SignetError.seUnavailable
@@ -91,6 +94,7 @@ public class SecureEnclaveManager {
 
     // MARK: - Signing
 
+    /// Sign either raw message bytes or a pre-hashed 32-byte digest with a signing key.
     public func signData(_ data: Data, dataRepresentation: Data) throws -> Data {
         let privateKey: SecureEnclave.P256.Signing.PrivateKey
         do {
@@ -228,10 +232,12 @@ public class SecureEnclaveManager {
 
     // MARK: - System Info
 
+    /// Return whether Secure Enclave support is available on this machine.
     public func isAvailable() -> Bool {
         SecureEnclave.isAvailable
     }
 
+    /// Return a best-effort chip identifier for diagnostics and JSON output.
     public func getChipName() -> String {
         var size: Int = 0
         sysctlbyname("machdep.cpu.brand_string", nil, &size, nil, 0)
@@ -250,6 +256,7 @@ public class SecureEnclaveManager {
         return "Unknown"
     }
 
+    /// Return the host macOS version string for diagnostics and JSON output.
     public func getMacOSVersion() -> String {
         let v = ProcessInfo.processInfo.operatingSystemVersion
         if v.patchVersion != 0 {

--- a/signet-signer/Sources/SignetCore/SignatureFormatter.swift
+++ b/signet-signer/Sources/SignetCore/SignatureFormatter.swift
@@ -1,18 +1,20 @@
 import Foundation
 
+/// Shared formatting and normalization helpers for P-256 signatures and hex I/O.
 public struct SignatureFormatter {
 
-    // P-256 curve order
+    /// The P-256 curve order used for low-S normalization.
     public static let curveOrder = dataFromHexLiteral(
         "FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551"
     )
-    // curve_order / 2
+    /// Half of the P-256 curve order used as the low-S threshold.
     public static let halfOrder = dataFromHexLiteral(
         "7FFFFFFF800000007FFFFFFFFFFFFFFFDE737D56D38BCF4279DCE5617E3192A8"
     )
 
     // MARK: - DER Parsing
 
+    /// Parse a DER-encoded ECDSA signature into its `r` and `s` components.
     public static func parseDERSignature(_ der: Data) throws -> (r: Data, s: Data) {
         guard der.count >= 8 else {
             throw SignetError.invalidHex("DER signature too short")
@@ -73,6 +75,7 @@ public struct SignatureFormatter {
 
     // MARK: - Low-S Normalization
 
+    /// Rewrite `s` into its low-S form when the signature is in the upper half of the curve order.
     public static func applyLowS(s: Data) -> Data {
         let sPadded = leftPad(s, to: 32)
         let halfPadded = leftPad(halfOrder, to: 32)
@@ -86,6 +89,7 @@ public struct SignatureFormatter {
 
     // MARK: - DER Reconstruction
 
+    /// Rebuild a DER-encoded ECDSA signature from normalized `r` and `s` values.
     public static func reconstructDER(r: Data, s: Data) -> Data {
         let rDER = encodeInteger(r)
         let sDER = encodeInteger(s)
@@ -117,10 +121,12 @@ public struct SignatureFormatter {
 
     // MARK: - Hex Helpers
 
+    /// Render bytes as lowercase hexadecimal without a `0x` prefix.
     public static func formatHex(_ data: Data) -> String {
         data.map { String(format: "%02x", $0) }.joined()
     }
 
+    /// Parse a hex string into bytes, accepting an optional `0x` prefix.
     public static func parseHex(_ hex: String) throws -> Data {
         var cleaned = hex.trimmingCharacters(in: .whitespacesAndNewlines)
         if cleaned.isEmpty {
@@ -154,6 +160,7 @@ public struct SignatureFormatter {
 
     // MARK: - Big-Endian Arithmetic
 
+    /// Compare two unsigned big-endian integers represented as `Data`.
     public static func compareBigEndian(_ a: Data, _ b: Data) -> Int {
         let maxLen = max(a.count, b.count)
         let aPadded = leftPad(a, to: maxLen)
@@ -188,6 +195,7 @@ public struct SignatureFormatter {
         return data
     }
 
+    /// Left-pad a byte string with zeroes until it reaches the requested length.
     public static func leftPad(_ data: Data, to length: Int) -> Data {
         if data.count >= length { return data }
         var padded = Data(repeating: 0, count: length - data.count)

--- a/signet-signer/Sources/signet-signer/CreateCommand.swift
+++ b/signet-signer/Sources/signet-signer/CreateCommand.swift
@@ -4,6 +4,7 @@ import SignetCore
 
 extension SecureEnclaveManager.KeyPurpose: ExpressibleByArgument {}
 
+/// Create a new Secure Enclave-backed P-256 key and print its public metadata.
 struct CreateCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "create",
@@ -21,6 +22,7 @@ struct CreateCommand: ParsableCommand {
     @Option(name: .long, help: "Key purpose: signing or key-agreement")
     var purpose: SecureEnclaveManager.KeyPurpose = .signing
 
+    /// Validate CLI input, create the key, and emit the JSON response payload.
     mutating func run() throws {
         let manager = SecureEnclaveManager()
 

--- a/signet-signer/Sources/signet-signer/DecryptCommand.swift
+++ b/signet-signer/Sources/signet-signer/DecryptCommand.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Foundation
 import SignetCore
 
+/// Decrypt an ECIES payload using a Secure Enclave key-agreement key.
 struct DecryptCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "decrypt",
@@ -25,6 +26,7 @@ struct DecryptCommand: ParsableCommand {
     @Option(name: .long, help: "Hex-encoded AES-GCM authentication tag (16 bytes)")
     var tag: String
 
+    /// Parse the CLI arguments, perform ECIES decryption, and emit the plaintext.
     mutating func run() throws {
         // Parse key reference
         guard let dataRep = Data(base64Encoded: keyRef) else {

--- a/signet-signer/Sources/signet-signer/DeleteCommand.swift
+++ b/signet-signer/Sources/signet-signer/DeleteCommand.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Foundation
 import SignetCore
 
+/// Best-effort deletion command for a persisted Secure Enclave key reference.
 struct DeleteCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "delete",
@@ -13,6 +14,7 @@ struct DeleteCommand: ParsableCommand {
     @Option(name: .long, help: "Base64-encoded SE key reference to delete")
     var keyRef: String
 
+    /// Attempt key deletion and exit successfully even if the underlying item is already gone.
     mutating func run() throws {
         let manager = SecureEnclaveManager()
         manager.deleteKey(keyRef)

--- a/signet-signer/Sources/signet-signer/InfoCommand.swift
+++ b/signet-signer/Sources/signet-signer/InfoCommand.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Foundation
 import SignetCore
 
+/// Inspect host Secure Enclave availability or resolve whether a key reference still exists.
 struct InfoCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "info",
@@ -16,6 +17,7 @@ struct InfoCommand: ParsableCommand {
     @Option(name: .long, help: "Base64-encoded SE key reference to check")
     var keyRef: String?
 
+    /// Validate the requested mode and emit either system info or key lookup results.
     mutating func run() throws {
         if system && keyRef != nil {
             writeStderr("cannot specify both --system and --key-ref")

--- a/signet-signer/Sources/signet-signer/SignCommand.swift
+++ b/signet-signer/Sources/signet-signer/SignCommand.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Foundation
 import SignetCore
 
+/// Sign input bytes with a Secure Enclave key and normalize the signature to low-S form.
 struct SignCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "sign",
@@ -16,6 +17,7 @@ struct SignCommand: ParsableCommand {
     @Option(name: .long, help: "Hex-encoded data to sign")
     var data: String
 
+    /// Parse the CLI inputs, sign the payload, normalize the signature, and emit JSON output.
     mutating func run() throws {
         // Parse key reference
         guard let dataRep = Data(base64Encoded: keyRef) else {

--- a/signet-signer/Sources/signet-signer/main.swift
+++ b/signet-signer/Sources/signet-signer/main.swift
@@ -4,6 +4,7 @@ import SignetCore
 
 extension KeyPolicy: ExpressibleByArgument {}
 
+/// Root CLI entrypoint for Secure Enclave-backed P-256 helper operations.
 struct SignetSigner: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "signet-signer",
@@ -21,6 +22,7 @@ struct SignetSigner: ParsableCommand {
 
 // MARK: - Global Options
 
+/// Shared command-line options supported by every subcommand.
 struct GlobalOptions: ParsableArguments {
     @Option(name: .long, help: "Output format: json")
     var format: String = "json"
@@ -28,24 +30,28 @@ struct GlobalOptions: ParsableArguments {
 
 // MARK: - Output Helpers
 
+/// Build the canonical JSON encoder used by command output helpers.
 func makeEncoder() -> JSONEncoder {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     return encoder
 }
 
+/// Write a UTF-8 string directly to stdout without additional formatting.
 func writeStdout(_ string: String) {
     if let data = string.data(using: .utf8) {
         FileHandle.standardOutput.write(data)
     }
 }
 
+/// Emit a standardized error line to stderr.
 func writeStderr(_ string: String) {
     if let data = "error: \(string)\n".data(using: .utf8) {
         FileHandle.standardError.write(data)
     }
 }
 
+/// Encode any `Encodable` value as canonical JSON and terminate with a newline.
 func outputJSON<T: Encodable>(_ value: T) throws {
     let encoder = makeEncoder()
     let data = try encoder.encode(value)


### PR DESCRIPTION
## Summary
- expand docstring coverage across CLI config/runtime, onboarding helpers, action derivation, MCP, policy, seal, and Secure Enclave signer surfaces
- document non-obvious internal helpers and invariants where the exported API checker does not help on its own
- keep the pass intentionally focused on meaningful explanation rather than blanket narration, with no runtime behavior changes

## Why
The repo already enforced exported API doc coverage, but several important seams still depended on reader inference: onboarding/profile adaptation, transport-derived action metadata, runtime/config plumbing, and the Secure Enclave signer internals. This pass fills in those gaps so the codebase is easier to navigate without turning it into comment spam.

## Validation
- `bun run docs:check` (`972/972`, 100.0% coverage)
- `bun run check`
- `swift test` in `signet-signer`

## Notes
- no functional behavior changes intended
- most edits are TSDoc/SwiftDoc plus a few targeted inline comments for tricky helper logic
