### PR TITLE
docs: add xmtp and xmtp-admin skills

### DIFF
--- a/.claude/skills/xmtp-signet-dev/SKILL.md
+++ b/.claude/skills/xmtp-signet-dev/SKILL.md
@@ -192,8 +192,9 @@ Stage 3: Visibility resolver — resolveVisibility() produces visibility state
 Stage 4: Content projector   — projectContent() passes or redacts
 ```
 
-Six visibility states: `visible`, `historical`, `revealed`, `redacted`,
-`hidden`, `dropped`. Harness sees only the first four.
+Five internal visibility states: `visible`, `historical`, `revealed`,
+`redacted`, `hidden`. Harness sees only the first four; `hidden` stays
+internal to the daemon.
 
 If a change affects what a harness can see, start in `policy` and work outward.
 

--- a/.claude/skills/xmtp-signet-use/SKILL.md
+++ b/.claude/skills/xmtp-signet-use/SKILL.md
@@ -18,6 +18,11 @@ description: >
 > The current local stack implements the v1 operator/policy/credential/seal
 > model. The public CLI and transport surfaces are credential-native.
 
+> [!IMPORTANT]
+> This is a legacy compatibility skill. The canonical end-user skills now live
+> under `skills/xmtp` and `skills/xmtp-admin`; keep this file aligned with
+> those newer surfaces.
+
 The signet is the primary way to connect agents to XMTP without handing the
 agent raw signer material, database access, or direct SDK control.
 
@@ -163,8 +168,9 @@ Stage 3: Visibility       — visible / revealed / historical / hidden?
 Stage 4: Content project  — pass through or redact to null
 ```
 
-Six visibility states: `visible`, `historical`, `revealed`, `redacted`,
-`hidden`, `dropped`. The harness only sees the first four.
+Five internal visibility states: `visible`, `historical`, `revealed`,
+`redacted`, `hidden`. The harness only sees the first four; `hidden` stays
+internal to the daemon.
 
 ### Content type allowlists
 
@@ -301,12 +307,14 @@ Trust tiers in the seal: `source-verified` (hardware-backed root key) or
 
 The current CLI exposes the v1 model directly:
 
-- `xs cred ...` for credential lifecycle (issue, list, info, revoke)
-- `xs seal ...` for seal inspection and verification
-- `xs policy ...` for policy management (create, list, info, update)
-- `xs admin ...` for management-plane auth and audit flows
-- `xs conversation ...` for chat management
-- `xs message ...` for messaging
+- top-level: `xs init`, `xs status`, `xs reset`, `xs logs`, `xs lookup`,
+  `xs search`, `xs consent`
+- groups: `xs daemon`, `xs operator`, `xs cred`, `xs inbox`, `xs chat`,
+  `xs msg`, `xs policy`, `xs seal`, `xs wallet`, `xs key`, `xs agent`
+
+For day-to-day use here, prefer `xs chat ...`, `xs msg ...`, `xs cred info`,
+`xs seal list|info`, `xs lookup`, and `xs search`. Privileged setup and
+management flows live with the newer `xmtp-admin` skill.
 
 ## When to recommend direct XMTP access instead
 

