### PR TITLE
fix: add lightweight cli adapter support surface

### DIFF
--- a/adapters/openclaw/src/__tests__/openclaw-setup.test.ts
+++ b/adapters/openclaw/src/__tests__/openclaw-setup.test.ts
@@ -3,7 +3,11 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { Result } from "better-result";
-import type { AdminClient, CliConfig, ResolvedPaths } from "@xmtp/signet-cli";
+import type {
+  AdminClient,
+  CliConfig,
+  ResolvedPaths,
+} from "@xmtp/signet-cli/adapter-support";
 import type {
   OperatorRecordType,
   PolicyRecordType,

--- a/adapters/openclaw/src/bin.ts
+++ b/adapters/openclaw/src/bin.ts
@@ -7,10 +7,7 @@ import {
   InternalError,
   type SignetError,
 } from "@xmtp/signet-schemas";
-import { runOpenClawDoctor } from "./doctor/index.js";
 import { formatAdapterOutput } from "./output.js";
-import { runOpenClawSetup } from "./setup/index.js";
-import { runOpenClawStatus } from "./status/index.js";
 function exitCodeFromCategory(category: SignetError["category"]): number {
   const meta = ERROR_CATEGORY_META[category];
   return meta?.exitCode ?? ERROR_CATEGORY_META.internal.exitCode;
@@ -170,16 +167,22 @@ const program = new Command()
   .description("Process-backed OpenClaw adapter for xmtp-signet");
 
 addVerb(program, "setup", (opts) =>
-  runOpenClawSetup({
-    configPath: opts.config,
-    force: opts.force,
-  }),
+  import("./setup/index.js").then(({ runOpenClawSetup }) =>
+    runOpenClawSetup({
+      configPath: opts.config,
+      force: opts.force,
+    }),
+  ),
 );
 addVerb(program, "status", (opts) =>
-  runOpenClawStatus({ configPath: opts.config }),
+  import("./status/index.js").then(({ runOpenClawStatus }) =>
+    runOpenClawStatus({ configPath: opts.config }),
+  ),
 );
 addVerb(program, "doctor", (opts) =>
-  runOpenClawDoctor({ configPath: opts.config }),
+  import("./doctor/index.js").then(({ runOpenClawDoctor }) =>
+    runOpenClawDoctor({ configPath: opts.config }),
+  ),
 );
 
 if (import.meta.main) {

--- a/adapters/openclaw/src/bridge/config.ts
+++ b/adapters/openclaw/src/bridge/config.ts
@@ -14,7 +14,7 @@ import {
   resolvePaths,
   type CliConfig,
   type ResolvedPaths,
-} from "@xmtp/signet-cli";
+} from "@xmtp/signet-cli/adapter-support";
 import { OPENCLAW_ADAPTER_NAME } from "../config/index.js";
 
 /** Local delivery modes supported by the first bridge spike. */

--- a/adapters/openclaw/src/setup/index.ts
+++ b/adapters/openclaw/src/setup/index.ts
@@ -2,7 +2,10 @@ import { access, mkdir, writeFile } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
 import { join } from "node:path";
 import { Result } from "better-result";
-import type { AdminClient, DaemonStatus } from "@xmtp/signet-cli";
+import type {
+  AdminClient,
+  DaemonStatus,
+} from "@xmtp/signet-cli/adapter-support";
 import {
   AdapterSetupResult,
   type SignetError,

--- a/adapters/openclaw/src/setup/runtime.ts
+++ b/adapters/openclaw/src/setup/runtime.ts
@@ -8,7 +8,7 @@ import {
   type AdminClient,
   type CliConfig,
   type ResolvedPaths,
-} from "@xmtp/signet-cli";
+} from "@xmtp/signet-cli/adapter-support";
 
 /** Context available to OpenClaw adapter setup/status/doctor handlers. */
 export interface OpenClawAdminContext {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,12 +9,18 @@
   "type": "module",
   "exports": {
     ".": {
+      "bun": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./adapter-support": {
+      "bun": "./src/adapter-support.ts",
+      "types": "./dist/adapter-support.d.ts",
+      "default": "./dist/adapter-support.js"
     }
   },
   "scripts": {
-    "build": "bun build ./src/index.ts --outdir ./dist --target bun && tsc --declaration --emitDeclarationOnly --outDir ./dist",
+    "build": "bun build ./src/index.ts ./src/adapter-support.ts --outdir ./dist --target bun && tsc --declaration --emitDeclarationOnly --outDir ./dist",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint .",
     "test": "bun test"

--- a/packages/cli/src/adapter-support.ts
+++ b/packages/cli/src/adapter-support.ts
@@ -1,0 +1,19 @@
+/**
+ * Lightweight adapter-facing CLI support surface.
+ *
+ * This entrypoint intentionally avoids the full `xs` program graph so harness
+ * adapters can reuse config and admin helpers without importing command
+ * surfaces or XMTP runtime bindings during unit tests.
+ *
+ * @module
+ */
+
+export type { CliConfig } from "./config/schema.js";
+export { CliConfigSchema } from "./config/schema.js";
+export type { ResolvedPaths } from "./config/paths.js";
+export { resolvePaths } from "./config/paths.js";
+export { loadConfig } from "./config/loader.js";
+export type { AdminClient } from "./admin/client.js";
+export { createAdminClient } from "./admin/client.js";
+export type { DaemonStatus } from "./daemon/status.js";
+export { DaemonStatusSchema } from "./daemon/status.js";


### PR DESCRIPTION
## Summary
This is the foundational repair under the smoke-fix stack. While validating the CLI smoke issues, the OpenClaw adapter tests were still importing the full `@xmtp/signet-cli` surface, which pulled in CLI runtime baggage too early and made repo-wide verification noisy and brittle.

## What Changed
- added a lightweight `@xmtp/signet-cli/adapter-support` entrypoint for adapter-facing config and admin helpers
- switched the OpenClaw setup and bridge code to import that narrower surface instead of the CLI root
- made the OpenClaw adapter bin lazy-load `setup`, `status`, and `doctor` so tests do not trigger the full CLI/runtime path at import time

## Why
This keeps the adapter boundary honest: OpenClaw should depend on the minimal support surface it actually needs, not the whole CLI package initialization path. It also restores reliable repo-wide test coverage for the smoke-fix stack above it.

## How To Test
- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `cd adapters/openclaw && bun test`

## Notes
Foundational follow-up uncovered while preparing the `#356`-`#360` smoke-fix stack.
