### PR TITLE
fix(cli): restore docs coverage on main

### DIFF
--- a/packages/cli/src/config/schema.ts
+++ b/packages/cli/src/config/schema.ts
@@ -74,6 +74,7 @@ export const HttpServerConfigSchema: z.ZodType<
 
 // -- CLI config --
 
+/** Supported onboarding scheme IDs for invite, profile, and first-run flows. */
 export type OnboardingSchemeId = "convos";
 
 type OnboardingConfig = {


### PR DESCRIPTION
## Summary
- add the missing exported doc comment for `OnboardingSchemeId`
- restore `bun run docs:check` on `main`
- keep this PR intentionally minimal so it can land independently of the broader docstring sweep

## Why
`main` is currently red on GitHub Actions run `24595815197` for head `b977037d6ce1bf7c37e2b0171472c4462c26ec86`.
The failure is a single docs-coverage violation:
- `packages/cli/src/config/schema.ts:77 TypeAliasDeclaration OnboardingSchemeId`

That is the exact hosted failure. This PR fixes only that regression so we have a fast path back to green.

## Validation
- `bun run docs:check`
- `bun run check`

## Notes
- the broader docstring pass in `#337` also contains this fix, but this PR isolates the CI recovery path for faster merge/review