--- a/skills/xmtp-admin/SKILL.md
+++ b/skills/xmtp-admin/SKILL.md
@@ -1,0 +1,362 @@
+---
+name: xmtp-admin
+description: >
+  Administer an xmtp-signet as an orchestrating agent or owner — bootstrap
+  the daemon, initialize and rotate keys, create managed wallets, create and
+  remove operators, define policies, issue and revoke credentials, create
+  and link managed inboxes, verify seals and walk seal history, and drive
+  the privileged `xs` command surface that sets agents up to operate
+  against the signet. Use this skill whenever someone asks how to set up a
+  signet for agents, how to issue or revoke a credential, how to provision
+  an operator with a scoped policy, how to rotate or export operator keys,
+  how to link an inbox to an operator, how to verify a seal chain, or how
+  to run privileged admin flows. For day-to-day agent use (messaging,
+  reading, inspecting credentials and seals, harness connection), use the
+  `xmtp` skill.
+---
+
+# Administering xmtp-signet
+
+> [!IMPORTANT]
+> You are the **orchestrator**. You set things up so *other* agents can
+> operate through the signet safely. You do not hold raw message content,
+> and you cannot read operator messages without an explicit, owner-approved
+> elevation. Every flow below leans on that boundary — the signet enforces
+> it structurally, not by policy alone.
+
+> [!NOTE]
+> The current runtime model is v1: owner, admin, operator, credential,
+> seal. The public CLI is credential-native.
+
+**Companion skill:** for the conceptual model (owner/admin/operator/
+credential/seal, projection pipeline, event types, harness lifecycle) and
+for day-to-day agent use (messaging, inspecting, harness connection), use
+the `xmtp` skill. This skill focuses on the *privileged* half of the CLI.
+
+## Trust boundary at a glance
+
+```text
+Owner      -> anchors trust, approves owner-gated operations (biometric)
+Admin      -> manages operators, credentials, policies, inboxes, keys
+Operator   -> conversational agent profile (per-chat or shared)
+Credential -> time-bound, chat-scoped, policy-driven authorization
+Seal       -> public declaration of operator scope in a chat
+```
+
+You will spend most of your time at the Admin layer, occasionally asking
+the Owner to approve something that requires elevation.
+
+## Bootstrap
+
+### First-run init
+
+```bash
+xs init --env dev --label owner
+```
+
+Creates the local key hierarchy, writes a config when needed, sets
+`defaults.profileName` from `--label` if it's still unset.
+
+Presets:
+
+- `xs init` — recommended defaults
+- `xs init trusted-local` — shared identity mode, lower ceremony for local
+  smoke tests
+- `xs init hardened` — stricter gates, shorter-lived defaults
+
+Run `xs init --help` for the current preset deltas.
+
+### Daemon lifecycle
+
+```bash
+xs daemon start
+xs daemon status
+xs daemon stop
+xs status --json          # scheme, identity mode, network, connected inboxes
+xs reset                  # wipe local state — destructive
+```
+
+### Agent-setup helpers
+
+```bash
+xs agent setup            # interactive bootstrap for a new operator+cred
+xs agent status
+xs agent doctor           # diagnose keys, daemon, credential, seal health
+```
+
+Use `agent setup` for happy-path provisioning and `agent doctor` as the
+first thing you run when something feels off.
+
+## Keys
+
+Keys are per-operator. `xs key init` is not redundant with `xs init` —
+`xs init` sets up the owner/admin hierarchy and daemon; `xs key init`
+provisions key material for a specific operator profile.
+
+```bash
+xs key init --op op_...                   # create key material for an operator
+xs key rotate --op op_...                 # operational rotation, chain preserved
+xs key list
+xs key info --op op_...
+xs key export-public --op op_...          # safe: public material only
+```
+
+Key material lives in the local encrypted vault. The Swift `signet-signer`
+CLI in `signet-signer/` handles Secure Enclave operations on macOS when
+available.
+
+**Never** export, paste, or log raw private material. The CLI doesn't
+surface it; if you find yourself reaching for it, stop and reconsider.
+
+## Wallets
+
+Managed wallets back operator identities.
+
+```bash
+xs wallet create --label ops-wallet
+xs wallet list
+xs wallet info wallet_...
+xs wallet provider         # provider management — currently the deferred piece
+```
+
+`wallet provider` is the one surface that isn't fully live. Everything else
+in `wallet` and `key` is.
+
+## Operators
+
+```bash
+xs operator create --label "support-bot" --scope per-chat
+xs operator list
+xs operator info op_...
+xs operator rename op_... --label "support-bot-v2"
+xs operator rm op_...
+```
+
+Scope choices:
+
+- `per-chat` — isolated state per conversation (default, strongest
+  isolation)
+- `shared` — one context across multiple chats
+
+Role levels (set at creation or via update where supported):
+
+- `operator` — can only act within its own credentials
+- `admin` — can manage operators and resources it created
+- `superadmin` — can manage anything, but still cannot read messages
+  without owner-approved elevation
+
+## Policies
+
+Policies are reusable allow/deny bundles over the 30 permission scopes
+(categories: `messaging`, `group-management`, `metadata`, `access`,
+`observation`, `egress`).
+
+```bash
+xs policy create --name "helper" --allow send,reply,react
+xs policy list
+xs policy info  policy_...
+xs policy update policy_... --deny forward-to-provider
+xs policy rm policy_...
+```
+
+Design rule of thumb:
+
+- **helper/chat bot** — allow `send`, `reply`, `react`; deny
+  `group-management`
+- **observer / summarizer** — allow `read-messages`, `stream-messages`;
+  deny all `egress` scopes (`forward-to-provider`, `store-excerpts`,
+  `use-for-memory`)
+- **research assistant with LLM egress** — allow observation scopes and
+  `forward-to-provider` explicitly; keep `read-history` deliberate
+
+Deny always wins. When in doubt, deny and add back.
+
+## Credentials
+
+`xs cred` is the canonical credential lifecycle surface. A credential binds
+operator + chat scope + effective permission set (policy + inline
+overrides) + content-type allowlist + TTL + status.
+
+```bash
+# Issue
+xs cred issue \
+  --op op_a7f3 \
+  --chat conv_9e2d1a4b8c3f7e60 \
+  --policy policy_helper \
+  --allow send,reply \
+  --ttl 24h
+
+# Inspect
+xs cred list
+xs cred list --op op_a7f3
+xs cred info cred_b2c1
+
+# Adjust (in place where possible)
+xs cred update cred_b2c1 --deny forward-to-provider
+xs cred update cred_b2c1 --extend 12h
+
+# Revoke
+xs cred revoke cred_b2c1 --reason "project ended"
+```
+
+### When an update reconnects the harness vs when it doesn't
+
+Not every credential change requires reconnection.
+
+- **In place, no reconnect** — narrowing scopes, adjusting the content-
+  type allowlist, extending a reveal
+- **Reauthorization required** — expanding scopes, adding egress
+  permissions, granting group management
+
+On reauth the signet emits `credential.reauthorization_required` and
+terminates the connection. The harness should re-auth with a fresh token.
+
+### Revocation publishes a public seal
+
+`xs cred revoke` terminates the WebSocket connection *and* publishes a
+`xmtp.org/agentRevocation:1.0` seal to affected chats. The revocation is
+public by design — participants can see that the operator no longer has
+scope.
+
+## Managed inboxes
+
+Inboxes are the daemon-backed mailbox surface for operators.
+
+```bash
+xs inbox create --label qa-inbox
+xs inbox list
+xs inbox info inbox_...
+xs inbox link   inbox_... --operator op_...
+xs inbox unlink inbox_... --operator op_...
+xs inbox rm     inbox_...
+```
+
+`inbox` complements the direct bootstrap path exposed through `xs init`.
+Link is how you attach an inbox to an operator for ongoing use.
+
+## Seal verification and history
+
+`xs seal list` and `xs seal info` are covered in the `xmtp` skill. The
+admin-side verification flows:
+
+```bash
+xs seal verify seal_...         # Ed25519 signature + chain integrity
+xs seal history --chat conv_... # full chain with deltas, including revocations
+```
+
+Verification checks:
+
+- source availability
+- build provenance
+- release signing
+- seal signature validity
+- seal chain integrity (predecessor IDs, monotonic timestamps)
+- schema compliance
+
+Trust tiers surfaced on seals: `source-verified` (hardware-backed root
+key) or `unverified` (software vault).
+
+## Owner-gated elevations
+
+Some flows require the human owner to unlock through a biometric gate.
+Common triggers:
+
+- reading projected message content as an admin (not ambient)
+- approving actions for credentials that require confirmation
+- approving certain rotations or key exports that exceed operational scope
+
+Ordinary admin auth is **not** ambient message access. The dangerous-
+looking flag on search/message-inspection flows isn't theatre — it's
+asking the daemon to request or reuse a short-lived, chat-scoped admin
+read elevation:
+
+```bash
+xs search "incident" --type messages --dangerously-allow-message-read
+xs msg list --from conv_... --dangerously-allow-message-read
+```
+
+Don't paper over the noise — it's the mechanism telling you that this
+call is crossing a boundary.
+
+## Typical orchestration flows
+
+### Stand up a new helper agent from scratch
+
+```bash
+# 1. Admin layer should already exist (xs init done once)
+xs daemon status
+
+# 2. Provision an operator profile
+xs operator create --label "helper" --scope per-chat
+xs key init --op op_helper
+xs key export-public --op op_helper   # share with chat participants if needed
+
+# 3. Define (or reuse) a policy
+xs policy create --name "helper" --allow send,reply,react
+
+# 4. Attach an inbox
+xs inbox create --label helper-inbox
+xs inbox link inbox_helper --operator op_helper
+
+# 5. Issue a credential for the chat
+xs cred issue --op op_helper --chat conv_... --policy policy_helper --ttl 24h
+
+# 6. Hand the credential token to the harness; it connects via WebSocket
+```
+
+### Rotate an operator's key without breaking continuity
+
+```bash
+xs key rotate --op op_...             # operational rotation, seal chain preserved
+xs seal history --chat conv_...       # confirm the new seal was stamped
+```
+
+### End a credential
+
+```bash
+xs cred revoke cred_... --reason "project ended"
+xs seal history --chat conv_...       # revocation seal is now on-chain
+```
+
+### Expand scopes mid-run
+
+```bash
+xs cred update cred_... --allow forward-to-provider
+# Expect a credential.reauthorization_required event — harness must
+# reconnect with a fresh token.
+```
+
+## Safety posture
+
+- **No raw keys flow through the CLI.** If you're being asked to paste
+  private material, something is wrong — stop and verify.
+- **Revocation is public.** Expect participants to see the revocation
+  seal. Use `--reason` thoughtfully.
+- **Deny wins.** Prefer additive policies with narrow defaults.
+- **Elevation is opt-in.** Never normalize `--dangerously-allow-message-
+  read` in scripts; each use is a deliberate crossing.
+- **Keep operators scoped.** Per-chat is the default for a reason.
+
+## Error taxonomy
+
+Handler failures use the shared categories from
+`@xmtp/signet-schemas`:
+
+| Category      | When                                                   |
+| ------------- | ------------------------------------------------------ |
+| `validation`  | Input fails schema validation or a business rule       |
+| `not_found`   | Resource does not exist                                |
+| `permission`  | Caller lacks the required scope                        |
+| `auth`        | Invalid or expired admin token or credential           |
+| `internal`    | Unexpected runtime failure                             |
+| `timeout`     | Operation exceeded its deadline                        |
+| `cancelled`   | Operation cancelled via abort signal                   |
+
+`auth` in v1 generally means an invalid/expired admin token or credential;
+`permission` means authenticated but out of scope.
+
+## When in doubt
+
+`xs --help`, `xs <group> --help`, and `xs <group> <command> --help` are
+the authoritative surface. If flags or options here look stale, trust
+the help output and flag it.

