### PR TITLE
fix: honor init data dir env overrides

### DIFF
--- a/packages/cli/src/__tests__/smoke.test.ts
+++ b/packages/cli/src/__tests__/smoke.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { existsSync } from "node:fs";
@@ -72,17 +72,22 @@ async function makeWorkspace(): Promise<{
 
 async function runCli(
   args: string[],
+  envOverrides?: Record<string, string>,
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-  const process = Bun.spawn(["bun", "packages/cli/src/bin.ts", ...args], {
+  const proc = Bun.spawn(["bun", "packages/cli/src/bin.ts", ...args], {
     cwd: repoRoot,
     stdout: "pipe",
     stderr: "pipe",
+    env: {
+      ...process.env,
+      ...envOverrides,
+    },
   });
 
   const [exitCode, stdout, stderr] = await Promise.all([
-    process.exited,
-    new Response(process.stdout).text(),
-    new Response(process.stderr).text(),
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
   ]);
 
   return { exitCode, stdout, stderr };
@@ -175,6 +180,33 @@ async function nextMessage(ws: WebSocket, timeoutMs = 5000): Promise<unknown> {
 }
 
 describe("Phase 2B smoke tests", () => {
+  test("init honors XMTP_SIGNET_DATA_DIR for the bootstrap session without baking it into config", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "xmtp-signet-init-env-"));
+    tempDirs.push(dir);
+
+    const configPath = join(dir, "signet.toml");
+    const dataDir = join(dir, "bounded-data");
+
+    const result = await runCli(["init", "--config", configPath, "--json"], {
+      XMTP_SIGNET_DATA_DIR: dataDir,
+    });
+
+    expect(result.exitCode).toBe(0);
+
+    const parsed = JSON.parse(result.stdout) as {
+      initialized: boolean;
+      dataDir: string;
+      configPath: string;
+    };
+    expect(parsed.initialized).toBe(true);
+    expect(parsed.dataDir).toBe(dataDir);
+    expect(parsed.configPath).toBe(configPath);
+    expect(existsSync(dataDir)).toBe(true);
+
+    const writtenConfig = await readFile(configPath, "utf8");
+    expect(writtenConfig).not.toContain(dataDir);
+  });
+
   test("start boots from an empty directory without creating admin credentials", async () => {
     const workspace = await makeWorkspace();
     const daemon = startDaemon([

--- a/packages/cli/src/__tests__/smoke.test.ts
+++ b/packages/cli/src/__tests__/smoke.test.ts
@@ -187,9 +187,12 @@ describe("Phase 2B smoke tests", () => {
     const configPath = join(dir, "signet.toml");
     const dataDir = join(dir, "bounded-data");
 
-    const result = await runCli(["init", "--config", configPath, "--json"], {
-      XMTP_SIGNET_DATA_DIR: dataDir,
-    });
+    const result = await runCli(
+      ["init", "--config", configPath, "--env", "local", "--json"],
+      {
+        XMTP_SIGNET_DATA_DIR: dataDir,
+      },
+    );
 
     expect(result.exitCode).toBe(0);
 

--- a/packages/cli/src/commands/identity.ts
+++ b/packages/cli/src/commands/identity.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync } from "node:fs";
 import { createKeyManager } from "@xmtp/signet-keys";
 import type { KeyManager } from "@xmtp/signet-keys";
 import { loadConfig, defaultConfigPath } from "../config/loader.js";
+import type { CliConfig } from "../config/schema.js";
 import {
   applyInitPreset,
   describeInitPreset,
@@ -150,7 +151,8 @@ export function createIdentityInitCommand(): Command {
       if (configWritten) {
         await writeConfig(configPath, config);
       }
-      const paths = resolvePaths(config);
+      const runtimeConfig = applyInitRuntimeEnvOverrides(config);
+      const paths = resolvePaths(runtimeConfig);
 
       mkdirSync(paths.dataDir, { recursive: true });
 
@@ -265,6 +267,25 @@ function resolveEnv(
     process.exit(1);
   }
   return raw as XmtpEnvLiteral;
+}
+
+/**
+ * Applies runtime-only init overrides that should affect the bootstrap
+ * session without being written back into config.toml.
+ */
+function applyInitRuntimeEnvOverrides(config: CliConfig): CliConfig {
+  const dataDir = process.env["XMTP_SIGNET_DATA_DIR"];
+  if (dataDir === undefined || dataDir.length === 0) {
+    return config;
+  }
+
+  return {
+    ...config,
+    signet: {
+      ...config.signet,
+      dataDir,
+    },
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
Make `xs init` honor `XMTP_SIGNET_DATA_DIR` so bounded setups and tracer environments land in the requested data directory.

## What Changed
- updated the init identity command to respect the environment override when deriving the signet data dir
- added smoke coverage for the env-driven init path

## Why
The tracer bullet showed that `xs init` still defaulted to the global data dir unless `signet.dataDir` was already present in config. That made isolated test setups harder than they should be.

## How To Test
- `bun test packages/cli/src/__tests__/smoke.test.ts --test-name-pattern 'XMTP_SIGNET_DATA_DIR'`
- `bun run test`

Closes #359
