### PR TITLE
fix: preserve chat names during group creation

### DIFF
--- a/packages/core/src/__tests__/conversation-actions.test.ts
+++ b/packages/core/src/__tests__/conversation-actions.test.ts
@@ -81,7 +81,7 @@ function createMockClient(options?: {
       if (createdGroup) return Result.ok(createdGroup);
       return Result.ok({
         groupId: "new-group-1",
-        name: opts?.name ?? "",
+        name: opts?.groupName ?? opts?.name ?? "",
         description: "",
         imageUrl: undefined,
         memberInboxIds: [inboxId, ...memberInboxIds],

--- a/packages/core/src/__tests__/fixtures.ts
+++ b/packages/core/src/__tests__/fixtures.ts
@@ -75,7 +75,7 @@ export function createMockXmtpClient(options?: {
     createGroup: async (memberInboxIds, opts) =>
       Result.ok({
         groupId: `group-${Date.now()}`,
-        name: opts?.name ?? "",
+        name: opts?.groupName ?? opts?.name ?? "",
         description: "",
         imageUrl: undefined,
         memberInboxIds: [inboxId, ...memberInboxIds],

--- a/packages/core/src/__tests__/sdk-client.test.ts
+++ b/packages/core/src/__tests__/sdk-client.test.ts
@@ -330,6 +330,32 @@ describe("createSdkClient", () => {
     });
   });
 
+  describe("createGroup", () => {
+    test("maps name to groupName for the SDK create call", async () => {
+      let capturedOptions: { name?: string; groupName?: string } | undefined;
+      const createdGroup = createMockGroup({
+        id: "g-created",
+        name: "Named Group",
+      });
+      const native = createMockSdkNativeClient();
+      native.conversations.createGroup = async (_inboxIds, options) => {
+        capturedOptions = options;
+        return createdGroup;
+      };
+      const client = createSdkClient({ client: native, syncTimeoutMs: 5000 });
+
+      const result = await client.createGroup(["inbox-a", "inbox-b"], {
+        name: "Named Group",
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        expect(result.value.name).toBe("Named Group");
+      }
+      expect(capturedOptions).toEqual({ groupName: "Named Group" });
+    });
+  });
+
   describe("addMembers", () => {
     test("delegates to group.addMembers", async () => {
       let addedIds: string[] = [];

--- a/packages/core/src/__tests__/sdk-fixtures.ts
+++ b/packages/core/src/__tests__/sdk-fixtures.ts
@@ -143,13 +143,10 @@ export function createMockSdkNativeClient(
       listGroups: () => groups,
       createDm: async (_inboxId: string) =>
         createMockGroup({ id: `dm-${Date.now()}` }),
-      createGroup: async (
-        inboxIds: string[],
-        opts?: { name?: string; groupName?: string },
-      ) =>
+      createGroup: async (inboxIds: string[], opts?: { groupName?: string }) =>
         createMockGroup({
           id: `group-${Date.now()}`,
-          name: opts?.groupName ?? opts?.name,
+          name: opts?.groupName,
         }),
       sync: async () => {},
       syncAll: async () => ({ numConversations: groups.length }),

--- a/packages/core/src/__tests__/sdk-fixtures.ts
+++ b/packages/core/src/__tests__/sdk-fixtures.ts
@@ -143,8 +143,14 @@ export function createMockSdkNativeClient(
       listGroups: () => groups,
       createDm: async (_inboxId: string) =>
         createMockGroup({ id: `dm-${Date.now()}` }),
-      createGroup: async (inboxIds: string[], opts?: { name?: string }) =>
-        createMockGroup({ id: `group-${Date.now()}`, name: opts?.name }),
+      createGroup: async (
+        inboxIds: string[],
+        opts?: { name?: string; groupName?: string },
+      ) =>
+        createMockGroup({
+          id: `group-${Date.now()}`,
+          name: opts?.groupName ?? opts?.name,
+        }),
       sync: async () => {},
       syncAll: async () => ({ numConversations: groups.length }),
       stream: async () => createMockAsyncStreamProxy<SdkGroupShape>([]),

--- a/packages/core/src/sdk/sdk-client.ts
+++ b/packages/core/src/sdk/sdk-client.ts
@@ -386,10 +386,14 @@ export function createSdkClient(options: SdkClientOptions): XmtpClient {
 
     async createGroup(
       memberInboxIds: readonly string[],
-      options?: { name?: string },
+      options?: { name?: string; groupName?: string },
     ): Promise<Result<XmtpGroupInfo, SignetError>> {
       return wrapSdkCall(async () => {
-        const opts = options?.name !== undefined ? { name: options.name } : {};
+        const requestedGroupName = options?.groupName ?? options?.name;
+        const opts =
+          requestedGroupName !== undefined
+            ? { groupName: requestedGroupName }
+            : {};
         const group = await client.conversations.createGroup(
           [...memberInboxIds],
           opts,

--- a/packages/core/src/sdk/sdk-types.ts
+++ b/packages/core/src/sdk/sdk-types.ts
@@ -125,7 +125,7 @@ export interface SdkConversationsShape {
   createDm(inboxId: string): Promise<SdkGroupShape>;
   createGroup(
     inboxIds: string[],
-    options?: { name?: string },
+    options?: { name?: string; groupName?: string },
   ): Promise<SdkGroupShape>;
   sync(): Promise<void>;
   syncAll(consentStates?: unknown[]): Promise<{ numConversations: number }>;

--- a/packages/core/src/sdk/sdk-types.ts
+++ b/packages/core/src/sdk/sdk-types.ts
@@ -1,10 +1,15 @@
 /**
- * Structural types mirroring @xmtp/node-sdk v6.0.0 shapes.
+ * Structural types mirroring @xmtp/node-sdk v6.0.0 (which re-exports
+ * core option/record shapes from @xmtp/node-bindings v1.10.0).
  *
  * These allow the signet to interact with SDK objects without importing
  * the real SDK, which requires native bindings. Both production code
  * (for structural typing against real SDK objects) and tests (for mock
  * construction) use these interfaces.
+ *
+ * When bumping @xmtp/node-sdk, re-verify these shapes against the
+ * installed bindings (e.g. CreateGroupOptions.groupName lives in
+ * node_modules/@xmtp/node-bindings/dist/index.d.ts).
  */
 
 /** Mirrors @xmtp/node-sdk Identifier */

--- a/packages/core/src/sdk/sdk-types.ts
+++ b/packages/core/src/sdk/sdk-types.ts
@@ -125,7 +125,7 @@ export interface SdkConversationsShape {
   createDm(inboxId: string): Promise<SdkGroupShape>;
   createGroup(
     inboxIds: string[],
-    options?: { name?: string; groupName?: string },
+    options?: { groupName?: string },
   ): Promise<SdkGroupShape>;
   sync(): Promise<void>;
   syncAll(consentStates?: unknown[]): Promise<{ numConversations: number }>;

--- a/packages/core/src/xmtp-client-factory.ts
+++ b/packages/core/src/xmtp-client-factory.ts
@@ -43,7 +43,7 @@ export interface XmtpClient {
   /** Create a new group conversation with the given members. */
   createGroup(
     memberInboxIds: readonly string[],
-    options?: { name?: string },
+    options?: { name?: string; groupName?: string },
   ): Promise<Result<XmtpGroupInfo, SignetError>>;
 
   /** Add members to a group by inbox ID. */

--- a/packages/integration/src/fixtures/mock-xmtp-client.ts
+++ b/packages/integration/src/fixtures/mock-xmtp-client.ts
@@ -177,7 +177,7 @@ export function createMockXmtpClient(options?: MockXmtpClientOptions): {
       const groupId = `group_${crypto.randomUUID()}`;
       const info: XmtpGroupInfo = {
         groupId,
-        name: opts?.name ?? "",
+        name: opts?.groupName ?? opts?.name ?? "",
         description: "",
         imageUrl: undefined,
         memberInboxIds: [inboxId, ...memberInboxIds],


### PR DESCRIPTION
## Summary
Preserve the initial chat name supplied at group creation time.

## What Changed
- threaded the requested chat name through the group creation path instead of dropping it during setup
- updated SDK-facing types and fixtures to keep the creation payload honest
- refreshed integration and factory mocks to match the corrected name behavior

## Why
The smoke tracer confirmed that `xs chat create --name ...` created a working conversation but lost the initial name in the returned and listed metadata. This branch fixes that metadata fidelity gap.

## How To Test
- `bun test packages/core/src/__tests__/conversation-actions.test.ts`
- `bun test packages/core/src/__tests__/sdk-client.test.ts`
- `bun run test`

Closes #358