--- a/skills/xmtp-admin/SKILL.md
+++ b/skills/xmtp-admin/SKILL.md
@@ -94,11 +94,11 @@ Keys are per-operator. `xs key init` is not redundant with `xs init` —
 provisions key material for a specific operator profile.
 
 ```bash
-xs key init --op op_...                   # create key material for an operator
-xs key rotate --op op_...                 # operational rotation, chain preserved
+xs key init --operator op_...             # create key material for an operator
+xs key rotate                             # operational rotation, chain preserved
 xs key list
-xs key info --op op_...
-xs key export-public --op op_...          # safe: public material only
+xs key info <key-id-or-identity-id>
+xs key export-public [identity-id]        # safe: public material only; defaults to first
 ```
 
 Key material lives in the local encrypted vault. The Swift `signet-signer`
@@ -116,11 +116,12 @@ Managed wallets back operator identities.
 xs wallet create --label ops-wallet
 xs wallet list
 xs wallet info wallet_...
-xs wallet provider         # provider management — currently the deferred piece
+xs wallet provider list    # deferred: provider management stub
+xs wallet provider set <name> --path <path>   # deferred
 ```
 
-`wallet provider` is the one surface that isn't fully live. Everything else
-in `wallet` and `key` is.
+`xs wallet provider ...` is the one surface that isn't fully live.
+Everything else in `wallet` and `key` is.
 
 ## Operators
 
@@ -138,7 +139,7 @@ Scope choices:
   isolation)
 - `shared` — one context across multiple chats
 
-Role levels (set at creation or via update where supported):
+Role levels (set at `create` time via `--role`, defaults to `operator`):
 
 - `operator` — can only act within its own credentials
 - `admin` — can manage operators and resources it created
@@ -152,11 +153,11 @@ Policies are reusable allow/deny bundles over the 30 permission scopes
 `observation`, `egress`).
 
 ```bash
