### PR TITLE
feat: add openclaw read-only bridge

### DIFF
--- a/adapters/openclaw/package.json
+++ b/adapters/openclaw/package.json
@@ -20,8 +20,10 @@
     "@xmtp/signet-cli": "workspace:*",
     "@xmtp/signet-keys": "workspace:*",
     "@xmtp/signet-schemas": "workspace:*",
+    "@xmtp/signet-ws": "workspace:*",
     "better-result": "catalog:",
-    "commander": "14.0.3"
+    "commander": "14.0.3",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "bun-types": "catalog:",

--- a/adapters/openclaw/src/__tests__/openclaw-bridge.test.ts
+++ b/adapters/openclaw/src/__tests__/openclaw-bridge.test.ts
@@ -2,7 +2,10 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import type { SignetEvent } from "@xmtp/signet-schemas";
+import { Result } from "better-result";
+import { InternalError, type SignetEvent } from "@xmtp/signet-schemas";
+import { WS_CLOSE_CODES } from "@xmtp/signet-ws";
+import { createOpenClawCheckpointStore } from "../bridge/index.js";
 import { createOpenClawReadOnlyBridge } from "../bridge/index.js";
 
 const tempDirs: string[] = [];
@@ -28,10 +31,20 @@ interface ReplayFrame {
 
 function createReplayAwareServer(options?: {
   readonly initialFrames?: readonly ReplayFrame[];
+  readonly closeAfterAuth?: {
+    readonly code: number;
+    readonly reason: string;
+  };
+  readonly closeOnOpenAttempt?: {
+    readonly afterConnection: number;
+    readonly code: number;
+    readonly reason: string;
+  };
 }) {
   const frames: ReplayFrame[] = [...(options?.initialFrames ?? [])];
   let nextSeq =
     frames.length === 0 ? 1 : Math.max(...frames.map((frame) => frame.seq)) + 1;
+  let connectionCount = 0;
   const connections = new Map<
     string,
     {
@@ -57,10 +70,20 @@ function createReplayAwareServer(options?: {
     },
     websocket: {
       open(ws) {
+        connectionCount += 1;
         connections.set(ws.data.connectionId, {
           ws,
           authenticated: false,
         });
+        if (
+          options?.closeOnOpenAttempt &&
+          connectionCount >= options.closeOnOpenAttempt.afterConnection
+        ) {
+          ws.close(
+            options.closeOnOpenAttempt.code,
+            options.closeOnOpenAttempt.reason,
+          );
+        }
       },
       message(ws, message) {
         const connection = connections.get(ws.data.connectionId);
@@ -105,6 +128,10 @@ function createReplayAwareServer(options?: {
         )) {
           ws.send(JSON.stringify(frame));
         }
+
+        if (options?.closeAfterAuth) {
+          ws.close(options.closeAfterAuth.code, options.closeAfterAuth.reason);
+        }
       },
       close(ws) {
         connections.delete(ws.data.connectionId);
@@ -134,7 +161,8 @@ function createReplayAwareServer(options?: {
         connection.ws.close(1001, "server stopping");
       }
       connections.clear();
-      await server.stop(true);
+      server.stop(true);
+      await new Promise((resolve) => setTimeout(resolve, 0));
     },
   };
 }
@@ -148,6 +176,34 @@ async function nextDelivery<T>(stream: AsyncIterable<T>): Promise<T> {
   return result.value;
 }
 
+async function expectToSettle(
+  promise: Promise<unknown>,
+  label: string,
+): Promise<void> {
+  await Promise.race([
+    promise.then(() => undefined),
+    new Promise<never>((_, reject) => {
+      setTimeout(() => {
+        reject(new Error(`${label} timed out`));
+      }, 1_000);
+    }),
+  ]);
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  label: string,
+  timeoutMs = 1_000,
+): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start >= timeoutMs) {
+      throw new Error(`${label} timed out`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
 describe("OpenClaw read-only bridge", () => {
   test("delivers sequenced events and persists credential checkpoints", async () => {
     const root = await mkdtemp(join(tmpdir(), "openclaw-bridge-"));
@@ -156,6 +212,7 @@ describe("OpenClaw read-only bridge", () => {
     const mock = createReplayAwareServer();
     const bridge = createOpenClawReadOnlyBridge({
       adapter: "openclaw",
+      credentialId: TEST_CREDENTIAL_ID,
       wsUrl: mock.url,
       token: "test-token",
       checkpointsDir: join(root, "checkpoints"),
@@ -187,8 +244,8 @@ describe("OpenClaw read-only bridge", () => {
       `${TEST_CREDENTIAL_ID}.json`,
     );
 
-    await bridge.stop();
-    await mock.stop();
+    await expectToSettle(bridge.stop(), "bridge.stop");
+    await expectToSettle(mock.stop(), "mock.stop");
   });
 
   test("resumes from the last checkpoint and skips replayed duplicates", async () => {
@@ -198,6 +255,7 @@ describe("OpenClaw read-only bridge", () => {
     const firstServer = createReplayAwareServer();
     const firstBridge = createOpenClawReadOnlyBridge({
       adapter: "openclaw",
+      credentialId: TEST_CREDENTIAL_ID,
       wsUrl: firstServer.url,
       token: "test-token",
       checkpointsDir: join(root, "checkpoints"),
@@ -230,8 +288,8 @@ describe("OpenClaw read-only bridge", () => {
     expect(firstDelivery.seq).toBe(1);
     expect(secondDelivery.seq).toBe(2);
 
-    await firstBridge.stop();
-    await firstServer.stop();
+    await expectToSettle(firstBridge.stop(), "firstBridge.stop");
+    await expectToSettle(firstServer.stop(), "firstServer.stop");
 
     const secondServer = createReplayAwareServer({
       initialFrames: [
@@ -256,6 +314,7 @@ describe("OpenClaw read-only bridge", () => {
 
     const secondBridge = createOpenClawReadOnlyBridge({
       adapter: "openclaw",
+      credentialId: TEST_CREDENTIAL_ID,
       wsUrl: secondServer.url,
       token: "test-token",
       checkpointsDir: join(root, "checkpoints"),
@@ -283,7 +342,252 @@ describe("OpenClaw read-only bridge", () => {
     expect(secondBridge.metrics.dedupedCount).toBe(0);
     expect(secondBridge.metrics.lastSeq).toBe(3);
 
-    await secondBridge.stop();
-    await secondServer.stop();
+    await expectToSettle(secondBridge.stop(), "secondBridge.stop");
+    await expectToSettle(secondServer.stop(), "secondServer.stop");
+  });
+
+  test("ignores checkpoints for other credentials when resuming", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-bridge-"));
+    tempDirs.push(root);
+
+    const store = createOpenClawCheckpointStore({
+      checkpointsDir: join(root, "checkpoints"),
+    });
+    await store.save({
+      credentialId: "cred_0000000000000002",
+      lastSeq: 99,
+      updatedAt: "2026-04-18T00:00:00.000Z",
+    });
+
+    const server = createReplayAwareServer({
+      initialFrames: [
+        {
+          seq: 1,
+          event: {
+            type: "heartbeat",
+            credentialId: TEST_CREDENTIAL_ID,
+            timestamp: "2026-04-18T00:00:00.000Z",
+          },
+        },
+      ],
+    });
+
+    const bridge = createOpenClawReadOnlyBridge({
+      adapter: "openclaw",
+      credentialId: TEST_CREDENTIAL_ID,
+      wsUrl: server.url,
+      token: "test-token",
+      checkpointsDir: join(root, "checkpoints"),
+      deliveryMode: "local",
+      reconnect: {
+        enabled: true,
+        maxAttempts: 3,
+        baseDelayMs: 10,
+        maxDelayMs: 20,
+        jitter: false,
+      },
+    });
+
+    const startResult = await bridge.start();
+    expect(startResult.isOk()).toBe(true);
+
+    const delivery = await nextDelivery(bridge.deliveries);
+    expect(delivery.seq).toBe(1);
+    expect(bridge.metrics.dedupedCount).toBe(0);
+
+    await expectToSettle(bridge.stop(), "bridge.stop");
+    await expectToSettle(server.stop(), "server.stop");
+  });
+
+  test("stops the bridge when checkpoint persistence fails", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-bridge-"));
+    tempDirs.push(root);
+
+    const server = createReplayAwareServer();
+    const bridge = createOpenClawReadOnlyBridge(
+      {
+        adapter: "openclaw",
+        credentialId: TEST_CREDENTIAL_ID,
+        wsUrl: server.url,
+        token: "test-token",
+        checkpointsDir: join(root, "checkpoints"),
+        deliveryMode: "local",
+        reconnect: {
+          enabled: true,
+          maxAttempts: 3,
+          baseDelayMs: 10,
+          maxDelayMs: 20,
+          jitter: false,
+        },
+      },
+      {
+        checkpointStoreFactory(config) {
+          const base = createOpenClawCheckpointStore(config);
+          return {
+            ...base,
+            async save() {
+              return Result.err(InternalError.create("disk full"));
+            },
+          };
+        },
+      },
+    );
+
+    const observedErrors: string[] = [];
+    bridge.onError((error) => {
+      observedErrors.push(error.message);
+    });
+
+    const startResult = await bridge.start();
+    expect(startResult.isOk()).toBe(true);
+
+    server.emit({
+      type: "heartbeat",
+      credentialId: TEST_CREDENTIAL_ID,
+      timestamp: "2026-04-18T00:00:00.000Z",
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(bridge.state).toBe("closed");
+    expect(bridge.metrics.deliveredCount).toBe(0);
+    expect(
+      observedErrors.some((message) => message.includes("disk full")),
+    ).toBe(true);
+
+    await expectToSettle(bridge.stop(), "bridge.stop");
+    await expectToSettle(server.stop(), "server.stop");
+  });
+
+  test("closes without reconnecting on non-retryable signet close codes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-bridge-"));
+    tempDirs.push(root);
+
+    const server = createReplayAwareServer({
+      closeAfterAuth: {
+        code: WS_CLOSE_CODES.AUTH_FAILED,
+        reason: "Credential revoked",
+      },
+    });
+    const bridge = createOpenClawReadOnlyBridge({
+      adapter: "openclaw",
+      credentialId: TEST_CREDENTIAL_ID,
+      wsUrl: server.url,
+      token: "test-token",
+      checkpointsDir: join(root, "checkpoints"),
+      deliveryMode: "local",
+      reconnect: {
+        enabled: true,
+        maxAttempts: 3,
+        baseDelayMs: 10,
+        maxDelayMs: 20,
+        jitter: false,
+      },
+    });
+
+    const observedErrors: string[] = [];
+    bridge.onError((error) => {
+      observedErrors.push(error.message);
+    });
+
+    const startResult = await bridge.start();
+    expect(startResult.isOk()).toBe(true);
+
+    await waitFor(() => bridge.state === "closed", "bridge close");
+    expect(bridge.metrics.reconnectCount).toBe(0);
+    expect(observedErrors).toContain("Credential revoked");
+
+    await expectToSettle(bridge.stop(), "bridge.stop");
+    await expectToSettle(server.stop(), "server.stop");
+  });
+
+  test("closes cleanly when reconnect is disabled", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-bridge-"));
+    tempDirs.push(root);
+
+    const server = createReplayAwareServer({
+      closeAfterAuth: {
+        code: WS_CLOSE_CODES.NORMAL,
+        reason: "signet restart",
+      },
+    });
+    const bridge = createOpenClawReadOnlyBridge({
+      adapter: "openclaw",
+      credentialId: TEST_CREDENTIAL_ID,
+      wsUrl: server.url,
+      token: "test-token",
+      checkpointsDir: join(root, "checkpoints"),
+      deliveryMode: "local",
+      reconnect: {
+        enabled: false,
+        maxAttempts: 3,
+        baseDelayMs: 10,
+        maxDelayMs: 20,
+        jitter: false,
+      },
+    });
+
+    const observedErrors: string[] = [];
+    bridge.onError((error) => {
+      observedErrors.push(error.message);
+    });
+
+    const startResult = await bridge.start();
+    expect(startResult.isOk()).toBe(true);
+
+    await waitFor(() => bridge.state === "closed", "bridge close");
+    expect(observedErrors).toContain("OpenClaw bridge reconnect is disabled");
+    expect(bridge.metrics.reconnectCount).toBe(0);
+
+    await expectToSettle(bridge.stop(), "bridge.stop");
+    await expectToSettle(server.stop(), "server.stop");
+  });
+
+  test("stops after exhausting retryable reconnect attempts", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-bridge-"));
+    tempDirs.push(root);
+
+    const server = createReplayAwareServer({
+      closeAfterAuth: {
+        code: WS_CLOSE_CODES.NORMAL,
+        reason: "transient disconnect",
+      },
+      closeOnOpenAttempt: {
+        afterConnection: 2,
+        code: WS_CLOSE_CODES.NORMAL,
+        reason: "retry auth never established",
+      },
+    });
+    const bridge = createOpenClawReadOnlyBridge({
+      adapter: "openclaw",
+      credentialId: TEST_CREDENTIAL_ID,
+      wsUrl: server.url,
+      token: "test-token",
+      checkpointsDir: join(root, "checkpoints"),
+      deliveryMode: "local",
+      reconnect: {
+        enabled: true,
+        maxAttempts: 1,
+        baseDelayMs: 10,
+        maxDelayMs: 20,
+        jitter: false,
+      },
+    });
+
+    const observedErrors: string[] = [];
+    bridge.onError((error) => {
+      observedErrors.push(error.message);
+    });
+
+    const startResult = await bridge.start();
+    expect(startResult.isOk()).toBe(true);
+
+    await waitFor(() => bridge.state === "closed", "bridge close");
+    expect(bridge.metrics.reconnectCount).toBe(1);
+    expect(observedErrors).toContain(
+      "OpenClaw bridge exhausted reconnect attempts",
+    );
+
+    await expectToSettle(bridge.stop(), "bridge.stop");
+    await expectToSettle(server.stop(), "server.stop");
   });
 });

--- a/adapters/openclaw/src/__tests__/openclaw-bridge.test.ts
+++ b/adapters/openclaw/src/__tests__/openclaw-bridge.test.ts
@@ -1,0 +1,289 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { SignetEvent } from "@xmtp/signet-schemas";
+import { createOpenClawReadOnlyBridge } from "../bridge/index.js";
+
+const tempDirs: string[] = [];
+const TEST_CREDENTIAL_ID = "cred_0000000000000001";
+const TEST_OPERATOR_ID = "op_0000000000000001";
+const TEST_FINGERPRINT = `sha256:${"a".repeat(64)}`;
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) =>
+      rm(dir, {
+        recursive: true,
+        force: true,
+      }),
+    ),
+  );
+});
+
+interface ReplayFrame {
+  readonly seq: number;
+  readonly event: SignetEvent;
+}
+
+function createReplayAwareServer(options?: {
+  readonly initialFrames?: readonly ReplayFrame[];
+}) {
+  const frames: ReplayFrame[] = [...(options?.initialFrames ?? [])];
+  let nextSeq =
+    frames.length === 0 ? 1 : Math.max(...frames.map((frame) => frame.seq)) + 1;
+  const connections = new Map<
+    string,
+    {
+      ws: Bun.ServerWebSocket<{ connectionId: string }>;
+      authenticated: boolean;
+    }
+  >();
+
+  const server = Bun.serve({
+    port: 0,
+    fetch(req, bunServer) {
+      const url = new URL(req.url);
+      if (url.pathname !== "/v1/agent") {
+        return new Response("not found", { status: 404 });
+      }
+      const connectionId = crypto.randomUUID();
+      const upgraded = bunServer.upgrade(req, {
+        data: { connectionId },
+      });
+      return upgraded
+        ? undefined
+        : new Response("upgrade failed", { status: 500 });
+    },
+    websocket: {
+      open(ws) {
+        connections.set(ws.data.connectionId, {
+          ws,
+          authenticated: false,
+        });
+      },
+      message(ws, message) {
+        const connection = connections.get(ws.data.connectionId);
+        if (!connection) {
+          return;
+        }
+        const data = JSON.parse(
+          typeof message === "string" ? message : message.toString(),
+        ) as {
+          type: string;
+          token?: string;
+          lastSeenSeq?: number | null;
+        };
+
+        if (data.type !== "auth") {
+          ws.close(4009, "Expected auth frame");
+          return;
+        }
+
+        connection.authenticated = true;
+        ws.send(
+          JSON.stringify({
+            type: "authenticated",
+            connectionId: ws.data.connectionId,
+            credential: {
+              credentialId: TEST_CREDENTIAL_ID,
+              operatorId: TEST_OPERATOR_ID,
+              fingerprint: TEST_FINGERPRINT,
+              issuedAt: "2026-04-18T00:00:00.000Z",
+              expiresAt: "2026-04-19T00:00:00.000Z",
+            },
+            effectiveScopes: {
+              allow: ["stream-messages"],
+              deny: [],
+            },
+            resumedFromSeq: data.lastSeenSeq ?? null,
+          }),
+        );
+
+        for (const frame of frames.filter(
+          (candidate) => candidate.seq > (data.lastSeenSeq ?? 0),
+        )) {
+          ws.send(JSON.stringify(frame));
+        }
+      },
+      close(ws) {
+        connections.delete(ws.data.connectionId);
+      },
+    },
+  });
+
+  return {
+    server,
+    url: `ws://127.0.0.1:${server.port}/v1/agent`,
+    emit(event: SignetEvent) {
+      const frame: ReplayFrame = {
+        seq: nextSeq,
+        event,
+      };
+      nextSeq += 1;
+      frames.push(frame);
+      for (const connection of connections.values()) {
+        if (connection.authenticated) {
+          connection.ws.send(JSON.stringify(frame));
+        }
+      }
+      return frame;
+    },
+    async stop() {
+      for (const connection of connections.values()) {
+        connection.ws.close(1001, "server stopping");
+      }
+      connections.clear();
+      await server.stop(true);
+    },
+  };
+}
+
+async function nextDelivery<T>(stream: AsyncIterable<T>): Promise<T> {
+  const iterator = stream[Symbol.asyncIterator]();
+  const result = await iterator.next();
+  if (result.done) {
+    throw new Error("Expected delivery but stream completed");
+  }
+  return result.value;
+}
+
+describe("OpenClaw read-only bridge", () => {
+  test("delivers sequenced events and persists credential checkpoints", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-bridge-"));
+    tempDirs.push(root);
+
+    const mock = createReplayAwareServer();
+    const bridge = createOpenClawReadOnlyBridge({
+      adapter: "openclaw",
+      wsUrl: mock.url,
+      token: "test-token",
+      checkpointsDir: join(root, "checkpoints"),
+      deliveryMode: "local",
+      reconnect: {
+        enabled: true,
+        maxAttempts: 3,
+        baseDelayMs: 10,
+        maxDelayMs: 20,
+        jitter: false,
+      },
+    });
+
+    const startResult = await bridge.start();
+    expect(startResult.isOk()).toBe(true);
+
+    mock.emit({
+      type: "heartbeat",
+      credentialId: TEST_CREDENTIAL_ID,
+      timestamp: "2026-04-18T00:00:00.000Z",
+    });
+
+    const delivery = await nextDelivery(bridge.deliveries);
+    expect(delivery.dedupeKey).toBe(`${TEST_CREDENTIAL_ID}:1`);
+    expect(delivery.event.type).toBe("heartbeat");
+    expect(bridge.metrics.lastSeq).toBe(1);
+    expect(bridge.metrics.deliveredCount).toBe(1);
+    expect(bridge.metrics.checkpointPath).toContain(
+      `${TEST_CREDENTIAL_ID}.json`,
+    );
+
+    await bridge.stop();
+    await mock.stop();
+  });
+
+  test("resumes from the last checkpoint and skips replayed duplicates", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-bridge-"));
+    tempDirs.push(root);
+
+    const firstServer = createReplayAwareServer();
+    const firstBridge = createOpenClawReadOnlyBridge({
+      adapter: "openclaw",
+      wsUrl: firstServer.url,
+      token: "test-token",
+      checkpointsDir: join(root, "checkpoints"),
+      deliveryMode: "local",
+      reconnect: {
+        enabled: true,
+        maxAttempts: 3,
+        baseDelayMs: 10,
+        maxDelayMs: 20,
+        jitter: false,
+      },
+    });
+
+    const firstStart = await firstBridge.start();
+    expect(firstStart.isOk()).toBe(true);
+
+    firstServer.emit({
+      type: "heartbeat",
+      credentialId: TEST_CREDENTIAL_ID,
+      timestamp: "2026-04-18T00:00:00.000Z",
+    });
+    firstServer.emit({
+      type: "heartbeat",
+      credentialId: TEST_CREDENTIAL_ID,
+      timestamp: "2026-04-18T00:00:01.000Z",
+    });
+
+    const firstDelivery = await nextDelivery(firstBridge.deliveries);
+    const secondDelivery = await nextDelivery(firstBridge.deliveries);
+    expect(firstDelivery.seq).toBe(1);
+    expect(secondDelivery.seq).toBe(2);
+
+    await firstBridge.stop();
+    await firstServer.stop();
+
+    const secondServer = createReplayAwareServer({
+      initialFrames: [
+        {
+          seq: 1,
+          event: {
+            type: "heartbeat",
+            credentialId: TEST_CREDENTIAL_ID,
+            timestamp: "2026-04-18T00:00:00.000Z",
+          },
+        },
+        {
+          seq: 2,
+          event: {
+            type: "heartbeat",
+            credentialId: TEST_CREDENTIAL_ID,
+            timestamp: "2026-04-18T00:00:01.000Z",
+          },
+        },
+      ],
+    });
+
+    const secondBridge = createOpenClawReadOnlyBridge({
+      adapter: "openclaw",
+      wsUrl: secondServer.url,
+      token: "test-token",
+      checkpointsDir: join(root, "checkpoints"),
+      deliveryMode: "local",
+      reconnect: {
+        enabled: true,
+        maxAttempts: 3,
+        baseDelayMs: 10,
+        maxDelayMs: 20,
+        jitter: false,
+      },
+    });
+
+    const secondStart = await secondBridge.start();
+    expect(secondStart.isOk()).toBe(true);
+
+    const freshFrame = secondServer.emit({
+      type: "heartbeat",
+      credentialId: TEST_CREDENTIAL_ID,
+      timestamp: "2026-04-18T00:00:02.000Z",
+    });
+
+    const resumedDelivery = await nextDelivery(secondBridge.deliveries);
+    expect(resumedDelivery.seq).toBe(freshFrame.seq);
+    expect(secondBridge.metrics.dedupedCount).toBe(0);
+    expect(secondBridge.metrics.lastSeq).toBe(3);
+
+    await secondBridge.stop();
+    await secondServer.stop();
+  });
+});

--- a/adapters/openclaw/src/__tests__/openclaw-bridge.test.ts
+++ b/adapters/openclaw/src/__tests__/openclaw-bridge.test.ts
@@ -31,6 +31,7 @@ interface ReplayFrame {
 
 function createReplayAwareServer(options?: {
   readonly initialFrames?: readonly ReplayFrame[];
+  readonly authenticatedCredentialId?: string;
   readonly closeAfterAuth?: {
     readonly code: number;
     readonly reason: string;
@@ -109,7 +110,8 @@ function createReplayAwareServer(options?: {
             type: "authenticated",
             connectionId: ws.data.connectionId,
             credential: {
-              credentialId: TEST_CREDENTIAL_ID,
+              credentialId:
+                options?.authenticatedCredentialId ?? TEST_CREDENTIAL_ID,
               operatorId: TEST_OPERATOR_ID,
               fingerprint: TEST_FINGERPRINT,
               issuedAt: "2026-04-18T00:00:00.000Z",
@@ -586,6 +588,118 @@ describe("OpenClaw read-only bridge", () => {
     expect(observedErrors).toContain(
       "OpenClaw bridge exhausted reconnect attempts",
     );
+
+    await expectToSettle(bridge.stop(), "bridge.stop");
+    await expectToSettle(server.stop(), "server.stop");
+  });
+
+  test("can restart cleanly after a checkpoint persistence failure", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-bridge-"));
+    tempDirs.push(root);
+
+    let failCheckpointSave = true;
+    const server = createReplayAwareServer();
+    const bridge = createOpenClawReadOnlyBridge(
+      {
+        adapter: "openclaw",
+        credentialId: TEST_CREDENTIAL_ID,
+        wsUrl: server.url,
+        token: "test-token",
+        checkpointsDir: join(root, "checkpoints"),
+        deliveryMode: "local",
+        reconnect: {
+          enabled: true,
+          maxAttempts: 3,
+          baseDelayMs: 10,
+          maxDelayMs: 20,
+          jitter: false,
+        },
+      },
+      {
+        checkpointStoreFactory(config) {
+          const base = createOpenClawCheckpointStore(config);
+          return {
+            ...base,
+            async save(checkpoint) {
+              if (failCheckpointSave) {
+                return Result.err(InternalError.create("disk full"));
+              }
+              return base.save(checkpoint);
+            },
+          };
+        },
+      },
+    );
+
+    const firstStart = await bridge.start();
+    expect(firstStart.isOk()).toBe(true);
+
+    server.emit({
+      type: "heartbeat",
+      credentialId: TEST_CREDENTIAL_ID,
+      timestamp: "2026-04-18T00:00:00.000Z",
+    });
+
+    await waitFor(() => bridge.state === "closed", "bridge close");
+    expect(bridge.metrics.deliveredCount).toBe(0);
+
+    failCheckpointSave = false;
+    const secondStart = await bridge.start();
+    expect(secondStart.isOk()).toBe(true);
+
+    server.emit({
+      type: "heartbeat",
+      credentialId: TEST_CREDENTIAL_ID,
+      timestamp: "2026-04-18T00:00:01.000Z",
+    });
+
+    const replayedDelivery = await nextDelivery(bridge.deliveries);
+    const freshDelivery = await nextDelivery(bridge.deliveries);
+    expect(replayedDelivery.seq).toBe(1);
+    expect(freshDelivery.seq).toBe(2);
+    expect(bridge.metrics.deliveredCount).toBe(2);
+
+    await expectToSettle(bridge.stop(), "bridge.stop");
+    await expectToSettle(server.stop(), "server.stop");
+  });
+
+  test("fails authentication when signet returns a different credential", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-bridge-"));
+    tempDirs.push(root);
+
+    const server = createReplayAwareServer({
+      authenticatedCredentialId: "cred_0000000000000099",
+    });
+    const bridge = createOpenClawReadOnlyBridge({
+      adapter: "openclaw",
+      credentialId: TEST_CREDENTIAL_ID,
+      wsUrl: server.url,
+      token: "test-token",
+      checkpointsDir: join(root, "checkpoints"),
+      deliveryMode: "local",
+      reconnect: {
+        enabled: true,
+        maxAttempts: 3,
+        baseDelayMs: 10,
+        maxDelayMs: 20,
+        jitter: false,
+      },
+    });
+
+    const observedErrors: string[] = [];
+    bridge.onError((error) => {
+      observedErrors.push(error.message);
+    });
+
+    const startResult = await bridge.start();
+    expect(startResult.isErr()).toBe(true);
+    if (startResult.isErr()) {
+      expect(startResult.error.message).toContain(
+        "configured bridge credential",
+      );
+    }
+    expect(observedErrors[0]).toContain("configured bridge credential");
+    expect(bridge.metrics.reconnectCount).toBe(0);
 
     await expectToSettle(bridge.stop(), "bridge.stop");
     await expectToSettle(server.stop(), "server.stop");

--- a/adapters/openclaw/src/__tests__/openclaw-bridge.test.ts
+++ b/adapters/openclaw/src/__tests__/openclaw-bridge.test.ts
@@ -717,6 +717,74 @@ describe("OpenClaw read-only bridge", () => {
     await expectToSettle(server.stop(), "server.stop");
   });
 
+  test("stop settles start while checkpoint loading is still pending", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-bridge-"));
+    tempDirs.push(root);
+
+    let checkpointLoadStarted = false;
+    let releaseCheckpointLoad: (() => void) | null = null;
+    const checkpointLoadGate = new Promise<void>((resolve) => {
+      releaseCheckpointLoad = resolve;
+    });
+    let webSocketFactoryCalls = 0;
+
+    const bridge = createOpenClawReadOnlyBridge(
+      {
+        adapter: "openclaw",
+        credentialId: TEST_CREDENTIAL_ID,
+        wsUrl: "ws://bridge.test/v1/agent",
+        token: "test-token",
+        checkpointsDir: join(root, "checkpoints"),
+        deliveryMode: "local",
+        reconnect: {
+          enabled: true,
+          maxAttempts: 3,
+          baseDelayMs: 10,
+          maxDelayMs: 20,
+          jitter: false,
+        },
+      },
+      {
+        checkpointStoreFactory(config) {
+          const base = createOpenClawCheckpointStore(config);
+          return {
+            ...base,
+            async loadForCredential(credentialId) {
+              checkpointLoadStarted = true;
+              await checkpointLoadGate;
+              return base.loadForCredential(credentialId);
+            },
+          };
+        },
+        webSocketFactory() {
+          webSocketFactoryCalls += 1;
+          throw new Error(
+            "webSocketFactory should not be called before checkpoint loading finishes",
+          );
+        },
+      },
+    );
+
+    const startPromise = bridge.start();
+    await waitFor(() => checkpointLoadStarted, "checkpoint load started");
+
+    const stopPromise = bridge.stop();
+    releaseCheckpointLoad?.();
+
+    await expectToSettle(startPromise, "bridge.start");
+    const startResult = await startPromise;
+    expect(startResult.isErr()).toBe(true);
+    if (startResult.isErr()) {
+      expect(startResult.error.message).toContain(
+        "stopped before authentication",
+      );
+    }
+
+    await expectToSettle(stopPromise, "bridge.stop");
+    expect(bridge.state).toBe("closed");
+    expect(webSocketFactoryCalls).toBe(0);
+  });
+
   test("can restart cleanly after a checkpoint persistence failure", async () => {
     const root = await mkdtemp(join(tmpdir(), "openclaw-bridge-"));
     tempDirs.push(root);

--- a/adapters/openclaw/src/__tests__/openclaw-bridge.test.ts
+++ b/adapters/openclaw/src/__tests__/openclaw-bridge.test.ts
@@ -537,6 +537,56 @@ describe("OpenClaw read-only bridge", () => {
     await expectToSettle(server.stop(), "server.stop");
   });
 
+  test("does not reconnect on expired or policy-change credential closes", async () => {
+    for (const closeCase of [
+      {
+        code: WS_CLOSE_CODES.CREDENTIAL_EXPIRED,
+        reason: "Credential is expired",
+      },
+      {
+        code: WS_CLOSE_CODES.POLICY_CHANGE,
+        reason: "Credential is suspended",
+      },
+    ]) {
+      const root = await mkdtemp(join(tmpdir(), "openclaw-bridge-"));
+      tempDirs.push(root);
+
+      const server = createReplayAwareServer({
+        closeAfterAuth: closeCase,
+      });
+      const bridge = createOpenClawReadOnlyBridge({
+        adapter: "openclaw",
+        credentialId: TEST_CREDENTIAL_ID,
+        wsUrl: server.url,
+        token: "test-token",
+        checkpointsDir: join(root, "checkpoints"),
+        deliveryMode: "local",
+        reconnect: {
+          enabled: true,
+          maxAttempts: 3,
+          baseDelayMs: 10,
+          maxDelayMs: 20,
+          jitter: false,
+        },
+      });
+
+      const observedErrors: string[] = [];
+      bridge.onError((error) => {
+        observedErrors.push(error.message);
+      });
+
+      const startResult = await bridge.start();
+      expect(startResult.isOk()).toBe(true);
+
+      await waitFor(() => bridge.state === "closed", "bridge close");
+      expect(bridge.metrics.reconnectCount).toBe(0);
+      expect(observedErrors).toContain(closeCase.reason);
+
+      await expectToSettle(bridge.stop(), "bridge.stop");
+      await expectToSettle(server.stop(), "server.stop");
+    }
+  });
+
   test("closes cleanly when reconnect is disabled", async () => {
     const root = await mkdtemp(join(tmpdir(), "openclaw-bridge-"));
     tempDirs.push(root);
@@ -625,6 +675,45 @@ describe("OpenClaw read-only bridge", () => {
     );
 
     await expectToSettle(bridge.stop(), "bridge.stop");
+    await expectToSettle(server.stop(), "server.stop");
+  });
+
+  test("stop interrupts reconnect backoff immediately", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-bridge-"));
+    tempDirs.push(root);
+
+    const server = createReplayAwareServer({
+      closeAfterAuth: {
+        code: WS_CLOSE_CODES.NORMAL,
+        reason: "transient disconnect",
+      },
+    });
+    const bridge = createOpenClawReadOnlyBridge({
+      adapter: "openclaw",
+      credentialId: TEST_CREDENTIAL_ID,
+      wsUrl: server.url,
+      token: "test-token",
+      checkpointsDir: join(root, "checkpoints"),
+      deliveryMode: "local",
+      reconnect: {
+        enabled: true,
+        maxAttempts: 3,
+        baseDelayMs: 5_000,
+        maxDelayMs: 5_000,
+        jitter: false,
+      },
+    });
+
+    const startResult = await bridge.start();
+    expect(startResult.isOk()).toBe(true);
+
+    await waitFor(() => bridge.state === "reconnecting", "bridge reconnecting");
+
+    const startedAt = Date.now();
+    await expectToSettle(bridge.stop(), "bridge.stop");
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(elapsedMs).toBeLessThan(500);
     await expectToSettle(server.stop(), "server.stop");
   });
 

--- a/adapters/openclaw/src/__tests__/openclaw-bridge.test.ts
+++ b/adapters/openclaw/src/__tests__/openclaw-bridge.test.ts
@@ -5,8 +5,8 @@ import { tmpdir } from "node:os";
 import { Result } from "better-result";
 import { InternalError, type SignetEvent } from "@xmtp/signet-schemas";
 import { WS_CLOSE_CODES } from "@xmtp/signet-ws";
-import { createOpenClawCheckpointStore } from "../bridge/index.js";
-import { createOpenClawReadOnlyBridge } from "../bridge/index.js";
+import { createOpenClawCheckpointStore } from "../bridge/checkpoint-store.js";
+import { createOpenClawReadOnlyBridge } from "../bridge/runtime.js";
 
 const tempDirs: string[] = [];
 const TEST_CREDENTIAL_ID = "cred_0000000000000001";

--- a/adapters/openclaw/src/__tests__/openclaw-bridge.test.ts
+++ b/adapters/openclaw/src/__tests__/openclaw-bridge.test.ts
@@ -29,6 +29,41 @@ interface ReplayFrame {
   readonly event: SignetEvent;
 }
 
+class FakeWebSocket extends EventTarget {
+  readonly sentFrames: string[] = [];
+  readonly closeCalls: Array<{ code: number; reason: string }> = [];
+
+  send(data: string): void {
+    this.sentFrames.push(data);
+  }
+
+  close(code = 1000, reason = ""): void {
+    this.closeCalls.push({ code, reason });
+  }
+
+  emitOpen(): void {
+    this.dispatchEvent(new Event("open"));
+  }
+
+  emitMessage(payload: unknown): void {
+    this.dispatchEvent(
+      new MessageEvent("message", {
+        data: JSON.stringify(payload),
+      }),
+    );
+  }
+
+  emitClose(code = 1000, reason = ""): void {
+    this.dispatchEvent(
+      new CloseEvent("close", {
+        code,
+        reason,
+        wasClean: true,
+      }),
+    );
+  }
+}
+
 function createReplayAwareServer(options?: {
   readonly initialFrames?: readonly ReplayFrame[];
   readonly authenticatedCredentialId?: string;
@@ -703,5 +738,108 @@ describe("OpenClaw read-only bridge", () => {
 
     await expectToSettle(bridge.stop(), "bridge.stop");
     await expectToSettle(server.stop(), "server.stop");
+  });
+
+  test("ignores close events from a stale socket after stop and restart", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-bridge-"));
+    tempDirs.push(root);
+
+    const sockets: FakeWebSocket[] = [];
+    const bridge = createOpenClawReadOnlyBridge(
+      {
+        adapter: "openclaw",
+        credentialId: TEST_CREDENTIAL_ID,
+        wsUrl: "ws://bridge.test/v1/agent",
+        token: "test-token",
+        checkpointsDir: join(root, "checkpoints"),
+        deliveryMode: "local",
+        reconnect: {
+          enabled: true,
+          maxAttempts: 3,
+          baseDelayMs: 10,
+          maxDelayMs: 20,
+          jitter: false,
+        },
+      },
+      {
+        webSocketFactory() {
+          const socket = new FakeWebSocket();
+          sockets.push(socket);
+          return socket as unknown as WebSocket;
+        },
+      },
+    );
+
+    const firstStart = bridge.start();
+    await waitFor(() => sockets.length === 1, "first socket");
+    const firstSocket = sockets[0]!;
+    firstSocket.emitOpen();
+    firstSocket.emitMessage({
+      type: "authenticated",
+      connectionId: "conn_first",
+      credential: {
+        credentialId: TEST_CREDENTIAL_ID,
+        operatorId: TEST_OPERATOR_ID,
+        fingerprint: TEST_FINGERPRINT,
+        issuedAt: "2026-04-18T00:00:00.000Z",
+        expiresAt: "2026-04-19T00:00:00.000Z",
+      },
+      effectiveScopes: {
+        allow: ["stream-messages"],
+        deny: [],
+      },
+      resumedFromSeq: null,
+    });
+    expect((await firstStart).isOk()).toBe(true);
+
+    await expectToSettle(bridge.stop(), "bridge.stop");
+    expect(firstSocket.closeCalls).toEqual([
+      {
+        code: WS_CLOSE_CODES.NORMAL,
+        reason: "Bridge stopping",
+      },
+    ]);
+
+    const secondStart = bridge.start();
+    await waitFor(() => sockets.length === 2, "second socket");
+    const secondSocket = sockets[1]!;
+    secondSocket.emitOpen();
+    secondSocket.emitMessage({
+      type: "authenticated",
+      connectionId: "conn_second",
+      credential: {
+        credentialId: TEST_CREDENTIAL_ID,
+        operatorId: TEST_OPERATOR_ID,
+        fingerprint: TEST_FINGERPRINT,
+        issuedAt: "2026-04-18T00:00:00.000Z",
+        expiresAt: "2026-04-19T00:00:00.000Z",
+      },
+      effectiveScopes: {
+        allow: ["stream-messages"],
+        deny: [],
+      },
+      resumedFromSeq: null,
+    });
+    expect((await secondStart).isOk()).toBe(true);
+
+    firstSocket.emitClose(WS_CLOSE_CODES.NORMAL, "Bridge stopping");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(bridge.state).toBe("connected");
+
+    secondSocket.emitMessage({
+      seq: 1,
+      event: {
+        type: "heartbeat",
+        credentialId: TEST_CREDENTIAL_ID,
+        timestamp: "2026-04-18T00:00:01.000Z",
+      },
+    });
+
+    const delivery = await nextDelivery(bridge.deliveries);
+    expect(delivery.seq).toBe(1);
+    expect(bridge.metrics.deliveredCount).toBe(1);
+
+    await expectToSettle(bridge.stop(), "second bridge.stop");
+    secondSocket.emitClose(WS_CLOSE_CODES.NORMAL, "Bridge stopping");
   });
 });

--- a/adapters/openclaw/src/__tests__/openclaw-checkpoint-store.test.ts
+++ b/adapters/openclaw/src/__tests__/openclaw-checkpoint-store.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createOpenClawCheckpointStore } from "../bridge/index.js";
+
+describe("OpenClaw checkpoint store", () => {
+  test("loadLatest skips malformed checkpoint files when valid checkpoints remain", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-checkpoints-"));
+
+    try {
+      const checkpointsDir = join(root, "checkpoints");
+      await mkdir(checkpointsDir, { recursive: true });
+      await writeFile(
+        join(checkpointsDir, "bad.json"),
+        JSON.stringify({
+          credentialId: "cred_0000000000000002",
+          lastSeq: -1,
+          updatedAt: "not-a-date",
+        }),
+      );
+      await writeFile(
+        join(checkpointsDir, "good.json"),
+        JSON.stringify({
+          credentialId: "cred_0000000000000001",
+          lastSeq: 7,
+          updatedAt: "2026-04-18T00:00:00.000Z",
+        }),
+      );
+
+      const store = createOpenClawCheckpointStore({ checkpointsDir });
+      const result = await store.loadLatest();
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        return;
+      }
+      expect(result.value).not.toBeNull();
+      expect(result.value?.credentialId).toBe("cred_0000000000000001");
+      expect(result.value?.lastSeq).toBe(7);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/adapters/openclaw/src/__tests__/openclaw-checkpoint-store.test.ts
+++ b/adapters/openclaw/src/__tests__/openclaw-checkpoint-store.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { createOpenClawCheckpointStore } from "../bridge/index.js";
+import { createOpenClawCheckpointStore } from "../bridge/checkpoint-store.js";
 
 describe("OpenClaw checkpoint store", () => {
   test("loadLatest skips malformed checkpoint files when valid checkpoints remain", async () => {

--- a/adapters/openclaw/src/__tests__/openclaw-scaffold.test.ts
+++ b/adapters/openclaw/src/__tests__/openclaw-scaffold.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import {
   OPENCLAW_ADAPTER_MANIFEST,
   openclawAdapterDefinition,
@@ -26,8 +29,71 @@ describe("openclaw adapter scaffold", () => {
     expect(openclawAdapterDefinition.args[0]).toContain("bin.ts");
   });
 
-  test("returns structured outputs for status and doctor", () => {
-    expect(runOpenClawStatus().details["phase"]).toBe("scaffold");
-    expect(runOpenClawDoctor().details["phase"]).toBe("scaffold");
+  test("returns structured outputs for status and doctor", async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), "openclaw-status-"));
+    const configPath = join(dataDir, "config.toml");
+    await mkdir(join(dataDir, "adapters", "openclaw", "checkpoints"), {
+      recursive: true,
+    });
+    await writeFile(
+      configPath,
+      `
+[signet]
+env = "dev"
+dataDir = "${dataDir}"
+
+[defaults]
+
+[keys]
+rootKeyPolicy = "biometric"
+operationalKeyPolicy = "open"
+vaultKeyPolicy = "open"
+
+[biometricGating]
+rootKeyCreation = false
+operationalKeyRotation = false
+scopeExpansion = false
+egressExpansion = false
+agentCreation = false
+adminReadElevation = false
+
+[ws]
+port = 8393
+host = "127.0.0.1"
+
+[http]
+enabled = false
+port = 8081
+host = "127.0.0.1"
+
+[admin]
+authMode = "admin-key"
+socketPath = "${join(dataDir, "admin.sock")}"
+
+[credentials]
+defaultTtlSeconds = 3600
+maxConcurrentPerOperator = 3
+actionExpirySeconds = 300
+
+[logging]
+level = "info"
+
+[onboarding]
+scheme = "convos"
+`,
+    );
+
+    const status = await runOpenClawStatus({ configPath });
+    const doctor = await runOpenClawDoctor({ configPath });
+
+    expect(status.details["phase"]).toBe("runtime");
+    expect(doctor.details["phase"]).toBe("runtime");
+    expect(status.details["bridgePhase"]).toBe("read-only");
+    expect(status.details["missingArtifacts"]).toBeDefined();
+
+    await rm(dataDir, {
+      recursive: true,
+      force: true,
+    });
   });
 });

--- a/adapters/openclaw/src/bin.ts
+++ b/adapters/openclaw/src/bin.ts
@@ -175,8 +175,12 @@ addVerb(program, "setup", (opts) =>
     force: opts.force,
   }),
 );
-addVerb(program, "status", () => runOpenClawStatus());
-addVerb(program, "doctor", () => runOpenClawDoctor());
+addVerb(program, "status", (opts) =>
+  runOpenClawStatus({ configPath: opts.config }),
+);
+addVerb(program, "doctor", (opts) =>
+  runOpenClawDoctor({ configPath: opts.config }),
+);
 
 if (import.meta.main) {
   await program.parseAsync(process.argv);

--- a/adapters/openclaw/src/bridge/checkpoint-store.ts
+++ b/adapters/openclaw/src/bridge/checkpoint-store.ts
@@ -115,6 +115,7 @@ export function createOpenClawCheckpointStore(
       try {
         const entries = await resolvedDeps.readdir(config.checkpointsDir);
         const checkpoints: OpenClawBridgeCheckpointType[] = [];
+        const issues: string[] = [];
 
         for (const entry of entries) {
           if (!entry.endsWith(".json")) {
@@ -124,7 +125,8 @@ export function createOpenClawCheckpointStore(
             join(config.checkpointsDir, entry),
           );
           if (checkpointResult.isErr()) {
-            return checkpointResult;
+            issues.push(checkpointResult.error.message);
+            continue;
           }
           if (checkpointResult.value !== null) {
             checkpoints.push(checkpointResult.value);
@@ -132,6 +134,17 @@ export function createOpenClawCheckpointStore(
         }
 
         if (checkpoints.length === 0) {
+          if (issues.length > 0) {
+            return Result.err(
+              toBridgeInternalError(
+                "All OpenClaw checkpoint files were unreadable",
+                {
+                  checkpointsDir: config.checkpointsDir,
+                  issues,
+                },
+              ),
+            );
+          }
           return Result.ok(null);
         }
 

--- a/adapters/openclaw/src/bridge/checkpoint-store.ts
+++ b/adapters/openclaw/src/bridge/checkpoint-store.ts
@@ -1,0 +1,194 @@
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { Result } from "better-result";
+import { z } from "zod";
+import { type SignetError } from "@xmtp/signet-schemas";
+import {
+  toBridgeInternalError,
+  type OpenClawBridgeConfigType,
+} from "./config.js";
+
+/** Persisted bridge checkpoint for replay-safe reconnect and restart. */
+export const OpenClawBridgeCheckpoint: z.ZodType<{
+  credentialId: string;
+  lastSeq: number;
+  updatedAt: string;
+}> = z
+  .object({
+    credentialId: z.string().min(1),
+    lastSeq: z.number().int().nonnegative(),
+    updatedAt: z.string().datetime(),
+  })
+  .strict();
+
+/** Inferred bridge checkpoint type. */
+export type OpenClawBridgeCheckpointType = z.infer<
+  typeof OpenClawBridgeCheckpoint
+>;
+
+/** Filesystem-backed checkpoint persistence for the OpenClaw bridge. */
+export interface OpenClawCheckpointStore {
+  loadLatest(): Promise<
+    Result<OpenClawBridgeCheckpointType | null, SignetError>
+  >;
+  loadForCredential(
+    credentialId: string,
+  ): Promise<Result<OpenClawBridgeCheckpointType | null, SignetError>>;
+  save(
+    checkpoint: OpenClawBridgeCheckpointType,
+  ): Promise<Result<string, SignetError>>;
+  pathForCredential(credentialId: string): string;
+}
+
+/** Dependencies for checkpoint store IO. */
+export interface OpenClawCheckpointStoreDeps {
+  readonly mkdir: typeof mkdir;
+  readonly readFile: typeof readFile;
+  readonly readdir: typeof readdir;
+  readonly writeFile: typeof writeFile;
+}
+
+const defaultDeps: OpenClawCheckpointStoreDeps = {
+  mkdir,
+  readFile,
+  readdir,
+  writeFile,
+};
+
+function checkpointFilename(credentialId: string): string {
+  return `${credentialId.replace(/[^a-zA-Z0-9_-]/g, "_")}.json`;
+}
+
+function updatedAtEpoch(updatedAt: string): number {
+  const parsed = Date.parse(updatedAt);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+/** Create a checkpoint store rooted at the configured checkpoints directory. */
+export function createOpenClawCheckpointStore(
+  config: Pick<OpenClawBridgeConfigType, "checkpointsDir">,
+  deps: Partial<OpenClawCheckpointStoreDeps> = {},
+): OpenClawCheckpointStore {
+  const resolvedDeps: OpenClawCheckpointStoreDeps = {
+    ...defaultDeps,
+    ...deps,
+  };
+
+  async function readCheckpointFile(
+    path: string,
+  ): Promise<Result<OpenClawBridgeCheckpointType | null, SignetError>> {
+    try {
+      const raw = await resolvedDeps.readFile(path, "utf-8");
+      const parsed = OpenClawBridgeCheckpoint.safeParse(JSON.parse(raw));
+      if (!parsed.success) {
+        return Result.err(
+          toBridgeInternalError("Invalid OpenClaw checkpoint file", {
+            path,
+            issues: parsed.error.issues.map(
+              (issue: { readonly message: string }) => issue.message,
+            ),
+          }),
+        );
+      }
+      return Result.ok(parsed.data);
+    } catch (error) {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        return Result.ok(null);
+      }
+
+      return Result.err(
+        toBridgeInternalError("Failed to read OpenClaw checkpoint", {
+          path,
+          error: error instanceof Error ? error.message : String(error),
+        }),
+      );
+    }
+  }
+
+  return {
+    async loadLatest() {
+      try {
+        const entries = await resolvedDeps.readdir(config.checkpointsDir);
+        const checkpoints: OpenClawBridgeCheckpointType[] = [];
+
+        for (const entry of entries) {
+          if (!entry.endsWith(".json")) {
+            continue;
+          }
+          const checkpointResult = await readCheckpointFile(
+            join(config.checkpointsDir, entry),
+          );
+          if (checkpointResult.isErr()) {
+            return checkpointResult;
+          }
+          if (checkpointResult.value !== null) {
+            checkpoints.push(checkpointResult.value);
+          }
+        }
+
+        if (checkpoints.length === 0) {
+          return Result.ok(null);
+        }
+
+        checkpoints.sort(
+          (a, b) => updatedAtEpoch(b.updatedAt) - updatedAtEpoch(a.updatedAt),
+        );
+        return Result.ok(checkpoints[0] ?? null);
+      } catch (error) {
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "code" in error &&
+          error.code === "ENOENT"
+        ) {
+          return Result.ok(null);
+        }
+
+        return Result.err(
+          toBridgeInternalError("Failed to enumerate OpenClaw checkpoints", {
+            checkpointsDir: config.checkpointsDir,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        );
+      }
+    },
+
+    async loadForCredential(credentialId) {
+      return readCheckpointFile(
+        join(config.checkpointsDir, checkpointFilename(credentialId)),
+      );
+    },
+
+    async save(checkpoint) {
+      try {
+        await resolvedDeps.mkdir(config.checkpointsDir, { recursive: true });
+        const path = join(
+          config.checkpointsDir,
+          checkpointFilename(checkpoint.credentialId),
+        );
+        await resolvedDeps.writeFile(
+          path,
+          JSON.stringify(OpenClawBridgeCheckpoint.parse(checkpoint), null, 2),
+        );
+        return Result.ok(path);
+      } catch (error) {
+        return Result.err(
+          toBridgeInternalError("Failed to persist OpenClaw checkpoint", {
+            checkpointsDir: config.checkpointsDir,
+            credentialId: checkpoint.credentialId,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        );
+      }
+    },
+
+    pathForCredential(credentialId) {
+      return join(config.checkpointsDir, checkpointFilename(credentialId));
+    },
+  };
+}

--- a/adapters/openclaw/src/bridge/checkpoint-store.ts
+++ b/adapters/openclaw/src/bridge/checkpoint-store.ts
@@ -48,12 +48,14 @@ export interface OpenClawCheckpointStoreDeps {
   readonly writeFile: typeof writeFile;
 }
 
-const defaultDeps: OpenClawCheckpointStoreDeps = {
-  mkdir,
-  readFile,
-  readdir,
-  writeFile,
-};
+function createDefaultCheckpointStoreDeps(): OpenClawCheckpointStoreDeps {
+  return {
+    mkdir,
+    readFile,
+    readdir,
+    writeFile,
+  };
+}
 
 function checkpointFilename(credentialId: string): string {
   return `${credentialId.replace(/[^a-zA-Z0-9_-]/g, "_")}.json`;
@@ -70,7 +72,7 @@ export function createOpenClawCheckpointStore(
   deps: Partial<OpenClawCheckpointStoreDeps> = {},
 ): OpenClawCheckpointStore {
   const resolvedDeps: OpenClawCheckpointStoreDeps = {
-    ...defaultDeps,
+    ...createDefaultCheckpointStoreDeps(),
     ...deps,
   };
 

--- a/adapters/openclaw/src/bridge/config.ts
+++ b/adapters/openclaw/src/bridge/config.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { Result } from "better-result";
 import { z } from "zod";
 import {
+  CredentialId,
   InternalError,
   ValidationError,
   type SignetError,
@@ -24,6 +25,7 @@ export const OpenClawBridgeDeliveryMode: z.ZodEnum<["local"]> = z.enum([
 /** Parsed bridge runtime configuration for the OpenClaw sidecar. */
 type OpenClawBridgeConfigInput = {
   adapter: string;
+  credentialId: string;
   wsUrl: string;
   token: string;
   checkpointsDir: string;
@@ -43,6 +45,7 @@ type OpenClawBridgeConfigInput = {
 export const OpenClawBridgeConfig: z.ZodType<
   {
     adapter: string;
+    credentialId: string;
     wsUrl: string;
     token: string;
     checkpointsDir: string;
@@ -60,6 +63,7 @@ export const OpenClawBridgeConfig: z.ZodType<
 > = z
   .object({
     adapter: z.literal(OPENCLAW_ADAPTER_NAME),
+    credentialId: CredentialId,
     wsUrl: z
       .string()
       .min(1)

--- a/adapters/openclaw/src/bridge/config.ts
+++ b/adapters/openclaw/src/bridge/config.ts
@@ -1,0 +1,215 @@
+import { access } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { join } from "node:path";
+import { Result } from "better-result";
+import { z } from "zod";
+import {
+  InternalError,
+  ValidationError,
+  type SignetError,
+} from "@xmtp/signet-schemas";
+import {
+  loadConfig,
+  resolvePaths,
+  type CliConfig,
+  type ResolvedPaths,
+} from "@xmtp/signet-cli";
+import { OPENCLAW_ADAPTER_NAME } from "../config/index.js";
+
+/** Local delivery modes supported by the first bridge spike. */
+export const OpenClawBridgeDeliveryMode: z.ZodEnum<["local"]> = z.enum([
+  "local",
+]);
+
+/** Parsed bridge runtime configuration for the OpenClaw sidecar. */
+type OpenClawBridgeConfigInput = {
+  adapter: string;
+  wsUrl: string;
+  token: string;
+  checkpointsDir: string;
+  deliveryMode?: "local" | undefined;
+  reconnect?:
+    | {
+        enabled?: boolean | undefined;
+        maxAttempts?: number | undefined;
+        baseDelayMs?: number | undefined;
+        maxDelayMs?: number | undefined;
+        jitter?: boolean | undefined;
+      }
+    | undefined;
+};
+
+/** Parsed bridge runtime configuration for the OpenClaw sidecar. */
+export const OpenClawBridgeConfig: z.ZodType<
+  {
+    adapter: string;
+    wsUrl: string;
+    token: string;
+    checkpointsDir: string;
+    deliveryMode: "local";
+    reconnect: {
+      enabled: boolean;
+      maxAttempts: number;
+      baseDelayMs: number;
+      maxDelayMs: number;
+      jitter: boolean;
+    };
+  },
+  z.ZodTypeDef,
+  OpenClawBridgeConfigInput
+> = z
+  .object({
+    adapter: z.literal(OPENCLAW_ADAPTER_NAME),
+    wsUrl: z
+      .string()
+      .min(1)
+      .regex(/^wss?:\/\//, "Bridge wsUrl must begin with ws:// or wss://"),
+    token: z.string().min(1),
+    checkpointsDir: z.string().min(1),
+    deliveryMode: OpenClawBridgeDeliveryMode.default("local"),
+    reconnect: z
+      .object({
+        enabled: z.boolean().default(true),
+        maxAttempts: z.number().int().nonnegative().default(10),
+        baseDelayMs: z.number().int().positive().default(1_000),
+        maxDelayMs: z.number().int().positive().default(30_000),
+        jitter: z.boolean().default(true),
+      })
+      .default({}),
+  })
+  .strict();
+
+/** Inferred OpenClaw bridge runtime config type. */
+export type OpenClawBridgeConfigType = z.infer<typeof OpenClawBridgeConfig>;
+
+/** Signet-derived paths relevant to the OpenClaw adapter. */
+export interface OpenClawAdapterPaths {
+  readonly config: CliConfig;
+  readonly paths: ResolvedPaths;
+  readonly adapterDir: string;
+  readonly checkpointsDir: string;
+}
+
+/** Dependencies for resolving OpenClaw adapter paths. */
+export interface OpenClawAdapterPathDeps {
+  readonly loadConfig: typeof loadConfig;
+  readonly resolvePaths: typeof resolvePaths;
+  readonly pathExists: (path: string) => Promise<boolean>;
+}
+
+const defaultPathDeps: OpenClawAdapterPathDeps = {
+  loadConfig,
+  resolvePaths,
+  async pathExists(path) {
+    try {
+      await access(path, fsConstants.F_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+};
+
+/** Resolve the signet-derived filesystem paths used by the OpenClaw adapter. */
+export async function resolveOpenClawAdapterPaths(
+  options: {
+    readonly configPath: string;
+  },
+  deps: Partial<OpenClawAdapterPathDeps> = {},
+): Promise<Result<OpenClawAdapterPaths, SignetError>> {
+  const resolvedDeps: OpenClawAdapterPathDeps = { ...defaultPathDeps, ...deps };
+  const configResult = await resolvedDeps.loadConfig({
+    configPath: options.configPath,
+  });
+  if (configResult.isErr()) {
+    return configResult;
+  }
+
+  const config = configResult.value;
+  const paths = resolvedDeps.resolvePaths(config);
+  const adapterDir = join(paths.dataDir, "adapters", OPENCLAW_ADAPTER_NAME);
+  const checkpointsDir = join(adapterDir, "checkpoints");
+
+  return Result.ok({
+    config,
+    paths,
+    adapterDir,
+    checkpointsDir,
+  });
+}
+
+/** Shared artifact/runtime presence snapshot for status and doctor commands. */
+export interface OpenClawRuntimePresence {
+  readonly adapterDir: string;
+  readonly checkpointsDir: string;
+  readonly presentFiles: readonly string[];
+  readonly missingFiles: readonly string[];
+  readonly checkpointsDirExists: boolean;
+}
+
+/** Inspect which OpenClaw adapter artifacts are currently present on disk. */
+export async function inspectOpenClawRuntimePresence(
+  options: {
+    readonly configPath: string;
+    readonly expectedFiles: readonly string[];
+  },
+  deps: Partial<OpenClawAdapterPathDeps> = {},
+): Promise<Result<OpenClawRuntimePresence, SignetError>> {
+  const resolvedDeps: OpenClawAdapterPathDeps = { ...defaultPathDeps, ...deps };
+  const pathsResult = await resolveOpenClawAdapterPaths(options, resolvedDeps);
+  if (pathsResult.isErr()) {
+    return pathsResult;
+  }
+
+  const { adapterDir, checkpointsDir } = pathsResult.value;
+  const presentFiles: string[] = [];
+  const missingFiles: string[] = [];
+
+  for (const file of options.expectedFiles) {
+    const exists = await resolvedDeps.pathExists(join(adapterDir, file));
+    if (exists) {
+      presentFiles.push(file);
+    } else {
+      missingFiles.push(file);
+    }
+  }
+
+  const checkpointsDirExists = await resolvedDeps.pathExists(checkpointsDir);
+
+  return Result.ok({
+    adapterDir,
+    checkpointsDir,
+    presentFiles,
+    missingFiles,
+    checkpointsDirExists,
+  });
+}
+
+/** Resolve the last-seen sequence hint from bridge checkpoints. */
+export function resolveResumeSeq(
+  checkpoint: { readonly lastSeq: number } | null,
+): number | null {
+  if (checkpoint === null) {
+    return null;
+  }
+
+  if (!Number.isInteger(checkpoint.lastSeq) || checkpoint.lastSeq < 0) {
+    throw ValidationError.create(
+      "bridge.lastSeq",
+      "Checkpoint lastSeq must be a non-negative integer",
+      {
+        lastSeq: checkpoint.lastSeq,
+      },
+    );
+  }
+
+  return checkpoint.lastSeq;
+}
+
+/** Convert a transport or persistence failure into a stable SignetError. */
+export function toBridgeInternalError(
+  message: string,
+  context?: Record<string, unknown>,
+): SignetError {
+  return InternalError.create(message, context);
+}

--- a/adapters/openclaw/src/bridge/config.ts
+++ b/adapters/openclaw/src/bridge/config.ts
@@ -101,18 +101,20 @@ export interface OpenClawAdapterPathDeps {
   readonly pathExists: (path: string) => Promise<boolean>;
 }
 
-const defaultPathDeps: OpenClawAdapterPathDeps = {
-  loadConfig,
-  resolvePaths,
-  async pathExists(path) {
-    try {
-      await access(path, fsConstants.F_OK);
-      return true;
-    } catch {
-      return false;
-    }
-  },
-};
+function createDefaultPathDeps(): OpenClawAdapterPathDeps {
+  return {
+    loadConfig,
+    resolvePaths,
+    async pathExists(path) {
+      try {
+        await access(path, fsConstants.F_OK);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  };
+}
 
 /** Resolve the signet-derived filesystem paths used by the OpenClaw adapter. */
 export async function resolveOpenClawAdapterPaths(
@@ -121,7 +123,10 @@ export async function resolveOpenClawAdapterPaths(
   },
   deps: Partial<OpenClawAdapterPathDeps> = {},
 ): Promise<Result<OpenClawAdapterPaths, SignetError>> {
-  const resolvedDeps: OpenClawAdapterPathDeps = { ...defaultPathDeps, ...deps };
+  const resolvedDeps: OpenClawAdapterPathDeps = {
+    ...createDefaultPathDeps(),
+    ...deps,
+  };
   const configResult = await resolvedDeps.loadConfig({
     configPath: options.configPath,
   });
@@ -159,7 +164,10 @@ export async function inspectOpenClawRuntimePresence(
   },
   deps: Partial<OpenClawAdapterPathDeps> = {},
 ): Promise<Result<OpenClawRuntimePresence, SignetError>> {
-  const resolvedDeps: OpenClawAdapterPathDeps = { ...defaultPathDeps, ...deps };
+  const resolvedDeps: OpenClawAdapterPathDeps = {
+    ...createDefaultPathDeps(),
+    ...deps,
+  };
   const pathsResult = await resolveOpenClawAdapterPaths(options, resolvedDeps);
   if (pathsResult.isErr()) {
     return pathsResult;

--- a/adapters/openclaw/src/bridge/envelope.ts
+++ b/adapters/openclaw/src/bridge/envelope.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import { SignetEvent } from "@xmtp/signet-schemas";
+import type { SignetEvent as SignetEventType } from "@xmtp/signet-schemas";
+import { OPENCLAW_ADAPTER_NAME } from "../config/index.js";
+
+/** Local delivery envelope emitted by the read-only OpenClaw bridge. */
+export const OpenClawBridgeEnvelope: z.ZodType<{
+  adapter: string;
+  deliveryMode: "local";
+  credentialId: string;
+  operatorId: string;
+  seq: number;
+  dedupeKey: string;
+  receivedAt: string;
+  checkpointPath: string;
+  event: SignetEventType;
+}> = z
+  .object({
+    adapter: z.literal(OPENCLAW_ADAPTER_NAME),
+    deliveryMode: z.literal("local"),
+    credentialId: z.string().min(1),
+    operatorId: z.string().min(1),
+    seq: z.number().int().positive(),
+    dedupeKey: z.string().min(1),
+    receivedAt: z.string().datetime(),
+    checkpointPath: z.string().min(1),
+    event: SignetEvent,
+  })
+  .strict();
+
+/** Inferred local delivery envelope type. */
+export type OpenClawBridgeEnvelopeType = z.infer<typeof OpenClawBridgeEnvelope>;
+
+/** Create the canonical local delivery envelope for one sequenced frame. */
+export function createOpenClawBridgeEnvelope(options: {
+  readonly credentialId: string;
+  readonly operatorId: string;
+  readonly seq: number;
+  readonly checkpointPath: string;
+  readonly event: SignetEventType;
+}): OpenClawBridgeEnvelopeType {
+  return OpenClawBridgeEnvelope.parse({
+    adapter: OPENCLAW_ADAPTER_NAME,
+    deliveryMode: "local",
+    credentialId: options.credentialId,
+    operatorId: options.operatorId,
+    seq: options.seq,
+    dedupeKey: `${options.credentialId}:${options.seq}`,
+    receivedAt: new Date().toISOString(),
+    checkpointPath: options.checkpointPath,
+    event: options.event,
+  });
+}

--- a/adapters/openclaw/src/bridge/index.ts
+++ b/adapters/openclaw/src/bridge/index.ts
@@ -1,7 +1,38 @@
-/** Current bridge phase for the OpenClaw adapter. */
-export const OPENCLAW_BRIDGE_PHASE = "scaffold";
+export type {
+  OpenClawBridgeConfigType,
+  OpenClawAdapterPaths,
+  OpenClawRuntimePresence,
+} from "./config.js";
+export {
+  OpenClawBridgeConfig,
+  OpenClawBridgeDeliveryMode,
+  inspectOpenClawRuntimePresence,
+  resolveOpenClawAdapterPaths,
+} from "./config.js";
+export type {
+  OpenClawBridgeCheckpointType,
+  OpenClawCheckpointStore,
+} from "./checkpoint-store.js";
+export {
+  OpenClawBridgeCheckpoint,
+  createOpenClawCheckpointStore,
+} from "./checkpoint-store.js";
+export type { OpenClawBridgeEnvelopeType } from "./envelope.js";
+export {
+  OpenClawBridgeEnvelope,
+  createOpenClawBridgeEnvelope,
+} from "./envelope.js";
+export type {
+  OpenClawBridgeState,
+  OpenClawBridgeMetrics,
+  OpenClawReadOnlyBridge,
+} from "./runtime.js";
+export { createOpenClawReadOnlyBridge } from "./runtime.js";
 
-/** Whether the read-only bridge is active yet. */
+/** Current bridge phase for the OpenClaw adapter. */
+export const OPENCLAW_BRIDGE_PHASE = "read-only";
+
+/** Whether the first read-only bridge slice is now implemented. */
 export function isOpenClawBridgeReady(): boolean {
-  return false;
+  return true;
 }

--- a/adapters/openclaw/src/bridge/index.ts
+++ b/adapters/openclaw/src/bridge/index.ts
@@ -28,11 +28,4 @@ export type {
   OpenClawReadOnlyBridge,
 } from "./runtime.js";
 export { createOpenClawReadOnlyBridge } from "./runtime.js";
-
-/** Current bridge phase for the OpenClaw adapter. */
-export const OPENCLAW_BRIDGE_PHASE = "read-only";
-
-/** Whether the first read-only bridge slice is now implemented. */
-export function isOpenClawBridgeReady(): boolean {
-  return true;
-}
+export { OPENCLAW_BRIDGE_PHASE, isOpenClawBridgeReady } from "./phase.js";

--- a/adapters/openclaw/src/bridge/phase.ts
+++ b/adapters/openclaw/src/bridge/phase.ts
@@ -1,0 +1,7 @@
+/** Current bridge phase for the OpenClaw adapter. */
+export const OPENCLAW_BRIDGE_PHASE = "read-only";
+
+/** Whether the first read-only bridge slice is now implemented. */
+export function isOpenClawBridgeReady(): boolean {
+  return true;
+}

--- a/adapters/openclaw/src/bridge/runtime.ts
+++ b/adapters/openclaw/src/bridge/runtime.ts
@@ -55,6 +55,11 @@ export interface OpenClawReadOnlyBridge {
   onError(callback: (error: SignetError) => void): () => void;
 }
 
+/** Injectable seams for bridge runtime tests and persistence handling. */
+export interface OpenClawBridgeRuntimeDeps {
+  readonly checkpointStoreFactory: typeof createOpenClawCheckpointStore;
+}
+
 type BridgeOutcome =
   | {
       retryable: true;
@@ -174,15 +179,22 @@ async function decodeSocketPayload(data: unknown): Promise<string> {
 /** Create the first read-only OpenClaw bridge runtime. */
 export function createOpenClawReadOnlyBridge(
   rawConfig: OpenClawBridgeConfigType,
+  deps: Partial<OpenClawBridgeRuntimeDeps> = {},
 ): OpenClawReadOnlyBridge {
   const config = OpenClawBridgeConfig.parse(rawConfig);
-  const checkpoints = createOpenClawCheckpointStore(config);
+  const resolvedDeps: OpenClawBridgeRuntimeDeps = {
+    checkpointStoreFactory: createOpenClawCheckpointStore,
+    ...deps,
+  };
+  const checkpoints = resolvedDeps.checkpointStoreFactory(config);
   const deliveries = createEnvelopeStream();
   const errorListeners = new Set<(error: SignetError) => void>();
   let bridgeState: OpenClawBridgeState = "idle";
   let ws: WebSocket | null = null;
   let stopped = false;
   let loop: Promise<void> | null = null;
+  let interruptCurrentConnection: ((outcome: BridgeOutcome) => void) | null =
+    null;
   let metricsState: OpenClawBridgeMetrics = {
     connectionAttempts: 0,
     reconnectCount: 0,
@@ -195,6 +207,7 @@ export function createOpenClawReadOnlyBridge(
     checkpointPath: null,
     lastError: null,
   };
+  let fatalCheckpointError: SignetError | null = null;
 
   function emitError(error: SignetError): void {
     metricsState = {
@@ -233,9 +246,11 @@ export function createOpenClawReadOnlyBridge(
         if (settled) {
           return;
         }
+        interruptCurrentConnection = null;
         settled = true;
         resolve(outcome);
       }
+      interruptCurrentConnection = settle;
 
       const authTimeout = setTimeout(() => {
         if (authenticated || settled) {
@@ -290,11 +305,23 @@ export function createOpenClawReadOnlyBridge(
           checkpointPath,
           event: frame.event,
         });
-        currentCheckpoint = {
+        const nextCheckpoint: OpenClawBridgeCheckpointType = {
           credentialId,
           lastSeq: frame.seq,
           updatedAt: new Date().toISOString(),
         };
+        const saveResult = await checkpoints.save(nextCheckpoint);
+        if (saveResult.isErr()) {
+          fatalCheckpointError = saveResult.error;
+          emitError(saveResult.error);
+          ws?.close(
+            WS_CLOSE_CODES.PROTOCOL_ERROR,
+            "Checkpoint persistence failed",
+          );
+          return;
+        }
+
+        currentCheckpoint = nextCheckpoint;
         lastDeliveredSeq = frame.seq;
         metricsState = {
           ...metricsState,
@@ -303,15 +330,9 @@ export function createOpenClawReadOnlyBridge(
           lastEventType: frame.event.type,
           credentialId,
           operatorId,
-          checkpointPath,
+          checkpointPath: saveResult.value,
         };
         deliveries.push(envelope);
-
-        const saveResult = await checkpoints.save(currentCheckpoint);
-        if (saveResult.isErr()) {
-          emitError(saveResult.error);
-          return;
-        }
 
         metricsState = {
           ...metricsState,
@@ -423,6 +444,16 @@ export function createOpenClawReadOnlyBridge(
             return;
           }
 
+          if (fatalCheckpointError !== null) {
+            bridgeState = "closed";
+            settle({
+              retryable: false,
+              lastCheckpoint: currentCheckpoint,
+              error: fatalCheckpointError,
+            });
+            return;
+          }
+
           if (!isRetryableClose(event.code)) {
             const error = AuthError.create(
               event.reason || "Bridge connection closed by signet",
@@ -457,16 +488,18 @@ export function createOpenClawReadOnlyBridge(
   async function runLoop(
     onInitialResult: (result: Result<void, SignetError>) => void,
   ): Promise<void> {
-    const latestCheckpointResult = await checkpoints.loadLatest();
-    if (latestCheckpointResult.isErr()) {
-      emitError(latestCheckpointResult.error);
-      onInitialResult(Result.err(latestCheckpointResult.error));
+    const checkpointResult = await checkpoints.loadForCredential(
+      config.credentialId,
+    );
+    if (checkpointResult.isErr()) {
+      emitError(checkpointResult.error);
+      onInitialResult(Result.err(checkpointResult.error));
       bridgeState = "closed";
       deliveries.complete();
       return;
     }
 
-    let resumeCheckpoint = latestCheckpointResult.value;
+    let resumeCheckpoint = checkpointResult.value;
     let attempt = 0;
     let initialResolved = false;
 
@@ -554,6 +587,11 @@ export function createOpenClawReadOnlyBridge(
 
     async stop() {
       stopped = true;
+      interruptCurrentConnection?.({
+        retryable: false,
+        lastCheckpoint: null,
+        error: ValidationError.create("bridge.state", "Bridge stopped"),
+      });
       if (ws !== null) {
         ws.close(WS_CLOSE_CODES.NORMAL, "Bridge stopping");
       }

--- a/adapters/openclaw/src/bridge/runtime.ts
+++ b/adapters/openclaw/src/bridge/runtime.ts
@@ -1,0 +1,583 @@
+import { Result } from "better-result";
+import {
+  AuthError,
+  InternalError,
+  ValidationError,
+  type SignetError,
+} from "@xmtp/signet-schemas";
+import {
+  AuthenticatedFrame,
+  AuthErrorFrame,
+  BackpressureFrame,
+  SequencedFrame,
+  WS_CLOSE_CODES,
+} from "@xmtp/signet-ws";
+import type { OpenClawBridgeEnvelopeType } from "./envelope.js";
+import { createOpenClawBridgeEnvelope } from "./envelope.js";
+import type { OpenClawBridgeCheckpointType } from "./checkpoint-store.js";
+import { createOpenClawCheckpointStore } from "./checkpoint-store.js";
+import {
+  OpenClawBridgeConfig,
+  resolveResumeSeq,
+  type OpenClawBridgeConfigType,
+} from "./config.js";
+
+/** Runtime lifecycle states for the read-only OpenClaw bridge. */
+export type OpenClawBridgeState =
+  | "idle"
+  | "connecting"
+  | "authenticating"
+  | "connected"
+  | "reconnecting"
+  | "closed";
+
+/** Observable counters and checkpoints for the bridge runtime. */
+export interface OpenClawBridgeMetrics {
+  readonly connectionAttempts: number;
+  readonly reconnectCount: number;
+  readonly deliveredCount: number;
+  readonly dedupedCount: number;
+  readonly lastSeq: number | null;
+  readonly lastEventType: string | null;
+  readonly credentialId: string | null;
+  readonly operatorId: string | null;
+  readonly checkpointPath: string | null;
+  readonly lastError: string | null;
+}
+
+/** Public runtime contract for the first read-only OpenClaw bridge. */
+export interface OpenClawReadOnlyBridge {
+  start(): Promise<Result<void, SignetError>>;
+  stop(): Promise<void>;
+  readonly deliveries: AsyncIterable<OpenClawBridgeEnvelopeType>;
+  readonly state: OpenClawBridgeState;
+  readonly metrics: OpenClawBridgeMetrics;
+  onError(callback: (error: SignetError) => void): () => void;
+}
+
+type BridgeOutcome =
+  | {
+      retryable: true;
+      lastCheckpoint: OpenClawBridgeCheckpointType | null;
+    }
+  | {
+      retryable: false;
+      lastCheckpoint: OpenClawBridgeCheckpointType | null;
+      error: SignetError;
+    };
+
+interface EnvelopeStream extends AsyncIterable<OpenClawBridgeEnvelopeType> {
+  push(value: OpenClawBridgeEnvelopeType): void;
+  complete(): void;
+}
+
+const NON_RETRYABLE_CODES = new Set<number>([
+  WS_CLOSE_CODES.AUTH_FAILED,
+  WS_CLOSE_CODES.AUTH_TIMEOUT,
+  WS_CLOSE_CODES.CREDENTIAL_REVOKED,
+  WS_CLOSE_CODES.PROTOCOL_ERROR,
+]);
+
+function isRetryableClose(code: number): boolean {
+  return !NON_RETRYABLE_CODES.has(code);
+}
+
+function createEnvelopeStream(): EnvelopeStream {
+  const queue: OpenClawBridgeEnvelopeType[] = [];
+  let done = false;
+  let waiter:
+    | ((result: IteratorResult<OpenClawBridgeEnvelopeType>) => void)
+    | null = null;
+
+  return {
+    push(value) {
+      if (done) {
+        return;
+      }
+      if (waiter !== null) {
+        const resolve = waiter;
+        waiter = null;
+        resolve({ value, done: false });
+        return;
+      }
+      queue.push(value);
+    },
+
+    complete() {
+      done = true;
+      if (waiter !== null) {
+        const resolve = waiter;
+        waiter = null;
+        resolve({
+          value: undefined as unknown as OpenClawBridgeEnvelopeType,
+          done: true,
+        });
+      }
+    },
+
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<OpenClawBridgeEnvelopeType>> {
+          const buffered = queue.shift();
+          if (buffered !== undefined) {
+            return Promise.resolve({ value: buffered, done: false });
+          }
+          if (done) {
+            return Promise.resolve({
+              value: undefined as unknown as OpenClawBridgeEnvelopeType,
+              done: true,
+            });
+          }
+          return new Promise((resolve) => {
+            waiter = resolve;
+          });
+        },
+      };
+    },
+  };
+}
+
+function reconnectDelay(
+  attempt: number,
+  config: OpenClawBridgeConfigType["reconnect"],
+): number {
+  const exponential = config.baseDelayMs * Math.pow(2, attempt);
+  const capped = Math.min(exponential, config.maxDelayMs);
+  if (config.jitter) {
+    return Math.floor(Math.random() * (capped + 1));
+  }
+  return capped;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function decodeSocketPayload(data: unknown): Promise<string> {
+  if (typeof data === "string") {
+    return data;
+  }
+  if (data instanceof ArrayBuffer) {
+    return new TextDecoder().decode(data);
+  }
+  if (ArrayBuffer.isView(data)) {
+    return new TextDecoder().decode(data);
+  }
+  if (typeof Blob !== "undefined" && data instanceof Blob) {
+    return await data.text();
+  }
+  return String(data);
+}
+
+/** Create the first read-only OpenClaw bridge runtime. */
+export function createOpenClawReadOnlyBridge(
+  rawConfig: OpenClawBridgeConfigType,
+): OpenClawReadOnlyBridge {
+  const config = OpenClawBridgeConfig.parse(rawConfig);
+  const checkpoints = createOpenClawCheckpointStore(config);
+  const deliveries = createEnvelopeStream();
+  const errorListeners = new Set<(error: SignetError) => void>();
+  let bridgeState: OpenClawBridgeState = "idle";
+  let ws: WebSocket | null = null;
+  let stopped = false;
+  let loop: Promise<void> | null = null;
+  let metricsState: OpenClawBridgeMetrics = {
+    connectionAttempts: 0,
+    reconnectCount: 0,
+    deliveredCount: 0,
+    dedupedCount: 0,
+    lastSeq: null,
+    lastEventType: null,
+    credentialId: null,
+    operatorId: null,
+    checkpointPath: null,
+    lastError: null,
+  };
+
+  function emitError(error: SignetError): void {
+    metricsState = {
+      ...metricsState,
+      lastError: error.message,
+    };
+    for (const listener of errorListeners) {
+      listener(error);
+    }
+  }
+
+  async function connectAndPump(
+    resumeCheckpoint: OpenClawBridgeCheckpointType | null,
+    onAuthenticated: (checkpoint: OpenClawBridgeCheckpointType | null) => void,
+  ): Promise<BridgeOutcome> {
+    metricsState = {
+      ...metricsState,
+      connectionAttempts: metricsState.connectionAttempts + 1,
+    };
+    bridgeState = "connecting";
+
+    const resumeSeq = resolveResumeSeq(resumeCheckpoint);
+
+    return new Promise((resolve) => {
+      const socket = new WebSocket(config.wsUrl);
+      ws = socket;
+      let authenticated = false;
+      let settled = false;
+      let currentCheckpoint = resumeCheckpoint;
+      let lastDeliveredSeq = resumeSeq ?? 0;
+      let credentialId = resumeCheckpoint?.credentialId ?? null;
+      let operatorId: string | null = null;
+      let frameChain = Promise.resolve();
+
+      function settle(outcome: BridgeOutcome): void {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        resolve(outcome);
+      }
+
+      const authTimeout = setTimeout(() => {
+        if (authenticated || settled) {
+          return;
+        }
+        socket.close(WS_CLOSE_CODES.AUTH_TIMEOUT, "Auth timeout");
+        settle({
+          retryable: false,
+          lastCheckpoint: currentCheckpoint,
+          error: AuthError.create("Auth response not received from signet"),
+        });
+      }, 30_000);
+
+      async function handleSequencedFrame(rawFrame: unknown): Promise<void> {
+        const frameResult = SequencedFrame.safeParse(rawFrame);
+        if (!frameResult.success) {
+          const error = ValidationError.create(
+            "bridge.frame",
+            "Received invalid sequenced frame from signet",
+            {
+              issues: frameResult.error.issues.map(
+                (issue: { readonly message: string }) => issue.message,
+              ),
+            },
+          );
+          emitError(error);
+          return;
+        }
+
+        const frame = frameResult.data;
+        if (credentialId === null || operatorId === null) {
+          const error = InternalError.create(
+            "Sequenced frame arrived before bridge authentication completed",
+          );
+          emitError(error);
+          return;
+        }
+
+        if (frame.seq <= lastDeliveredSeq) {
+          metricsState = {
+            ...metricsState,
+            dedupedCount: metricsState.dedupedCount + 1,
+          };
+          return;
+        }
+
+        const checkpointPath = checkpoints.pathForCredential(credentialId);
+        const envelope = createOpenClawBridgeEnvelope({
+          credentialId,
+          operatorId,
+          seq: frame.seq,
+          checkpointPath,
+          event: frame.event,
+        });
+        currentCheckpoint = {
+          credentialId,
+          lastSeq: frame.seq,
+          updatedAt: new Date().toISOString(),
+        };
+        lastDeliveredSeq = frame.seq;
+        metricsState = {
+          ...metricsState,
+          deliveredCount: metricsState.deliveredCount + 1,
+          lastSeq: frame.seq,
+          lastEventType: frame.event.type,
+          credentialId,
+          operatorId,
+          checkpointPath,
+        };
+        deliveries.push(envelope);
+
+        const saveResult = await checkpoints.save(currentCheckpoint);
+        if (saveResult.isErr()) {
+          emitError(saveResult.error);
+          return;
+        }
+
+        metricsState = {
+          ...metricsState,
+          checkpointPath: saveResult.value,
+        };
+      }
+
+      socket.addEventListener("open", () => {
+        bridgeState = "authenticating";
+        socket.send(
+          JSON.stringify({
+            type: "auth",
+            token: config.token,
+            lastSeenSeq: resumeSeq,
+          }),
+        );
+      });
+
+      socket.addEventListener("message", (message) => {
+        void (async () => {
+          const rawText = await decodeSocketPayload(message.data);
+
+          let payload: unknown;
+          try {
+            payload = JSON.parse(rawText);
+          } catch {
+            emitError(
+              ValidationError.create(
+                "bridge.frame",
+                "Bridge received non-JSON data from signet",
+              ),
+            );
+            return;
+          }
+
+          if (!authenticated) {
+            const authenticatedResult = AuthenticatedFrame.safeParse(payload);
+            if (authenticatedResult.success) {
+              authenticated = true;
+              clearTimeout(authTimeout);
+              credentialId = authenticatedResult.data.credential.credentialId;
+              operatorId = authenticatedResult.data.credential.operatorId;
+              bridgeState = "connected";
+              metricsState = {
+                ...metricsState,
+                credentialId,
+                operatorId,
+                checkpointPath: checkpoints.pathForCredential(credentialId),
+              };
+              onAuthenticated(currentCheckpoint);
+              return;
+            }
+
+            const authErrorResult = AuthErrorFrame.safeParse(payload);
+            if (authErrorResult.success) {
+              clearTimeout(authTimeout);
+              const error = AuthError.create(authErrorResult.data.message, {
+                code: authErrorResult.data.code,
+              });
+              emitError(error);
+              settle({
+                retryable: false,
+                lastCheckpoint: currentCheckpoint,
+                error,
+              });
+              return;
+            }
+          }
+
+          const backpressureResult = BackpressureFrame.safeParse(payload);
+          if (backpressureResult.success) {
+            emitError(
+              InternalError.create("OpenClaw bridge hit signet backpressure", {
+                buffered: backpressureResult.data.buffered,
+                limit: backpressureResult.data.limit,
+              }),
+            );
+            return;
+          }
+
+          frameChain = frameChain
+            .then(async () => handleSequencedFrame(payload))
+            .catch((error) => {
+              emitError(
+                InternalError.create(
+                  "OpenClaw bridge frame processing failed",
+                  {
+                    error:
+                      error instanceof Error ? error.message : String(error),
+                  },
+                ),
+              );
+            });
+        })();
+      });
+
+      socket.addEventListener("close", (event) => {
+        clearTimeout(authTimeout);
+        void frameChain.finally(() => {
+          ws = null;
+
+          if (stopped) {
+            bridgeState = "closed";
+            settle({
+              retryable: false,
+              lastCheckpoint: currentCheckpoint,
+              error: ValidationError.create("bridge.state", "Bridge stopped"),
+            });
+            return;
+          }
+
+          if (!isRetryableClose(event.code)) {
+            const error = AuthError.create(
+              event.reason || "Bridge connection closed by signet",
+              {
+                code: event.code,
+              },
+            );
+            emitError(error);
+            bridgeState = "closed";
+            settle({
+              retryable: false,
+              lastCheckpoint: currentCheckpoint,
+              error,
+            });
+            return;
+          }
+
+          bridgeState = "reconnecting";
+          settle({
+            retryable: true,
+            lastCheckpoint: currentCheckpoint,
+          });
+        });
+      });
+
+      socket.addEventListener("error", () => {
+        // Close handling owns reconnect/error decisions.
+      });
+    });
+  }
+
+  async function runLoop(
+    onInitialResult: (result: Result<void, SignetError>) => void,
+  ): Promise<void> {
+    const latestCheckpointResult = await checkpoints.loadLatest();
+    if (latestCheckpointResult.isErr()) {
+      emitError(latestCheckpointResult.error);
+      onInitialResult(Result.err(latestCheckpointResult.error));
+      bridgeState = "closed";
+      deliveries.complete();
+      return;
+    }
+
+    let resumeCheckpoint = latestCheckpointResult.value;
+    let attempt = 0;
+    let initialResolved = false;
+
+    while (!stopped) {
+      const outcome = await connectAndPump(resumeCheckpoint, (checkpoint) => {
+        resumeCheckpoint = checkpoint;
+        attempt = 0;
+        if (!initialResolved) {
+          initialResolved = true;
+          onInitialResult(Result.ok(undefined));
+        }
+      });
+      resumeCheckpoint = outcome.lastCheckpoint;
+      if (!initialResolved && !outcome.retryable) {
+        initialResolved = true;
+        onInitialResult(Result.err(outcome.error));
+      }
+
+      if (stopped) {
+        break;
+      }
+
+      if (!outcome.retryable) {
+        bridgeState = "closed";
+        deliveries.complete();
+        return;
+      }
+
+      if (!config.reconnect.enabled) {
+        const error = InternalError.create(
+          "OpenClaw bridge reconnect is disabled",
+        );
+        emitError(error);
+        bridgeState = "closed";
+        deliveries.complete();
+        return;
+      }
+
+      if (
+        config.reconnect.maxAttempts !== 0 &&
+        attempt >= config.reconnect.maxAttempts
+      ) {
+        const error = InternalError.create(
+          "OpenClaw bridge exhausted reconnect attempts",
+          {
+            maxAttempts: config.reconnect.maxAttempts,
+          },
+        );
+        emitError(error);
+        bridgeState = "closed";
+        deliveries.complete();
+        return;
+      }
+
+      metricsState = {
+        ...metricsState,
+        reconnectCount: metricsState.reconnectCount + 1,
+      };
+      bridgeState = "reconnecting";
+      const delay = reconnectDelay(attempt, config.reconnect);
+      attempt += 1;
+      await sleep(delay);
+    }
+
+    bridgeState = "closed";
+    deliveries.complete();
+  }
+
+  return {
+    async start() {
+      if (loop !== null) {
+        return Result.err(
+          ValidationError.create(
+            "bridge.state",
+            "OpenClaw bridge is already running",
+          ),
+        );
+      }
+
+      stopped = false;
+      return await new Promise<Result<void, SignetError>>((resolve) => {
+        loop = runLoop(resolve);
+      });
+    },
+
+    async stop() {
+      stopped = true;
+      if (ws !== null) {
+        ws.close(WS_CLOSE_CODES.NORMAL, "Bridge stopping");
+      }
+      await loop;
+      loop = null;
+    },
+
+    get deliveries() {
+      return deliveries;
+    },
+
+    get state() {
+      return bridgeState;
+    },
+
+    get metrics() {
+      return metricsState;
+    },
+
+    onError(callback) {
+      errorListeners.add(callback);
+      return () => {
+        errorListeners.delete(callback);
+      };
+    },
+  };
+}

--- a/adapters/openclaw/src/bridge/runtime.ts
+++ b/adapters/openclaw/src/bridge/runtime.ts
@@ -631,6 +631,18 @@ export function createOpenClawReadOnlyBridge(
       });
     }
 
+    if (!initialResolved) {
+      initialResolved = true;
+      onInitialResult(
+        Result.err(
+          ValidationError.create(
+            "bridge.state",
+            "OpenClaw bridge stopped before authentication",
+          ),
+        ),
+      );
+    }
+
     bridgeState = "closed";
     deliveries.complete();
   }

--- a/adapters/openclaw/src/bridge/runtime.ts
+++ b/adapters/openclaw/src/bridge/runtime.ts
@@ -81,6 +81,8 @@ interface EnvelopeStream extends AsyncIterable<OpenClawBridgeEnvelopeType> {
 const NON_RETRYABLE_CODES = new Set<number>([
   WS_CLOSE_CODES.AUTH_FAILED,
   WS_CLOSE_CODES.AUTH_TIMEOUT,
+  WS_CLOSE_CODES.CREDENTIAL_EXPIRED,
+  WS_CLOSE_CODES.POLICY_CHANGE,
   WS_CLOSE_CODES.CREDENTIAL_REVOKED,
   WS_CLOSE_CODES.PROTOCOL_ERROR,
 ]);
@@ -162,12 +164,6 @@ function reconnectDelay(
   return capped;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
-
 async function decodeSocketPayload(data: unknown): Promise<string> {
   if (typeof data === "string") {
     return data;
@@ -204,6 +200,7 @@ export function createOpenClawReadOnlyBridge(
   let loop: Promise<void> | null = null;
   let interruptCurrentConnection: ((outcome: BridgeOutcome) => void) | null =
     null;
+  let interruptReconnectSleep: (() => void) | null = null;
   let activeConnectionId = 0;
   let metricsState: OpenClawBridgeMetrics = {
     connectionAttempts: 0,
@@ -620,7 +617,18 @@ export function createOpenClawReadOnlyBridge(
       bridgeState = "reconnecting";
       const delay = reconnectDelay(attempt, config.reconnect);
       attempt += 1;
-      await sleep(delay);
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(() => {
+          interruptReconnectSleep = null;
+          resolve();
+        }, delay);
+
+        interruptReconnectSleep = () => {
+          clearTimeout(timer);
+          interruptReconnectSleep = null;
+          resolve();
+        };
+      });
     }
 
     bridgeState = "closed";
@@ -651,6 +659,7 @@ export function createOpenClawReadOnlyBridge(
     async stop() {
       stopped = true;
       const currentSocket = ws;
+      interruptReconnectSleep?.();
       interruptCurrentConnection?.({
         retryable: false,
         lastCheckpoint: null,

--- a/adapters/openclaw/src/bridge/runtime.ts
+++ b/adapters/openclaw/src/bridge/runtime.ts
@@ -58,6 +58,7 @@ export interface OpenClawReadOnlyBridge {
 /** Injectable seams for bridge runtime tests and persistence handling. */
 export interface OpenClawBridgeRuntimeDeps {
   readonly checkpointStoreFactory: typeof createOpenClawCheckpointStore;
+  readonly webSocketFactory: (url: string) => WebSocket;
 }
 
 type BridgeOutcome =
@@ -191,6 +192,7 @@ export function createOpenClawReadOnlyBridge(
   const config = OpenClawBridgeConfig.parse(rawConfig);
   const resolvedDeps: OpenClawBridgeRuntimeDeps = {
     checkpointStoreFactory: createOpenClawCheckpointStore,
+    webSocketFactory: (url) => new WebSocket(url),
     ...deps,
   };
   const checkpoints = resolvedDeps.checkpointStoreFactory(config);
@@ -202,6 +204,7 @@ export function createOpenClawReadOnlyBridge(
   let loop: Promise<void> | null = null;
   let interruptCurrentConnection: ((outcome: BridgeOutcome) => void) | null =
     null;
+  let activeConnectionId = 0;
   let metricsState: OpenClawBridgeMetrics = {
     connectionAttempts: 0,
     reconnectCount: 0,
@@ -239,7 +242,9 @@ export function createOpenClawReadOnlyBridge(
     const resumeSeq = resolveResumeSeq(resumeCheckpoint);
 
     return new Promise((resolve) => {
-      const socket = new WebSocket(config.wsUrl);
+      const connectionId = activeConnectionId + 1;
+      activeConnectionId = connectionId;
+      const socket = resolvedDeps.webSocketFactory(config.wsUrl);
       ws = socket;
       let authenticated = false;
       let settled = false;
@@ -249,18 +254,31 @@ export function createOpenClawReadOnlyBridge(
       let operatorId: string | null = null;
       let frameChain = Promise.resolve();
 
+      function isActiveConnection(): boolean {
+        return activeConnectionId === connectionId && ws === socket;
+      }
+
       function settle(outcome: BridgeOutcome): void {
         if (settled) {
           return;
         }
-        interruptCurrentConnection = null;
         settled = true;
+        if (isActiveConnection()) {
+          interruptCurrentConnection = null;
+          ws = null;
+          activeConnectionId = 0;
+        }
         resolve(outcome);
       }
-      interruptCurrentConnection = settle;
+      interruptCurrentConnection = (outcome) => {
+        if (!isActiveConnection()) {
+          return;
+        }
+        settle(outcome);
+      };
 
       const authTimeout = setTimeout(() => {
-        if (authenticated || settled) {
+        if (authenticated || settled || !isActiveConnection()) {
           return;
         }
         socket.close(WS_CLOSE_CODES.AUTH_TIMEOUT, "Auth timeout");
@@ -348,6 +366,9 @@ export function createOpenClawReadOnlyBridge(
       }
 
       socket.addEventListener("open", () => {
+        if (!isActiveConnection()) {
+          return;
+        }
         bridgeState = "authenticating";
         socket.send(
           JSON.stringify({
@@ -360,6 +381,9 @@ export function createOpenClawReadOnlyBridge(
 
       socket.addEventListener("message", (message) => {
         void (async () => {
+          if (!isActiveConnection()) {
+            return;
+          }
           const rawText = await decodeSocketPayload(message.data);
 
           let payload: unknown;
@@ -378,6 +402,9 @@ export function createOpenClawReadOnlyBridge(
           if (!authenticated) {
             const authenticatedResult = AuthenticatedFrame.safeParse(payload);
             if (authenticatedResult.success) {
+              if (!isActiveConnection()) {
+                return;
+              }
               clearTimeout(authTimeout);
               const authenticatedCredentialId =
                 authenticatedResult.data.credential.credentialId;
@@ -415,6 +442,9 @@ export function createOpenClawReadOnlyBridge(
 
             const authErrorResult = AuthErrorFrame.safeParse(payload);
             if (authErrorResult.success) {
+              if (!isActiveConnection()) {
+                return;
+              }
               clearTimeout(authTimeout);
               const error = AuthError.create(authErrorResult.data.message, {
                 code: authErrorResult.data.code,
@@ -459,7 +489,9 @@ export function createOpenClawReadOnlyBridge(
       socket.addEventListener("close", (event) => {
         clearTimeout(authTimeout);
         void frameChain.finally(() => {
-          ws = null;
+          if (!isActiveConnection()) {
+            return;
+          }
 
           if (stopped) {
             bridgeState = "closed";
@@ -618,13 +650,14 @@ export function createOpenClawReadOnlyBridge(
 
     async stop() {
       stopped = true;
+      const currentSocket = ws;
       interruptCurrentConnection?.({
         retryable: false,
         lastCheckpoint: null,
         error: ValidationError.create("bridge.state", "Bridge stopped"),
       });
-      if (ws !== null) {
-        ws.close(WS_CLOSE_CODES.NORMAL, "Bridge stopping");
+      if (currentSocket !== null) {
+        currentSocket.close(WS_CLOSE_CODES.NORMAL, "Bridge stopping");
       }
       await loop;
     },

--- a/adapters/openclaw/src/bridge/runtime.ts
+++ b/adapters/openclaw/src/bridge/runtime.ts
@@ -74,6 +74,7 @@ type BridgeOutcome =
 interface EnvelopeStream extends AsyncIterable<OpenClawBridgeEnvelopeType> {
   push(value: OpenClawBridgeEnvelopeType): void;
   complete(): void;
+  reset(): void;
 }
 
 const NON_RETRYABLE_CODES = new Set<number>([
@@ -118,6 +119,12 @@ function createEnvelopeStream(): EnvelopeStream {
           done: true,
         });
       }
+    },
+
+    reset() {
+      queue.length = 0;
+      done = false;
+      waiter = null;
     },
 
     [Symbol.asyncIterator]() {
@@ -371,9 +378,29 @@ export function createOpenClawReadOnlyBridge(
           if (!authenticated) {
             const authenticatedResult = AuthenticatedFrame.safeParse(payload);
             if (authenticatedResult.success) {
-              authenticated = true;
               clearTimeout(authTimeout);
-              credentialId = authenticatedResult.data.credential.credentialId;
+              const authenticatedCredentialId =
+                authenticatedResult.data.credential.credentialId;
+              if (authenticatedCredentialId !== config.credentialId) {
+                const error = AuthError.create(
+                  "Authenticated credential does not match the configured bridge credential",
+                  {
+                    configuredCredentialId: config.credentialId,
+                    authenticatedCredentialId,
+                  },
+                );
+                emitError(error);
+                socket.close(WS_CLOSE_CODES.AUTH_FAILED, "Credential mismatch");
+                settle({
+                  retryable: false,
+                  lastCheckpoint: currentCheckpoint,
+                  error,
+                });
+                return;
+              }
+
+              authenticated = true;
+              credentialId = authenticatedCredentialId;
               operatorId = authenticatedResult.data.credential.operatorId;
               bridgeState = "connected";
               metricsState = {
@@ -580,8 +607,12 @@ export function createOpenClawReadOnlyBridge(
       }
 
       stopped = false;
+      fatalCheckpointError = null;
+      deliveries.reset();
       return await new Promise<Result<void, SignetError>>((resolve) => {
-        loop = runLoop(resolve);
+        loop = runLoop(resolve).finally(() => {
+          loop = null;
+        });
       });
     },
 
@@ -596,7 +627,6 @@ export function createOpenClawReadOnlyBridge(
         ws.close(WS_CLOSE_CODES.NORMAL, "Bridge stopping");
       }
       await loop;
-      loop = null;
     },
 
     get deliveries() {

--- a/adapters/openclaw/src/doctor/index.ts
+++ b/adapters/openclaw/src/doctor/index.ts
@@ -4,20 +4,67 @@ import {
 } from "@xmtp/signet-schemas";
 import { OPENCLAW_BRIDGE_PHASE } from "../bridge/index.js";
 import { OPENCLAW_ADAPTER_NAME } from "../config/index.js";
+import {
+  inspectOpenClawRuntime,
+  type OpenClawRuntimeInspection,
+} from "../status/runtime.js";
+import type { OpenClawAdapterPathDeps } from "../bridge/config.js";
 
-/** Stub doctor result for the scaffold branch. */
-export function runOpenClawDoctor(): AdapterStatusResultType {
+function diagnosticsForInspection(
+  inspection: OpenClawRuntimeInspection,
+): readonly string[] {
+  if (inspection.status === "ok") {
+    return [
+      "OpenClaw adapter artifacts are present.",
+      "Read-only bridge primitives are available for local delivery.",
+    ];
+  }
+
+  const diagnostics: string[] = [];
+  if (inspection.presence.missingFiles.length > 0) {
+    diagnostics.push(
+      `Missing artifacts: ${inspection.presence.missingFiles.join(", ")}`,
+    );
+  }
+  if (!inspection.presence.checkpointsDirExists) {
+    diagnostics.push("Missing checkpoints directory for bridge replay state.");
+  }
+  diagnostics.push("Run `xs agent setup openclaw` to provision or repair.");
+  return diagnostics;
+}
+
+/** Diagnose the current OpenClaw adapter install and bridge prerequisites. */
+export async function runOpenClawDoctor(
+  options: {
+    readonly configPath: string;
+  },
+  deps: Partial<OpenClawAdapterPathDeps> = {},
+): Promise<AdapterStatusResultType> {
+  const inspectionResult = await inspectOpenClawRuntime(options, deps);
+  if (inspectionResult.isErr()) {
+    return AdapterStatusResult.parse({
+      adapter: OPENCLAW_ADAPTER_NAME,
+      adapterSource: "builtin",
+      status: "missing",
+      details: {
+        phase: "runtime",
+        bridgePhase: OPENCLAW_BRIDGE_PHASE,
+        diagnostics: [inspectionResult.error.message],
+      },
+    });
+  }
+
+  const inspection = inspectionResult.value;
   return AdapterStatusResult.parse({
     adapter: OPENCLAW_ADAPTER_NAME,
     adapterSource: "builtin",
-    status: "missing",
+    status: inspection.status,
     details: {
-      phase: "scaffold",
+      phase: "runtime",
       bridgePhase: OPENCLAW_BRIDGE_PHASE,
-      diagnostics: [
-        "Provisioning is not implemented on this branch yet.",
-        "Read-only bridge work lands on the follow-on bridge branch.",
-      ],
+      adapterDir: inspection.presence.adapterDir,
+      checkpointsDir: inspection.presence.checkpointsDir,
+      diagnostics: diagnosticsForInspection(inspection),
     },
   });
 }

--- a/adapters/openclaw/src/doctor/index.ts
+++ b/adapters/openclaw/src/doctor/index.ts
@@ -2,7 +2,7 @@ import {
   AdapterStatusResult,
   type AdapterStatusResultType,
 } from "@xmtp/signet-schemas";
-import { OPENCLAW_BRIDGE_PHASE } from "../bridge/index.js";
+import { OPENCLAW_BRIDGE_PHASE } from "../bridge/phase.js";
 import { OPENCLAW_ADAPTER_NAME } from "../config/index.js";
 import {
   inspectOpenClawRuntime,

--- a/adapters/openclaw/src/index.ts
+++ b/adapters/openclaw/src/index.ts
@@ -6,6 +6,26 @@ export { listOpenClawArtifactFiles } from "./artifacts/index.js";
 export {
   OPENCLAW_BRIDGE_PHASE,
   isOpenClawBridgeReady,
+  OpenClawBridgeConfig,
+  OpenClawBridgeDeliveryMode,
+  OpenClawBridgeCheckpoint,
+  OpenClawBridgeEnvelope,
+  createOpenClawCheckpointStore,
+  createOpenClawBridgeEnvelope,
+  createOpenClawReadOnlyBridge,
+  inspectOpenClawRuntimePresence,
+  resolveOpenClawAdapterPaths,
+} from "./bridge/index.js";
+export type {
+  OpenClawAdapterPaths,
+  OpenClawBridgeConfigType,
+  OpenClawBridgeCheckpointType,
+  OpenClawCheckpointStore,
+  OpenClawBridgeEnvelopeType,
+  OpenClawReadOnlyBridge,
+  OpenClawBridgeState,
+  OpenClawBridgeMetrics,
+  OpenClawRuntimePresence,
 } from "./bridge/index.js";
 export { runOpenClawSetup } from "./setup/index.js";
 export { runOpenClawStatus } from "./status/index.js";

--- a/adapters/openclaw/src/status/index.ts
+++ b/adapters/openclaw/src/status/index.ts
@@ -8,18 +8,54 @@ import {
 } from "../bridge/index.js";
 import { listOpenClawArtifactFiles } from "../artifacts/index.js";
 import { OPENCLAW_ADAPTER_NAME } from "../config/index.js";
+import {
+  inspectOpenClawRuntime,
+  type OpenClawRuntimeInspection,
+} from "./runtime.js";
+import type { OpenClawAdapterPathDeps } from "../bridge/config.js";
 
-/** Stub status result for the scaffold branch. */
-export function runOpenClawStatus(): AdapterStatusResultType {
+function toStatusResult(
+  inspection: OpenClawRuntimeInspection,
+): AdapterStatusResultType {
   return AdapterStatusResult.parse({
     adapter: OPENCLAW_ADAPTER_NAME,
     adapterSource: "builtin",
-    status: "missing",
+    status: inspection.status,
     details: {
-      phase: "scaffold",
+      phase: "runtime",
       bridgePhase: OPENCLAW_BRIDGE_PHASE,
       bridgeReady: isOpenClawBridgeReady(),
       expectedArtifacts: listOpenClawArtifactFiles(),
+      adapterDir: inspection.presence.adapterDir,
+      checkpointsDir: inspection.presence.checkpointsDir,
+      checkpointsDirExists: inspection.presence.checkpointsDirExists,
+      presentArtifacts: inspection.presence.presentFiles,
+      missingArtifacts: inspection.presence.missingFiles,
     },
   });
+}
+
+/** Inspect the provisioned OpenClaw adapter plus read-only bridge readiness. */
+export async function runOpenClawStatus(
+  options: {
+    readonly configPath: string;
+  },
+  deps: Partial<OpenClawAdapterPathDeps> = {},
+): Promise<AdapterStatusResultType> {
+  const inspectionResult = await inspectOpenClawRuntime(options, deps);
+  if (inspectionResult.isErr()) {
+    return AdapterStatusResult.parse({
+      adapter: OPENCLAW_ADAPTER_NAME,
+      adapterSource: "builtin",
+      status: "missing",
+      details: {
+        phase: "runtime",
+        bridgePhase: OPENCLAW_BRIDGE_PHASE,
+        bridgeReady: isOpenClawBridgeReady(),
+        error: inspectionResult.error.message,
+      },
+    });
+  }
+
+  return toStatusResult(inspectionResult.value);
 }

--- a/adapters/openclaw/src/status/index.ts
+++ b/adapters/openclaw/src/status/index.ts
@@ -5,7 +5,7 @@ import {
 import {
   OPENCLAW_BRIDGE_PHASE,
   isOpenClawBridgeReady,
-} from "../bridge/index.js";
+} from "../bridge/phase.js";
 import { listOpenClawArtifactFiles } from "../artifacts/index.js";
 import { OPENCLAW_ADAPTER_NAME } from "../config/index.js";
 import {

--- a/adapters/openclaw/src/status/runtime.ts
+++ b/adapters/openclaw/src/status/runtime.ts
@@ -1,0 +1,46 @@
+import { Result } from "better-result";
+import type { SignetError } from "@xmtp/signet-schemas";
+import {
+  inspectOpenClawRuntimePresence,
+  type OpenClawAdapterPathDeps,
+  type OpenClawRuntimePresence,
+} from "../bridge/config.js";
+import { listOpenClawArtifactFiles } from "../artifacts/index.js";
+
+/** Shared OpenClaw runtime inspection result used by status and doctor. */
+export interface OpenClawRuntimeInspection {
+  readonly presence: OpenClawRuntimePresence;
+  readonly status: "ok" | "degraded" | "missing";
+}
+
+/** Inspect adapter artifacts and derive a normalized runtime status. */
+export async function inspectOpenClawRuntime(
+  options: {
+    readonly configPath: string;
+  },
+  deps: Partial<OpenClawAdapterPathDeps> = {},
+): Promise<Result<OpenClawRuntimeInspection, SignetError>> {
+  const presenceResult = await inspectOpenClawRuntimePresence(
+    {
+      configPath: options.configPath,
+      expectedFiles: listOpenClawArtifactFiles(),
+    },
+    deps,
+  );
+  if (presenceResult.isErr()) {
+    return presenceResult;
+  }
+
+  const presence = presenceResult.value;
+  const status =
+    presence.missingFiles.length === 0 && presence.checkpointsDirExists
+      ? "ok"
+      : presence.presentFiles.length > 0 || presence.checkpointsDirExists
+        ? "degraded"
+        : "missing";
+
+  return Result.ok({
+    presence,
+    status,
+  });
+}

--- a/bun.lock
+++ b/bun.lock
@@ -22,8 +22,10 @@
         "@xmtp/signet-cli": "workspace:*",
         "@xmtp/signet-keys": "workspace:*",
         "@xmtp/signet-schemas": "workspace:*",
+        "@xmtp/signet-ws": "workspace:*",
         "better-result": "catalog:",
         "commander": "14.0.3",
+        "zod": "catalog:",
       },
       "devDependencies": {
         "bun-types": "catalog:",


### PR DESCRIPTION
## Summary
This PR ships the first read-only OpenClaw bridge slice and hardens its replay/checkpoint behavior so the adapter can consume credential-scoped XMTP activity safely.

## What Changed
- adds the read-only OpenClaw bridge runtime for credential-scoped WebSocket consumption
- persists replay checkpoints and translates sequenced signet events into adapter-local delivery envelopes
- scopes checkpoint resume to the configured credential instead of using the newest checkpoint across all credentials
- fails closed when checkpoint persistence breaks so delivery state does not advance ahead of durable replay state
- tolerates malformed sibling checkpoint files when valid checkpoints remain
- expands bridge coverage for replay, checkpoint failures, non-retryable closes, reconnect-disabled behavior, and retry exhaustion

## Why This Shape
This is the first thin runtime slice for the adapter, so correctness matters more than breadth. The follow-up hardening in this PR keeps replay and durability behavior honest before any outbound or higher-level orchestration work lands on top.

## How To Test
- `bun test adapters/openclaw/src/__tests__/openclaw-bridge.test.ts`
- `bun test adapters/openclaw/src/__tests__/openclaw-checkpoint-store.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run docs:check`

## Issues
Closes #345
