### PR TITLE
feat: add xs agent registry dispatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,7 @@ The `xs` command groups are:
 - `operator` — `create`, `list`, `info`, `rename`, `rm`
 - `cred` — `issue`, `list`, `info`, `revoke`, `update`
 - `inbox` — `create`, `list`, `info`, `rm`, `link`, `unlink`
+- `agent` — `setup`, `status`, `doctor`
 - `chat` — `create`, `list`, `info`, `update`, `sync`, `join`, `invite`,
   `update-profile`, `leave`, `rm`, plus `member` subgroup (`list`, `add`,
   `rm`, `promote`, `demote`)

--- a/packages/cli/src/__tests__/agent-registry.test.ts
+++ b/packages/cli/src/__tests__/agent-registry.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { resolveAgentAdapterCommand } from "../agent/registry.js";
+import type { CliConfig } from "../config/schema.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) =>
+      rm(dir, {
+        recursive: true,
+        force: true,
+      }),
+    ),
+  );
+});
+
+function stubConfig(adapters: CliConfig["agent"]["adapters"] = {}): CliConfig {
+  return {
+    onboarding: {
+      scheme: "convos",
+    },
+    signet: {
+      env: "dev",
+      identityMode: "per-group",
+      dataDir: undefined,
+    },
+    defaults: {
+      profileName: undefined,
+    },
+    keys: {
+      rootKeyPolicy: "biometric",
+      operationalKeyPolicy: "open",
+      vaultKeyPolicy: "open",
+    },
+    biometricGating: {
+      rootKeyCreation: false,
+      operationalKeyRotation: false,
+      scopeExpansion: false,
+      egressExpansion: false,
+      agentCreation: false,
+      adminReadElevation: false,
+    },
+    ws: {
+      port: 8393,
+      host: "127.0.0.1",
+    },
+    http: {
+      enabled: false,
+      port: 8081,
+      host: "127.0.0.1",
+    },
+    admin: {
+      authMode: "admin-key",
+      socketPath: undefined,
+    },
+    credentials: {
+      defaultTtlSeconds: 3600,
+      maxConcurrentPerOperator: 3,
+      actionExpirySeconds: 300,
+    },
+    logging: {
+      level: "info",
+      auditLogPath: undefined,
+    },
+    agent: {
+      adapters,
+    },
+  };
+}
+
+async function makeConfigDir(): Promise<{ dir: string; configPath: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "agent-registry-test-"));
+  tempDirs.push(dir);
+  return {
+    dir,
+    configPath: join(dir, "config.toml"),
+  };
+}
+
+describe("resolveAgentAdapterCommand", () => {
+  test("resolves built-in adapters without config overrides", async () => {
+    const { configPath } = await makeConfigDir();
+    const result = await resolveAgentAdapterCommand(
+      {
+        adapterName: "openclaw",
+        verb: "setup",
+        config: stubConfig(),
+        configPath,
+      },
+      {
+        builtinRegistry: {
+          openclaw: {
+            manifest: {
+              name: "openclaw",
+              source: "builtin",
+              supports: ["setup", "status"],
+              entrypoints: {
+                setup: "setup",
+                status: "status",
+              },
+            },
+            command: "/usr/local/bin/openclaw-adapter",
+          },
+        },
+      },
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.source).toBe("builtin");
+    expect(result.value.command).toBe("/usr/local/bin/openclaw-adapter");
+    expect(result.value.manifest.entrypoints.setup).toBe("setup");
+  });
+
+  test("resolves explicit external adapter adoption from config", async () => {
+    const { dir, configPath } = await makeConfigDir();
+    const manifestPath = join(dir, "custom-adapter.toml");
+    await writeFile(
+      manifestPath,
+      [
+        `name = "custom-harness"`,
+        `source = "external"`,
+        `supports = ["setup", "doctor"]`,
+        "",
+        "[entrypoints]",
+        `setup = "bootstrap"`,
+        `doctor = "doctor"`,
+      ].join("\n"),
+    );
+
+    const result = await resolveAgentAdapterCommand({
+      adapterName: "custom-harness",
+      verb: "doctor",
+      config: stubConfig({
+        "custom-harness": {
+          source: "external",
+          manifest: "./custom-adapter.toml",
+          command: "./bin/custom-adapter",
+        },
+      }),
+      configPath,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.source).toBe("external");
+    expect(result.value.command).toBe(join(dir, "bin", "custom-adapter"));
+    expect(result.value.manifest.entrypoints.doctor).toBe("doctor");
+  });
+
+  test("rejects unsupported verbs from the adapter manifest", async () => {
+    const { configPath } = await makeConfigDir();
+    const result = await resolveAgentAdapterCommand(
+      {
+        adapterName: "openclaw",
+        verb: "doctor",
+        config: stubConfig(),
+        configPath,
+      },
+      {
+        builtinRegistry: {
+          openclaw: {
+            manifest: {
+              name: "openclaw",
+              source: "builtin",
+              supports: ["setup"],
+              entrypoints: {
+                setup: "setup",
+              },
+            },
+            command: "/usr/local/bin/openclaw-adapter",
+          },
+        },
+      },
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) return;
+
+    expect(result.error.category).toBe("validation");
+    expect(result.error.message).toContain("does not support 'doctor'");
+  });
+
+  test("rejects external manifests whose name does not match the adapter", async () => {
+    const { dir, configPath } = await makeConfigDir();
+    const manifestPath = join(dir, "custom-adapter.toml");
+    await writeFile(
+      manifestPath,
+      [
+        `name = "wrong-name"`,
+        `source = "external"`,
+        `supports = ["setup"]`,
+        "",
+        "[entrypoints]",
+        `setup = "bootstrap"`,
+      ].join("\n"),
+    );
+
+    const result = await resolveAgentAdapterCommand({
+      adapterName: "custom-harness",
+      verb: "setup",
+      config: stubConfig({
+        "custom-harness": {
+          source: "external",
+          manifest: "./custom-adapter.toml",
+          command: "./bin/custom-adapter",
+        },
+      }),
+      configPath,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) return;
+
+    expect(result.error.category).toBe("validation");
+    expect(result.error.message).toContain("Manifest name 'wrong-name'");
+  });
+
+  test("returns not_found when no built-in or adopted adapter is available", async () => {
+    const { configPath } = await makeConfigDir();
+    const result = await resolveAgentAdapterCommand({
+      adapterName: "openclaw",
+      verb: "setup",
+      config: stubConfig(),
+      configPath,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) return;
+
+    expect(result.error.category).toBe("not_found");
+    expect(result.error.message).toContain("adapter 'openclaw' not found");
+  });
+});

--- a/packages/cli/src/__tests__/xs-agent-command-wiring.test.ts
+++ b/packages/cli/src/__tests__/xs-agent-command-wiring.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, test } from "bun:test";
+import { Result } from "better-result";
+import { NotFoundError } from "@xmtp/signet-schemas";
+import { createAgentCommands } from "../commands/xs-agent.js";
+import type { CliConfig } from "../config/schema.js";
+
+function stubConfig(): CliConfig {
+  return {
+    onboarding: {
+      scheme: "convos",
+    },
+    signet: {
+      env: "dev",
+      identityMode: "per-group",
+      dataDir: undefined,
+    },
+    defaults: {
+      profileName: undefined,
+    },
+    keys: {
+      rootKeyPolicy: "biometric",
+      operationalKeyPolicy: "open",
+      vaultKeyPolicy: "open",
+    },
+    biometricGating: {
+      rootKeyCreation: false,
+      operationalKeyRotation: false,
+      scopeExpansion: false,
+      egressExpansion: false,
+      agentCreation: false,
+      adminReadElevation: false,
+    },
+    ws: {
+      port: 8393,
+      host: "127.0.0.1",
+    },
+    http: {
+      enabled: false,
+      port: 8081,
+      host: "127.0.0.1",
+    },
+    admin: {
+      authMode: "admin-key",
+      socketPath: undefined,
+    },
+    credentials: {
+      defaultTtlSeconds: 3600,
+      maxConcurrentPerOperator: 3,
+      actionExpirySeconds: 300,
+    },
+    logging: {
+      level: "info",
+      auditLogPath: undefined,
+    },
+    agent: {
+      adapters: {},
+    },
+  };
+}
+
+function createHarness() {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const loadConfigCalls: Array<{ configPath?: string | undefined }> = [];
+  const resolveCalls: Array<{
+    adapterName: string;
+    verb: "setup" | "status" | "doctor";
+    configPath: string;
+  }> = [];
+  const runCalls: Array<{
+    adapterName: string;
+    verb: "setup" | "status" | "doctor";
+    configPath: string;
+    json: boolean;
+  }> = [];
+  let exitCode: number | undefined;
+
+  return {
+    deps: {
+      async loadConfig(options?: { configPath?: string }) {
+        loadConfigCalls.push(options ?? {});
+        return Result.ok(stubConfig());
+      },
+      defaultConfigPath() {
+        return "/tmp/default-config.toml";
+      },
+      async resolveAdapterCommand(options: {
+        adapterName: string;
+        verb: "setup" | "status" | "doctor";
+        config: CliConfig;
+        configPath: string;
+      }) {
+        resolveCalls.push({
+          adapterName: options.adapterName,
+          verb: options.verb,
+          configPath: options.configPath,
+        });
+        return Result.ok({
+          adapterName: options.adapterName,
+          verb: options.verb,
+          source: "builtin" as const,
+          command: "/usr/local/bin/openclaw-adapter",
+          manifest: {
+            name: options.adapterName,
+            source: "builtin" as const,
+            supports: [options.verb],
+            entrypoints: {
+              [options.verb]: options.verb,
+            },
+          },
+        });
+      },
+      async runAdapterCommand(
+        adapter: {
+          adapterName: string;
+        },
+        options: {
+          verb: "setup" | "status" | "doctor";
+          configPath: string;
+          json: boolean;
+        },
+      ) {
+        runCalls.push({
+          adapterName: adapter.adapterName,
+          verb: options.verb,
+          configPath: options.configPath,
+          json: options.json,
+        });
+        return Result.ok({
+          exitCode: 0,
+          stdout: '{"status":"ok"}\n',
+          stderr: "",
+        });
+      },
+      writeStdout(message: string) {
+        stdout.push(message);
+      },
+      writeStderr(message: string) {
+        stderr.push(message);
+      },
+      exit(code: number) {
+        exitCode = code;
+      },
+    },
+    loadConfigCalls,
+    resolveCalls,
+    runCalls,
+    stdout,
+    stderr,
+    get exitCode() {
+      return exitCode;
+    },
+  };
+}
+
+describe("xs agent command wiring", () => {
+  test("routes setup requests through config loading, registry resolution, and adapter execution", async () => {
+    const harness = createHarness();
+    const command = createAgentCommands(harness.deps);
+
+    await command.parseAsync([
+      "node",
+      "agent",
+      "setup",
+      "openclaw",
+      "--config",
+      "/tmp/signet.toml",
+      "--json",
+    ]);
+
+    expect(harness.loadConfigCalls).toEqual([
+      { configPath: "/tmp/signet.toml" },
+    ]);
+    expect(harness.resolveCalls).toEqual([
+      {
+        adapterName: "openclaw",
+        verb: "setup",
+        configPath: "/tmp/signet.toml",
+      },
+    ]);
+    expect(harness.runCalls).toEqual([
+      {
+        adapterName: "openclaw",
+        verb: "setup",
+        configPath: "/tmp/signet.toml",
+        json: true,
+      },
+    ]);
+    expect(harness.stdout).toEqual(['{"status":"ok"}\n']);
+    expect(harness.stderr).toEqual([]);
+    expect(harness.exitCode).toBeUndefined();
+  });
+
+  test("uses the default config path when one is not provided", async () => {
+    const harness = createHarness();
+    const command = createAgentCommands(harness.deps);
+
+    await command.parseAsync(["node", "agent", "status", "openclaw"]);
+
+    expect(harness.loadConfigCalls).toEqual([
+      { configPath: "/tmp/default-config.toml" },
+    ]);
+    expect(harness.resolveCalls[0]?.configPath).toBe(
+      "/tmp/default-config.toml",
+    );
+    expect(harness.runCalls[0]?.configPath).toBe("/tmp/default-config.toml");
+  });
+
+  test("normalizes registry errors through the shared CLI error surface", async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    let exitCode: number | undefined;
+    const command = createAgentCommands({
+      async loadConfig() {
+        return Result.ok(stubConfig());
+      },
+      defaultConfigPath() {
+        return "/tmp/default-config.toml";
+      },
+      async resolveAdapterCommand() {
+        return Result.err(NotFoundError.create("adapter", "openclaw"));
+      },
+      async runAdapterCommand() {
+        throw new Error("should not execute the adapter process");
+      },
+      writeStdout(message: string) {
+        stdout.push(message);
+      },
+      writeStderr(message: string) {
+        stderr.push(message);
+      },
+      exit(code: number) {
+        exitCode = code;
+      },
+    });
+
+    await command.parseAsync(["node", "agent", "doctor", "openclaw", "--json"]);
+
+    expect(stdout).toEqual([]);
+    expect(stderr.join("")).toContain('"category": "not_found"');
+    expect(stderr.join("")).toContain("adapter 'openclaw' not found");
+    expect(exitCode).toBe(2);
+  });
+
+  test("forwards adapter stderr and exit codes unchanged", async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    let exitCode: number | undefined;
+    const command = createAgentCommands({
+      async loadConfig() {
+        return Result.ok(stubConfig());
+      },
+      defaultConfigPath() {
+        return "/tmp/default-config.toml";
+      },
+      async resolveAdapterCommand() {
+        return Result.ok({
+          adapterName: "openclaw",
+          verb: "setup",
+          source: "builtin" as const,
+          command: "/usr/local/bin/openclaw-adapter",
+          manifest: {
+            name: "openclaw",
+            source: "builtin" as const,
+            supports: ["setup"],
+            entrypoints: {
+              setup: "setup",
+            },
+          },
+        });
+      },
+      async runAdapterCommand() {
+        return Result.ok({
+          exitCode: 23,
+          stdout: "partial output\n",
+          stderr: "adapter failed\n",
+        });
+      },
+      writeStdout(message: string) {
+        stdout.push(message);
+      },
+      writeStderr(message: string) {
+        stderr.push(message);
+      },
+      exit(code: number) {
+        exitCode = code;
+      },
+    });
+
+    await command.parseAsync(["node", "agent", "setup", "openclaw"]);
+
+    expect(stdout).toEqual(["partial output\n"]);
+    expect(stderr).toEqual(["adapter failed\n"]);
+    expect(exitCode).toBe(23);
+  });
+});