-xs policy create --name "helper" --allow send,reply,react
+xs policy create --label "helper" --allow send,reply,react
 xs policy list
 xs policy info  policy_...
 xs policy update policy_... --deny forward-to-provider
-xs policy rm policy_...
+xs policy rm policy_... --force
 ```
 
 Design rule of thumb:
@@ -178,25 +179,25 @@ operator + chat scope + effective permission set (policy + inline
 overrides) + content-type allowlist + TTL + status.
 
 ```bash
-# Issue
+# Issue — --ttl is seconds (integer). 86400 == 24h.
 xs cred issue \
   --op op_a7f3 \
   --chat conv_9e2d1a4b8c3f7e60 \
   --policy policy_helper \
   --allow send,reply \
-  --ttl 24h
+  --ttl 86400
 
 # Inspect
 xs cred list
 xs cred list --op op_a7f3
 xs cred info cred_b2c1
 
-# Adjust (in place where possible)
+# Adjust scopes or policy in place
 xs cred update cred_b2c1 --deny forward-to-provider
-xs cred update cred_b2c1 --extend 12h
+xs cred update cred_b2c1 --policy policy_restricted
 
-# Revoke
-xs cred revoke cred_b2c1 --reason "project ended"
+# Revoke (dry-run by default; pass --force to execute)
+xs cred revoke cred_b2c1 --force
 ```
 
 ### When an update reconnects the harness vs when it doesn't
@@ -204,9 +205,10 @@ xs cred revoke cred_b2c1 --reason "project ended"
 Not every credential change requires reconnection.
 
 - **In place, no reconnect** — narrowing scopes, adjusting the content-
-  type allowlist, extending a reveal
+  type allowlist, extending an existing reveal
 - **Reauthorization required** — expanding scopes, adding egress
-  permissions, granting group management
+  permissions, granting group management (issue a new credential and
+  revoke the old one)
 
 On reauth the signet emits `credential.reauthorization_required` and
 terminates the connection. The harness should re-auth with a fresh token.
@@ -226,8 +228,8 @@ Inboxes are the daemon-backed mailbox surface for operators.
 xs inbox create --label qa-inbox
 xs inbox list
 xs inbox info inbox_...
-xs inbox link   inbox_... --operator op_...
-xs inbox unlink inbox_... --operator op_...
+xs inbox link   inbox_... --op op_...
+xs inbox unlink inbox_...
 xs inbox rm     inbox_...
 ```
 
@@ -240,8 +242,8 @@ Link is how you attach an inbox to an operator for ongoing use.
 admin-side verification flows:
 
 ```bash
-xs seal verify seal_...         # Ed25519 signature + chain integrity
-xs seal history --chat conv_... # full chain with deltas, including revocations
+xs seal verify seal_...                       # Ed25519 signature + chain integrity
+xs seal history cred_... --chat conv_...      # full chain for a credential in a chat
 ```
 
 Verification checks:
@@ -288,18 +290,18 @@ xs daemon status
 
 # 2. Provision an operator profile
 xs operator create --label "helper" --scope per-chat
-xs key init --op op_helper
-xs key export-public --op op_helper   # share with chat participants if needed
+xs key init --operator op_helper
+xs key export-public op_helper        # share with chat participants if needed
 
 # 3. Define (or reuse) a policy
