### PR TITLE
fix: daemonize start and report bound ws port

### DIFF
--- a/packages/cli/src/__tests__/background-start.test.ts
+++ b/packages/cli/src/__tests__/background-start.test.ts
@@ -77,4 +77,65 @@ describe("daemonizeCurrentProcess", () => {
     expect(result.error.message).toContain("Validation failed on 'config'");
     expect(child.killCalls).toBe(0);
   });
+
+  test("preserves the child stderr message verbatim for not_found exits", async () => {
+    const child = createFakeChild();
+    const resultPromise = daemonizeCurrentProcess({
+      timeoutMs: 100,
+      spawnProcess: (() => child) as never,
+    });
+
+    const stderrMessage = "Config file not found at /tmp/config.toml";
+    child.stderr.write(JSON.stringify({ message: stderrMessage }));
+    // Exit code 2 maps to the `not_found` category via ERROR_CATEGORY_META.
+    child.exitCode = 2;
+    child.emit("exit", 2);
+
+    const result = await resultPromise;
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+
+    expect(result.error.category).toBe("not_found");
+    // The child's actual diagnostic must be the message verbatim — no
+    // double "not found" wrapping or quoting from NotFoundError.create.
+    expect(result.error.message).toBe(stderrMessage);
+    expect(result.error.message).not.toContain("'");
+    const context = (result.error as { context?: Record<string, unknown> })
+      .context;
+    expect(context).toBeDefined();
+    expect(context?.exitCode).toBe(2);
+    expect(context?.stderr).toContain(stderrMessage);
+  });
+
+  test("preserves the child stderr message verbatim for timeout exits", async () => {
+    const child = createFakeChild();
+    const resultPromise = daemonizeCurrentProcess({
+      timeoutMs: 100,
+      spawnProcess: (() => child) as never,
+    });
+
+    const stderrMessage =
+      "XMTP network handshake exceeded 30000ms while connecting";
+    child.stderr.write(JSON.stringify({ message: stderrMessage }));
+    // Exit code 5 maps to the `timeout` category via ERROR_CATEGORY_META.
+    child.exitCode = 5;
+    child.emit("exit", 5);
+
+    const result = await resultPromise;
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+
+    expect(result.error.category).toBe("timeout");
+    // The child's actual diagnostic must survive verbatim — not be replaced
+    // by the synthetic "Operation 'daemon.start' timed out after 15000ms".
+    expect(result.error.message).toBe(stderrMessage);
+    expect(result.error.message).not.toContain("15000ms");
+    const context = (result.error as { context?: Record<string, unknown> })
+      .context;
+    expect(context).toBeDefined();
+    expect(context?.exitCode).toBe(5);
+    expect(context?.stderr).toContain(stderrMessage);
+    // No real timeout was parsed from the child — sentinel signals that.
+    expect(context?.timeoutMs).toBe(0);
+  });
 });

--- a/packages/cli/src/__tests__/background-start.test.ts
+++ b/packages/cli/src/__tests__/background-start.test.ts
@@ -150,6 +150,37 @@ describe("daemonizeCurrentProcess", () => {
     expect(context?.stderr).toContain(stderrMessage);
   });
 