--- a/packages/cli/src/__tests__/xs-program.test.ts
+++ b/packages/cli/src/__tests__/xs-program.test.ts
@@ -74,6 +74,16 @@ describe("v1 subcommand groups", () => {
     expect(subs).toContain("rm");
   });
 
+  test("agent group has setup, status, doctor subcommands", () => {
+    const program = createXsProgram();
+    const agent = program.commands.find((c) => c.name() === "agent");
+    expect(agent).toBeDefined();
+    const subs = agent!.commands.map((c) => c.name());
+    expect(subs).toContain("setup");
+    expect(subs).toContain("status");
+    expect(subs).toContain("doctor");
+  });
+
   test("cred group has issue, list, info, revoke, update subcommands", () => {
     const program = createXsProgram();
     const cred = program.commands.find((c) => c.name() === "cred");

--- a/packages/cli/src/agent/builtin-registry.ts
+++ b/packages/cli/src/agent/builtin-registry.ts
@@ -1,0 +1,45 @@
+import type {
+  AdapterManifestType,
+  AdapterVerbType,
+} from "@xmtp/signet-schemas";
+
+/** First-party adapter registration known to the CLI. */
+export interface BuiltinAgentAdapterDefinition {
+  readonly manifest: AdapterManifestType;
+  readonly command: string;
+  readonly cwd?: string | undefined;
+}
+
+/** Mapping of first-party adapter names to process-backed registrations. */
+export type BuiltinAgentAdapterRegistry = Record<
+  string,
+  BuiltinAgentAdapterDefinition
+>;
+
+/**
+ * First-party adapter registrations bundled with the repo.
+ *
+ * The initial registry is intentionally sparse; later branches add OpenClaw as
+ * the first concrete built-in adapter.
+ */
+const builtinAgentAdapters: BuiltinAgentAdapterRegistry = {};
+
+/** Returns the current built-in adapter registry. */
+export function getBuiltinAgentAdapters(): BuiltinAgentAdapterRegistry {
+  return builtinAgentAdapters;
+}
+
+/** Read a single built-in adapter registration if present. */
+export function getBuiltinAgentAdapter(
+  name: string,
+): BuiltinAgentAdapterDefinition | undefined {
+  return builtinAgentAdapters[name];
+}
+
+/** Returns true when the built-in adapter manifest declares the given verb. */
+export function builtinAdapterSupportsVerb(
+  adapter: BuiltinAgentAdapterDefinition,
+  verb: AdapterVerbType,
+): boolean {
+  return adapter.manifest.supports.includes(verb);
+}

--- a/packages/cli/src/agent/registry.ts
+++ b/packages/cli/src/agent/registry.ts
@@ -1,0 +1,264 @@
+import { readFile } from "node:fs/promises";
+import { dirname, isAbsolute, resolve as resolvePath } from "node:path";
+import { Result } from "better-result";
+import { parse as parseToml } from "smol-toml";
+import {
+  AdapterManifest,
+  type AdapterManifestType,
+  type AdapterVerbType,
+  InternalError,
+  NotFoundError,
+  ValidationError,
+  type SignetError,
+} from "@xmtp/signet-schemas";
+import type { CliConfig } from "../config/schema.js";
+import {
+  getBuiltinAgentAdapters,
+  type BuiltinAgentAdapterDefinition,
+  type BuiltinAgentAdapterRegistry,
+} from "./builtin-registry.js";
+
+/** Resolved adapter command that the generic CLI can execute. */
+export interface ResolvedAgentAdapterCommand {
+  readonly adapterName: string;
+  readonly verb: AdapterVerbType;
+  readonly manifest: AdapterManifestType;
+  readonly source: "builtin" | "external";
+  readonly command: string;
+  readonly cwd?: string | undefined;
+}
+
+/** Dependencies for adapter resolution. */
+export interface ResolveAgentAdapterDeps {
+  readonly readFile: typeof readFile;
+  readonly builtinRegistry: BuiltinAgentAdapterRegistry;
+}
+
+const defaultDeps: ResolveAgentAdapterDeps = {
+  readFile,
+  builtinRegistry: getBuiltinAgentAdapters(),
+};
+
+function resolveAgainstConfigPath(configPath: string, target: string): string {
+  if (isAbsolute(target)) {
+    return target;
+  }
+
+  return resolvePath(dirname(configPath), target);
+}
+
+async function loadExternalManifest(
+  deps: ResolveAgentAdapterDeps,
+  options: {
+    readonly adapterName: string;
+    readonly configPath: string;
+    readonly manifestPath: string;
+  },
+): Promise<Result<AdapterManifestType, SignetError>> {
+  const resolvedManifestPath = resolveAgainstConfigPath(
+    options.configPath,
+    options.manifestPath,
+  );
+
+  let manifestSource: string;
+  try {
+    manifestSource = await deps.readFile(resolvedManifestPath, "utf-8");
+  } catch (error) {
+    return Result.err(
+      InternalError.create("Failed to read adapter manifest", {
+        adapter: options.adapterName,
+        manifestPath: resolvedManifestPath,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
+  }
+
+  let rawManifest: unknown;
+  try {
+    rawManifest = parseToml(manifestSource);
+  } catch (error) {
+    return Result.err(
+      ValidationError.create(
+        "manifest",
+        `Invalid adapter manifest TOML: ${String(error)}`,
+        {
+          adapter: options.adapterName,
+          manifestPath: resolvedManifestPath,
+        },
+      ),
+    );
+  }
+
+  const manifestResult = AdapterManifest.safeParse(rawManifest);
+  if (!manifestResult.success) {
+    return Result.err(
+      ValidationError.create(
+        "manifest",
+        manifestResult.error.issues
+          .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+          .join("; "),
+        {
+          adapter: options.adapterName,
+          manifestPath: resolvedManifestPath,
+        },
+      ),
+    );
+  }
+
+  const manifest = manifestResult.data;
+  if (manifest.name !== options.adapterName) {
+    return Result.err(
+      ValidationError.create(
+        "manifest.name",
+        `Manifest name '${manifest.name}' does not match requested adapter '${options.adapterName}'`,
+        {
+          adapter: options.adapterName,
+          manifestPath: resolvedManifestPath,
+          manifestName: manifest.name,
+        },
+      ),
+    );
+  }
+
+  if (manifest.source !== "external") {
+    return Result.err(
+      ValidationError.create(
+        "manifest.source",
+        `External adapter manifest must declare source 'external'`,
+        {
+          adapter: options.adapterName,
+          manifestPath: resolvedManifestPath,
+          manifestSource: manifest.source,
+        },
+      ),
+    );
+  }
+
+  return Result.ok(manifest);
+}
+
+function validateManifestVerb(
+  adapterName: string,
+  verb: AdapterVerbType,
+  manifest: AdapterManifestType,
+): Result<void, ValidationError> {
+  if (!manifest.supports.includes(verb)) {
+    return Result.err(
+      ValidationError.create(
+        "verb",
+        `Adapter '${adapterName}' does not support '${verb}'`,
+        {
+          adapter: adapterName,
+          verb,
+          supportedVerbs: manifest.supports,
+        },
+      ),
+    );
+  }
+
+  const entrypoint = manifest.entrypoints[verb];
+  if (entrypoint === undefined) {
+    return Result.err(
+      ValidationError.create(
+        "entrypoints",
+        `Adapter '${adapterName}' is missing an entrypoint for '${verb}'`,
+        {
+          adapter: adapterName,
+          verb,
+        },
+      ),
+    );
+  }
+
+  return Result.ok(undefined);
+}
+
+function resolveBuiltinAdapter(
+  adapterName: string,
+  verb: AdapterVerbType,
+  builtin: BuiltinAgentAdapterDefinition | undefined,
+): Result<ResolvedAgentAdapterCommand, SignetError> {
+  if (builtin === undefined) {
+    return Result.err(NotFoundError.create("adapter", adapterName));
+  }
+
+  const supportResult = validateManifestVerb(
+    adapterName,
+    verb,
+    builtin.manifest,
+  );
+  if (supportResult.isErr()) {
+    return supportResult;
+  }
+
+  return Result.ok({
+    adapterName,
+    verb,
+    manifest: builtin.manifest,
+    source: "builtin",
+    command: builtin.command,
+    ...(builtin.cwd !== undefined ? { cwd: builtin.cwd } : {}),
+  });
+}
+
+/** Resolve a requested adapter to a process-backed command. */
+export async function resolveAgentAdapterCommand(
+  options: {
+    readonly adapterName: string;
+    readonly verb: AdapterVerbType;
+    readonly config: CliConfig;
+    readonly configPath: string;
+  },
+  deps: Partial<ResolveAgentAdapterDeps> = {},
+): Promise<Result<ResolvedAgentAdapterCommand, SignetError>> {
+  const resolvedDeps: ResolveAgentAdapterDeps = {
+    ...defaultDeps,
+    builtinRegistry: deps.builtinRegistry ?? getBuiltinAgentAdapters(),
+    ...deps,
+  };
+  const configuredAdapter = options.config.agent.adapters[options.adapterName];
+
+  if (configuredAdapter?.source === "external") {
+    const manifestResult = await loadExternalManifest(resolvedDeps, {
+      adapterName: options.adapterName,
+      configPath: options.configPath,
+      manifestPath: configuredAdapter.manifest,
+    });
+    if (manifestResult.isErr()) {
+      return manifestResult;
+    }
+
+    const supportResult = validateManifestVerb(
+      options.adapterName,
+      options.verb,
+      manifestResult.value,
+    );
+    if (supportResult.isErr()) {
+      return supportResult;
+    }
+
+    return Result.ok({
+      adapterName: options.adapterName,
+      verb: options.verb,
+      manifest: manifestResult.value,
+      source: "external",
+      command: resolveAgainstConfigPath(
+        options.configPath,
+        configuredAdapter.command,
+      ),
+    });
+  }
+
+  const builtin = resolvedDeps.builtinRegistry[options.adapterName];
+  if (builtin !== undefined) {
+    return resolveBuiltinAdapter(options.adapterName, options.verb, builtin);
+  }
+
+  if (configuredAdapter?.source === "builtin") {
+    return Result.err(
+      NotFoundError.create("built-in adapter", options.adapterName),
+    );
+  }
+
+  return Result.err(NotFoundError.create("adapter", options.adapterName));
+}

--- a/packages/cli/src/agent/registry.ts
+++ b/packages/cli/src/agent/registry.ts
@@ -213,8 +213,8 @@ export async function resolveAgentAdapterCommand(
 ): Promise<Result<ResolvedAgentAdapterCommand, SignetError>> {
   const resolvedDeps: ResolveAgentAdapterDeps = {
     ...defaultDeps,
-    builtinRegistry: deps.builtinRegistry ?? getBuiltinAgentAdapters(),
     ...deps,
+    builtinRegistry: deps.builtinRegistry ?? defaultDeps.builtinRegistry,
   };
   const configuredAdapter = options.config.agent.adapters[options.adapterName];
 

--- a/packages/cli/src/agent/runner.ts
+++ b/packages/cli/src/agent/runner.ts
@@ -1,0 +1,107 @@
+import { Result } from "better-result";
+import {
+  InternalError,
+  type AdapterVerbType,
+  type SignetError,
+} from "@xmtp/signet-schemas";
+import type { ResolvedAgentAdapterCommand } from "./registry.js";
+
+/** Captured output from an adapter process invocation. */
+export interface AgentProcessResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+/** Dependencies for adapter process execution. */
+export interface RunResolvedAgentAdapterDeps {
+  readonly spawn: typeof Bun.spawn;
+}
+
+const defaultDeps: RunResolvedAgentAdapterDeps = {
+  spawn: Bun.spawn,
+};
+
+function assertPipedStream(
+  stream: number | ReadableStream<Uint8Array> | undefined,
+  streamName: "stdout" | "stderr",
+): ReadableStream<Uint8Array> {
+  if (!(stream instanceof ReadableStream)) {
+    throw new Error(`Expected adapter ${streamName} to be piped`);
+  }
+
+  return stream;
+}
+
+function buildAdapterArgs(
+  adapter: ResolvedAgentAdapterCommand,
+  options: {
+    readonly verb: AdapterVerbType;
+    readonly configPath: string;
+    readonly json: boolean;
+  },
+): string[] {
+  const entrypoint = adapter.manifest.entrypoints[options.verb];
+  if (entrypoint === undefined) {
+    throw new Error(
+      `Adapter '${adapter.adapterName}' is missing an entrypoint for '${options.verb}'`,
+    );
+  }
+
+  return [
+    options.verb,
+    "--adapter",
+    adapter.adapterName,
+    "--entrypoint",
+    entrypoint,
+    "--config",
+    options.configPath,
+    ...(options.json ? ["--json"] : []),
+  ];
+}
+
+/** Run a resolved adapter command as a child process. */
+export async function runResolvedAgentAdapter(
+  adapter: ResolvedAgentAdapterCommand,
+  options: {
+    readonly verb: AdapterVerbType;
+    readonly configPath: string;
+    readonly json: boolean;
+  },
+  deps: Partial<RunResolvedAgentAdapterDeps> = {},
+): Promise<Result<AgentProcessResult, SignetError>> {
+  const resolvedDeps: RunResolvedAgentAdapterDeps = { ...defaultDeps, ...deps };
+
+  let process: Bun.Subprocess;
+  try {
+    process = resolvedDeps.spawn(
+      [adapter.command, ...buildAdapterArgs(adapter, options)],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+        stdin: "ignore",
+        ...(adapter.cwd !== undefined ? { cwd: adapter.cwd } : {}),
+      },
+    );
+  } catch (error) {
+    return Result.err(
+      InternalError.create("Failed to start adapter command", {
+        adapter: adapter.adapterName,
+        command: adapter.command,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
+  }
+
+  const [exitCode, stdout, stderr] = await Promise.all([
+    process.exited,
+    new Response(assertPipedStream(process.stdout, "stdout")).text(),
+    new Response(assertPipedStream(process.stderr, "stderr")).text(),
+  ]);
+
+  return Result.ok({
+    exitCode,
+    stdout,
+    stderr,
+  });
+}

--- a/packages/cli/src/commands/xs-agent.ts
+++ b/packages/cli/src/commands/xs-agent.ts
@@ -1,0 +1,160 @@
+/**
+ * Generic harness adapter commands for the `xs agent` subcommand group.
+ *
+ * This namespace owns harness/runtime integration workflows while keeping
+ * signet-native control-plane nouns under `operator`, `cred`, `policy`, etc.
+ *
+ * @module
+ */
+
+import { Command } from "commander";
+import { Result } from "better-result";
+import type { AdapterVerbType, SignetError } from "@xmtp/signet-schemas";
+import { loadConfig, defaultConfigPath } from "../config/loader.js";
+import type { CliConfig } from "../config/schema.js";
+import { exitCodeFromCategory } from "../output/exit-codes.js";
+import { formatOutput } from "../output/formatter.js";
+import {
+  resolveAgentAdapterCommand,
+  type ResolvedAgentAdapterCommand,
+} from "../agent/registry.js";
+import {
+  runResolvedAgentAdapter,
+  type AgentProcessResult,
+} from "../agent/runner.js";
+
+/** Dependencies for the generic `xs agent` command family. */
+export interface XsAgentCommandDeps {
+  readonly loadConfig: (options?: {
+    configPath?: string;
+    envOverrides?: Record<string, string>;
+  }) => Promise<Result<CliConfig, SignetError>>;
+  readonly defaultConfigPath: () => string;
+  readonly resolveAdapterCommand: (options: {
+    adapterName: string;
+    verb: AdapterVerbType;
+    config: CliConfig;
+    configPath: string;
+  }) => Promise<Result<ResolvedAgentAdapterCommand, SignetError>>;
+  readonly runAdapterCommand: (
+    adapter: ResolvedAgentAdapterCommand,
+    options: {
+      verb: AdapterVerbType;
+      configPath: string;
+      json: boolean;
+    },
+  ) => Promise<Result<AgentProcessResult, SignetError>>;
+  readonly writeStdout: (message: string) => void;
+  readonly writeStderr: (message: string) => void;
+  readonly exit: (code: number) => void;
+}
+
+const defaultDeps: XsAgentCommandDeps = {
+  loadConfig: (options) => loadConfig(options),
+  defaultConfigPath: () => defaultConfigPath(),
+  resolveAdapterCommand: (options) => resolveAgentAdapterCommand(options),
+  runAdapterCommand: (adapter, options) =>
+    runResolvedAgentAdapter(adapter, options),
+  writeStdout(message) {
+    process.stdout.write(message);
+  },
+  writeStderr(message) {
+    process.stderr.write(message);
+  },
+  exit(code) {
+    process.exit(code);
+  },
+};
+
+function writeError(
+  deps: XsAgentCommandDeps,
+  error: SignetError,
+  json: boolean,
+): void {
+  deps.writeStderr(
+    formatOutput(
+      {
+        error: error._tag,
+        category: error.category,
+        message: error.message,
+        ...(error.context !== null ? { context: error.context } : {}),
+      },
+      { json },
+    ) + "\n",
+  );
+  deps.exit(exitCodeFromCategory(error.category));
+}
+
+function addAgentVerb(
+  command: Command,
+  verb: AdapterVerbType,
+  deps: XsAgentCommandDeps,
+): void {
+  command
+    .command(verb)
+    .description(`${verb[0]!.toUpperCase()}${verb.slice(1)} a harness adapter`)
+    .argument("<harness>", "Harness adapter name")
+    .option("--config <path>", "Path to config file")
+    .option("--json", "JSON output")
+    .action(
+      async (
+        harness: string,
+        opts: { config?: string; json?: true },
+      ): Promise<void> => {
+        const json = opts.json === true;
+        const configPath = opts.config ?? deps.defaultConfigPath();
+        const configResult = await deps.loadConfig({ configPath });
+        if (configResult.isErr()) {
+          writeError(deps, configResult.error, json);
+          return;
+        }
+
+        const adapterResult = await deps.resolveAdapterCommand({
+          adapterName: harness,
+          verb,
+          config: configResult.value,
+          configPath,
+        });
+        if (adapterResult.isErr()) {
+          writeError(deps, adapterResult.error, json);
+          return;
+        }
+
+        const runResult = await deps.runAdapterCommand(adapterResult.value, {
+          verb,
+          configPath,
+          json,
+        });
+        if (runResult.isErr()) {
+          writeError(deps, runResult.error, json);
+          return;
+        }
+
+        if (runResult.value.stdout.length > 0) {
+          deps.writeStdout(runResult.value.stdout);
+        }
+        if (runResult.value.stderr.length > 0) {
+          deps.writeStderr(runResult.value.stderr);
+        }
+        if (runResult.value.exitCode !== 0) {
+          deps.exit(runResult.value.exitCode);
+        }
+      },
+    );
+}
+
+/** Create the `agent` subcommand group. */
+export function createAgentCommands(
+  deps: Partial<XsAgentCommandDeps> = {},
+): Command {
+  const resolvedDeps: XsAgentCommandDeps = { ...defaultDeps, ...deps };
+  const command = new Command("agent").description(
+    "Manage harness adapter setup and runtime wiring",
+  );
+
+  addAgentVerb(command, "setup", resolvedDeps);
+  addAgentVerb(command, "status", resolvedDeps);
+  addAgentVerb(command, "doctor", resolvedDeps);
+
+  return command;
+}

--- a/packages/cli/src/commands/xs-agent.ts
+++ b/packages/cli/src/commands/xs-agent.ts
@@ -9,6 +9,7 @@
 
 import { Command } from "commander";
 import { Result } from "better-result";
+import { resolve as resolvePath } from "node:path";
 import type { AdapterVerbType, SignetError } from "@xmtp/signet-schemas";
 import { loadConfig, defaultConfigPath } from "../config/loader.js";
 import type { CliConfig } from "../config/schema.js";
@@ -102,7 +103,7 @@ function addAgentVerb(
         opts: { config?: string; json?: true },
       ): Promise<void> => {
         const json = opts.json === true;
-        const configPath = opts.config ?? deps.defaultConfigPath();
+        const configPath = resolvePath(opts.config ?? deps.defaultConfigPath());
         const configResult = await deps.loadConfig({ configPath });
         if (configResult.isErr()) {
           writeError(deps, configResult.error, json);

--- a/packages/cli/src/xs-program.ts
+++ b/packages/cli/src/xs-program.ts
@@ -9,6 +9,7 @@
 import { Command } from "commander";
 import { createLifecycleCommands } from "./commands/lifecycle.js";
 import { createIdentityInitCommand } from "./commands/identity.js";
+import { createAgentCommands } from "./commands/xs-agent.js";
 import { createOperatorCommands } from "./commands/xs-operator.js";
 import { createCredentialCommands } from "./commands/xs-credential.js";
 import { createChatCommands } from "./commands/xs-chat.js";
@@ -83,6 +84,10 @@ export function createXsProgram(): Command {
   // --- operator ---
 
   program.addCommand(createOperatorCommands());
+
+  // --- agent ---
+
+  program.addCommand(createAgentCommands());
 
   // --- cred ---
 


### PR DESCRIPTION
## Summary
This PR adds the generic `xs agent <verb> <harness>` CLI surface and the adapter registry dispatch layer that keeps harness-specific behavior out of `packages/cli`.

## What Changed
- adds the new `xs agent` command namespace to the CLI program surface
- introduces adapter registry resolution for built-in adapters and explicit external-adoption config
- normalizes user-facing errors for unknown adapters, unsupported verbs, and bad registry entries
- keeps harness-specific logic out of the CLI so future adapters can plug into the same surface cleanly

## Why This Shape
The CLI should own orchestration and discovery, not adapter implementation details. This keeps the user-facing command grammar stable while allowing the actual harness logic to live under `adapters/<harness>/`.

## How To Test
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run docs:check`

## Issues
Closes #342
