### PR TITLE
fix: encode reply reaction and read receipt messages

### DIFF
--- a/packages/core/src/__tests__/message-actions.test.ts
+++ b/packages/core/src/__tests__/message-actions.test.ts
@@ -877,6 +877,42 @@ describe("message actions", () => {
         referenceInboxId: "inbox-a",
       });
     });
+
+    test("allows replies when the referenced message is not cached locally", async () => {
+      const managed = await seedIdentity("replier", {
+        sentMessageId: "msg-reply-3",
+      });
+      setupDeps();
+
+      const actions = createMessageActions(deps);
+      const replyAction = actions.find((a) => a.id === "message.reply");
+
+      const result = await replyAction!.handler(
+        {
+          chatId: "g1",
+          messageId: "msg-remote-only",
+          text: "Reply without cache",
+          identityLabel: "replier",
+        },
+        stubCtx(),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+
+      const sendCalls = (
+        managed.client as unknown as {
+          _sendCalls: {
+            groupId: string;
+            content: unknown;
+            contentType?: string;
+          }[];
+        }
+      )._sendCalls;
+      expect(sendCalls[0]!.content).toEqual({
+        text: "Reply without cache",
+        reference: "msg-remote-only",
+      });
+    });
   });
 
   describe("message.react", () => {
@@ -969,6 +1005,44 @@ describe("message actions", () => {
         referenceInboxId: "inbox-a",
         action: "added",
         content: "🎉",
+        schema: "unicode",
+      });
+    });
+
+    test("allows reactions when the referenced message is not cached locally", async () => {
+      const managed = await seedIdentity("reactor", {
+        sentMessageId: "msg-react-3",
+      });
+      setupDeps();
+
+      const actions = createMessageActions(deps);
+      const reactAction = actions.find((a) => a.id === "message.react");
+
+      const result = await reactAction!.handler(
+        {
+          chatId: "g1",
+          messageId: "msg-remote-only",
+          reaction: "👍",
+          identityLabel: "reactor",
+        },
+        stubCtx(),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+
+      const sendCalls = (
+        managed.client as unknown as {
+          _sendCalls: {
+            groupId: string;
+            content: unknown;
+            contentType?: string;
+          }[];
+        }
+      )._sendCalls;
+      expect(sendCalls[0]!.content).toEqual({
+        reference: "msg-remote-only",
+        action: "added",
+        content: "👍",
         schema: "unicode",
       });
     });

--- a/packages/core/src/__tests__/message-actions.test.ts
+++ b/packages/core/src/__tests__/message-actions.test.ts
@@ -783,6 +783,7 @@ describe("message actions", () => {
     test("sends reply content type with reference", async () => {
       const managed = await seedIdentity("replier", {
         sentMessageId: "msg-reply-1",
+        messages: sampleMessages,
       });
       setupDeps();
 
@@ -827,12 +828,14 @@ describe("message actions", () => {
       expect(sendCalls[0]!.content).toEqual({
         text: "Reply text",
         reference: "msg-aaa",
+        referenceInboxId: "inbox-a",
       });
     });
 
     test("resolves msg_ local ID to network ID in reference", async () => {
       const managed = await seedIdentity("replier", {
         sentMessageId: "msg-reply-2",
+        messages: sampleMessages,
       });
       idMappings.set("msg-aaa", "msg_0123456789abcdef", "message");
       setupDeps();
@@ -871,6 +874,7 @@ describe("message actions", () => {
       expect(sendCalls[0]!.content).toEqual({
         text: "Reply text",
         reference: "msg-aaa",
+        referenceInboxId: "inbox-a",
       });
     });
   });
@@ -879,6 +883,7 @@ describe("message actions", () => {
     test("sends reaction content type with reference", async () => {
       const managed = await seedIdentity("reactor", {
         sentMessageId: "msg-react-1",
+        messages: sampleMessages,
       });
       setupDeps();
 
@@ -922,6 +927,7 @@ describe("message actions", () => {
       expect(sendCalls[0]!.contentType).toBe("reaction");
       expect(sendCalls[0]!.content).toEqual({
         reference: "msg-aaa",
+        referenceInboxId: "inbox-a",
         action: "added",
         content: "👍",
         schema: "unicode",
@@ -931,6 +937,7 @@ describe("message actions", () => {
     test("resolves msg_ local ID to network ID in reference", async () => {
       const managed = await seedIdentity("reactor", {
         sentMessageId: "msg-react-2",
+        messages: sampleMessages,
       });
       idMappings.set("msg-aaa", "msg_0123456789abcdef", "message");
       setupDeps();
@@ -959,6 +966,7 @@ describe("message actions", () => {
       )._sendCalls;
       expect(sendCalls[0]!.content).toEqual({
         reference: "msg-aaa",
+        referenceInboxId: "inbox-a",
         action: "added",
         content: "🎉",
         schema: "unicode",

--- a/packages/core/src/__tests__/sdk-client.test.ts
+++ b/packages/core/src/__tests__/sdk-client.test.ts
@@ -140,7 +140,23 @@ describe("createSdkClient", () => {
       });
       expect(capturedReply).not.toBeNull();
       if (capturedReply && typeof capturedReply === "object") {
-        expect((capturedReply as { content?: unknown }).content).not.toBe(
+        const replyContent = (capturedReply as { content?: unknown }).content;
+        expect(replyContent).not.toBe("Reply text");
+        // Mirror @xmtp/node-bindings encodeText shape: xmtp.org/text:1.0,
+        // UTF-8 encoded body. Locally constructed to keep sdk-client.ts
+        // free of @xmtp/node-sdk runtime imports.
+        expect(replyContent).toMatchObject({
+          type: {
+            authorityId: "xmtp.org",
+            typeId: "text",
+            versionMajor: 1,
+            versionMinor: 0,
+          },
+          parameters: { encoding: "UTF-8" },
+        });
+        const encodedBytes = (replyContent as { content?: unknown }).content;
+        expect(encodedBytes).toBeInstanceOf(Uint8Array);
+        expect(new TextDecoder().decode(encodedBytes as Uint8Array)).toBe(
           "Reply text",
         );
       }

--- a/packages/core/src/__tests__/sdk-client.test.ts
+++ b/packages/core/src/__tests__/sdk-client.test.ts
@@ -146,11 +146,11 @@ describe("createSdkClient", () => {
       }
     });
 
-    test("encodes reaction content before sending", async () => {
-      let capturedPayload: unknown = null;
+    test("uses the SDK reaction helper", async () => {
+      let capturedReaction: unknown = null;
       const group = createMockGroup({ id: "g1" });
-      group.send = async (encoded: unknown) => {
-        capturedPayload = encoded;
+      group.sendReaction = async (reaction) => {
+        capturedReaction = reaction;
         return "msg-id-reaction";
       };
       const native = createMockSdkNativeClient({ groups: [group] });
@@ -172,19 +172,20 @@ describe("createSdkClient", () => {
       if (result.isOk()) {
         expect(result.value).toBe("msg-id-reaction");
       }
-      expect(capturedPayload).not.toEqual({
+      expect(capturedReaction).toEqual({
         reference: "msg-aaa",
+        referenceInboxId: "inbox-original",
         action: "added",
         content: "👍",
         schema: "unicode",
       });
     });
 
-    test("encodes read receipts before sending", async () => {
-      let capturedPayload: unknown = null;
+    test("uses the SDK read-receipt helper", async () => {
+      let readReceiptCalled = false;
       const group = createMockGroup({ id: "g1" });
-      group.send = async (encoded: unknown) => {
-        capturedPayload = encoded;
+      group.sendReadReceipt = async () => {
+        readReceiptCalled = true;
         return "msg-id-read-receipt";
       };
       const native = createMockSdkNativeClient({ groups: [group] });
@@ -196,7 +197,7 @@ describe("createSdkClient", () => {
       if (result.isOk()) {
         expect(result.value).toBe("msg-id-read-receipt");
       }
-      expect(capturedPayload).not.toEqual({});
+      expect(readReceiptCalled).toBe(true);
     });
   });
 

--- a/packages/core/src/__tests__/sdk-client.test.ts
+++ b/packages/core/src/__tests__/sdk-client.test.ts
@@ -109,6 +109,95 @@ describe("createSdkClient", () => {
       }
       expect(capturedPayload).toBe(customEncoded);
     });
+
+    test("encodes reply content with the SDK reply helper", async () => {
+      let capturedReply: unknown = null;
+      const group = createMockGroup({ id: "g1" });
+      group.sendReply = async (reply) => {
+        capturedReply = reply;
+        return "msg-id-reply";
+      };
+      const native = createMockSdkNativeClient({ groups: [group] });
+      const client = createSdkClient({ client: native, syncTimeoutMs: 5000 });
+
+      const result = await client.sendMessage(
+        "g1",
+        {
+          reference: "msg-aaa",
+          referenceInboxId: "inbox-original",
+          text: "Reply text",
+        },
+        "reply",
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe("msg-id-reply");
+      }
+      expect(capturedReply).toMatchObject({
+        reference: "msg-aaa",
+        referenceInboxId: "inbox-original",
+      });
+      expect(capturedReply).not.toBeNull();
+      if (capturedReply && typeof capturedReply === "object") {
+        expect((capturedReply as { content?: unknown }).content).not.toBe(
+          "Reply text",
+        );
+      }
+    });
+
+    test("encodes reaction content before sending", async () => {
+      let capturedPayload: unknown = null;
+      const group = createMockGroup({ id: "g1" });
+      group.send = async (encoded: unknown) => {
+        capturedPayload = encoded;
+        return "msg-id-reaction";
+      };
+      const native = createMockSdkNativeClient({ groups: [group] });
+      const client = createSdkClient({ client: native, syncTimeoutMs: 5000 });
+
+      const result = await client.sendMessage(
+        "g1",
+        {
+          reference: "msg-aaa",
+          referenceInboxId: "inbox-original",
+          action: "added",
+          content: "👍",
+          schema: "unicode",
+        },
+        "reaction",
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe("msg-id-reaction");
+      }
+      expect(capturedPayload).not.toEqual({
+        reference: "msg-aaa",
+        action: "added",
+        content: "👍",
+        schema: "unicode",
+      });
+    });
+
+    test("encodes read receipts before sending", async () => {
+      let capturedPayload: unknown = null;
+      const group = createMockGroup({ id: "g1" });
+      group.send = async (encoded: unknown) => {
+        capturedPayload = encoded;
+        return "msg-id-read-receipt";
+      };
+      const native = createMockSdkNativeClient({ groups: [group] });
+      const client = createSdkClient({ client: native, syncTimeoutMs: 5000 });
+
+      const result = await client.sendMessage("g1", {}, "readReceipt");
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value).toBe("msg-id-read-receipt");
+      }
+      expect(capturedPayload).not.toEqual({});
+    });
   });
 
   describe("syncAll", () => {

--- a/packages/core/src/__tests__/sdk-fixtures.ts
+++ b/packages/core/src/__tests__/sdk-fixtures.ts
@@ -80,6 +80,8 @@ export function createMockGroup(
     sync: async () => {},
     sendText: async (_text: string) => `msg-${Date.now()}`,
     send: async (_encoded: unknown) => `msg-${Date.now()}`,
+    sendReaction: async (_reaction) => `msg-${Date.now()}`,
+    sendReadReceipt: async () => `msg-${Date.now()}`,
     sendReply: async (_reply) => `msg-${Date.now()}`,
     addMembers: async (_inboxIds: string[]) => {},
     removeMembers: async (_inboxIds: string[]) => {},

--- a/packages/core/src/__tests__/sdk-fixtures.ts
+++ b/packages/core/src/__tests__/sdk-fixtures.ts
@@ -80,6 +80,7 @@ export function createMockGroup(
     sync: async () => {},
     sendText: async (_text: string) => `msg-${Date.now()}`,
     send: async (_encoded: unknown) => `msg-${Date.now()}`,
+    sendReply: async (_reply) => `msg-${Date.now()}`,
     addMembers: async (_inboxIds: string[]) => {},
     removeMembers: async (_inboxIds: string[]) => {},
     updateName: async (_name: string) => {},

--- a/packages/core/src/message-actions.ts
+++ b/packages/core/src/message-actions.ts
@@ -55,12 +55,18 @@ function resolveMessageId(
   return networkId ?? messageId;
 }
 
-function resolveReferencedMessage(
+function resolveMessageReference(
   client: ManagedClient["client"],
   idMappings: IdMappingStore | undefined,
   chatId: string,
   messageId: string,
-): Result<XmtpDecodedMessage, SignetError> {
+): Result<
+  {
+    messageId: string;
+    senderInboxId?: string;
+  },
+  SignetError
+> {
   const resolvedMessageId = resolveMessageId(idMappings, messageId);
   const lookupResult = client.getMessageById(resolvedMessageId);
   if (Result.isError(lookupResult)) {
@@ -69,9 +75,9 @@ function resolveReferencedMessage(
 
   const message = lookupResult.value;
   if (!message) {
-    return Result.err(
-      NotFoundError.create("message", messageId) as SignetError,
-    );
+    return Result.ok({
+      messageId: resolvedMessageId,
+    });
   }
 
   const expectedGroupId = resolveGroupId(idMappings, chatId);
@@ -81,7 +87,10 @@ function resolveReferencedMessage(
     );
   }
 
-  return Result.ok(message);
+  return Result.ok({
+    messageId: message.messageId,
+    senderInboxId: message.senderInboxId,
+  });
 }
 
 /**
@@ -479,7 +488,7 @@ export function createMessageActions(
       }
 
       const groupId = resolveGroupId(deps.idMappings, input.chatId);
-      const referenceMessage = resolveReferencedMessage(
+      const referenceMessage = resolveMessageReference(
         managed.client,
         deps.idMappings,
         input.chatId,
@@ -492,7 +501,9 @@ export function createMessageActions(
         {
           text: input.text,
           reference: referenceMessage.value.messageId,
-          referenceInboxId: referenceMessage.value.senderInboxId,
+          ...(referenceMessage.value.senderInboxId
+            ? { referenceInboxId: referenceMessage.value.senderInboxId }
+            : {}),
         },
         "reply",
       );
@@ -552,7 +563,7 @@ export function createMessageActions(
       }
 
       const groupId = resolveGroupId(deps.idMappings, input.chatId);
-      const referenceMessage = resolveReferencedMessage(
+      const referenceMessage = resolveMessageReference(
         managed.client,
         deps.idMappings,
         input.chatId,
@@ -564,7 +575,9 @@ export function createMessageActions(
         groupId,
         {
           reference: referenceMessage.value.messageId,
-          referenceInboxId: referenceMessage.value.senderInboxId,
+          ...(referenceMessage.value.senderInboxId
+            ? { referenceInboxId: referenceMessage.value.senderInboxId }
+            : {}),
           action: "added",
           content: input.reaction,
           schema: "unicode",

--- a/packages/core/src/message-actions.ts
+++ b/packages/core/src/message-actions.ts
@@ -55,6 +55,35 @@ function resolveMessageId(
   return networkId ?? messageId;
 }
 
+function resolveReferencedMessage(
+  client: ManagedClient["client"],
+  idMappings: IdMappingStore | undefined,
+  chatId: string,
+  messageId: string,
+): Result<XmtpDecodedMessage, SignetError> {
+  const resolvedMessageId = resolveMessageId(idMappings, messageId);
+  const lookupResult = client.getMessageById(resolvedMessageId);
+  if (Result.isError(lookupResult)) {
+    return lookupResult;
+  }
+
+  const message = lookupResult.value;
+  if (!message) {
+    return Result.err(
+      NotFoundError.create("message", messageId) as SignetError,
+    );
+  }
+
+  const expectedGroupId = resolveGroupId(idMappings, chatId);
+  if (message.groupId !== expectedGroupId) {
+    return Result.err(
+      NotFoundError.create("message", messageId) as SignetError,
+    );
+  }
+
+  return Result.ok(message);
+}
+
 /**
  * Compute effective scopes from credential config allow/deny.
  * Deny always wins.
@@ -450,10 +479,21 @@ export function createMessageActions(
       }
 
       const groupId = resolveGroupId(deps.idMappings, input.chatId);
-      const resolvedMsgId = resolveMessageId(deps.idMappings, input.messageId);
+      const referenceMessage = resolveReferencedMessage(
+        managed.client,
+        deps.idMappings,
+        input.chatId,
+        input.messageId,
+      );
+      if (Result.isError(referenceMessage)) return referenceMessage;
+
       const sendResult = await managed.client.sendMessage(
         groupId,
-        { text: input.text, reference: resolvedMsgId },
+        {
+          text: input.text,
+          reference: referenceMessage.value.messageId,
+          referenceInboxId: referenceMessage.value.senderInboxId,
+        },
         "reply",
       );
       if (Result.isError(sendResult)) return sendResult;
@@ -512,11 +552,19 @@ export function createMessageActions(
       }
 
       const groupId = resolveGroupId(deps.idMappings, input.chatId);
-      const resolvedMsgId = resolveMessageId(deps.idMappings, input.messageId);
+      const referenceMessage = resolveReferencedMessage(
+        managed.client,
+        deps.idMappings,
+        input.chatId,
+        input.messageId,
+      );
+      if (Result.isError(referenceMessage)) return referenceMessage;
+
       const sendResult = await managed.client.sendMessage(
         groupId,
         {
-          reference: resolvedMsgId,
+          reference: referenceMessage.value.messageId,
+          referenceInboxId: referenceMessage.value.senderInboxId,
           action: "added",
           content: input.reaction,
           schema: "unicode",

--- a/packages/core/src/sdk/sdk-client.ts
+++ b/packages/core/src/sdk/sdk-client.ts
@@ -1,5 +1,4 @@
 import { Result } from "better-result";
-import { encodeText } from "@xmtp/node-sdk";
 import type { SignetError } from "@xmtp/signet-schemas";
 import {
   InternalError,
@@ -30,6 +29,7 @@ import { createConvosOnboardingScheme } from "../schemes/default-onboarding-sche
 import type { OnboardingScheme } from "../schemes/onboarding-scheme.js";
 import type {
   SdkClientShape,
+  SdkContentTypeIdShape,
   SdkGroupShape,
   SdkConsentEntityType,
   SdkConsentState,
@@ -65,6 +65,33 @@ async function getGroup(
     return Result.err(NotFoundError.create("group", groupId));
   }
   return Result.ok(result.value);
+}
+
+/**
+ * Build an EncodedContent payload for the `xmtp.org/text:1.0` content type.
+ *
+ * Mirrors `encodeText` from `@xmtp/node-bindings` (re-exported by
+ * `@xmtp/node-sdk`) without taking a runtime dependency on the SDK,
+ * preserving this module's structural-typing-only boundary against the
+ * SDK. The shape is fixed by the XMTP text content-type spec
+ * (authority `xmtp.org`, type `text`, version `1.0`, UTF-8 encoded body)
+ * and matches the existing generic encoded-content construction below.
+ */
+function encodeTextContent(text: string): {
+  type: SdkContentTypeIdShape;
+  parameters: Record<string, string>;
+  content: Uint8Array;
+} {
+  return {
+    type: {
+      authorityId: "xmtp.org",
+      typeId: "text",
+      versionMajor: 1,
+      versionMinor: 0,
+    },
+    parameters: { encoding: "UTF-8" },
+    content: new TextEncoder().encode(text),
+  };
 }
 
 /**
@@ -217,7 +244,7 @@ export function createSdkClient(options: SdkClientOptions): XmtpClient {
                 ...(content.referenceInboxId
                   ? { referenceInboxId: content.referenceInboxId }
                   : {}),
-                content: encodeText(content.text),
+                content: encodeTextContent(content.text),
               }),
             "sendMessage",
           );

--- a/packages/core/src/sdk/sdk-client.ts
+++ b/packages/core/src/sdk/sdk-client.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { encodeReadReceipt, encodeText } from "@xmtp/node-sdk";
+import { encodeText } from "@xmtp/node-sdk";
 import type { SignetError } from "@xmtp/signet-schemas";
 import {
   InternalError,
@@ -106,7 +106,7 @@ function isReplyContent(content: unknown): content is {
 
 function isReactionContent(content: unknown): content is {
   reference: string;
-  referenceInboxId: string;
+  referenceInboxId?: string;
   action: "added" | "removed";
   content: string;
   schema: "unicode" | "shortcode" | "custom";
@@ -120,7 +120,8 @@ function isReactionContent(content: unknown): content is {
   const schema = record["schema"];
   return (
     typeof record["reference"] === "string" &&
-    typeof record["referenceInboxId"] === "string" &&
+    (record["referenceInboxId"] === undefined ||
+      typeof record["referenceInboxId"] === "string") &&
     typeof record["content"] === "string" &&
     (action === "added" || action === "removed") &&
     (schema === "unicode" || schema === "shortcode" || schema === "custom")
@@ -208,17 +209,10 @@ export function createSdkClient(options: SdkClientOptions): XmtpClient {
               ),
             );
           }
-          if (typeof group.sendReply !== "function") {
-            return Result.err(
-              InternalError.create("SDK group does not support reply content", {
-                groupId,
-              }),
-            );
-          }
 
           return wrapSdkCall(
             async () =>
-              group.sendReply!({
+              group.sendReply({
                 reference: content.reference,
                 ...(content.referenceInboxId
                   ? { referenceInboxId: content.referenceInboxId }
@@ -237,31 +231,13 @@ export function createSdkClient(options: SdkClientOptions): XmtpClient {
             return Result.err(
               ValidationError.create(
                 "content",
-                "Reaction messages require reference, referenceInboxId, action, content, and schema fields",
+                "Reaction messages require reference, action, content, and schema fields",
               ),
             );
           }
 
           return wrapSdkCall(
-            async () =>
-              group.send({
-                type: {
-                  authorityId: "xmtp.org",
-                  typeId: "reaction",
-                  versionMajor: 1,
-                  versionMinor: 0,
-                },
-                parameters: {},
-                content: new TextEncoder().encode(
-                  JSON.stringify({
-                    action: content.action,
-                    reference: content.reference,
-                    referenceInboxId: content.referenceInboxId,
-                    schema: content.schema,
-                    content: content.content,
-                  }),
-                ),
-              }),
+            async () => group.sendReaction(content),
             "sendMessage",
           );
         }
@@ -271,7 +247,7 @@ export function createSdkClient(options: SdkClientOptions): XmtpClient {
           contentType === "xmtp.org/readReceipt:1.0"
         ) {
           return wrapSdkCall(
-            async () => group.send(encodeReadReceipt({})),
+            async () => group.sendReadReceipt(),
             "sendMessage",
           );
         }

--- a/packages/core/src/sdk/sdk-client.ts
+++ b/packages/core/src/sdk/sdk-client.ts
@@ -1,4 +1,5 @@
 import { Result } from "better-result";
+import { encodeReadReceipt, encodeText } from "@xmtp/node-sdk";
 import type { SignetError } from "@xmtp/signet-schemas";
 import {
   InternalError,
@@ -85,6 +86,47 @@ function resolveTextContent(content: unknown): string {
   return JSON.stringify(content);
 }
 
+function isReplyContent(content: unknown): content is {
+  reference: string;
+  text: string;
+  referenceInboxId?: string;
+} {
+  if (typeof content !== "object" || content === null) {
+    return false;
+  }
+
+  const record = content as Record<string, unknown>;
+  return (
+    typeof record["reference"] === "string" &&
+    typeof record["text"] === "string" &&
+    (record["referenceInboxId"] === undefined ||
+      typeof record["referenceInboxId"] === "string")
+  );
+}
+
+function isReactionContent(content: unknown): content is {
+  reference: string;
+  referenceInboxId: string;
+  action: "added" | "removed";
+  content: string;
+  schema: "unicode" | "shortcode" | "custom";
+} {
+  if (typeof content !== "object" || content === null) {
+    return false;
+  }
+
+  const record = content as Record<string, unknown>;
+  const action = record["action"];
+  const schema = record["schema"];
+  return (
+    typeof record["reference"] === "string" &&
+    typeof record["referenceInboxId"] === "string" &&
+    typeof record["content"] === "string" &&
+    (action === "added" || action === "removed") &&
+    (schema === "unicode" || schema === "shortcode" || schema === "custom")
+  );
+}
+
 /** Map our consent entity types to SDK enum string equivalents. */
 function toSdkConsentEntityType(
   entityType: ConsentEntityType,
@@ -156,6 +198,84 @@ export function createSdkClient(options: SdkClientOptions): XmtpClient {
         ) {
           return wrapSdkCall(async () => group.send(content), "sendMessage");
         }
+
+        if (contentType === "reply" || contentType === "xmtp.org/reply:1.0") {
+          if (!isReplyContent(content)) {
+            return Result.err(
+              ValidationError.create(
+                "content",
+                "Reply messages require text and reference fields",
+              ),
+            );
+          }
+          if (typeof group.sendReply !== "function") {
+            return Result.err(
+              InternalError.create("SDK group does not support reply content", {
+                groupId,
+              }),
+            );
+          }
+
+          return wrapSdkCall(
+            async () =>
+              group.sendReply!({
+                reference: content.reference,
+                ...(content.referenceInboxId
+                  ? { referenceInboxId: content.referenceInboxId }
+                  : {}),
+                content: encodeText(content.text),
+              }),
+            "sendMessage",
+          );
+        }
+
+        if (
+          contentType === "reaction" ||
+          contentType === "xmtp.org/reaction:1.0"
+        ) {
+          if (!isReactionContent(content)) {
+            return Result.err(
+              ValidationError.create(
+                "content",
+                "Reaction messages require reference, referenceInboxId, action, content, and schema fields",
+              ),
+            );
+          }
+
+          return wrapSdkCall(
+            async () =>
+              group.send({
+                type: {
+                  authorityId: "xmtp.org",
+                  typeId: "reaction",
+                  versionMajor: 1,
+                  versionMinor: 0,
+                },
+                parameters: {},
+                content: new TextEncoder().encode(
+                  JSON.stringify({
+                    action: content.action,
+                    reference: content.reference,
+                    referenceInboxId: content.referenceInboxId,
+                    schema: content.schema,
+                    content: content.content,
+                  }),
+                ),
+              }),
+            "sendMessage",
+          );
+        }
+
+        if (
+          contentType === "readReceipt" ||
+          contentType === "xmtp.org/readReceipt:1.0"
+        ) {
+          return wrapSdkCall(
+            async () => group.send(encodeReadReceipt({})),
+            "sendMessage",
+          );
+        }
+
         // Parse "authority/type:major.minor" format
         const slashIdx = contentType.indexOf("/");
         const colonIdx = contentType.indexOf(":");

--- a/packages/core/src/sdk/sdk-types.ts
+++ b/packages/core/src/sdk/sdk-types.ts
@@ -63,7 +63,18 @@ export interface SdkGroupShape {
   sync(): Promise<void>;
   sendText(text: string): Promise<string>;
   send(encoded: unknown): Promise<string>;
-  sendReply?(
+  sendReaction(
+    reaction: {
+      reference: string;
+      referenceInboxId?: string;
+      action: "added" | "removed";
+      content: string;
+      schema: "unicode" | "shortcode" | "custom";
+    },
+    isOptimistic?: boolean,
+  ): Promise<string>;
+  sendReadReceipt(isOptimistic?: boolean): Promise<string>;
+  sendReply(
     reply: {
       reference: string;
       referenceInboxId?: string;

--- a/packages/core/src/sdk/sdk-types.ts
+++ b/packages/core/src/sdk/sdk-types.ts
@@ -63,6 +63,14 @@ export interface SdkGroupShape {
   sync(): Promise<void>;
   sendText(text: string): Promise<string>;
   send(encoded: unknown): Promise<string>;
+  sendReply?(
+    reply: {
+      reference: string;
+      referenceInboxId?: string;
+      content: unknown;
+    },
+    isOptimistic?: boolean,
+  ): Promise<string>;
   addMembers(inboxIds: string[]): Promise<void>;
   removeMembers(inboxIds: string[]): Promise<void>;
   updateName(name: string): Promise<void>;


### PR DESCRIPTION
## Summary
Fix reply, reaction, and read-receipt message flows so the CLI emits the parameter payloads the SDK layer actually expects.

## What Changed
- corrected reply, react, and read action encoding in the core message flow
- tightened SDK client typing around message parameter handling
- added targeted regression coverage for the missing-parameters failure mode

## Why
The smoke pass found that `xs msg reply`, `xs msg react`, and `xs msg read` all failed at runtime with `Missing field parameters`. This branch repairs that action encoding path so those message operations work end to end.

## How To Test
- `bun test packages/core/src/__tests__/message-actions.test.ts`
- `bun test packages/core/src/__tests__/sdk-client.test.ts`
- `bun run test`

Closes #357