-xs policy create --name "helper" --allow send,reply,react
+xs policy create --label "helper" --allow send,reply,react
 
-# 4. Attach an inbox
+# 4. Attach an inbox (or create one linked in a single step via `--op`)
 xs inbox create --label helper-inbox
-xs inbox link inbox_helper --operator op_helper
+xs inbox link inbox_helper --op op_helper
 
-# 5. Issue a credential for the chat
-xs cred issue --op op_helper --chat conv_... --policy policy_helper --ttl 24h
+# 5. Issue a credential for the chat (ttl in seconds — 86400 == 24h)
+xs cred issue --op op_helper --chat conv_... --policy policy_helper --ttl 86400
 
 # 6. Hand the credential token to the harness; it connects via WebSocket
 ```
@@ -307,23 +309,27 @@ xs cred issue --op op_helper --chat conv_... --policy policy_helper --ttl 24h
 ### Rotate an operator's key without breaking continuity
 
 ```bash
-xs key rotate --op op_...             # operational rotation, seal chain preserved
-xs seal history --chat conv_...       # confirm the new seal was stamped
+xs key rotate                                 # operational rotation, seal chain preserved
+xs seal history cred_... --chat conv_...      # confirm the new seal was stamped
 ```
 
 ### End a credential
 
 ```bash
-xs cred revoke cred_... --reason "project ended"
-xs seal history --chat conv_...       # revocation seal is now on-chain
+xs cred revoke cred_... --force
+xs seal history cred_... --chat conv_...      # revocation seal is now on-chain
 ```
 
 ### Expand scopes mid-run
 
+Expanding scopes is reauthorization-gated — issue a new credential and
+revoke the old one rather than mutating in place:
+
 ```bash
