### PR TITLE
fix: accept inbox ids for identity selection

### DIFF
--- a/packages/core/src/__tests__/conversation-actions.test.ts
+++ b/packages/core/src/__tests__/conversation-actions.test.ts
@@ -339,6 +339,7 @@ describe("conversation actions", () => {
       client,
       groupIds: new Set(),
     };
+    await identityStore.setInboxId(identity.id, client.inboxId);
     managedClients.set(identity.id, managed);
     return managed;
   }
@@ -398,6 +399,32 @@ describe("conversation actions", () => {
       if (Result.isOk(result)) {
         const val = result.value as { memberCount: number };
         expect(val.memberCount).toBe(1);
+      }
+    });
+
+    test("creates a group when creator is selected by inbox ID", async () => {
+      const managed = await seedIdentity("agent-2");
+      setupDeps();
+
+      const actions = createConversationActions(deps);
+      const createAction = actions.find((a) => a.id === "chat.create");
+
+      const result = await createAction!.handler(
+        {
+          memberInboxIds: ["inbox-peer-1"],
+          creatorIdentityLabel: managed.inboxId,
+        },
+        stubCtx(),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isOk(result)) {
+        const val = result.value as {
+          creatorInboxId: string;
+          memberCount: number;
+        };
+        expect(val.creatorInboxId).toBe(managed.inboxId);
+        expect(val.memberCount).toBe(2);
       }
     });
 

--- a/packages/core/src/__tests__/identity-selector.test.ts
+++ b/packages/core/src/__tests__/identity-selector.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { SqliteIdentityStore } from "../identity-store.js";
+import { resolveIdentitySelector } from "../identity-selector.js";
+
+describe("resolveIdentitySelector", () => {
+  test("falls back to the default identity when selector is an empty string", async () => {
+    const store = new SqliteIdentityStore(":memory:");
+    const created = await store.create(null, "default");
+    expect(created.isOk()).toBe(true);
+    if (!created.isOk()) return;
+
+    const updated = await store.setInboxId(created.value.id, "inbox-default");
+    expect(updated.isOk()).toBe(true);
+    if (!updated.isOk()) return;
+
+    const result = await resolveIdentitySelector(store, "");
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+
+    expect(result.value.identityId).toBe(created.value.id);
+    expect(result.value.inboxId).toBe("inbox-default");
+
+    store.close();
+  });
+});

--- a/packages/core/src/__tests__/identity-store.test.ts
+++ b/packages/core/src/__tests__/identity-store.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, beforeEach } from "bun:test";
+import { Result } from "better-result";
 import { SqliteIdentityStore } from "../identity-store.js";
 
 let store: SqliteIdentityStore;
@@ -111,6 +112,22 @@ describe("SqliteIdentityStore", () => {
       expect(result.isErr()).toBe(true);
       if (!result.isErr()) return;
       expect(result.error._tag).toBe("NotFoundError");
+    });
+
+    test("rejects duplicate non-null inbox IDs", async () => {
+      const first = await store.create("group-1");
+      const second = await store.create("group-2");
+      expect(first.isOk()).toBe(true);
+      expect(second.isOk()).toBe(true);
+      if (!first.isOk() || !second.isOk()) return;
+
+      const initial = await store.setInboxId(first.value.id, "inbox-1");
+      expect(initial.isOk()).toBe(true);
+
+      const duplicate = await store.setInboxId(second.value.id, "inbox-1");
+      expect(Result.isError(duplicate)).toBe(true);
+      if (!Result.isError(duplicate)) return;
+      expect(duplicate.error._tag).toBe("InternalError");
     });
   });
 

--- a/packages/core/src/__tests__/identity-store.test.ts
+++ b/packages/core/src/__tests__/identity-store.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, test, beforeEach } from "bun:test";
+import { describe, expect, test, beforeEach, afterEach, spyOn } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Result } from "better-result";
 import { SqliteIdentityStore } from "../identity-store.js";
 
