### PR TITLE
feat: scaffold openclaw adapter workspace

### DIFF
--- a/adapters/openclaw/README.md
+++ b/adapters/openclaw/README.md
@@ -1,0 +1,13 @@
+# OpenClaw Adapter
+
+The OpenClaw adapter is the first built-in `adapters/` workspace for
+`xmtp-signet`.
+
+This branch only establishes the reference package shape:
+
+- adapter manifest and registration surface
+- process-backed adapter CLI entrypoint
+- stub `setup`, `status`, and `doctor` verbs
+- dedicated `artifacts/`, `bridge/`, and `config/` modules for follow-on work
+
+Later branches replace the stubs with real provisioning and bridge behavior.

--- a/adapters/openclaw/adapter-manifest.json
+++ b/adapters/openclaw/adapter-manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "openclaw",
+  "source": "builtin",
+  "supports": ["setup", "status", "doctor"],
+  "entrypoints": {
+    "setup": "builtin:openclaw:setup",
+    "status": "builtin:openclaw:status",
+    "doctor": "builtin:openclaw:doctor"
+  }
+}

--- a/adapters/openclaw/package.json
+++ b/adapters/openclaw/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@xmtp/openclaw-adapter",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "bun build ./src/index.ts ./src/bin.ts --outdir ./dist --target bun && tsc --declaration --emitDeclarationOnly --outDir ./dist",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint .",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@xmtp/signet-schemas": "workspace:*",
+    "commander": "14.0.3"
+  },
+  "devDependencies": {
+    "bun-types": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/adapters/openclaw/package.json
+++ b/adapters/openclaw/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "bun": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/adapters/openclaw/src/__tests__/openclaw-output.test.ts
+++ b/adapters/openclaw/src/__tests__/openclaw-output.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { formatAdapterOutput } from "../output.js";
+
+describe("formatAdapterOutput", () => {
+  test("renders nested objects and arrays as JSON in text mode", () => {
+    const output = formatAdapterOutput(
+      {
+        status: "missing",
+        details: {
+          phase: "scaffold",
+          bridgePhase: "scaffold",
+        },
+        artifacts: {
+          config: "/tmp/openclaw.toml",
+        },
+        diagnostics: ["one", "two"],
+      },
+      false,
+    );
+
+    expect(output).toContain("status: missing");
+    expect(output).toContain(
+      'details: {"phase":"scaffold","bridgePhase":"scaffold"}',
+    );
+    expect(output).toContain('artifacts: {"config":"/tmp/openclaw.toml"}');
+    expect(output).toContain('diagnostics: ["one","two"]');
+  });
+
+  test("preserves pretty JSON mode", () => {
+    const output = formatAdapterOutput(
+      {
+        details: {
+          phase: "scaffold",
+        },
+      },
+      true,
+    );
+
+    expect(output).toBe('{\n  "details": {\n    "phase": "scaffold"\n  }\n}');
+  });
+});

--- a/adapters/openclaw/src/__tests__/openclaw-scaffold.test.ts
+++ b/adapters/openclaw/src/__tests__/openclaw-scaffold.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import {
+  OPENCLAW_ADAPTER_MANIFEST,
+  openclawAdapterDefinition,
+  runOpenClawDoctor,
+  runOpenClawSetup,
+  runOpenClawStatus,
+} from "../index.js";
+
+describe("openclaw adapter scaffold", () => {
+  test("exports a built-in manifest for setup, status, and doctor", () => {
+    expect(OPENCLAW_ADAPTER_MANIFEST.name).toBe("openclaw");
+    expect(OPENCLAW_ADAPTER_MANIFEST.source).toBe("builtin");
+    expect(OPENCLAW_ADAPTER_MANIFEST.supports).toEqual([
+      "setup",
+      "status",
+      "doctor",
+    ]);
+    expect(OPENCLAW_ADAPTER_MANIFEST.entrypoints.setup).toBe(
+      "builtin:openclaw:setup",
+    );
+  });
+
+  test("exports process-backed registration metadata", () => {
+    expect(openclawAdapterDefinition.command).toBe("bun");
+    expect(openclawAdapterDefinition.args.length).toBe(1);
+    expect(openclawAdapterDefinition.args[0]).toContain("bin.js");
+  });
+
+  test("returns structured stub outputs for setup, status, and doctor", () => {
+    expect(runOpenClawSetup().adapter).toBe("openclaw");
+    expect(runOpenClawSetup().status).toBe("missing");
+    expect(runOpenClawStatus().details["phase"]).toBe("scaffold");
+    expect(runOpenClawDoctor().details["phase"]).toBe("scaffold");
+  });
+});

--- a/adapters/openclaw/src/__tests__/openclaw-scaffold.test.ts
+++ b/adapters/openclaw/src/__tests__/openclaw-scaffold.test.ts
@@ -24,7 +24,7 @@ describe("openclaw adapter scaffold", () => {
   test("exports process-backed registration metadata", () => {
     expect(openclawAdapterDefinition.command).toBe("bun");
     expect(openclawAdapterDefinition.args.length).toBe(1);
-    expect(openclawAdapterDefinition.args[0]).toContain("bin.js");
+    expect(openclawAdapterDefinition.args[0]).toContain("bin.ts");
   });
 
   test("returns structured stub outputs for setup, status, and doctor", () => {

--- a/adapters/openclaw/src/artifacts/index.ts
+++ b/adapters/openclaw/src/artifacts/index.ts
@@ -1,0 +1,6 @@
+import { OPENCLAW_ARTIFACT_FILES } from "../config/index.js";
+
+/** Placeholder artifact inventory for the scaffolded adapter. */
+export function listOpenClawArtifactFiles(): readonly string[] {
+  return OPENCLAW_ARTIFACT_FILES;
+}

--- a/adapters/openclaw/src/bin.ts
+++ b/adapters/openclaw/src/bin.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env bun
+
+import { Command } from "commander";
+import { runOpenClawDoctor } from "./doctor/index.js";
+import { runOpenClawSetup } from "./setup/index.js";
+import { runOpenClawStatus } from "./status/index.js";
+
+function formatAdapterOutput(data: unknown, json: boolean): string {
+  if (json) {
+    return JSON.stringify(data, null, 2);
+  }
+
+  if (typeof data === "object" && data !== null && !Array.isArray(data)) {
+    return Object.entries(data as Record<string, unknown>)
+      .map(([key, value]) => `${key}: ${String(value)}`)
+      .join("\n");
+  }
+
+  return String(data);
+}
+
+function addVerb(
+  program: Command,
+  verb: "setup" | "status" | "doctor",
+  run: () => unknown,
+): void {
+  program
+    .command(verb)
+    .requiredOption("--adapter <name>", "Adapter name")
+    .requiredOption("--entrypoint <name>", "Entrypoint identifier")
+    .requiredOption("--config <path>", "Resolved signet config path")
+    .option("--json", "JSON output")
+    .action(
+      (opts: {
+        adapter: string;
+        entrypoint: string;
+        config: string;
+        json?: true;
+      }) => {
+        const output = run();
+        process.stdout.write(
+          formatAdapterOutput(
+            {
+              ...((output ?? {}) as Record<string, unknown>),
+              adapter: opts.adapter,
+              entrypoint: opts.entrypoint,
+              configPath: opts.config,
+            },
+            opts.json === true,
+          ) + "\n",
+        );
+      },
+    );
+}
+
+const program = new Command()
+  .name("openclaw-adapter")
+  .description("Process-backed OpenClaw adapter for xmtp-signet");
+
+addVerb(program, "setup", runOpenClawSetup);
+addVerb(program, "status", runOpenClawStatus);
+addVerb(program, "doctor", runOpenClawDoctor);
+
+await program.parseAsync(process.argv);

--- a/adapters/openclaw/src/bin.ts
+++ b/adapters/openclaw/src/bin.ts
@@ -2,22 +2,9 @@
 
 import { Command } from "commander";
 import { runOpenClawDoctor } from "./doctor/index.js";
+import { formatAdapterOutput } from "./output.js";
 import { runOpenClawSetup } from "./setup/index.js";
 import { runOpenClawStatus } from "./status/index.js";
-
-function formatAdapterOutput(data: unknown, json: boolean): string {
-  if (json) {
-    return JSON.stringify(data, null, 2);
-  }
-
-  if (typeof data === "object" && data !== null && !Array.isArray(data)) {
-    return Object.entries(data as Record<string, unknown>)
-      .map(([key, value]) => `${key}: ${String(value)}`)
-      .join("\n");
-  }
-
-  return String(data);
-}
 
 function addVerb(
   program: Command,

--- a/adapters/openclaw/src/bridge/index.ts
+++ b/adapters/openclaw/src/bridge/index.ts
@@ -1,0 +1,7 @@
+/** Current bridge phase for the OpenClaw adapter. */
+export const OPENCLAW_BRIDGE_PHASE = "scaffold";
+
+/** Whether the read-only bridge is active yet. */
+export function isOpenClawBridgeReady(): boolean {
+  return false;
+}

--- a/adapters/openclaw/src/config/index.ts
+++ b/adapters/openclaw/src/config/index.ts
@@ -1,0 +1,11 @@
+/** Canonical adapter slug for OpenClaw. */
+export const OPENCLAW_ADAPTER_NAME = "openclaw";
+
+/** Files the adapter will eventually generate under the signet data dir. */
+export const OPENCLAW_ARTIFACT_FILES = [
+  "adapter.toml",
+  "adapter-manifest.toml",
+  "openclaw-account.json",
+  "operator-templates.json",
+  "policy-templates.json",
+] as const;

--- a/adapters/openclaw/src/doctor/index.ts
+++ b/adapters/openclaw/src/doctor/index.ts
@@ -1,0 +1,23 @@
+import {
+  AdapterStatusResult,
+  type AdapterStatusResultType,
+} from "@xmtp/signet-schemas";
+import { OPENCLAW_BRIDGE_PHASE } from "../bridge/index.js";
+import { OPENCLAW_ADAPTER_NAME } from "../config/index.js";
+
+/** Stub doctor result for the scaffold branch. */
+export function runOpenClawDoctor(): AdapterStatusResultType {
+  return AdapterStatusResult.parse({
+    adapter: OPENCLAW_ADAPTER_NAME,
+    adapterSource: "builtin",
+    status: "missing",
+    details: {
+      phase: "scaffold",
+      bridgePhase: OPENCLAW_BRIDGE_PHASE,
+      diagnostics: [
+        "Provisioning is not implemented on this branch yet.",
+        "Read-only bridge work lands on the follow-on bridge branch.",
+      ],
+    },
+  });
+}

--- a/adapters/openclaw/src/index.ts
+++ b/adapters/openclaw/src/index.ts
@@ -1,0 +1,16 @@
+export {
+  OPENCLAW_ADAPTER_NAME,
+  OPENCLAW_ARTIFACT_FILES,
+} from "./config/index.js";
+export { listOpenClawArtifactFiles } from "./artifacts/index.js";
+export {
+  OPENCLAW_BRIDGE_PHASE,
+  isOpenClawBridgeReady,
+} from "./bridge/index.js";
+export { runOpenClawSetup } from "./setup/index.js";
+export { runOpenClawStatus } from "./status/index.js";
+export { runOpenClawDoctor } from "./doctor/index.js";
+export {
+  OPENCLAW_ADAPTER_MANIFEST,
+  openclawAdapterDefinition,
+} from "./registry.js";

--- a/adapters/openclaw/src/output.ts
+++ b/adapters/openclaw/src/output.ts
@@ -1,0 +1,30 @@
+function formatAdapterValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return String(value);
+  }
+
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+
+  return String(value);
+}
+
+/** Format adapter command output for JSON or human-readable CLI mode. */
+export function formatAdapterOutput(data: unknown, json: boolean): string {
+  if (json) {
+    return JSON.stringify(data, null, 2);
+  }
+
+  if (typeof data === "object" && data !== null && !Array.isArray(data)) {
+    return Object.entries(data as Record<string, unknown>)
+      .map(([key, value]) => `${key}: ${formatAdapterValue(value)}`)
+      .join("\n");
+  }
+
+  return formatAdapterValue(data);
+}

--- a/adapters/openclaw/src/registry.ts
+++ b/adapters/openclaw/src/registry.ts
@@ -1,0 +1,32 @@
+import { fileURLToPath } from "node:url";
+import {
+  AdapterManifest,
+  type AdapterManifestType,
+} from "@xmtp/signet-schemas";
+
+/** Process-backed registration metadata exported by the OpenClaw adapter. */
+export interface OpenClawAdapterDefinition {
+  readonly manifest: AdapterManifestType;
+  readonly command: string;
+  readonly args: readonly string[];
+}
+
+/** Built-in manifest for the OpenClaw adapter. */
+export const OPENCLAW_ADAPTER_MANIFEST: AdapterManifestType =
+  AdapterManifest.parse({
+    name: "openclaw",
+    source: "builtin",
+    supports: ["setup", "status", "doctor"],
+    entrypoints: {
+      setup: "builtin:openclaw:setup",
+      status: "builtin:openclaw:status",
+      doctor: "builtin:openclaw:doctor",
+    },
+  });
+
+/** Process-backed registration exported to the CLI's built-in registry. */
+export const openclawAdapterDefinition: OpenClawAdapterDefinition = {
+  manifest: OPENCLAW_ADAPTER_MANIFEST,
+  command: "bun",
+  args: [fileURLToPath(new URL("./bin.js", import.meta.url))],
+};

--- a/adapters/openclaw/src/registry.ts
+++ b/adapters/openclaw/src/registry.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import {
   AdapterManifest,
@@ -14,16 +15,14 @@ export interface OpenClawAdapterDefinition {
 
 /** Built-in manifest for the OpenClaw adapter. */
 export const OPENCLAW_ADAPTER_MANIFEST: AdapterManifestType =
-  AdapterManifest.parse({
-    name: "openclaw",
-    source: "builtin",
-    supports: ["setup", "status", "doctor"],
-    entrypoints: {
-      setup: "builtin:openclaw:setup",
-      status: "builtin:openclaw:status",
-      doctor: "builtin:openclaw:doctor",
-    },
-  });
+  AdapterManifest.parse(
+    JSON.parse(
+      readFileSync(
+        fileURLToPath(new URL("../adapter-manifest.json", import.meta.url)),
+        "utf-8",
+      ),
+    ),
+  );
 
 function resolveOpenClawAdapterEntryFile(): string {
   const sourceEntrypoint = fileURLToPath(new URL("./bin.ts", import.meta.url));

--- a/adapters/openclaw/src/registry.ts
+++ b/adapters/openclaw/src/registry.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import {
   AdapterManifest,
@@ -24,9 +25,18 @@ export const OPENCLAW_ADAPTER_MANIFEST: AdapterManifestType =
     },
   });
 
+function resolveOpenClawAdapterEntryFile(): string {
+  const sourceEntrypoint = fileURLToPath(new URL("./bin.ts", import.meta.url));
+  if (existsSync(sourceEntrypoint)) {
+    return sourceEntrypoint;
+  }
+
+  return fileURLToPath(new URL("./bin.js", import.meta.url));
+}
+
 /** Process-backed registration exported to the CLI's built-in registry. */
 export const openclawAdapterDefinition: OpenClawAdapterDefinition = {
   manifest: OPENCLAW_ADAPTER_MANIFEST,
   command: "bun",
-  args: [fileURLToPath(new URL("./bin.js", import.meta.url))],
+  args: [resolveOpenClawAdapterEntryFile()],
 };

--- a/adapters/openclaw/src/setup/index.ts
+++ b/adapters/openclaw/src/setup/index.ts
@@ -1,0 +1,23 @@
+import {
+  AdapterSetupResult,
+  type AdapterSetupResultType,
+} from "@xmtp/signet-schemas";
+import { listOpenClawArtifactFiles } from "../artifacts/index.js";
+import { OPENCLAW_ADAPTER_NAME } from "../config/index.js";
+
+/** Stub setup result for the scaffold branch. */
+export function runOpenClawSetup(): AdapterSetupResultType {
+  return AdapterSetupResult.parse({
+    adapter: OPENCLAW_ADAPTER_NAME,
+    adapterSource: "builtin",
+    status: "missing",
+    created: [],
+    reused: [],
+    artifacts: Object.fromEntries(
+      listOpenClawArtifactFiles().map((file) => [file, "pending"]),
+    ),
+    nextSteps: [
+      "Implement provisioning and artifact generation on the next branch.",
+    ],
+  });
+}

--- a/adapters/openclaw/src/status/index.ts
+++ b/adapters/openclaw/src/status/index.ts
@@ -1,0 +1,25 @@
+import {
+  AdapterStatusResult,
+  type AdapterStatusResultType,
+} from "@xmtp/signet-schemas";
+import {
+  OPENCLAW_BRIDGE_PHASE,
+  isOpenClawBridgeReady,
+} from "../bridge/index.js";
+import { listOpenClawArtifactFiles } from "../artifacts/index.js";
+import { OPENCLAW_ADAPTER_NAME } from "../config/index.js";
+
+/** Stub status result for the scaffold branch. */
+export function runOpenClawStatus(): AdapterStatusResultType {
+  return AdapterStatusResult.parse({
+    adapter: OPENCLAW_ADAPTER_NAME,
+    adapterSource: "builtin",
+    status: "missing",
+    details: {
+      phase: "scaffold",
+      bridgePhase: OPENCLAW_BRIDGE_PHASE,
+      bridgeReady: isOpenClawBridgeReady(),
+      expectedArtifacts: listOpenClawArtifactFiles(),
+    },
+  });
+}

--- a/adapters/openclaw/tsconfig.json
+++ b/adapters/openclaw/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "src/__tests__"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,18 @@
         "typescript": "catalog:",
       },
     },
+    "adapters/openclaw": {
+      "name": "@xmtp/openclaw-adapter",
+      "version": "0.0.0",
+      "dependencies": {
+        "@xmtp/signet-schemas": "workspace:*",
+        "commander": "14.0.3",
+      },
+      "devDependencies": {
+        "bun-types": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "packages/cli": {
       "name": "@xmtp/signet-cli",
       "version": "0.1.0",
@@ -23,6 +35,7 @@
         "xs": "src/bin.ts",
       },
       "dependencies": {
+        "@xmtp/openclaw-adapter": "workspace:*",
         "@xmtp/signet-contracts": "workspace:*",
         "@xmtp/signet-core": "workspace:*",
         "@xmtp/signet-keys": "workspace:*",
@@ -349,6 +362,8 @@
     "@xmtp/node-bindings": ["@xmtp/node-bindings@1.10.0", "", {}, "sha512-US/YvMP7RL1DkNeiZ75ZjEyvMwLIrEPn12dBj5h7lAesM2N5snwnstJ2NNk3LpW3kCNDdzwhe/G0ZSb0PhwNeg=="],
 
     "@xmtp/node-sdk": ["@xmtp/node-sdk@6.0.0", "", { "dependencies": { "@xmtp/content-type-primitives": "3.0.0", "@xmtp/node-bindings": "1.10.0" } }, "sha512-UMClg1+WkC3pfeHffJoZMYzhqsUa2wZpSJtIrpvBqUD+n1VYVQTfhTqGyaavVIPgITxjHBi/uMS/K18E4qDbPA=="],
+
+    "@xmtp/openclaw-adapter": ["@xmtp/openclaw-adapter@workspace:adapters/openclaw"],
 
     "@xmtp/signet-cli": ["@xmtp/signet-cli@workspace:packages/cli"],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,6 +20,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@xmtp/openclaw-adapter": "workspace:*",
     "@xmtp/signet-contracts": "workspace:*",
     "@xmtp/signet-core": "workspace:*",
     "@xmtp/signet-keys": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,6 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@xmtp/openclaw-adapter": "workspace:*",
     "@xmtp/signet-contracts": "workspace:*",
     "@xmtp/signet-core": "workspace:*",
     "@xmtp/signet-keys": "workspace:*",

--- a/packages/cli/src/__tests__/agent-registry.test.ts
+++ b/packages/cli/src/__tests__/agent-registry.test.ts
@@ -225,7 +225,7 @@ describe("resolveAgentAdapterCommand", () => {
   test("returns not_found when no built-in or adopted adapter is available", async () => {
     const { configPath } = await makeConfigDir();
     const result = await resolveAgentAdapterCommand({
-      adapterName: "openclaw",
+      adapterName: "unknown-harness",
       verb: "setup",
       config: stubConfig(),
       configPath,
@@ -235,6 +235,8 @@ describe("resolveAgentAdapterCommand", () => {
     if (result.isOk()) return;
 
     expect(result.error.category).toBe("not_found");
-    expect(result.error.message).toContain("adapter 'openclaw' not found");
+    expect(result.error.message).toContain(
+      "adapter 'unknown-harness' not found",
+    );
   });
 });

--- a/packages/cli/src/agent/builtin-registry.ts
+++ b/packages/cli/src/agent/builtin-registry.ts
@@ -1,12 +1,15 @@
-import type {
-  AdapterManifestType,
-  AdapterVerbType,
+import { fileURLToPath } from "node:url";
+import {
+  AdapterManifest,
+  type AdapterManifestType,
+  type AdapterVerbType,
 } from "@xmtp/signet-schemas";
 
 /** First-party adapter registration known to the CLI. */
 export interface BuiltinAgentAdapterDefinition {
   readonly manifest: AdapterManifestType;
   readonly command: string;
+  readonly args?: readonly string[] | undefined;
   readonly cwd?: string | undefined;
 }
 
@@ -22,7 +25,28 @@ export type BuiltinAgentAdapterRegistry = Record<
  * The initial registry is intentionally sparse; later branches add OpenClaw as
  * the first concrete built-in adapter.
  */
-const builtinAgentAdapters: BuiltinAgentAdapterRegistry = {};
+const OPENCLAW_MANIFEST: AdapterManifestType = AdapterManifest.parse({
+  name: "openclaw",
+  source: "builtin",
+  supports: ["setup", "status", "doctor"],
+  entrypoints: {
+    setup: "builtin:openclaw:setup",
+    status: "builtin:openclaw:status",
+    doctor: "builtin:openclaw:doctor",
+  },
+});
+
+const builtinAgentAdapters: BuiltinAgentAdapterRegistry = {
+  [OPENCLAW_MANIFEST.name]: {
+    manifest: OPENCLAW_MANIFEST,
+    command: "bun",
+    args: [
+      fileURLToPath(
+        new URL("../../../../adapters/openclaw/src/bin.ts", import.meta.url),
+      ),
+    ],
+  },
+};
 
 /** Returns the current built-in adapter registry. */
 export function getBuiltinAgentAdapters(): BuiltinAgentAdapterRegistry {

--- a/packages/cli/src/agent/builtin-registry.ts
+++ b/packages/cli/src/agent/builtin-registry.ts
@@ -1,9 +1,8 @@
-import { fileURLToPath } from "node:url";
 import {
-  AdapterManifest,
   type AdapterManifestType,
   type AdapterVerbType,
 } from "@xmtp/signet-schemas";
+import { openclawAdapterDefinition } from "@xmtp/openclaw-adapter";
 
 /** First-party adapter registration known to the CLI. */
 export interface BuiltinAgentAdapterDefinition {
@@ -21,31 +20,11 @@ export type BuiltinAgentAdapterRegistry = Record<
 
 /**
  * First-party adapter registrations bundled with the repo.
- *
- * The initial registry is intentionally sparse; later branches add OpenClaw as
- * the first concrete built-in adapter.
  */
-const OPENCLAW_MANIFEST: AdapterManifestType = AdapterManifest.parse({
-  name: "openclaw",
-  source: "builtin",
-  supports: ["setup", "status", "doctor"],
-  entrypoints: {
-    setup: "builtin:openclaw:setup",
-    status: "builtin:openclaw:status",
-    doctor: "builtin:openclaw:doctor",
-  },
-});
+const OPENCLAW_DEFINITION = openclawAdapterDefinition;
 
 const builtinAgentAdapters: BuiltinAgentAdapterRegistry = {
-  [OPENCLAW_MANIFEST.name]: {
-    manifest: OPENCLAW_MANIFEST,
-    command: "bun",
-    args: [
-      fileURLToPath(
-        new URL("../../../../adapters/openclaw/src/bin.ts", import.meta.url),
-      ),
-    ],
-  },
+  [OPENCLAW_DEFINITION.manifest.name]: OPENCLAW_DEFINITION,
 };
 
 /** Returns the current built-in adapter registry. */

--- a/packages/cli/src/agent/builtin-registry.ts
+++ b/packages/cli/src/agent/builtin-registry.ts
@@ -57,20 +57,40 @@ const openclawBinPath = resolveOpenClawPath([
   ),
 ]);
 
-const OPENCLAW_DEFINITION: BuiltinAgentAdapterDefinition = {
-  manifest: AdapterManifest.parse(
-    JSON.parse(readFileSync(openclawManifestPath, "utf-8")),
-  ),
-  command: "bun",
-  args: [openclawBinPath],
-};
+let builtinAgentAdapters: BuiltinAgentAdapterRegistry | null = null;
 
-const builtinAgentAdapters: BuiltinAgentAdapterRegistry = {
-  [OPENCLAW_DEFINITION.manifest.name]: OPENCLAW_DEFINITION,
-};
+function loadOpenClawDefinition(): BuiltinAgentAdapterDefinition | null {
+  if (!existsSync(openclawManifestPath) || !existsSync(openclawBinPath)) {
+    return null;
+  }
+
+  try {
+    return {
+      manifest: AdapterManifest.parse(
+        JSON.parse(readFileSync(openclawManifestPath, "utf-8")),
+      ),
+      command: "bun",
+      args: [openclawBinPath],
+    };
+  } catch {
+    return null;
+  }
+}
 
 /** Returns the current built-in adapter registry. */
 export function getBuiltinAgentAdapters(): BuiltinAgentAdapterRegistry {
+  if (builtinAgentAdapters !== null) {
+    return builtinAgentAdapters;
+  }
+
+  const openclawDefinition = loadOpenClawDefinition();
+  builtinAgentAdapters =
+    openclawDefinition === null
+      ? {}
+      : {
+          [openclawDefinition.manifest.name]: openclawDefinition,
+        };
+
   return builtinAgentAdapters;
 }
 
@@ -78,7 +98,7 @@ export function getBuiltinAgentAdapters(): BuiltinAgentAdapterRegistry {
 export function getBuiltinAgentAdapter(
   name: string,
 ): BuiltinAgentAdapterDefinition | undefined {
-  return builtinAgentAdapters[name];
+  return getBuiltinAgentAdapters()[name];
 }
 
 /** Returns true when the built-in adapter manifest declares the given verb. */

--- a/packages/cli/src/agent/builtin-registry.ts
+++ b/packages/cli/src/agent/builtin-registry.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import {
   AdapterManifest,
@@ -23,26 +23,46 @@ export type BuiltinAgentAdapterRegistry = Record<
 /**
  * First-party adapter registrations bundled with the repo.
  */
-const OPENCLAW_DEFINITION: BuiltinAgentAdapterDefinition = {
-  manifest: AdapterManifest.parse(
-    JSON.parse(
-      readFileSync(
-        fileURLToPath(
-          new URL(
-            "../../../../adapters/openclaw/adapter-manifest.json",
-            import.meta.url,
-          ),
-        ),
-        "utf-8",
-      ),
+function resolveOpenClawPath(candidates: readonly string[]): string {
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return candidates[0] ?? "";
+}
+
+const openclawManifestPath = resolveOpenClawPath([
+  fileURLToPath(
+    new URL(
+      "../../../../adapters/openclaw/adapter-manifest.json",
+      import.meta.url,
     ),
   ),
-  command: "bun",
-  args: [
-    fileURLToPath(
-      new URL("../../../../adapters/openclaw/src/bin.ts", import.meta.url),
+  fileURLToPath(
+    new URL(
+      "../../../adapters/openclaw/adapter-manifest.json",
+      import.meta.url,
     ),
-  ],
+  ),
+]);
+
+const openclawBinPath = resolveOpenClawPath([
+  fileURLToPath(
+    new URL("../../../../adapters/openclaw/src/bin.ts", import.meta.url),
+  ),
+  fileURLToPath(
+    new URL("../../../adapters/openclaw/src/bin.ts", import.meta.url),
+  ),
+]);
+
+const OPENCLAW_DEFINITION: BuiltinAgentAdapterDefinition = {
+  manifest: AdapterManifest.parse(
+    JSON.parse(readFileSync(openclawManifestPath, "utf-8")),
+  ),
+  command: "bun",
+  args: [openclawBinPath],
 };
 
 const builtinAgentAdapters: BuiltinAgentAdapterRegistry = {

--- a/packages/cli/src/agent/builtin-registry.ts
+++ b/packages/cli/src/agent/builtin-registry.ts
@@ -1,8 +1,10 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import {
+  AdapterManifest,
   type AdapterManifestType,
   type AdapterVerbType,
 } from "@xmtp/signet-schemas";
-import { openclawAdapterDefinition } from "@xmtp/openclaw-adapter";
 
 /** First-party adapter registration known to the CLI. */
 export interface BuiltinAgentAdapterDefinition {
@@ -21,7 +23,27 @@ export type BuiltinAgentAdapterRegistry = Record<
 /**
  * First-party adapter registrations bundled with the repo.
  */
-const OPENCLAW_DEFINITION = openclawAdapterDefinition;
+const OPENCLAW_DEFINITION: BuiltinAgentAdapterDefinition = {
+  manifest: AdapterManifest.parse(
+    JSON.parse(
+      readFileSync(
+        fileURLToPath(
+          new URL(
+            "../../../../adapters/openclaw/adapter-manifest.json",
+            import.meta.url,
+          ),
+        ),
+        "utf-8",
+      ),
+    ),
+  ),
+  command: "bun",
+  args: [
+    fileURLToPath(
+      new URL("../../../../adapters/openclaw/src/bin.ts", import.meta.url),
+    ),
+  ],
+};
 
 const builtinAgentAdapters: BuiltinAgentAdapterRegistry = {
   [OPENCLAW_DEFINITION.manifest.name]: OPENCLAW_DEFINITION,

--- a/packages/cli/src/agent/registry.ts
+++ b/packages/cli/src/agent/registry.ts
@@ -25,6 +25,7 @@ export interface ResolvedAgentAdapterCommand {
   readonly manifest: AdapterManifestType;
   readonly source: "builtin" | "external";
   readonly command: string;
+  readonly args?: readonly string[] | undefined;
   readonly cwd?: string | undefined;
 }
 
@@ -197,6 +198,7 @@ function resolveBuiltinAdapter(
     manifest: builtin.manifest,
     source: "builtin",
     command: builtin.command,
+    ...(builtin.args !== undefined ? { args: builtin.args } : {}),
     ...(builtin.cwd !== undefined ? { cwd: builtin.cwd } : {}),
   });
 }

--- a/packages/cli/src/agent/registry.ts
+++ b/packages/cli/src/agent/registry.ts
@@ -37,7 +37,7 @@ export interface ResolveAgentAdapterDeps {
 
 const defaultDeps: ResolveAgentAdapterDeps = {
   readFile,
-  builtinRegistry: getBuiltinAgentAdapters(),
+  builtinRegistry: {},
 };
 
 function resolveAgainstConfigPath(configPath: string, target: string): string {
@@ -216,7 +216,7 @@ export async function resolveAgentAdapterCommand(
   const resolvedDeps: ResolveAgentAdapterDeps = {
     ...defaultDeps,
     ...deps,
-    builtinRegistry: deps.builtinRegistry ?? defaultDeps.builtinRegistry,
+    builtinRegistry: deps.builtinRegistry ?? getBuiltinAgentAdapters(),
   };
   const configuredAdapter = options.config.agent.adapters[options.adapterName];
 

--- a/packages/cli/src/agent/runner.ts
+++ b/packages/cli/src/agent/runner.ts
@@ -75,7 +75,11 @@ export async function runResolvedAgentAdapter(
   let process: Bun.Subprocess;
   try {
     process = resolvedDeps.spawn(
-      [adapter.command, ...buildAdapterArgs(adapter, options)],
+      [
+        adapter.command,
+        ...(adapter.args ?? []),
+        ...buildAdapterArgs(adapter, options),
+      ],
       {
         stdout: "pipe",
         stderr: "pipe",


### PR DESCRIPTION
## Summary
This PR scaffolds `adapters/openclaw` as the first first-party reference adapter package and establishes the package boundaries the rest of the stack builds on.

## What Changed
- adds the `@xmtp/openclaw-adapter` workspace under `adapters/openclaw`
- lays out adapter-local modules for setup, status, doctor, artifacts, bridge, and config concerns
- keeps the OpenClaw-specific implementation surface isolated from the core CLI and shared contracts
- adds package-local tests and README scaffolding so the adapter can serve as the reference shape for future harnesses

## Why This Shape
OpenClaw is the first adapter, but it should not be a special case. This package layout is meant to become the template other first-party and external adapters can follow.

## How To Test
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run docs:check`

## Issues
Closes #343