+  test("preserves the child stderr message verbatim for network exits", async () => {
+    const child = createFakeChild();
+    const resultPromise = daemonizeCurrentProcess({
+      timeoutMs: 100,
+      spawnProcess: (() => child) as never,
+    });
+
+    const stderrMessage = "Network error reaching 'xmtp': connection refused";
+    child.stderr.write(JSON.stringify({ message: stderrMessage }));
+    // Exit code 6 maps to the `network` category via ERROR_CATEGORY_META.
+    child.exitCode = 6;
+    child.emit("exit", 6);
+
+    const result = await resultPromise;
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+
+    expect(result.error.category).toBe("network");
+    // The child's already-formatted diagnostic must survive verbatim — not
+    // be double-wrapped as
+    // `Network error reaching 'daemon.start': Network error reaching 'xmtp': ...`.
+    expect(result.error.message).toBe(stderrMessage);
+    expect(result.error.message).not.toContain("daemon.start");
+    const context = (result.error as { context?: Record<string, unknown> })
+      .context;
+    expect(context).toBeDefined();
+    expect(context?.endpoint).toBe("daemon.start");
+    expect(context?.exitCode).toBe(6);
+    expect(context?.stderr).toContain(stderrMessage);
+  });
+
   test("preserves the child stderr message verbatim for timeout exits", async () => {
     const child = createFakeChild();
     const resultPromise = daemonizeCurrentProcess({

--- a/packages/cli/src/__tests__/background-start.test.ts
+++ b/packages/cli/src/__tests__/background-start.test.ts
@@ -1,0 +1,80 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { describe, expect, test } from "bun:test";
+import { daemonizeCurrentProcess } from "../daemon/background-start.js";
+
+function createFakeChild() {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const emitter = new EventEmitter() as EventEmitter & {
+    stdout: PassThrough;
+    stderr: PassThrough;
+    pid: number;
+    exitCode: number | null;
+    signalCode: NodeJS.Signals | null;
+    unrefCalls: number;
+    killCalls: number;
+    unref(): void;
+    kill(): boolean;
+  };
+
+  emitter.stdout = stdout;
+  emitter.stderr = stderr;
+  emitter.pid = 4321;
+  emitter.exitCode = null;
+  emitter.signalCode = null;
+  emitter.unrefCalls = 0;
+  emitter.killCalls = 0;
+  emitter.unref = () => {
+    emitter.unrefCalls += 1;
+  };
+  emitter.kill = () => {
+    emitter.killCalls += 1;
+    return true;
+  };
+
+  return emitter;
+}
+
+describe("daemonizeCurrentProcess", () => {
+  test("kills the detached child when startup times out", async () => {
+    const child = createFakeChild();
+
+    const result = await daemonizeCurrentProcess({
+      timeoutMs: 10,
+      spawnProcess: (() => child) as never,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+
+    expect(result.error.category).toBe("timeout");
+    expect(child.unrefCalls).toBe(1);
+    expect(child.killCalls).toBe(1);
+  });
+
+  test("preserves the child failure category when startup exits early", async () => {
+    const child = createFakeChild();
+    const resultPromise = daemonizeCurrentProcess({
+      timeoutMs: 100,
+      spawnProcess: (() => child) as never,
+    });
+
+    child.stderr.write(
+      JSON.stringify({
+        error: "Config load failed",
+        message: "Validation failed on 'config': missing required field",
+      }),
+    );
+    child.exitCode = 1;
+    child.emit("exit", 1);
+
+    const result = await resultPromise;
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+
+    expect(result.error.category).toBe("validation");
+    expect(result.error.message).toContain("Validation failed on 'config'");
+    expect(child.killCalls).toBe(0);
+  });
+});

--- a/packages/cli/src/__tests__/background-start.test.ts
+++ b/packages/cli/src/__tests__/background-start.test.ts
@@ -53,19 +53,22 @@ describe("daemonizeCurrentProcess", () => {
     expect(child.killCalls).toBe(1);
   });
 
-  test("preserves the child failure category when startup exits early", async () => {
+  test("preserves the child stderr message verbatim for validation exits", async () => {
     const child = createFakeChild();
     const resultPromise = daemonizeCurrentProcess({
       timeoutMs: 100,
       spawnProcess: (() => child) as never,
     });
 
+    const stderrMessage =
+      "Validation failed on 'config': missing required field";
     child.stderr.write(
       JSON.stringify({
         error: "Config load failed",
-        message: "Validation failed on 'config': missing required field",
+        message: stderrMessage,
       }),
     );
+    // Exit code 1 maps to the `validation` category via ERROR_CATEGORY_META.
     child.exitCode = 1;
     child.emit("exit", 1);
 
@@ -74,8 +77,48 @@ describe("daemonizeCurrentProcess", () => {
     if (!result.isErr()) return;
 
     expect(result.error.category).toBe("validation");
-    expect(result.error.message).toContain("Validation failed on 'config'");
+    // The child's already-formatted diagnostic must survive verbatim — not
+    // be double-wrapped as
+    // `Validation failed on 'daemon.start': Validation failed on 'config': ...`.
+    expect(result.error.message).toBe(stderrMessage);
+    expect(result.error.message).not.toContain("daemon.start");
+    const context = (result.error as { context?: Record<string, unknown> })
+      .context;
+    expect(context).toBeDefined();
+    expect(context?.field).toBe("daemon.start");
+    expect(context?.reason).toBe(stderrMessage);
+    expect(context?.exitCode).toBe(1);
+    expect(context?.stderr).toContain(stderrMessage);
     expect(child.killCalls).toBe(0);
+  });
+
+  test("preserves the child stderr message and context for cancelled exits", async () => {
+    const child = createFakeChild();
+    const resultPromise = daemonizeCurrentProcess({
+      timeoutMs: 100,
+      spawnProcess: (() => child) as never,
+    });
+
+    const stderrMessage = "Daemon startup cancelled by SIGINT";
+    child.stderr.write(JSON.stringify({ message: stderrMessage }));
+    // Exit code 130 maps to the `cancelled` category via ERROR_CATEGORY_META.
+    child.exitCode = 130;
+    child.emit("exit", 130);
+
+    const result = await resultPromise;
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+
+    expect(result.error.category).toBe("cancelled");
+    expect(result.error.message).toBe(stderrMessage);
+    // CancelledError.create() drops context — the direct constructor must
+    // preserve the parsed exitCode/stderr/stdout extras like every other
+    // branch in errorFromChildExit.
+    const context = (result.error as { context?: Record<string, unknown> })
+      .context;
+    expect(context).toBeDefined();
+    expect(context?.exitCode).toBe(130);
+    expect(context?.stderr).toContain(stderrMessage);
   });
 
   test("preserves the child stderr message verbatim for not_found exits", async () => {

--- a/packages/cli/src/__tests__/child-log.test.ts
+++ b/packages/cli/src/__tests__/child-log.test.ts
@@ -1,0 +1,65 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { redirectChildStdioToLogFile } from "../daemon/child-log.js";
+
+describe("redirectChildStdioToLogFile", () => {
+  let tmp: string;
+  let originalStdoutWrite: typeof process.stdout.write;
+  let originalStderrWrite: typeof process.stderr.write;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "xs-child-log-"));
+    originalStdoutWrite = process.stdout.write.bind(process.stdout);
+    originalStderrWrite = process.stderr.write.bind(process.stderr);
+  });
+
+  afterEach(() => {
+    // Restore so a single broken test does not corrupt the rest of the suite.
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("routes process.stdout.write to a log file inside dataDir", async () => {
+    const { logFile, stream } = redirectChildStdioToLogFile(tmp);
+    expect(logFile).toBe(join(tmp, "daemon.log"));
+
+    process.stdout.write("hello stdout\n");
+    process.stderr.write("hello stderr\n");
+
+    // Restore before reading so failures inside the assertions still print.
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+
+    await new Promise<void>((resolve) => stream.end(() => resolve()));
+
+    const contents = readFileSync(logFile, "utf8");
+    expect(contents).toContain("hello stdout");
+    expect(contents).toContain("hello stderr");
+  });
+
+  test("does not crash on EPIPE errors emitted by the original streams", () => {
+    redirectChildStdioToLogFile(tmp);
+
+    // Simulating the race where the parent destroys its read end of the
+    // pipe and the original stdout stream emits an EPIPE error. Without
+    // the swallowing listener installed by the redirect helper this would
+    // become an uncaught 'error' event and crash the process.
+    expect(() => {
+      process.stdout.emit(
+        "error",
+        Object.assign(new Error("broken"), {
+          code: "EPIPE",
+        }) as NodeJS.ErrnoException,
+      );
+      process.stderr.emit(
+        "error",
+        Object.assign(new Error("broken"), {
+          code: "EPIPE",
+        }) as NodeJS.ErrnoException,
+      );
+    }).not.toThrow();
+  });
+});

--- a/packages/cli/src/__tests__/daemon-command-wiring.test.ts
+++ b/packages/cli/src/__tests__/daemon-command-wiring.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Result } from "better-result";
+import { ValidationError } from "@xmtp/signet-schemas";
 import type { SignetError } from "@xmtp/signet-schemas";
 import type { Command } from "commander";
 import type { AdminClient } from "../admin/client.js";
@@ -273,6 +274,62 @@ describe("daemon-backed CLI command wiring", () => {
     expect(exits).toEqual([0]);
     const parsed = JSON.parse(stdout.join("")) as { ws: string };
     expect(parsed.ws).toBe("ws://127.0.0.1:4242");
+  });
+
+  test("start --daemon preserves the daemonizer error category in the parent exit code", async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const exits: number[] = [];
+
+    const command = findCommand(
+      createLifecycleCommands({
+        async daemonizeCurrentProcess() {
+          return Result.err(
+            ValidationError.create("config", "missing required field"),
+          );
+        },
+        async loadConfig() {
+          throw new Error("loadConfig should not run in the parent daemonizer");
+        },
+        resolvePaths() {
+          throw new Error(
+            "resolvePaths should not run in the parent daemonizer",
+          );
+        },
+        async createSignetRuntime() {
+          throw new Error(
+            "createSignetRuntime should not run in the parent daemonizer",
+          );
+        },
+        createProductionDeps() {
+          throw new Error(
+            "createProductionDeps should not run in the parent daemonizer",
+          );
+        },
+        setupSignalHandlers() {
+          throw new Error("setupSignalHandlers should not run on failure");
+        },
+        async withDaemonClient() {
+          throw new Error("withDaemonClient should not be used in start");
+        },
+        writeStdout(message: string) {
+          stdout.push(message);
+        },
+        writeStderr(message: string) {
+          stderr.push(message);
+        },
+        exit(code: number) {
+          exits.push(code);
+        },
+      }),
+      "start",
+    );
+
+    await command.parseAsync(["node", "start", "--daemon", "--json"]);
+
+    expect(stdout).toEqual([]);
+    expect(stderr.join("")).toContain("Validation failed on 'config'");
+    expect(exits).toEqual([1]);
   });
 
   test("start reports the bound ws port from runtime status instead of the config port", async () => {

--- a/packages/cli/src/__tests__/daemon-command-wiring.test.ts
+++ b/packages/cli/src/__tests__/daemon-command-wiring.test.ts
@@ -206,4 +206,206 @@ describe("daemon-backed CLI command wiring", () => {
     expect(harness.stderr).toEqual([]);
     expect(harness.stdout.join("")).toContain("running");
   });
+
+  test("start --daemon delegates to background startup and exits after printing the startup payload", async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const exits: number[] = [];
+    let daemonizeCalls = 0;
+    let signalRegistrations = 0;
+
+    const command = findCommand(
+      createLifecycleCommands({
+        async daemonizeCurrentProcess() {
+          daemonizeCalls += 1;
+          return Result.ok({
+            status: "running",
+            pid: 4321,
+            ws: "ws://127.0.0.1:4242",
+            adminSocket: "/tmp/signet-admin.sock",
+            env: "local",
+            dataDir: "/tmp/signet-data",
+          });
+        },
+        async loadConfig() {
+          throw new Error("loadConfig should not run in the parent daemonizer");
+        },
+        resolvePaths() {
+          throw new Error(
+            "resolvePaths should not run in the parent daemonizer",
+          );
+        },
+        async createSignetRuntime() {
+          throw new Error(
+            "createSignetRuntime should not run in the parent daemonizer",
+          );
+        },
+        createProductionDeps() {
+          throw new Error(
+            "createProductionDeps should not run in the parent daemonizer",
+          );
+        },
+        setupSignalHandlers() {
+          signalRegistrations += 1;
+          return () => {};
+        },
+        async withDaemonClient() {
+          throw new Error("withDaemonClient should not be used in start");
+        },
+        writeStdout(message: string) {
+          stdout.push(message);
+        },
+        writeStderr(message: string) {
+          stderr.push(message);
+        },
+        exit(code: number) {
+          exits.push(code);
+        },
+      }),
+      "start",
+    );
+
+    await command.parseAsync(["node", "start", "--daemon", "--json"]);
+
+    expect(daemonizeCalls).toBe(1);
+    expect(signalRegistrations).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(exits).toEqual([0]);
+    const parsed = JSON.parse(stdout.join("")) as { ws: string };
+    expect(parsed.ws).toBe("ws://127.0.0.1:4242");
+  });
+
+  test("start reports the bound ws port from runtime status instead of the config port", async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    let signalRegistrations = 0;
+
+    const command = findCommand(
+      createLifecycleCommands({
+        async loadConfig() {
+          return Result.ok({
+            signet: {
+              env: "local" as const,
+              identityMode: "per-group" as const,
+              dataDir: "/tmp/config-data",
+            },
+            keys: {
+              rootKeyPolicy: "open" as const,
+              operationalKeyPolicy: "open" as const,
+              vaultKeyPolicy: "open" as const,
+            },
+            credentials: {
+              defaultTtlSeconds: 3600,
+              maxConcurrentPerOperator: 5,
+            },
+            ws: {
+              host: "127.0.0.1",
+              port: 0,
+            },
+            admin: {
+              socketPath: "/tmp/admin.sock",
+            },
+            http: {
+              enabled: false,
+              host: "127.0.0.1",
+              port: 8080,
+            },
+            logging: {
+              level: "info" as const,
+              auditLogPath: "/tmp/audit.jsonl",
+            },
+            onboarding: {
+              scheme: "convos" as const,
+            },
+            biometricGating: {
+              adminReadElevation: true,
+              agentCreation: false,
+              egressExpansion: false,
+              scopeExpansion: false,
+            },
+            defaults: {
+              profileName: undefined,
+            },
+          });
+        },
+        resolvePaths() {
+          return {
+            configFile: "/tmp/config.toml",
+            dataDir: "/tmp/config-data",
+            pidFile: "/tmp/signet.pid",
+            adminSocket: "/tmp/admin.sock",
+            auditLog: "/tmp/audit.jsonl",
+            identityKeyFile: "/tmp/vault.db",
+          };
+        },
+        async createSignetRuntime() {
+          return Result.ok({
+            state: "running" as const,
+            core: {} as never,
+            credentialManager: {} as never,
+            sealManager: {} as never,
+            keyManager: {} as never,
+            wsServer: {} as never,
+            adminServer: {} as never,
+            httpServer: null,
+            auditLog: {} as never,
+            config: {} as never,
+            paths: {} as never,
+            async start() {
+              return Result.ok(undefined);
+            },
+            async shutdown() {
+              return Result.ok(undefined);
+            },
+            async status() {
+              return {
+                state: "running" as const,
+                coreState: "ready" as const,
+                pid: 2468,
+                uptime: 1,
+                activeCredentials: 0,
+                activeConnections: 0,
+                onboardingScheme: "convos" as const,
+                xmtpEnv: "local" as const,
+                identityMode: "per-group" as const,
+                wsPort: 4242,
+                version: "0.1.0",
+              };
+            },
+          });
+        },
+        createProductionDeps() {
+          return {} as never;
+        },
+        async daemonizeCurrentProcess() {
+          throw new Error("daemonizeCurrentProcess should not run");
+        },
+        setupSignalHandlers() {
+          signalRegistrations += 1;
+          return () => {};
+        },
+        async withDaemonClient() {
+          throw new Error("withDaemonClient should not be used in start");
+        },
+        writeStdout(message: string) {
+          stdout.push(message);
+        },
+        writeStderr(message: string) {
+          stderr.push(message);
+        },
+        exit(code: number) {
+          throw new Error(`unexpected exit ${String(code)}`);
+        },
+      }),
+      "start",
+    );
+
+    await command.parseAsync(["node", "start", "--json"]);
+
+    expect(signalRegistrations).toBe(1);
+    expect(stderr).toEqual([]);
+    const parsed = JSON.parse(stdout.join("")) as { ws: string };
+    expect(parsed.ws).toBe("ws://127.0.0.1:4242");
+    expect(parsed.ws).not.toBe("ws://127.0.0.1:0");
+  });
 });

--- a/packages/cli/src/__tests__/smoke.test.ts
+++ b/packages/cli/src/__tests__/smoke.test.ts
@@ -7,6 +7,7 @@ import { existsSync } from "node:fs";
 const repoRoot = resolve(import.meta.dir, "../../../..");
 const tempDirs: string[] = [];
 const backgroundProcesses: Bun.Subprocess[] = [];
+const detachedPids: number[] = [];
 
 afterEach(async () => {
   await Promise.all(
@@ -19,6 +20,12 @@ afterEach(async () => {
       } catch {}
     }),
   );
+
+  for (const pid of detachedPids.splice(0)) {
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {}
+  }
 
   await Promise.all(
     tempDirs.splice(0).map((dir) =>
@@ -235,6 +242,55 @@ describe("Phase 2B smoke tests", () => {
 
     daemon.kill("SIGTERM");
     expect(await daemon.exited).toBe(0);
+  });
+
+  test("daemon start --daemon --json exits promptly and reports the bound ws endpoint", async () => {
+    const workspace = await makeWorkspace();
+
+    const initResult = await runCli([
+      "init",
+      "--config",
+      workspace.configPath,
+      "--json",
+    ]);
+    expect(initResult.exitCode).toBe(0);
+
+    const startResult = await runCli([
+      "daemon",
+      "start",
+      "--daemon",
+      "--config",
+      workspace.configPath,
+      "--json",
+    ]);
+    expect(startResult.exitCode).toBe(0);
+
+    const started = JSON.parse(startResult.stdout) as {
+      status: string;
+      pid: number;
+      ws: string;
+    };
+    detachedPids.push(started.pid);
+
+    expect(started.status).toBe("running");
+    expect(started.ws).toMatch(/^ws:\/\/127\.0\.0\.1:\d+$/);
+    expect(started.ws).not.toBe("ws://127.0.0.1:0");
+
+    await waitFor(async () => existsSync(workspace.adminSocket));
+
+    const stopResult = await runCli([
+      "daemon",
+      "stop",
+      "--config",
+      workspace.configPath,
+      "--json",
+    ]);
+    expect(stopResult.exitCode).toBe(0);
+
+    const pidIndex = detachedPids.indexOf(started.pid);
+    if (pidIndex >= 0) {
+      detachedPids.splice(pidIndex, 1);
+    }
   });
 
   test("credentialed daemon flow issues a credential, authenticates over WS, enforces scope/auth checks, binds heartbeat to the authenticated credential, and stops cleanly", async () => {

--- a/packages/cli/src/commands/lifecycle.ts
+++ b/packages/cli/src/commands/lifecycle.ts
@@ -12,6 +12,7 @@ import { createSignetRuntime } from "../runtime.js";
 import { createProductionDeps } from "../start.js";
 import { setupSignalHandlers } from "../daemon/signals.js";
 import { daemonizeCurrentProcess } from "../daemon/background-start.js";
+import { redirectChildStdioToLogFile } from "../daemon/child-log.js";
 import {
   createWithDaemonClient,
   type WithDaemonClient,
@@ -223,6 +224,17 @@ export function createLifecycleCommands(
           { json },
         ),
       );
+
+      if (daemonChild) {
+        // The parent (`daemonizeCurrentProcess`) destroys its read end of
+        // our stdout/stderr pipes as soon as it parses the startup JSON
+        // line above. Any subsequent write from this detached daemon —
+        // most notably `console.error` from `daemon/signals.ts` during a
+        // SIGTERM/SIGINT shutdown — would EPIPE and silently crash the
+        // process. Redirect both streams to a log file in the data dir
+        // before that race can happen.
+        redirectChildStdioToLogFile(paths.dataDir);
+      }
     });
 
   const stop = new Command("stop")

--- a/packages/cli/src/commands/lifecycle.ts
+++ b/packages/cli/src/commands/lifecycle.ts
@@ -11,6 +11,7 @@ import { exitCodeFromCategory } from "../output/exit-codes.js";
 import { createSignetRuntime } from "../runtime.js";
 import { createProductionDeps } from "../start.js";
 import { setupSignalHandlers } from "../daemon/signals.js";
+import { daemonizeCurrentProcess } from "../daemon/background-start.js";
 import {
   createWithDaemonClient,
   type WithDaemonClient,
@@ -22,6 +23,7 @@ export interface SignetLifecycleCommandDeps {
   readonly resolvePaths: typeof resolvePaths;
   readonly createSignetRuntime: typeof createSignetRuntime;
   readonly createProductionDeps: typeof createProductionDeps;
+  readonly daemonizeCurrentProcess: typeof daemonizeCurrentProcess;
   readonly setupSignalHandlers: typeof setupSignalHandlers;
   readonly withDaemonClient: WithDaemonClient;
   readonly writeStdout: (message: string) => void;
@@ -34,6 +36,7 @@ const defaultDeps: SignetLifecycleCommandDeps = {
   resolvePaths,
   createSignetRuntime,
   createProductionDeps,
+  daemonizeCurrentProcess,
   setupSignalHandlers,
   withDaemonClient: createWithDaemonClient(),
   writeStdout(message) {
@@ -68,6 +71,7 @@ export function createLifecycleCommands(
     .option("--json", "JSON output")
     .action(async (options) => {
       const json = Boolean(options.json);
+      const daemonChild = process.env["XMTP_SIGNET_DAEMON_CHILD"] === "1";
       const write = (msg: string, stream: "stdout" | "stderr" = "stdout") => {
         const target =
           stream === "stderr"
@@ -75,6 +79,28 @@ export function createLifecycleCommands(
             : resolvedDeps.writeStdout;
         target(msg + "\n");
       };
+
+      if (Boolean(options.daemon) && !daemonChild) {
+        const daemonResult = await resolvedDeps.daemonizeCurrentProcess();
+        if (Result.isError(daemonResult)) {
+          write(
+            formatOutput(
+              {
+                error: "Startup failed",
+                message: daemonResult.error.message,
+              },
+              { json },
+            ),
+            "stderr",
+          );
+          resolvedDeps.exit(exitCodeFromCategory(daemonResult.error.category));
+          return;
+        }
+
+        write(formatOutput(daemonResult.value, { json }));
+        resolvedDeps.exit(0);
+        return;
+      }
 
       const configOptions: Parameters<typeof loadConfig>[0] =
         typeof options.config === "string"
@@ -181,12 +207,15 @@ export function createLifecycleCommands(
         resolvedDeps.exit(0);
       });
 
+      const status = await runtime.status();
+      const wsPort = status.wsPort ?? config.ws.port;
+
       write(
         formatOutput(
           {
             status: "running",
-            pid: process.pid,
-            ws: `ws://${config.ws.host}:${config.ws.port}`,
+            pid: status.pid,
+            ws: `ws://${config.ws.host}:${wsPort}`,
             adminSocket: paths.adminSocket,
             env: config.signet.env,
             dataDir: paths.dataDir,

--- a/packages/cli/src/daemon/background-start.ts
+++ b/packages/cli/src/daemon/background-start.ts
@@ -91,13 +91,30 @@ function errorFromChildExit(
     case "validation":
       return ValidationError.create("daemon.start", message, extra);
     case "not_found":
-      return NotFoundError.create("daemon.start", message);
+      // Use the direct constructor so the child's stderr message survives
+      // verbatim. NotFoundError.create() formats as
+      // `<resourceType> '<resourceId>' not found`, which would garble the
+      // already-descriptive child diagnostic.
+      return new NotFoundError(message, {
+        resourceType: "daemon.start",
+        resourceId: "unknown",
+        ...extra,
+      });
     case "permission":
       return PermissionError.create(message, extra);
     case "auth":
       return AuthError.create(message, extra);
     case "timeout":
-      return TimeoutError.create("daemon.start", 15_000);
+      // Use the direct constructor so the child's stderr message survives
+      // verbatim. TimeoutError.create() would discard the parsed message and
+      // hardcode a timeout value we did not actually observe; `timeoutMs: 0`
+      // signals "no real timeout value parsed from the child" rather than
+      // fabricating one.
+      return new TimeoutError(message, {
+        operation: "daemon.start",
+        timeoutMs: 0,
+        ...extra,
+      });
     case "cancelled":
       return CancelledError.create(message);
     case "network":

--- a/packages/cli/src/daemon/background-start.ts
+++ b/packages/cli/src/daemon/background-start.ts
@@ -1,8 +1,18 @@
 import { spawn, type ChildProcessByStdio } from "node:child_process";
 import type { Readable } from "node:stream";
 import { Result } from "better-result";
-import { InternalError } from "@xmtp/signet-schemas";
-import type { SignetError } from "@xmtp/signet-schemas";
+import {
+  AuthError,
+  CancelledError,
+  ERROR_CATEGORY_META,
+  InternalError,
+  NetworkError,
+  NotFoundError,
+  PermissionError,
+  TimeoutError,
+  ValidationError,
+} from "@xmtp/signet-schemas";
+import type { ErrorCategory, SignetError } from "@xmtp/signet-schemas";
 
 /** Startup payload emitted by `daemon start --json`. */
 export interface BackgroundDaemonStartPayload {
@@ -13,6 +23,8 @@ export interface BackgroundDaemonStartPayload {
   readonly env: string;
   readonly dataDir: string;
 }
+
+type SpawnProcess = typeof spawn;
 
 function currentProcessArgv(): string[] {
   if (
@@ -25,12 +37,84 @@ function currentProcessArgv(): string[] {
   return [...process.argv];
 }
 
+function parseErrorMessage(stderrBuffer: string): string | null {
+  const trimmed = stderrBuffer.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as {
+      message?: unknown;
+      error?: unknown;
+    };
+    if (typeof parsed.message === "string" && parsed.message.length > 0) {
+      return parsed.message;
+    }
+    if (typeof parsed.error === "string" && parsed.error.length > 0) {
+      return parsed.error;
+    }
+  } catch {
+    // Fall through to the raw stderr payload.
+  }
+
+  return trimmed;
+}
+
+function categoryFromExitCode(code: number | null): ErrorCategory {
+  if (code !== null) {
+    for (const [category, meta] of Object.entries(ERROR_CATEGORY_META)) {
+      if (meta.exitCode === code) {
+        return category as ErrorCategory;
+      }
+    }
+  }
+  return "internal";
+}
+
+function errorFromChildExit(
+  code: number | null,
+  stderrBuffer: string,
+  stdoutBuffer: string,
+): SignetError {
+  const category = categoryFromExitCode(code);
+  const message =
+    parseErrorMessage(stderrBuffer) ??
+    "Daemon process exited before reporting startup";
+  const extra = {
+    exitCode: code,
+    stderr: stderrBuffer.trim() || undefined,
+    stdout: stdoutBuffer.trim() || undefined,
+  };
+
+  switch (category) {
+    case "validation":
+      return ValidationError.create("daemon.start", message, extra);
+    case "not_found":
+      return NotFoundError.create("daemon.start", message);
+    case "permission":
+      return PermissionError.create(message, extra);
+    case "auth":
+      return AuthError.create(message, extra);
+    case "timeout":
+      return TimeoutError.create("daemon.start", 15_000);
+    case "cancelled":
+      return CancelledError.create(message);
+    case "network":
+      return NetworkError.create("daemon.start", message, extra);
+    case "internal":
+    default:
+      return InternalError.create(message, extra);
+  }
+}
+
 /**
  * Respawns the current CLI as a detached child process and waits for the
  * child's first JSON startup line before returning to the parent.
  */
 export async function daemonizeCurrentProcess(options?: {
   timeoutMs?: number;
+  spawnProcess?: SpawnProcess;
 }): Promise<Result<BackgroundDaemonStartPayload, SignetError>> {
   const argv = currentProcessArgv();
   if (argv.length === 0) {
@@ -47,19 +131,17 @@ export async function daemonizeCurrentProcess(options?: {
   }
 
   return await new Promise((resolve) => {
-    const child: ChildProcessByStdio<null, Readable, Readable> = spawn(
-      command,
-      childArgs,
-      {
-        cwd: process.cwd(),
-        env: {
-          ...process.env,
-          XMTP_SIGNET_DAEMON_CHILD: "1",
-        },
-        detached: true,
-        stdio: ["ignore", "pipe", "pipe"],
+    const child: ChildProcessByStdio<null, Readable, Readable> = (
+      options?.spawnProcess ?? spawn
+    )(command, childArgs, {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        XMTP_SIGNET_DAEMON_CHILD: "1",
       },
-    );
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
     child.unref();
 
     let stdoutBuffer = "";
@@ -72,6 +154,15 @@ export async function daemonizeCurrentProcess(options?: {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      const childHasExited =
+        child.exitCode !== null || child.signalCode !== null;
+      if (Result.isError(result) && !childHasExited) {
+        try {
+          child.kill();
+        } catch {
+          // Best effort: the child may already have exited.
+        }
+      }
       child.stdout?.destroy();
       child.stderr?.destroy();
       resolve(result);
@@ -107,28 +198,15 @@ export async function daemonizeCurrentProcess(options?: {
       if (settled) return;
       parseStartupPayload();
       if (settled) return;
-      finish(
-        Result.err(
-          InternalError.create(
-            "Daemon process exited before reporting startup",
-            {
-              exitCode: code,
-              stderr: stderrBuffer.trim() || undefined,
-            },
-          ),
-        ),
-      );
+      finish(Result.err(errorFromChildExit(code, stderrBuffer, stdoutBuffer)));
     });
 
     const timer = setTimeout(() => {
       finish(
         Result.err(
-          InternalError.create("Timed out waiting for daemon startup", {
-            stdout: stdoutBuffer.trim() || undefined,
-            stderr: stderrBuffer.trim() || undefined,
-          }),
+          TimeoutError.create("daemon.start", options?.timeoutMs ?? 15_000),
         ),
       );
-    }, options?.timeoutMs ?? 5_000);
+    }, options?.timeoutMs ?? 15_000);
   });
 }

--- a/packages/cli/src/daemon/background-start.ts
+++ b/packages/cli/src/daemon/background-start.ts
@@ -1,0 +1,134 @@
+import { spawn, type ChildProcessByStdio } from "node:child_process";
+import type { Readable } from "node:stream";
+import { Result } from "better-result";
+import { InternalError } from "@xmtp/signet-schemas";
+import type { SignetError } from "@xmtp/signet-schemas";
+
+/** Startup payload emitted by `daemon start --json`. */
+export interface BackgroundDaemonStartPayload {
+  readonly status: string;
+  readonly pid: number;
+  readonly ws: string;
+  readonly adminSocket: string;
+  readonly env: string;
+  readonly dataDir: string;
+}
+
+function currentProcessArgv(): string[] {
+  if (
+    typeof Bun !== "undefined" &&
+    Array.isArray(Bun.argv) &&
+    Bun.argv.length
+  ) {
+    return [...Bun.argv];
+  }
+  return [...process.argv];
+}
+
+/**
+ * Respawns the current CLI as a detached child process and waits for the
+ * child's first JSON startup line before returning to the parent.
+ */
+export async function daemonizeCurrentProcess(options?: {
+  timeoutMs?: number;
+}): Promise<Result<BackgroundDaemonStartPayload, SignetError>> {
+  const argv = currentProcessArgv();
+  if (argv.length === 0) {
+    return Result.err(
+      InternalError.create("Cannot determine the current process arguments"),
+    );
+  }
+
+  const command = argv[0]!;
+  const args = argv.slice(1);
+  const childArgs = args.filter((arg) => arg !== "--daemon");
+  if (!childArgs.includes("--json")) {
+    childArgs.push("--json");
+  }
+
+  return await new Promise((resolve) => {
+    const child: ChildProcessByStdio<null, Readable, Readable> = spawn(
+      command,
+      childArgs,
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          XMTP_SIGNET_DAEMON_CHILD: "1",
+        },
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    child.unref();
+
+    let stdoutBuffer = "";
+    let stderrBuffer = "";
+    let settled = false;
+
+    const finish = (
+      result: Result<BackgroundDaemonStartPayload, SignetError>,
+    ) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.stdout?.destroy();
+      child.stderr?.destroy();
+      resolve(result);
+    };
+
+    const parseStartupPayload = () => {
+      const payload = stdoutBuffer.trim();
+      if (payload.length === 0) return;
+      try {
+        finish(Result.ok(JSON.parse(payload) as BackgroundDaemonStartPayload));
+      } catch {
+        // Wait for more output until the JSON document is complete.
+      }
+    };
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdoutBuffer += chunk.toString();
+      parseStartupPayload();
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderrBuffer += chunk.toString();
+    });
+    child.on("error", (error) => {
+      finish(
+        Result.err(
+          InternalError.create(
+            `Failed to spawn daemon process: ${error.message}`,
+          ),
+        ),
+      );
+    });
+    child.on("exit", (code) => {
+      if (settled) return;
+      parseStartupPayload();
+      if (settled) return;
+      finish(
+        Result.err(
+          InternalError.create(
+            "Daemon process exited before reporting startup",
+            {
+              exitCode: code,
+              stderr: stderrBuffer.trim() || undefined,
+            },
+          ),
+        ),
+      );
+    });
+
+    const timer = setTimeout(() => {
+      finish(
+        Result.err(
+          InternalError.create("Timed out waiting for daemon startup", {
+            stdout: stdoutBuffer.trim() || undefined,
+            stderr: stderrBuffer.trim() || undefined,
+          }),
+        ),
+      );
+    }, options?.timeoutMs ?? 5_000);
+  });
+}

--- a/packages/cli/src/daemon/background-start.ts
+++ b/packages/cli/src/daemon/background-start.ts
@@ -131,7 +131,15 @@ function errorFromChildExit(
       // payload that every other branch in this switch propagates.
       return new CancelledError(message, extra);
     case "network":
-      return NetworkError.create("daemon.start", message, extra);
+      // Use the direct constructor so the child's stderr message survives
+      // verbatim. NetworkError.create() formats as
+      // `Network error reaching '<endpoint>': <reason>`, which double-wraps
+      // any already-formatted child diagnostic (e.g. nested
+      // "Network error reaching 'xmtp': connection refused").
+      return new NetworkError(message, {
+        endpoint: "daemon.start",
+        ...extra,
+      });
     case "internal":
     default:
       return InternalError.create(message, extra);

--- a/packages/cli/src/daemon/background-start.ts
+++ b/packages/cli/src/daemon/background-start.ts
@@ -89,7 +89,16 @@ function errorFromChildExit(
 
   switch (category) {
     case "validation":
-      return ValidationError.create("daemon.start", message, extra);
+      // Use the direct constructor so the child's stderr message survives
+      // verbatim. ValidationError.create() formats as
+      // `Validation failed on '<field>': <reason>`, which double-wraps any
+      // already-formatted child diagnostic (e.g. nested "Validation failed
+      // on 'config': ...").
+      return new ValidationError(message, {
+        field: "daemon.start",
+        reason: message,
+        ...extra,
+      });
     case "not_found":
       // Use the direct constructor so the child's stderr message survives
       // verbatim. NotFoundError.create() formats as
@@ -116,7 +125,11 @@ function errorFromChildExit(
         ...extra,
       });
     case "cancelled":
-      return CancelledError.create(message);
+      // Use the direct constructor so the parsed `extra` (exitCode, stderr,
+      // stdout) is preserved on the error context. CancelledError.create()
+      // accepts only a message and would silently drop the diagnostic
+      // payload that every other branch in this switch propagates.
+      return new CancelledError(message, extra);
     case "network":
       return NetworkError.create("daemon.start", message, extra);
     case "internal":

--- a/packages/cli/src/daemon/child-log.ts
+++ b/packages/cli/src/daemon/child-log.ts
@@ -1,0 +1,83 @@
+/**
+ * Daemon child stdio redirection.
+ *
+ * When `xs start --daemon` forks, the parent reads the child's startup JSON
+ * line from a stdout pipe, then closes its read end. Once that happens the
+ * child's fd 1 / fd 2 point at broken pipes — any subsequent
+ * `process.stdout.write` or `console.error` (for example, the signal handler
+ * shutdown banner in `daemon/signals.ts`) raises EPIPE and can crash the
+ * detached daemon silently.
+ *
+ * To survive past the parent handshake the child must redirect its own
+ * stdout / stderr to a log file before the next write. This module owns
+ * that redirection and is called once, immediately after the child writes
+ * the startup JSON line.
+ */
+import { createWriteStream, mkdirSync, type WriteStream } from "node:fs";
+import { dirname, join } from "node:path";
+
+/** Result of a child stdio redirect. */
+export interface ChildLogRedirect {
+  /** Absolute path to the log file the child now writes to. */
+  readonly logFile: string;
+  /** Underlying writable stream — kept alive for the lifetime of the daemon. */
+  readonly stream: WriteStream;
+}
+
+/**
+ * Redirect `process.stdout.write` and `process.stderr.write` to a log file
+ * inside `dataDir`. Subsequent writes (including `console.log`/`console.error`,
+ * which delegate to these streams) are routed to the log file instead of the
+ * inherited pipe ends from the parent.
+ *
+ * Must be called from the daemon child only, after the startup JSON line has
+ * been flushed to the original stdout pipe.
+ */
+export function redirectChildStdioToLogFile(dataDir: string): ChildLogRedirect {
+  const logFile = join(dataDir, "daemon.log");
+  mkdirSync(dirname(logFile), { recursive: true });
+
+  // Open the log file once, in append mode. A single shared stream backs
+  // both stdout and stderr so write ordering is preserved.
+  const stream = createWriteStream(logFile, { flags: "a" });
+
+  // Replace the user-facing `write` methods. We deliberately do NOT touch
+  // `process.stdout._handle` / fd 1 itself — that would require platform
+  // tricks (`dup2`) that Node/Bun don't expose stably. Reassigning `write`
+  // covers `console.log`/`console.error`, which is where every later
+  // diagnostic in the daemon child funnels.
+  const writeToLog = (
+    chunk: string | Uint8Array,
+    encodingOrCb?: BufferEncoding | ((error?: Error | null) => void),
+    cb?: (error?: Error | null) => void,
+  ): boolean => {
+    if (typeof encodingOrCb === "function") {
+      return stream.write(chunk, encodingOrCb);
+    }
+    if (encodingOrCb !== undefined && cb !== undefined) {
+      return stream.write(chunk, encodingOrCb, cb);
+    }
+    if (encodingOrCb !== undefined) {
+      return stream.write(chunk, encodingOrCb);
+    }
+    return stream.write(chunk);
+  };
+
+  // The Node typings overload `write` heavily; cast through `unknown` to
+  // satisfy both signatures without resorting to `any`.
+  process.stdout.write = writeToLog as unknown as typeof process.stdout.write;
+  process.stderr.write = writeToLog as unknown as typeof process.stderr.write;
+
+  // Swallow EPIPE errors emitted directly on the original stream objects
+  // before this redirect took effect. The parent's `destroy()` of its read
+  // end can race with a final flush from the child; without this listener
+  // Node would crash the daemon on the unhandled 'error' event.
+  process.stdout.on("error", (err: NodeJS.ErrnoException) => {
+    if (err.code !== "EPIPE") throw err;
+  });
+  process.stderr.on("error", (err: NodeJS.ErrnoException) => {
+    if (err.code !== "EPIPE") throw err;
+  });
+
+  return { logFile, stream };
+}


### PR DESCRIPTION
## Summary
Fix `xs daemon start --daemon` so it exits cleanly after spawning the background process and reports the real bound WebSocket endpoint.

## What Changed
- added a background-start handshake that captures the child daemon's bound WS port before returning control to the caller
- updated lifecycle command output to report the actual daemon endpoint instead of `ws://127.0.0.1:0`
- added regression coverage for daemon-mode startup and JSON output wiring

## Why
The smoke pass showed that daemon startup reported success but returned a bogus WS endpoint and did not exit cleanly on its own. This makes the daemonized startup path trustworthy for scripts and follow-on tooling.

## How To Test
- `bun test packages/cli/src/__tests__/daemon-command-wiring.test.ts`
- `bun test packages/cli/src/__tests__/smoke.test.ts --test-name-pattern 'daemon start --daemon --json'`
- `bun run test`

Closes #360