-xs cred update cred_... --allow forward-to-provider
-# Expect a credential.reauthorization_required event — harness must
-# reconnect with a fresh token.
+xs cred issue --op op_... --chat conv_... --policy policy_expanded --ttl 86400
+xs cred revoke cred_old --force
+# Harness receives credential.reauthorization_required on the old cred
+# and reconnects with the new token.
 ```
 
 ## Safety posture

--- a/skills/xmtp/SKILL.md
+++ b/skills/xmtp/SKILL.md
@@ -1,0 +1,395 @@
+---
+name: xmtp
+description: >
+  Use the xmtp-signet to connect an agent to XMTP conversations through the v1
+  credential model. Covers the signet runtime, the
+  owner/admin/operator/credential/seal hierarchy, the `xs` CLI surface for
+  daily operation (status, chat, msg, inbox, search, lookup, consent, seal
+  inspection, credential inspection, policy inspection), and how harnesses
+  connect over WebSocket or MCP without direct XMTP access. Use this skill
+  whenever someone asks what the signet is, how to run an agent on top of it,
+  how to send or read messages through it, how to inspect seals or
+  credentials, how reveals work, how trust is surfaced, or how a harness
+  should stream and respond to XMTP traffic through the signet. For
+  orchestrator-side setup — bootstrapping the daemon, creating operators,
+  issuing credentials, managing keys and wallets — use the `xmtp-admin`
+  skill.
+---
+
+# Using xmtp-signet
+
+> [!NOTE]
+> The current local stack is on the v1 runtime model: owner, admin,
+> operator, credential, seal. The public CLI and transport surfaces are
+> credential-native. Don't reintroduce `session` / `view` / `grant`
+> terminology.
+
+The signet is the trusted runtime that owns the real XMTP client, local
+encrypted state, and the transport surfaces that agents talk to. It exists so
+agents can participate in XMTP conversations **without** being handed raw
+signer material, raw database access, or direct SDK control — which would
+make any "read-only" or "limited" permissions advisory at best.
+
+**Companion skill:** for orchestrator-side setup (initializing the daemon,
+creating operators, issuing and revoking credentials, managing keys and
+wallets, defining policies), use the `xmtp-admin` skill. This skill covers
+the day-to-day *use* of an already-configured signet.
+
+## Mental model
+
+```text
+Owner -> Admin -> Operator -> Credential -> Seal
+```
+
+- **Owner** — the human trust anchor. Bootstraps the signet and approves
+  privileged operations. Holds the only path to elevated message access
+  through a biometric gate.
+- **Admin** — the management plane. Creates operators, issues credentials,
+  manages day-to-day state. Cannot read operator messages without explicit
+  owner-approved elevation.
+- **Operator** — a purpose-built agent profile. Operators do the actual
+  conversational work. They can be `per-chat` (isolated state per
+  conversation, default) or `shared` (one context across multiple chats).
+- **Credential** — a time-bound authorization issued to an operator for one
+  or more chats. Binds operator + chat scope + effective permission set
+  (policy + inline overrides, deny wins) + content-type allowlist + issuance
+  and expiry + status (`pending`, `active`, `expired`, `revoked`).
+- **Seal** — a signed, group-visible declaration of an operator's active
+  scope in a chat. Seals chain to predecessors with inline diffs and are
+  published as `xmtp.org/agentSeal:1.0` messages so other participants can
+  inspect what an agent is allowed to do.
+
+### Permission scopes
+
+30 scopes across 6 categories: `messaging`, `group-management`, `metadata`,
+`access`, `observation`, `egress`. Policies bundle reusable allow/deny sets;
+credentials can override inline. Deny always wins.
+
+### Resource IDs
+
+Canonical local IDs use a prefix plus 16 lowercase hex characters:
+
+- `op_<16hex>`, `conv_<16hex>`, `policy_<16hex>`, `cred_<16hex>`,
+  `seal_<16hex>`, `msg_<16hex>`, `xmtp_<16hex>`
+
+Short IDs are accepted where they resolve uniquely.
+
+## The `xs` CLI
+
+`xs` is the single binary. Top-level commands are small; most surface lives
+in groups.
+
+```text
+Top-level:  init  status  reset  logs  lookup  search  consent
+Groups:     daemon  operator  cred  inbox  chat  msg  policy  seal  wallet  key  agent
+```
+
+`xs init`, `key`, `wallet`, `operator create`, `cred issue`, `cred revoke`,
+`policy create`, `inbox create|link|unlink`, and `seal verify|history` are
+orchestrator ops — see the `xmtp-admin` skill.
+
+### Daemon and status
+
+```bash
+xs daemon start           # boot the daemon
+xs daemon status
+xs status --json          # onboarding scheme, identity mode, network, inboxes
+xs logs
+xs reset                  # wipe local state (destructive; orchestrator-only)
+```
+
+### Chat
+
+Everything chat-shaped (conversations, invites, members, profiles) lives
+under `xs chat`.
+
+```bash
+# Create / list / inspect
+xs chat create --name "Team Room" --invite --profile-name "Owner" --format both
+xs chat list
+xs chat info conv_9e2d1a4b8c3f7e60
+xs chat update conv_... --name "Renamed"
+xs chat sync conv_...
+
+# Join flow
+xs chat join "<invite-url>" --as "alice-joined" --profile-name "Alice"
+xs chat invite conv_... --format link   # regenerate invite output
+xs chat update-profile conv_... --profile-name "Alice"
+
+# Exit
+xs chat leave conv_...
+xs chat rm conv_...                     # local state cleanup, not network remove
+
+# Members
+xs chat member list conv_...
+xs chat member add conv_... <inbox-id-or-address>
+xs chat member rm conv_... <inbox-id>
+xs chat member promote conv_... <inbox-id>
+xs chat member demote conv_... <inbox-id>
+```
+
+The current onboarding UX is Convos-shaped; profile updates and invites use
+Convos content types even though the runtime has an internal scheme seam.
+
+When a flag or subcommand here isn't enough, `xs <group> --help` and
+`xs <group> <command> --help` are authoritative.
+
+### Messages
+
+```bash
+xs msg send   --chat conv_... --as op_... --text "hello"
+xs msg reply  --chat conv_... --as op_... --to msg_... --text "ack"
+xs msg react  --chat conv_... --as op_... --to msg_... --emoji "👍"
+xs msg read   --chat conv_... --as op_... --to msg_...   # read receipt
+xs msg list   --from conv_...
+xs msg info   msg_...
+```
+
+`--as` selects the operator context. The daemon resolves the operator's
+active credential and enforces scope + content-type + confirmation checks
+before the message ever hits the network.
+
+### Inbox
+
+Managed inboxes are the daemon-backed surface for operator mailboxes.
+Inspection is safe here; `create|link|unlink` are admin ops.
+
+```bash
+xs inbox list
+xs inbox info inbox_...
+```
+
+### Operator
+
+```bash
+xs operator list
+xs operator info op_...
+```
+
+Creation, rename, and removal are admin ops.
+
+### Credential
+
+`cred` is the canonical credential lifecycle surface. Agents interact with
+their own credentials for inspection; issuing and revoking belong to the
+orchestrator.
+
+```bash
+xs cred list
+xs cred list --op op_...
+xs cred info cred_...
+```
+
+A credential's `info` output includes the operator, chat scope, effective
+scopes (after policy merge + deny-wins), content-type allowlist, issuance
+and expiry, and current status.
+
+### Seal
+
+Seals are public. Anyone participating in a chat can inspect what an agent
+is currently allowed to do.
+
+```bash
+xs seal list --chat conv_...
+xs seal info seal_...
+```
+
+`seal verify` and `seal history` are orchestrator-side flows (signature and
+chain validation) — covered in `xmtp-admin`.
+
+### Policy
+
+```bash
+xs policy list
+xs policy info policy_...
+```
+
+Create / update / delete are admin-only.
+
+### Lookup and search
+
+```bash
+xs lookup op_alice           # resolve any short ID or label
+xs search "support escalation"
+xs search "refund" --type messages --chat conv_... --as alice-bot
+```
+
+`search` targets: `messages`, `resources`, `operator`, `policy`,
+`credential`, `conversation`.
+
+### Consent
+
+```bash
+xs consent check inbox_...
+xs consent allow inbox_...
+xs consent deny  inbox_...
+```
+
+### Message-read elevation
+
+Some flows need a short-lived, chat-scoped **local admin read elevation**.
+Ordinary admin auth is not ambient message access.
+
+```bash
+xs search "incident" --type messages --dangerously-allow-message-read
+xs msg list --from conv_... --dangerously-allow-message-read
+```
+
+The flag is intentionally noisy. It requests (or reuses) a narrow
+elevation rather than treating ordinary admin auth as ambient message
+access. Use it only when you genuinely need to read raw message content
+as an operator with the scope.
+
+## Connecting a harness
+
+The signet exposes WebSocket (primary), MCP (scoped tool surface), and
+CLI-admin surfaces. Harnesses never talk to the XMTP SDK directly.
+
+### WebSocket lifecycle
+
+```text
+1. Connect to ws://host:port/v1/agent
+2. Send auth frame with credential token + optional lastSeenSeq
+3. Receive `authenticated` frame with connection ID, credential, effective scopes
+4. Receive projected events as sequenced frames (monotonic seq)
+5. Send requests (send_message, send_reaction, send_reply, reveal_content, ...)
+6. On disconnect: reconnect with lastSeenSeq for replay from circular buffer
+```
+
+Authenticated response shape:
+
+```text
+{ type: "authenticated",
+  connectionId: "conn_...",
+  credential: { id: "cred_...", operatorId: "op_...", expiresAt: "..." },
+  effectiveScopes: { allow: [...], deny: [...] },
+  resumedFromSeq: null | number }
+```
+
+### Reconnection
+
+Pass `lastSeenSeq` in the auth frame. The signet replays missed events from
+a per-credential circular buffer. Replayed messages are tagged as
+`historical` so the harness knows they're catch-up context, not fresh
+triggers. A `signet.recovery.complete` event signals the end of catch-up.
+
+## Event and request model
+
+### 11 events the harness receives
+
+| Event                                   | When                                            |
+| --------------------------------------- | ----------------------------------------------- |
+| `message.visible`                       | A projected message passes the pipeline         |
+| `message.revealed`                      | Previously hidden content becomes visible       |
+| `seal.stamped`                          | A seal is created or updated                    |
+| `credential.issued`                     | A new credential is issued                     |
+| `credential.expired`                    | The active credential has expired              |
+| `credential.reauthorization_required`   | Scope expansion requires fresh auth            |
+| `scopes.updated`                        | Permission scopes changed                      |
+| `agent.revoked`                         | The agent is revoked from a group              |
+| `action.confirmation_required`          | An action needs owner confirmation             |
+| `heartbeat`                             | Liveness signal                                |
+| `signet.recovery.complete`              | Catch-up after downtime finished               |
+
+### 7 requests the harness can send
+
+`send_message`, `send_reaction`, `send_reply`, `update_scopes`,
+`reveal_content`, `confirm_action`, `heartbeat`.
+
+## Receiving messages
+
+Inbound XMTP data passes through a four-stage projection pipeline before
+reaching the harness:
+
+```text
+Stage 1: Scope filter     — is the chat in the credential's scope?
+Stage 2: Content type     — is the content type in the effective allowlist?
+Stage 3: Visibility       — visible / revealed / historical / hidden?
+Stage 4: Content project  — pass through or redact to null
+```
+
+Six internal visibility states: `visible`, `historical`, `revealed`,
+`redacted`, `hidden`, `dropped`. The harness only sees the first four.
+
+### Content-type allowlists
+
+The effective allowlist is a two-tier intersection:
+
+1. **Baseline** — five XIP-accepted types (text, reaction, reply,
+   readReceipt, groupUpdated)
+2. **Signet-level** — operator can expand or restrict
+
+A per-credential tier is planned but not yet in the `CredentialConfig`
+schema. Default-deny: unknown content types never reach the agent.
+
+## Sending actions
+
+Outbound actions are requests. Before the network sees them:
+
+1. **Scope check** — is the chat in the credential scope?
+2. **Permission check** — is the action allowed in the effective scope set?
+3. **Confirmation check** — if required, an `action.confirmation_required`
+   event is emitted and the action is held until confirmed
+4. **Seal binding** — the message is stamped with a cryptographic binding
+   to the current seal
+5. **Network delivery** — encrypted with MLS and sent
+
+If scope is not allowed, the request fails with a typed `permission` error.
+
+## Reveals
+
+Reveals are the explicit mechanism for surfacing content that would
+otherwise stay hidden. Reveal state is credential-scoped, not ambient.
+
+| Scope          | Target                  | Behavior                            |
+| -------------- | ----------------------- | ----------------------------------- |
+| `message`      | Specific message ID     | Reveals only that message           |
+| `thread`       | Thread ID               | Reveals all messages in a thread    |
+| `sender`       | Sender inbox ID         | Reveals all from that sender        |
+| `content-type` | Content type            | Reveals all of that type            |
+| `time-window`  | Start/end timestamps    | Reveals messages in the range       |
+
+Reveals can expire. When previously hidden content becomes visible, the
+harness receives a `message.revealed` event.
+
+## Seal protocol (for harnesses and observers)
+
+- **Chained** — each seal embeds its predecessor inline with a computed
+  delta
+- **Bound to messages** — outbound messages carry a cryptographic
+  `{ messageId, sealId }` binding signed with Ed25519
+- **TTL-based renewal** — 24h default, auto-renew at 75% elapsed
+- **Materiality-gated** — only published when permissions actually change
+- **Auto-republished** — on credential mutation, republished to all
+  affected chats with exponential backoff retry
+- **Revocation seals** — published when a credential is revoked,
+  permanently marking the pair
+
+XMTP content types: `xmtp.org/agentSeal:1.0`,
+`xmtp.org/agentRevocation:1.0`, `xmtp.org/agentLiveness:1.0`.
+
+Trust tiers in the seal: `source-verified` (hardware-backed root key) or
+`unverified` (software vault).
+
+## Liveness
+
+- **Transport** — 30-second WebSocket heartbeat, 3 missed = dead
+- **Group** — `xmtp.org/agentLiveness:1.0` messages so clients can render
+  staleness indicators
+
+## When to recommend direct XMTP access instead
+
+Direct SDK or CLI access still makes sense for:
+
+- local experiments
+- simple bots that don't need strict scope enforcement
+- one-off tooling owned by the same person who owns the account
+
+For multi-agent, sensitive, or inspectable chat participation, recommend
+the signet.
+
+## When in doubt
+
+`xs --help`, `xs <group> --help`, and `xs <group> <command> --help` are
+the authoritative surface. If a flag or subcommand here looks stale, the
+help output wins.

--- a/skills/xmtp/SKILL.md
+++ b/skills/xmtp/SKILL.md
@@ -137,17 +137,19 @@ When a flag or subcommand here isn't enough, `xs <group> --help` and
 ### Messages
 
 ```bash