@@ -128,6 +132,74 @@ describe("SqliteIdentityStore", () => {
       expect(Result.isError(duplicate)).toBe(true);
       if (!Result.isError(duplicate)) return;
       expect(duplicate.error._tag).toBe("InternalError");
+    });
+  });
+
+  describe("migration", () => {
+    let tempDir: string;
+    let dbPath: string;
+
+    beforeEach(() => {
+      tempDir = mkdtempSync(join(tmpdir(), "signet-identity-migration-"));
+      dbPath = join(tempDir, "identities.db");
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    test("warns and skips unique index when pre-existing duplicate inbox_ids exist", () => {
+      // Seed the database with duplicate inbox_id rows before migration runs.
+      const seed = new Database(dbPath);
+      seed.run(`
+        CREATE TABLE identities (
+          id TEXT PRIMARY KEY,
+          inbox_id TEXT,
+          group_id TEXT UNIQUE,
+          label TEXT UNIQUE,
+          created_at TEXT NOT NULL
+        )
+      `);
+      const insert = seed.prepare(
+        "INSERT INTO identities (id, inbox_id, group_id, label, created_at) VALUES (?, ?, ?, ?, ?)",
+      );
+      insert.run("inbox_a", "dup-inbox", "group-a", "label-a", "2025-01-01");
+      insert.run("inbox_b", "dup-inbox", "group-b", "label-b", "2025-01-02");
+      seed.close();
+
+      const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const migratedStore = new SqliteIdentityStore(dbPath);
+        try {
+          expect(warnSpy).toHaveBeenCalledTimes(1);
+          const [message, payload] = warnSpy.mock.calls[0] ?? [];
+          expect(String(message)).toContain("inbox_id");
+          expect(String(message)).toContain("skipped");
+          expect(String(message)).toContain("Clean up duplicates");
+          expect(payload).toMatchObject({
+            duplicateInboxIdCount: 1,
+            indexSkipped: "idx_identities_inbox_id",
+          });
+        } finally {
+          migratedStore.close();
+        }
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    test("does not warn when no duplicate inbox_ids exist", () => {
+      const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const freshStore = new SqliteIdentityStore(dbPath);
+        try {
+          expect(warnSpy).not.toHaveBeenCalled();
+        } finally {
+          freshStore.close();
+        }
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/core/src/__tests__/message-actions.test.ts
+++ b/packages/core/src/__tests__/message-actions.test.ts
@@ -187,6 +187,7 @@ describe("message actions", () => {
       client,
       groupIds: new Set<string>(),
     };
+    await identityStore.setInboxId(identity.id, client.inboxId);
     managedClients.set(identity.id, managed);
     return managed;
   }
@@ -218,6 +219,33 @@ describe("message actions", () => {
       if (Result.isOk(result)) {
         const val = result.value as { messageId: string; chatId: string };
         expect(val.messageId).toBe("msg-sent-1");
+        expect(val.chatId).toBe("g1");
+      }
+    });
+
+    test("resolves the acting identity from inbox ID", async () => {
+      const managed = await seedIdentity("sender", {
+        sentMessageId: "msg-sent-2",
+      });
+      setupDeps();
+
+      const actions = createMessageActions(deps);
+      const sendAction = actions.find((a) => a.id === "message.send");
+      expect(sendAction).toBeDefined();
+
+      const result = await sendAction!.handler(
+        {
+          chatId: "g1",
+          text: "Hello from inbox",
+          identityLabel: managed.inboxId,
+        },
+        stubCtx(),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      if (Result.isOk(result)) {
+        const val = result.value as { messageId: string; chatId: string };
+        expect(val.messageId).toBe("msg-sent-2");
         expect(val.chatId).toBe("g1");
       }
     });

--- a/packages/core/src/__tests__/search-actions.test.ts
+++ b/packages/core/src/__tests__/search-actions.test.ts
@@ -238,6 +238,33 @@ describe("createSearchActions", () => {
       expect(value.matches).toHaveLength(2);
     });
 
+    test("resolves the acting identity from inbox ID", async () => {
+      await seedIdentity();
+
+      const msgs: Record<string, XmtpDecodedMessage[]> = {
+        "group-1": [makeMessage("group-1", "alpha match")],
+      };
+      const groups = [makeGroup("group-1", "Group A")];
+      const client = createMockClient({ messages: msgs, groups });
+      const deps = buildDeps(client);
+      const actions = createSearchActions(deps);
+
+      const spec = actions.find((a) => a.id === "search.messages");
+      const result = await spec!.handler!(
+        {
+          query: "alpha",
+          chatId: "group-1",
+          identityLabel: "mock-inbox-1",
+        },
+        stubCtx(),
+      );
+      expect(Result.isOk(result)).toBe(true);
+      const value = (result as { value: { matches: unknown[]; total: number } })
+        .value;
+      expect(value.matches).toHaveLength(1);
+      expect(value.total).toBe(1);
+    });
+
     test("case-insensitive matching", async () => {
       await seedIdentity();
 

--- a/packages/core/src/consent-actions.ts
+++ b/packages/core/src/consent-actions.ts
@@ -6,6 +6,7 @@ import type { SignetError } from "@xmtp/signet-schemas";
 import type { SqliteIdentityStore } from "./identity-store.js";
 import type { ManagedClient } from "./client-registry.js";
 import type { ConsentEntityType, ConsentState } from "./xmtp-client-factory.js";
+import { resolveIdentitySelector } from "./identity-selector.js";
 
 /** Zod schema for consent entity type. */
 const ConsentEntityTypeSchema = z.enum(["inbox_id", "group_id"]);
@@ -25,40 +26,6 @@ export interface ConsentActionDeps {
   ) => ManagedClient | undefined;
 }
 
-/**
- * Resolve an identity by label, or fall back to the first identity
- * in the store when no label is provided.
- */
-async function resolveIdentity(
-  identityStore: SqliteIdentityStore,
-  label: string | undefined,
-): Promise<
-  Result<{ identityId: string; inboxId: string | null }, SignetError>
-> {
-  if (label) {
-    const identity = await identityStore.getByLabel(label);
-    if (!identity) {
-      return Result.err(NotFoundError.create("identity", label) as SignetError);
-    }
-    return Result.ok({
-      identityId: identity.id,
-      inboxId: identity.inboxId,
-    });
-  }
-
-  const identities = await identityStore.list();
-  const first = identities[0];
-  if (!first) {
-    return Result.err(
-      NotFoundError.create("identity", "(none)") as SignetError,
-    );
-  }
-  return Result.ok({
-    identityId: first.id,
-    inboxId: first.inboxId,
-  });
-}
-
 /** Resolve a managed client, preferring group ownership when applicable. */
 async function resolveManagedClient(
   deps: ConsentActionDeps,
@@ -67,7 +34,10 @@ async function resolveManagedClient(
   entity: string,
 ): Promise<Result<ManagedClient, SignetError>> {
   if (identityLabel) {
-    const resolved = await resolveIdentity(deps.identityStore, identityLabel);
+    const resolved = await resolveIdentitySelector(
+      deps.identityStore,
+      identityLabel,
+    );
     if (Result.isError(resolved)) return resolved;
 
     const managed = deps.getManagedClient(resolved.value.identityId);
@@ -90,7 +60,7 @@ async function resolveManagedClient(
     }
   }
 
-  const resolved = await resolveIdentity(deps.identityStore, undefined);
+  const resolved = await resolveIdentitySelector(deps.identityStore, undefined);
   if (Result.isError(resolved)) return resolved;
 
   const managed = deps.getManagedClient(resolved.value.identityId);

--- a/packages/core/src/conversation-actions.ts
+++ b/packages/core/src/conversation-actions.ts
@@ -18,6 +18,7 @@ import type { SignetCoreConfig } from "./config.js";
 import { joinConversation } from "./schemes/join.js";
 import type { SignerProviderFactory } from "./identity-registration.js";
 import type { OnboardingScheme } from "./schemes/onboarding-scheme.js";
+import { resolveIdentitySelector } from "./identity-selector.js";
 
 const GroupInfoSchema = z.object({
   chatId: z.string().optional(),
@@ -103,41 +104,6 @@ export interface ConversationActionDeps {
 }
 
 /**
- * Resolve an identity by label, or fall back to the first identity
- * in the store when no label is provided.
- */
-async function resolveIdentity(
-  identityStore: SqliteIdentityStore,
-  label: string | undefined,
-): Promise<
-  Result<{ identityId: string; inboxId: string | null }, SignetError>
-> {
-  if (label) {
-    const identity = await identityStore.getByLabel(label);
-    if (!identity) {
-      return Result.err(NotFoundError.create("identity", label) as SignetError);
-    }
-    return Result.ok({
-      identityId: identity.id,
-      inboxId: identity.inboxId,
-    });
-  }
-
-  // Fall back to first identity
-  const identities = await identityStore.list();
-  const first = identities[0];
-  if (!first) {
-    return Result.err(
-      NotFoundError.create("identity", "(none)") as SignetError,
-    );
-  }
-  return Result.ok({
-    identityId: first.id,
-    inboxId: first.inboxId,
-  });
-}
-
-/**
  * Resolve a chatId (which may be a conv_ local ID or a raw groupId)
  * to the underlying network groupId using the mapping store.
  */
@@ -214,7 +180,10 @@ async function resolveManagedClientForGroup(
   identityLabel?: string,
 ): Promise<Result<ManagedClient, SignetError>> {
   if (identityLabel !== undefined) {
-    const resolved = await resolveIdentity(deps.identityStore, identityLabel);
+    const resolved = await resolveIdentitySelector(
+      deps.identityStore,
+      identityLabel,
+    );
     if (Result.isError(resolved)) return resolved;
 
     const managed = deps.getManagedClient(resolved.value.identityId);
@@ -234,7 +203,7 @@ async function resolveManagedClientForGroup(
     return Result.ok(byGroup);
   }
 
-  const fallback = await resolveIdentity(deps.identityStore, undefined);
+  const fallback = await resolveIdentitySelector(deps.identityStore, undefined);
   if (Result.isError(fallback)) return fallback;
 
   const managed = deps.getManagedClient(fallback.value.identityId);
@@ -304,7 +273,7 @@ export function createConversationActions(
       creatorIdentityLabel: z.string().optional(),
     }),
     handler: async (input) => {
-      const resolved = await resolveIdentity(
+      const resolved = await resolveIdentitySelector(
         deps.identityStore,
         input.creatorIdentityLabel,
       );
@@ -359,7 +328,7 @@ export function createConversationActions(
       identityLabel: z.string().optional(),
     }),
     handler: async (input) => {
-      const resolved = await resolveIdentity(
+      const resolved = await resolveIdentitySelector(
         deps.identityStore,
         input.identityLabel,
       );
@@ -582,7 +551,7 @@ export function createConversationActions(
       }
 
       // Resolve identity
-      const resolved = await resolveIdentity(
+      const resolved = await resolveIdentitySelector(
         deps.identityStore,
         input.identityLabel,
       );

--- a/packages/core/src/identity-selector.ts
+++ b/packages/core/src/identity-selector.ts
@@ -1,0 +1,57 @@
+import { Result } from "better-result";
+import { NotFoundError } from "@xmtp/signet-schemas";
+import type { SignetError } from "@xmtp/signet-schemas";
+import type { SqliteIdentityStore } from "./identity-store.js";
+
+/** Normalized identity match used by action handlers after selector lookup. */
+export interface ResolvedIdentitySelection {
+  readonly identityId: string;
+  readonly inboxId: string | null;
+}
+
+function toResolvedIdentity(identity: {
+  readonly id: string;
+  readonly inboxId: string | null;
+}): ResolvedIdentitySelection {
+  return {
+    identityId: identity.id,
+    inboxId: identity.inboxId,
+  };
+}
+
+/**
+ * Resolve an acting identity from either a label or a registered inbox ID.
+ *
+ * Label matching keeps precedence so existing label-based flows behave exactly
+ * as before even if a label could also look like an inbox identifier.
+ */
+export async function resolveIdentitySelector(
+  identityStore: SqliteIdentityStore,
+  selector: string | undefined,
+): Promise<Result<ResolvedIdentitySelection, SignetError>> {
+  if (selector !== undefined) {
+    const byLabel = await identityStore.getByLabel(selector);
+    if (byLabel !== null) {
+      return Result.ok(toResolvedIdentity(byLabel));
+    }
+
+    const byInboxId = await identityStore.getByInboxId(selector);
+    if (byInboxId !== null) {
+      return Result.ok(toResolvedIdentity(byInboxId));
+    }
+
+    return Result.err(
+      NotFoundError.create("identity", selector) as SignetError,
+    );
+  }
+
+  const identities = await identityStore.list();
+  const first = identities[0];
+  if (!first) {
+    return Result.err(
+      NotFoundError.create("identity", "(none)") as SignetError,
+    );
+  }
+
+  return Result.ok(toResolvedIdentity(first));
+}

--- a/packages/core/src/identity-selector.ts
+++ b/packages/core/src/identity-selector.ts
@@ -29,19 +29,22 @@ export async function resolveIdentitySelector(
   identityStore: SqliteIdentityStore,
   selector: string | undefined,
 ): Promise<Result<ResolvedIdentitySelection, SignetError>> {
-  if (selector !== undefined) {
-    const byLabel = await identityStore.getByLabel(selector);
+  const normalizedSelector =
+    selector !== undefined && selector.length > 0 ? selector : undefined;
+
+  if (normalizedSelector !== undefined) {
+    const byLabel = await identityStore.getByLabel(normalizedSelector);
     if (byLabel !== null) {
       return Result.ok(toResolvedIdentity(byLabel));
     }
 
-    const byInboxId = await identityStore.getByInboxId(selector);
+    const byInboxId = await identityStore.getByInboxId(normalizedSelector);
     if (byInboxId !== null) {
       return Result.ok(toResolvedIdentity(byInboxId));
     }
 
     return Result.err(
-      NotFoundError.create("identity", selector) as SignetError,
+      NotFoundError.create("identity", normalizedSelector) as SignetError,
     );
   }
 

--- a/packages/core/src/identity-store.ts
+++ b/packages/core/src/identity-store.ts
@@ -75,6 +75,29 @@ export class SqliteIdentityStore {
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_identities_label ON identities(label)",
       );
     }
+
+    const duplicateInbox = this.#db
+      .prepare(
+        `
+          SELECT inbox_id
+          FROM identities
+          WHERE inbox_id IS NOT NULL
+          GROUP BY inbox_id
+          HAVING COUNT(*) > 1
+          LIMIT 1
+        `,
+      )
+      .get() as { inbox_id: string } | null;
+
+    if (duplicateInbox === null) {
+      this.#db.run(
+        `
+          CREATE UNIQUE INDEX IF NOT EXISTS idx_identities_inbox_id
+          ON identities(inbox_id)
+          WHERE inbox_id IS NOT NULL
+        `,
+      );
+    }
   }
 
   /** Create a new identity with fresh key material. */
@@ -135,7 +158,9 @@ export class SqliteIdentityStore {
   /** Look up an identity by its XMTP inbox ID. */
   async getByInboxId(inboxId: string): Promise<AgentIdentity | null> {
     const row = this.#db
-      .prepare("SELECT * FROM identities WHERE inbox_id = ?")
+      .prepare(
+        "SELECT * FROM identities WHERE inbox_id = ? ORDER BY created_at ASC LIMIT 1",
+      )
       .get(inboxId) as IdentityRow | null;
     return row ? rowToIdentity(row) : null;
   }
@@ -152,15 +177,25 @@ export class SqliteIdentityStore {
   async setInboxId(
     id: string,
     inboxId: string,
-  ): Promise<Result<AgentIdentity, NotFoundError>> {
+  ): Promise<Result<AgentIdentity, NotFoundError | InternalError>> {
     const existing = await this.getById(id);
     if (existing === null) {
       return Result.err(NotFoundError.create("identity", id));
     }
 
-    this.#db
-      .prepare("UPDATE identities SET inbox_id = ? WHERE id = ?")
-      .run(inboxId, id);
+    try {
+      this.#db
+        .prepare("UPDATE identities SET inbox_id = ? WHERE id = ?")
+        .run(inboxId, id);
+    } catch (cause) {
+      return Result.err(
+        InternalError.create("Failed to persist inbox ID", {
+          identityId: id,
+          inboxId,
+          cause: String(cause),
+        }),
+      );
+    }
 
     return Result.ok({
       ...existing,

--- a/packages/core/src/identity-store.ts
+++ b/packages/core/src/identity-store.ts
@@ -76,26 +76,41 @@ export class SqliteIdentityStore {
       );
     }
 
-    const duplicateInbox = this.#db
+    const duplicateInboxCount = this.#db
       .prepare(
         `
-          SELECT inbox_id
-          FROM identities
-          WHERE inbox_id IS NOT NULL
-          GROUP BY inbox_id
-          HAVING COUNT(*) > 1
-          LIMIT 1
+          SELECT COUNT(*) AS count
+          FROM (
+            SELECT inbox_id
+            FROM identities
+            WHERE inbox_id IS NOT NULL
+            GROUP BY inbox_id
+            HAVING COUNT(*) > 1
+          )
         `,
       )
-      .get() as { inbox_id: string } | null;
+      .get() as { count: number };
 
-    if (duplicateInbox === null) {
+    if (duplicateInboxCount.count === 0) {
       this.#db.run(
         `
           CREATE UNIQUE INDEX IF NOT EXISTS idx_identities_inbox_id
           ON identities(inbox_id)
           WHERE inbox_id IS NOT NULL
         `,
+      );
+    } else {
+      // Pre-existing duplicate inbox_id rows block the unique index. Skip
+      // index creation so the migration completes, but warn loudly: without
+      // the index, setInboxId will silently allow further duplicates.
+      // Operators must clean up the duplicates and restart to enable
+      // uniqueness protection.
+      console.warn(
+        `[xmtp-signet] identities.inbox_id unique index skipped: ${duplicateInboxCount.count} duplicate inbox_id value(s) found. Clean up duplicates and restart to enable uniqueness protection.`,
+        {
+          duplicateInboxIdCount: duplicateInboxCount.count,
+          indexSkipped: "idx_identities_inbox_id",
+        },
       );
     }
   }

--- a/packages/core/src/message-actions.ts
+++ b/packages/core/src/message-actions.ts
@@ -10,6 +10,7 @@ import type {
 } from "@xmtp/signet-schemas";
 import type { SqliteIdentityStore } from "./identity-store.js";
 import type { ManagedClient } from "./client-registry.js";
+import { resolveIdentitySelector } from "./identity-selector.js";
 import type { XmtpDecodedMessage } from "./xmtp-client-factory.js";
 
 /** Dependencies used to build message-related action specs. */
@@ -26,41 +27,6 @@ export interface MessageActionDeps {
         credentialId: string,
       ) => Promise<Result<CredentialRecordType, SignetError>>)
     | undefined;
-}
-
-/**
- * Resolve an identity by label, or fall back to the first identity
- * in the store when no label is provided.
- */
-async function resolveIdentity(
-  identityStore: SqliteIdentityStore,
-  label: string | undefined,
-): Promise<
-  Result<{ identityId: string; inboxId: string | null }, SignetError>
-> {
-  if (label) {
-    const identity = await identityStore.getByLabel(label);
-    if (!identity) {
-      return Result.err(NotFoundError.create("identity", label) as SignetError);
-    }
-    return Result.ok({
-      identityId: identity.id,
-      inboxId: identity.inboxId,
-    });
-  }
-
-  // Fall back to first identity
-  const identities = await identityStore.list();
-  const first = identities[0];
-  if (!first) {
-    return Result.err(
-      NotFoundError.create("identity", "(none)") as SignetError,
-    );
-  }
-  return Result.ok({
-    identityId: first.id,
-    inboxId: first.inboxId,
-  });
 }
 
 /**
@@ -193,7 +159,7 @@ export function createMessageActions(
       identityLabel: z.string().optional(),
     }),
     handler: async (input) => {
-      const resolved = await resolveIdentity(
+      const resolved = await resolveIdentitySelector(
         deps.identityStore,
         input.identityLabel,
       );
@@ -295,7 +261,7 @@ export function createMessageActions(
         }
       }
 
-      const resolved = await resolveIdentity(
+      const resolved = await resolveIdentitySelector(
         deps.identityStore,
         input.identityLabel,
       );
@@ -403,7 +369,7 @@ export function createMessageActions(
         }
       }
 
-      const resolved = await resolveIdentity(
+      const resolved = await resolveIdentitySelector(
         deps.identityStore,
         input.identityLabel,
       );
@@ -467,7 +433,7 @@ export function createMessageActions(
       identityLabel: z.string().optional(),
     }),
     handler: async (input) => {
-      const resolved = await resolveIdentity(
+      const resolved = await resolveIdentitySelector(
         deps.identityStore,
         input.identityLabel,
       );
@@ -529,7 +495,7 @@ export function createMessageActions(
       identityLabel: z.string().optional(),
     }),
     handler: async (input) => {
-      const resolved = await resolveIdentity(
+      const resolved = await resolveIdentitySelector(
         deps.identityStore,
         input.identityLabel,
       );
@@ -589,7 +555,7 @@ export function createMessageActions(
       identityLabel: z.string().optional(),
     }),
     handler: async (input) => {
-      const resolved = await resolveIdentity(
+      const resolved = await resolveIdentitySelector(
         deps.identityStore,
         input.identityLabel,
       );

--- a/packages/core/src/search-actions.ts
+++ b/packages/core/src/search-actions.ts
@@ -15,6 +15,7 @@ import type {
 } from "@xmtp/signet-schemas";
 import type { SqliteIdentityStore } from "./identity-store.js";
 import type { ManagedClient } from "./client-registry.js";
+import { resolveIdentitySelector } from "./identity-selector.js";
 
 /** Dependencies used to build search-related action specs. */
 export interface SearchActionDeps {
@@ -40,40 +41,6 @@ interface ResourceSearchHit {
   readonly type: "operator" | "policy" | "credential" | "conversation";
   readonly id: string;
   readonly label: string;
-}
-
-/**
- * Resolve an identity by label, or fall back to the first identity
- * in the store when no label is provided.
- */
-async function resolveIdentity(
-  identityStore: SqliteIdentityStore,
-  label: string | undefined,
-): Promise<
-  Result<{ identityId: string; inboxId: string | null }, SignetError>
-> {
-  if (label) {
-    const identity = await identityStore.getByLabel(label);
-    if (!identity) {
-      return Result.err(NotFoundError.create("identity", label) as SignetError);
-    }
-    return Result.ok({
-      identityId: identity.id,
-      inboxId: identity.inboxId,
-    });
-  }
-
-  const identities = await identityStore.list();
-  const first = identities[0];
-  if (!first) {
-    return Result.err(
-      NotFoundError.create("identity", "(none)") as SignetError,
-    );
-  }
-  return Result.ok({
-    identityId: first.id,
-    inboxId: first.inboxId,
-  });
 }
 
 /**
@@ -251,7 +218,7 @@ export function createSearchActions(
         );
       }
 
-      const resolved = await resolveIdentity(
+      const resolved = await resolveIdentitySelector(
         deps.identityStore,
         input.identityLabel,
       );
@@ -453,7 +420,10 @@ export function createSearchActions(
       // credential results.  Only hard-fail when conversation was explicitly
       // requested via the `type` filter.
       if (shouldSearch("conversation")) {
-        const resolved = await resolveIdentity(deps.identityStore, undefined);
+        const resolved = await resolveIdentitySelector(
+          deps.identityStore,
+          undefined,
+        );
         if (Result.isError(resolved)) {
           if (input.type === "conversation") return resolved;
         } else {


### PR DESCRIPTION
## Summary
Align `--as` handling with the documented inbox-ID contract across the core conversation, message, search, and consent flows.

## What Changed
- updated identity selection to resolve inbox IDs directly instead of only working reliably with labels
- propagated the normalization path through conversation, message, search, and consent actions
- added regression coverage around inbox-ID based identity selection

## Why
The smoke tracer showed a real ergonomics bug: CLI help said `--as` accepted inbox IDs, but live behavior only worked consistently with identity labels. This makes the implementation match the contract.

## How To Test
- `bun test packages/core/src/__tests__/conversation-actions.test.ts`
- `bun test packages/core/src/__tests__/message-actions.test.ts`
- `bun test packages/core/src/__tests__/search-actions.test.ts`
- `bun run test`

Closes #356