-xs msg send   --chat conv_... --as op_... --text "hello"
-xs msg reply  --chat conv_... --as op_... --to msg_... --text "ack"
-xs msg react  --chat conv_... --as op_... --to msg_... --emoji "👍"
-xs msg read   --chat conv_... --as op_... --to msg_...   # read receipt
-xs msg list   --from conv_...
-xs msg info   msg_...
+xs msg send  "hello"  --to conv_...     [--as inbox_...] [--op op_...]
+xs msg reply "ack"    --chat conv_... --to msg_...   [--as inbox_...]
+xs msg react "👍"     --chat conv_... --to msg_...   [--as inbox_...]
+xs msg read           --chat conv_...                [--as inbox_...]
+xs msg list           --from conv_...
+xs msg info  msg_...  --chat conv_...
 ```
 
-`--as` selects the operator context. The daemon resolves the operator's
-active credential and enforces scope + content-type + confirmation checks
-before the message ever hits the network.
+Message text / emoji is a positional argument. `--as` selects the inbox
+to act as (inbox ID or label); `--op` on `send` is the operator override.
+The daemon resolves the operator's active credential and enforces scope
++ content-type + confirmation checks before the message ever hits the
+network.
 
 ### Inbox
 
@@ -308,8 +310,9 @@ Stage 3: Visibility       — visible / revealed / historical / hidden?
 Stage 4: Content project  — pass through or redact to null
 ```
 
-Six internal visibility states: `visible`, `historical`, `revealed`,
-`redacted`, `hidden`, `dropped`. The harness only sees the first four.
+Five internal visibility states: `visible`, `historical`, `revealed`,
+`redacted`, `hidden`. The harness only sees the first four — `hidden`
+stays internal to the daemon.
 
 ### Content-type allowlists
 


### PR DESCRIPTION
## Summary

Adds two self-contained skills at `skills/` that document how to work with xmtp-signet from the two sides of the trust boundary:

- **`skills/xmtp`** — day-to-day use: the owner/admin/operator/credential/seal model, the non-privileged `xs` CLI surface (`status`, `chat`, `msg`, `inbox`, `cred`/`seal`/`policy` inspect, `lookup`, `search`, `consent`), harness WebSocket lifecycle, event/request model, projection pipeline, reveals, and seal semantics. Points to `xmtp-admin` for privileged flows.
- **`skills/xmtp-admin`** — orchestrator/admin surface: `xs init` + daemon lifecycle, `key` init/rotate/export-public, `wallet`, `operator` create/rename/rm, `policy` create/update/rm, `cred` issue/revoke/update (with reauth vs in-place rules), `inbox` create/link/unlink, `seal verify|history`, owner-gated elevations, and end-to-end flows. Points back to `xmtp` for the concept model and non-privileged use.

Both skills are self-contained (no cross-refs to `docs/`, `blz`, or `qmd`) and defer to `xs --help` as the authoritative surface when something here looks stale.

## Test plan

- [ ] Skim both `SKILL.md` files for accuracy against the current CLI
- [ ] Confirm frontmatter triggers feel right for both skills
- [ ] Decide whether to retire the overlapping `.claude/skills/xmtp-signet-use` skill in a follow-up