### PR TITLE
feat: add xmtp.fyi installer host and simplify OpenClaw setup

### DIFF
--- a/.plugins/xmtp-signet/skills/xmtp-admin/SKILL.md
+++ b/.plugins/xmtp-signet/skills/xmtp-admin/SKILL.md
@@ -33,6 +33,44 @@ credential/seal, projection pipeline, event types, harness lifecycle) and
 for day-to-day agent use (messaging, inspecting, harness connection), use
 the `xmtp` skill. This skill focuses on the *privileged* half of the CLI.
 
+## If `xs` is not installed yet
+
+Before you can provision operators, credentials, or adapters, the machine needs
+an `xmtp-signet` checkout and a runnable CLI.
+
+### Canonical path: clone and bootstrap
+
+```bash
+git clone https://github.com/xmtp/xmtp-signet.git
+cd xmtp-signet
+bun run bootstrap
+bun packages/cli/src/bin.ts --help
+```
+
+From a plain clone, the repo entrypoint is the reliable path. If you want
+`xs` as a shell command, create an alias for the current session:
+
+```bash
+alias xs='bun packages/cli/src/bin.ts'
+```
+
+### Convenience path: one-shot installer
+
+```bash
+curl -fsSL \
+  https://raw.githubusercontent.com/xmtp/xmtp-signet/main/scripts/install.sh \
+  | bash
+```
+
+That installer clones the repo, runs `bun run bootstrap`, and writes `xs`
+wrappers into `~/.local/bin`.
+
+If `xs` is still not found in a new shell, add this to your shell profile:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
 ## Trust boundary at a glance
 
 ```text

--- a/.plugins/xmtp-signet/skills/xmtp-admin/SKILL.md
+++ b/.plugins/xmtp-signet/skills/xmtp-admin/SKILL.md
@@ -87,6 +87,15 @@ xs agent doctor           # diagnose keys, daemon, credential, seal health
 Use `agent setup` for happy-path provisioning and `agent doctor` as the
 first thing you run when something feels off.
 
+For OpenClaw specifically, the happy-path adapter bootstrap is:
+
+```bash
+xs agent setup openclaw
+```
+
+Follow with `xs agent status openclaw` only when you want a verification pass,
+and `xs agent doctor openclaw` when setup or wiring looks wrong.
+
 ## Keys
 
 Keys are per-operator. `xs key init` is not redundant with `xs init` —

--- a/.plugins/xmtp-signet/skills/xmtp-admin/SKILL.md
+++ b/.plugins/xmtp-signet/skills/xmtp-admin/SKILL.md
@@ -71,10 +71,15 @@ curl -fsSL \
 That installer clones the repo, runs `bun run bootstrap`, and writes `xs`
 wrappers into an XDG-aware bin directory.
 
-If `xs` is still not found in a new shell, add this to your shell profile:
+If `xs` is still not found in a new shell, add the installer's printed wrapper
+path to your shell profile. Common defaults are:
 
 ```bash
+# Linux / XDG
 export PATH="$HOME/.local/bin:$PATH"
+
+# macOS fallback (only if the installer chose ~/bin)
+export PATH="$HOME/bin:$PATH"
 ```
 
 ## Trust boundary at a glance

--- a/.plugins/xmtp-signet/skills/xmtp-admin/SKILL.md
+++ b/.plugins/xmtp-signet/skills/xmtp-admin/SKILL.md
@@ -41,7 +41,7 @@ an `xmtp-signet` checkout and a runnable CLI.
 ### Canonical path: clone and bootstrap
 
 ```bash
-git clone https://github.com/xmtp/xmtp-signet.git
+git clone https://github.com/galligan/xmtp-signet.git
 cd xmtp-signet
 bun run bootstrap
 bun packages/cli/src/bin.ts --help
@@ -57,13 +57,19 @@ alias xs='bun packages/cli/src/bin.ts'
 ### Convenience path: one-shot installer
 
 ```bash
+curl -fsSL https://xmtp.fyi/install.sh | bash
+```
+
+Repo-backed fallback:
+
+```bash
 curl -fsSL \
-  https://raw.githubusercontent.com/xmtp/xmtp-signet/main/scripts/install.sh \
+  https://raw.githubusercontent.com/galligan/xmtp-signet/main/scripts/install.sh \
   | bash
 ```
 
 That installer clones the repo, runs `bun run bootstrap`, and writes `xs`
-wrappers into `~/.local/bin`.
+wrappers into an XDG-aware bin directory.
 
 If `xs` is still not found in a new shell, add this to your shell profile:
 

--- a/.plugins/xmtp-signet/skills/xmtp/SKILL.md
+++ b/.plugins/xmtp-signet/skills/xmtp/SKILL.md
@@ -35,6 +35,23 @@ creating operators, issuing and revoking credentials, managing keys and
 wallets, defining policies), use the `xmtp-admin` skill. This skill covers
 the day-to-day *use* of an already-configured signet.
 
+## OpenClaw adapter
+
+If the harness is OpenClaw, make that visible early instead of treating it like
+an implementation detail.
+
+- OpenClaw setup is a signet adapter flow, not a direct XMTP SDK flow.
+- The provisioning side belongs to the `xmtp-admin` skill:
+  - `xs agent setup openclaw`
+  - `xs agent status openclaw`
+  - `xs agent doctor openclaw`
+- Once the adapter is provisioned, the agent still operates through the normal
+  signet model described in this skill.
+
+For the short operator handoff, see
+`references/openclaw-adapter.md`. For the full bootstrap guide, see
+`docs/agent-setup/openclaw.md`.
+
 ## Mental model
 
 ```text

--- a/.plugins/xmtp-signet/skills/xmtp/SKILL.md
+++ b/.plugins/xmtp-signet/skills/xmtp/SKILL.md
@@ -35,9 +35,28 @@ creating operators, issuing and revoking credentials, managing keys and
 wallets, defining policies), use the `xmtp-admin` skill. This skill covers
 the day-to-day *use* of an already-configured signet.
 
-If `xs` is not installed yet, stop here and hand off to `xmtp-admin` first.
-That skill now includes the clone/bootstrap path and the one-shot installer
-path for getting a signet checkout onto a machine.
+## First check: is `xs` available?
+
+Before using this skill, check whether `xs` is already available:
+
+```bash
+if command -v xs >/dev/null 2>&1; then
+  xs --help >/dev/null
+else
+  echo "xs is not installed yet"
+fi
+```
+
+If `xs` is not installed yet:
+
+- preferred public installer: `curl -fsSL https://xmtp.fyi/install.sh | bash`
+- repo-backed fallback:
+  `curl -fsSL https://raw.githubusercontent.com/galligan/xmtp-signet/main/scripts/install.sh | bash`
+- if you already have a local clone, use the repo entrypoint directly:
+  `bun packages/cli/src/bin.ts --help`
+
+Then hand off to `xmtp-admin` for `xs init`, daemon startup, operator setup,
+credential issuance, and adapter provisioning.
 
 ## OpenClaw adapter
 

--- a/.plugins/xmtp-signet/skills/xmtp/SKILL.md
+++ b/.plugins/xmtp-signet/skills/xmtp/SKILL.md
@@ -35,6 +35,10 @@ creating operators, issuing and revoking credentials, managing keys and
 wallets, defining policies), use the `xmtp-admin` skill. This skill covers
 the day-to-day *use* of an already-configured signet.
 
+If `xs` is not installed yet, stop here and hand off to `xmtp-admin` first.
+That skill now includes the clone/bootstrap path and the one-shot installer
+path for getting a signet checkout onto a machine.
+
 ## OpenClaw adapter
 
 If the harness is OpenClaw, make that visible early instead of treating it like

--- a/.plugins/xmtp-signet/skills/xmtp/SKILL.md
+++ b/.plugins/xmtp-signet/skills/xmtp/SKILL.md
@@ -41,10 +41,12 @@ If the harness is OpenClaw, make that visible early instead of treating it like
 an implementation detail.
 
 - OpenClaw setup is a signet adapter flow, not a direct XMTP SDK flow.
-- The provisioning side belongs to the `xmtp-admin` skill:
-  - `xs agent setup openclaw`
-  - `xs agent status openclaw`
-  - `xs agent doctor openclaw`
+- The happy-path provisioning command is `xs agent setup openclaw`.
+- The provisioning side still belongs to the `xmtp-admin` skill.
+- `xs agent status openclaw` is a follow-up verification command, not a
+  required setup step.
+- `xs agent doctor openclaw` is the repair/diagnostic path when setup or wiring
+  looks wrong.
 - Once the adapter is provisioned, the agent still operates through the normal
   signet model described in this skill.
 

--- a/.plugins/xmtp-signet/skills/xmtp/references/openclaw-adapter.md
+++ b/.plugins/xmtp-signet/skills/xmtp/references/openclaw-adapter.md
@@ -20,6 +20,9 @@ run an OpenClaw-managed agent against XMTP, the shape is:
 - **`docs/agent-setup/openclaw.md`**
   - use for the full operator-facing bootstrap guide and artifact layout
 
+If `xs` is missing on the machine, stop and install the signet first through
+the `xmtp-admin` skill before trying to provision the OpenClaw adapter.
+
 ## Happy path
 
 If the signet is already initialized and the daemon is running, the setup

--- a/.plugins/xmtp-signet/skills/xmtp/references/openclaw-adapter.md
+++ b/.plugins/xmtp-signet/skills/xmtp/references/openclaw-adapter.md
@@ -20,14 +20,34 @@ run an OpenClaw-managed agent against XMTP, the shape is:
 - **`docs/agent-setup/openclaw.md`**
   - use for the full operator-facing bootstrap guide and artifact layout
 
+## Happy path
+
+If the signet is already initialized and the daemon is running, the setup
+command to start with is:
+
+```bash
+xs agent setup openclaw
+```
+
+That is the main setup flow. It provisions or reuses the OpenClaw operator and
+policy templates, verifies daemon and websocket readiness, and writes the
+adapter bundle under the signet data directory.
+
+## Follow-up commands
+
+Use these only when you want confirmation or troubleshooting:
+
+```bash
+xs agent status openclaw   # verify the provisioned adapter bundle
+xs agent doctor openclaw   # diagnose missing prerequisites or broken wiring
+```
+
 ## Minimum OpenClaw setup flow
 
 The OpenClaw adapter uses the generic harness surface:
 
 ```bash
 xs agent setup openclaw
-xs agent status openclaw
-xs agent doctor openclaw
 ```
 
 Provisioning writes the adapter bundle under the signet data directory:
@@ -48,7 +68,8 @@ Important generated artifacts:
 ## What to tell an agent or operator
 
 If the question is "how do I get OpenClaw wired up?" then route to the
-`xmtp-admin` skill and `docs/agent-setup/openclaw.md`.
+`xmtp-admin` skill and `docs/agent-setup/openclaw.md`, and start with
+`xs agent setup openclaw`.
 
 If the question is "how does the agent behave once OpenClaw is connected?" then
 stay in the main `xmtp` skill. The harness still talks to the signet over the

--- a/.plugins/xmtp-signet/skills/xmtp/references/openclaw-adapter.md
+++ b/.plugins/xmtp-signet/skills/xmtp/references/openclaw-adapter.md
@@ -1,0 +1,56 @@
+# OpenClaw adapter quick reference
+
+OpenClaw is the first built-in adapter for the signet. If someone asks how to
+run an OpenClaw-managed agent against XMTP, the shape is:
+
+1. An orchestrator provisions the adapter bundle with `xs agent setup openclaw`
+2. OpenClaw consumes the generated adapter artifacts
+3. The agent itself operates through the normal signet surfaces described in
+   the main `xmtp` skill
+
+## What belongs where
+
+- **This `xmtp` skill**
+  - use after the adapter is already provisioned
+  - explains the signet model, day-to-day `xs` usage, and harness-facing XMTP
+    behavior
+- **`xmtp-admin` skill**
+  - use for privileged setup work such as starting the daemon, provisioning
+    operators and credentials, and running `xs agent setup openclaw`
+- **`docs/agent-setup/openclaw.md`**
+  - use for the full operator-facing bootstrap guide and artifact layout
+
+## Minimum OpenClaw setup flow
+
+The OpenClaw adapter uses the generic harness surface:
+
+```bash
+xs agent setup openclaw
+xs agent status openclaw
+xs agent doctor openclaw
+```
+
+Provisioning writes the adapter bundle under the signet data directory:
+
+```text
+${SIGNET_DATA_DIR}/adapters/openclaw/
+```
+
+Important generated artifacts:
+
+- `adapter.toml`
+- `adapter-manifest.toml`
+- `openclaw-account.json`
+- `operator-templates.json`
+- `policy-templates.json`
+- `checkpoints/`
+
+## What to tell an agent or operator
+
+If the question is "how do I get OpenClaw wired up?" then route to the
+`xmtp-admin` skill and `docs/agent-setup/openclaw.md`.
+
+If the question is "how does the agent behave once OpenClaw is connected?" then
+stay in the main `xmtp` skill. The harness still talks to the signet over the
+credential-native boundary; OpenClaw is the adapter, not a bypass around the
+signet model.

--- a/.plugins/xmtp-signet/skills/xmtp/references/openclaw-adapter.md
+++ b/.plugins/xmtp-signet/skills/xmtp/references/openclaw-adapter.md
@@ -21,7 +21,8 @@ run an OpenClaw-managed agent against XMTP, the shape is:
   - use for the full operator-facing bootstrap guide and artifact layout
 
 If `xs` is missing on the machine, stop and install the signet first through
-the `xmtp-admin` skill before trying to provision the OpenClaw adapter.
+the `xmtp-admin` skill before trying to provision the OpenClaw adapter. The
+preferred public installer is `https://xmtp.fyi/install.sh`.
 
 ## Happy path
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,75 @@ touch raw credentials, raw databases, or the XMTP SDK directly. They connect
 through a controlled interface with scoped credentials, policy-based permission
 sets, and public seals that disclose what an agent can do.
 
+## Install the signet
+
+If the machine does not already have a runnable `xs`, there are two supported
+paths:
+
+### Clone and bootstrap
+
+This is the canonical development path and the most transparent way to get
+started.
+
+```bash
+git clone https://github.com/xmtp/xmtp-signet.git
+cd xmtp-signet
+bun run bootstrap
+```
+
+From a plain clone, run the CLI via the repo entrypoint:
+
+```bash
+bun packages/cli/src/bin.ts --help
+```
+
+If you want `xs` as a shell command after a clone-based install, use the
+installer script below or create your own alias/wrapper.
+
+### One-shot installer
+
+If you want a stable installer URL, this repo also ships a GitHub-friendly
+bootstrap script. It still expects `git` and `bun` to be installed first:
+
+```bash
+curl -fsSL \
+  https://raw.githubusercontent.com/xmtp/xmtp-signet/main/scripts/install.sh \
+  | bash
+```
+
+That script:
+
+- clones `xmtp-signet` into `~/.local/share/xmtp-signet`
+- runs `bun run bootstrap`
+- installs `xs` and `xmtp-signet` wrappers into `~/.local/bin`
+
+Safer inspect-first variant:
+
+```bash
+curl -fsSL \
+  https://raw.githubusercontent.com/xmtp/xmtp-signet/main/scripts/install.sh \
+  -o /tmp/xmtp-signet-install.sh
+less /tmp/xmtp-signet-install.sh
+bash /tmp/xmtp-signet-install.sh
+```
+
+Useful installer flags:
+
+- `--dir <path>` to choose the checkout path
+- `--bin-dir <path>` to choose where the wrappers are written
+- `--ref <branch-or-tag>` to pin what gets cloned
+- `--update` to fast-forward an existing checkout before bootstrapping
+
+This script is designed so you can later publish it behind a stable redirect or
+proxy such as `https://xmtp.fyi/install.sh` without changing the script itself.
+The minimal hosting setup is just a tiny Vercel or Cloudflare project that
+redirects or proxies `/install.sh` to this script's raw GitHub URL.
+
 ## Install the skills
 
 If you mainly want to use the signet from an agent harness, the fastest path is
-to install the packaged skills first. This repo currently ships two bundled
-skills:
+to install the packaged skills first. If `xs` is not installed yet, start with
+the signet install flow above. This repo currently ships two bundled skills:
 
 - `xmtp` for day-to-day signet use
 - `xmtp-admin` for privileged setup, provisioning, and policy work
@@ -145,6 +209,10 @@ runtime, transport, event model, and connection lifecycle details.
 git clone https://github.com/xmtp/xmtp-signet.git
 cd xmtp-signet
 bun run bootstrap
+
+# Use the repo entrypoint directly, or alias it for this shell session
+bun packages/cli/src/bin.ts --help
+alias xs='bun packages/cli/src/bin.ts'
 
 # Build and verify
 bun run build

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is the canonical development path and the most transparent way to get
 started.
 
 ```bash
-git clone https://github.com/xmtp/xmtp-signet.git
+git clone https://github.com/galligan/xmtp-signet.git
 cd xmtp-signet
 bun run bootstrap
 ```
@@ -33,12 +33,17 @@ installer script below or create your own alias/wrapper.
 
 ### One-shot installer
 
-If you want a stable installer URL, this repo also ships a GitHub-friendly
-bootstrap script. It still expects `git` and `bun` to be installed first:
+If you want a stable installer URL, the preferred public path is:
+
+```bash
+curl -fsSL https://xmtp.fyi/install.sh | bash
+```
+
+That host should proxy the script from this repo. The repo-backed fallback is:
 
 ```bash
 curl -fsSL \
-  https://raw.githubusercontent.com/xmtp/xmtp-signet/main/scripts/install.sh \
+  https://raw.githubusercontent.com/galligan/xmtp-signet/main/scripts/install.sh \
   | bash
 ```
 
@@ -52,7 +57,7 @@ Safer inspect-first variant:
 
 ```bash
 curl -fsSL \
-  https://raw.githubusercontent.com/xmtp/xmtp-signet/main/scripts/install.sh \
+  https://raw.githubusercontent.com/galligan/xmtp-signet/main/scripts/install.sh \
   -o /tmp/xmtp-signet-install.sh
 less /tmp/xmtp-signet-install.sh
 bash /tmp/xmtp-signet-install.sh
@@ -69,6 +74,8 @@ This script is designed so you can later publish it behind a stable redirect or
 proxy such as `https://xmtp.fyi/install.sh` without changing the script itself.
 The minimal hosting setup is just a tiny Vercel or Cloudflare project that
 redirects or proxies `/install.sh` to this script's raw GitHub URL.
+It is XDG-aware on Linux and uses macOS-friendly fallbacks for the checkout
+path as well.
 
 ## Install the skills
 
@@ -206,7 +213,7 @@ runtime, transport, event model, and connection lifecycle details.
 
 ```bash
 # Clone and bootstrap
-git clone https://github.com/xmtp/xmtp-signet.git
+git clone https://github.com/galligan/xmtp-signet.git
 cd xmtp-signet
 bun run bootstrap
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,14 @@ curl -fsSL \
 
 That script:
 
-- clones `xmtp-signet` into `~/.local/share/xmtp-signet`
+- clones `xmtp-signet` into an XDG-aware checkout path
 - runs `bun run bootstrap`
-- installs `xs` and `xmtp-signet` wrappers into `~/.local/bin`
+- installs `xs` and `xmtp-signet` wrappers into an XDG-aware bin path
+
+Default locations:
+
+- Linux / XDG: `${XDG_DATA_HOME:-~/.local/share}/xmtp-signet` and `${XDG_BIN_HOME:-~/.local/bin}`
+- macOS fallback: `~/Library/Application Support/xmtp-signet` and either `~/.local/bin` or `~/bin`
 
 Safer inspect-first variant:
 
@@ -74,8 +79,6 @@ This script is designed so you can later publish it behind a stable redirect or
 proxy such as `https://xmtp.fyi/install.sh` without changing the script itself.
 The minimal hosting setup is just a tiny Vercel or Cloudflare project that
 redirects or proxies `/install.sh` to this script's raw GitHub URL.
-It is XDG-aware on Linux and uses macOS-friendly fallbacks for the checkout
-path as well.
 
 ## Install the skills
 

--- a/apps/xmtp-fyi-install/README.md
+++ b/apps/xmtp-fyi-install/README.md
@@ -1,0 +1,48 @@
+# xmtp.fyi installer host
+
+This tiny Worker exists to serve a stable public installer URL:
+
+```text
+https://xmtp.fyi/install.sh
+```
+
+The Worker proxies the repo-backed installer script from GitHub so the public
+URL stays stable even if the repo layout or bootstrap story changes.
+
+## Expected URLs
+
+- `/` - plain-text landing output with the install command
+- `/install.sh` - current installer script
+- `/install/v1.sh` - versioned alias for the same installer
+- `/healthz` - liveness probe
+
+## Post-merge deploy
+
+From this repo:
+
+```bash
+cd apps/xmtp-fyi-install
+npx wrangler deploy
+```
+
+The Wrangler config attaches the Worker to the apex custom domain:
+
+```text
+xmtp.fyi
+```
+
+## DNS and zone notes
+
+- `xmtp.fyi` must already exist as an active Cloudflare zone
+- the hostname used as a custom domain cannot already have a conflicting CNAME
+- Cloudflare will provision the certificate for the custom domain
+
+## Verification
+
+After deploy:
+
+```bash
+curl -i https://xmtp.fyi/healthz
+curl -i https://xmtp.fyi/install.sh
+curl -fsSL https://xmtp.fyi/install.sh | sed -n '1,40p'
+```

--- a/apps/xmtp-fyi-install/worker.js
+++ b/apps/xmtp-fyi-install/worker.js
@@ -1,0 +1,103 @@
+const DEFAULT_REPO = "galligan/xmtp-signet";
+const DEFAULT_REF = "main";
+
+function installScriptUrl(env) {
+  if (env.INSTALL_SCRIPT_URL) {
+    return env.INSTALL_SCRIPT_URL;
+  }
+
+  const repo = env.GITHUB_REPO || DEFAULT_REPO;
+  const ref = env.GITHUB_REF || DEFAULT_REF;
+  return `https://raw.githubusercontent.com/${repo}/${ref}/scripts/install.sh`;
+}
+
+function installCommand() {
+  return "curl -fsSL https://xmtp.fyi/install.sh | bash";
+}
+
+function textResponse(body, init = {}) {
+  const headers = new Headers(init.headers);
+  if (!headers.has("content-type")) {
+    headers.set("content-type", "text/plain; charset=utf-8");
+  }
+
+  return new Response(body, {
+    ...init,
+    headers,
+  });
+}
+
+async function proxyInstallScript(env) {
+  const upstreamUrl = installScriptUrl(env);
+  const upstream = await fetch(upstreamUrl, {
+    headers: {
+      "user-agent": "xmtp-fyi-install-worker",
+    },
+  });
+
+  if (!upstream.ok) {
+    return textResponse(
+      `Failed to fetch upstream installer: ${upstream.status}\n`,
+      {
+        status: 502,
+        headers: {
+          "cache-control": "no-store",
+          "x-install-upstream": upstreamUrl,
+        },
+      },
+    );
+  }
+
+  const headers = new Headers(upstream.headers);
+  headers.set("content-type", "text/x-shellscript; charset=utf-8");
+  headers.set("cache-control", "public, max-age=300");
+  headers.set("x-install-upstream", upstreamUrl);
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers,
+  });
+}
+
+export default {
+  async fetch(request, env) {
+    const { pathname } = new URL(request.url);
+
+    if (pathname === "/healthz") {
+      return textResponse("ok\n", {
+        headers: {
+          "cache-control": "no-store",
+        },
+      });
+    }
+
+    if (pathname === "/install.sh" || pathname === "/install/v1.sh") {
+      return proxyInstallScript(env);
+    }
+
+    if (pathname === "/") {
+      return textResponse(
+        [
+          "xmtp-signet installer",
+          "",
+          `Run: ${installCommand()}`,
+          "",
+          `Upstream: ${installScriptUrl(env)}`,
+          "",
+          "Health: /healthz",
+        ].join("\n") + "\n",
+        {
+          headers: {
+            "cache-control": "public, max-age=60",
+          },
+        },
+      );
+    }
+
+    return textResponse("Not found\n", {
+      status: 404,
+      headers: {
+        "cache-control": "no-store",
+      },
+    });
+  },
+};

--- a/apps/xmtp-fyi-install/wrangler.jsonc
+++ b/apps/xmtp-fyi-install/wrangler.jsonc
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/cloudflare/workers-sdk/main/packages/wrangler/config-schema.json",
+  "name": "xmtp-fyi-install",
+  "main": "worker.js",
+  "compatibility_date": "2026-04-23",
+  "workers_dev": true,
+  "routes": [
+    {
+      "pattern": "xmtp.fyi",
+      "custom_domain": true,
+    },
+  ],
+  "vars": {
+    "GITHUB_REPO": "galligan/xmtp-signet",
+    "GITHUB_REF": "main",
+  },
+}

--- a/docs/agent-setup/openclaw.md
+++ b/docs/agent-setup/openclaw.md
@@ -16,6 +16,24 @@ and currently supports:
 - `xs agent status openclaw`
 - `xs agent doctor openclaw`
 
+## Happy path
+
+If signet is already initialized and the daemon is running, the main command to
+start with is:
+
+```bash
+xs agent setup openclaw
+```
+
+That is the actual provisioning step. It checks prerequisites, ensures the
+OpenClaw operator and policy templates exist, and writes the adapter bundle
+under the signet data directory.
+
+Use the other commands only when you need follow-up inspection:
+
+- `xs agent status openclaw` to verify the generated bundle
+- `xs agent doctor openclaw` to diagnose a broken or partial setup
+
 ## Prerequisites
 
 - `xs` is configured and initialized (`xs init`) so an admin key exists.
@@ -44,30 +62,30 @@ xs status --json
 2. Run OpenClaw provisioning:
 
 ```bash
-xs agent setup openclaw --json
+xs agent setup openclaw
 ```
 
 Use a custom config path with:
 
 ```bash
-xs agent setup openclaw --config /path/to/config.toml --json
+xs agent setup openclaw --config /path/to/config.toml
 ```
 
 3. If you need to rewrite generated files (for example after a bad manual edit),
 re-run with force:
 
 ```bash
-xs agent setup openclaw --config /path/to/config.toml --force --json
+xs agent setup openclaw --config /path/to/config.toml --force
 ```
 
-Successful setup returns a structured result with:
+With `--json`, successful setup returns a structured result with:
 
 - `created`: newly created operators, policies, and artifacts.
 - `reused`: already-existing resources and artifacts.
 - `artifacts`: map of artifact label to absolute path.
 - `nextSteps`: follow-up commands.
 
-Typical output shape:
+Typical JSON output shape:
 
 ```json
 {
@@ -180,13 +198,13 @@ export SIGNET_DATA_DIR="/absolute/path/to/dataDir"
 ls -la "${SIGNET_DATA_DIR}/adapters/openclaw"
 ```
 
-2. Inspect adapter status:
+2. If you want a verification pass after setup, inspect adapter status:
 
 ```bash
-xs agent status openclaw --json
+xs agent status openclaw
 ```
 
-Expected post-setup shape:
+Expected post-setup shape when using `--json`:
 
 - `details.phase: "runtime"`
 - `details.bridgePhase: "read-only"`
@@ -206,10 +224,10 @@ Expected post-setup shape:
 - `degraded` when setup is partially present
 - `missing` when the adapter root is not provisioned yet
 
-3. Run doctor for installation diagnostics:
+3. If setup or wiring looks wrong, run doctor for installation diagnostics:
 
 ```bash
-xs agent doctor openclaw --json
+xs agent doctor openclaw
 ```
 
 Expected doctor behavior:
@@ -264,7 +282,7 @@ If setup is incomplete, doctor calls out:
 
 - You need to verify the bridge runtime itself
   - The adapter now ships the first read-only bridge slice.
-  - `xs agent status openclaw --json` confirms the provisioned adapter bundle
+  - `xs agent status openclaw` confirms the provisioned adapter bundle
     and bridge prerequisites, but it does not prove a live bridge process is
     currently connected to signet.
   - Bridge checkpoint files will appear under `checkpoints/` once a runtime

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3,6 +3,11 @@
 This document describes the live `xs` command surface on `main`. For config
 layout and path resolution, see [configuration.md](./configuration.md).
 
+If `xs` is not already on your `PATH`, either:
+
+- run the repo entrypoint directly with `bun packages/cli/src/bin.ts ...`, or
+- install the wrapper script from `scripts/install.sh`
+
 ## Command Map
 
 Top-level commands:

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,7 +15,10 @@ cd xmtp-signet
 bun run bootstrap
 ```
 
-Bootstrap installs workspace dependencies, repo hooks, and local CLI tools.
+Bootstrap installs workspace dependencies and repo hooks so the repo-local CLI
+entrypoint can run cleanly.
+For a wrapper-style install that creates `xs` under `~/.local/bin`, use
+`scripts/install.sh` instead.
 
 For the current docs map, start with [index.md](./index.md).
 
@@ -104,20 +107,21 @@ bun run lint
 
 ### CLI
 
-After bootstrap, the local CLI is available as `xs`:
-
-```bash
-xs --help
-xs daemon start
-xs status --json
-xs cred issue --op alice-bot --chat conv_9e2d1a4b8c3f7e60 --allow send,reply
-xs cred info cred_b2c1
-```
-
-If you want to run the entrypoint directly from the repo:
+After bootstrap, run the CLI from the repo entrypoint:
 
 ```bash
 bun packages/cli/src/bin.ts --help
+bun packages/cli/src/bin.ts daemon start
+bun packages/cli/src/bin.ts status --json
+bun packages/cli/src/bin.ts cred issue --op alice-bot --chat conv_9e2d1a4b8c3f7e60 --allow send,reply
+bun packages/cli/src/bin.ts cred info cred_b2c1
+```
+
+If you prefer `xs` while working from a clone, create a shell alias or run the
+installer script so it writes a wrapper into `~/.local/bin`:
+
+```bash
+alias xs='bun packages/cli/src/bin.ts'
 ```
 
 For current-state command and config references:

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,7 +10,7 @@
 ## Setup
 
 ```bash
-git clone https://github.com/xmtp/xmtp-signet.git
+git clone https://github.com/galligan/xmtp-signet.git
 cd xmtp-signet
 bun run bootstrap
 ```

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_URL="${XMTP_SIGNET_REPO:-https://github.com/xmtp/xmtp-signet.git}"
+REF="${XMTP_SIGNET_REF:-main}"
+INSTALL_DIR="${XMTP_SIGNET_INSTALL_DIR:-$HOME/.local/share/xmtp-signet}"
+BIN_DIR="${XMTP_SIGNET_BIN_DIR:-$HOME/.local/bin}"
+LINK_BIN=1
+UPDATE=0
+
+usage() {
+  cat <<'EOF'
+Install xmtp-signet from GitHub into a local checkout and create an `xs` wrapper.
+
+Usage:
+  install.sh [options]
+
+Options:
+  --dir <path>       Install checkout path (default: ~/.local/share/xmtp-signet)
+  --bin-dir <path>   Wrapper install path (default: ~/.local/bin)
+  --repo <url>       Git repository to clone (default: official GitHub repo)
+  --ref <name>       Git branch, tag, or ref to clone (default: main)
+  --update           Fetch and fast-forward an existing checkout before bootstrap
+  --no-link-bin      Skip creating xs/xmtp-signet wrapper scripts
+  -h, --help         Show this help
+
+Environment overrides:
+  XMTP_SIGNET_INSTALL_DIR
+  XMTP_SIGNET_BIN_DIR
+  XMTP_SIGNET_REPO
+  XMTP_SIGNET_REF
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dir)
+      INSTALL_DIR="$2"
+      shift 2
+      ;;
+    --bin-dir)
+      BIN_DIR="$2"
+      shift 2
+      ;;
+    --repo)
+      REPO_URL="$2"
+      shift 2
+      ;;
+    --ref)
+      REF="$2"
+      shift 2
+      ;;
+    --update)
+      UPDATE=1
+      shift
+      ;;
+    --no-link-bin)
+      LINK_BIN=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_tool() {
+  local tool="$1"
+  local hint="$2"
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "missing required tool: $tool" >&2
+    echo "$hint" >&2
+    exit 1
+  fi
+}
+
+require_tool git "Install Git first, then re-run this installer."
+require_tool bun "Install Bun from https://bun.sh, then re-run this installer."
+
+ensure_checkout() {
+  if [[ ! -e "$INSTALL_DIR" ]]; then
+    mkdir -p "$(dirname "$INSTALL_DIR")"
+    echo "==> Cloning xmtp-signet into $INSTALL_DIR"
+    git clone --branch "$REF" --single-branch "$REPO_URL" "$INSTALL_DIR"
+    return
+  fi
+
+  if [[ ! -d "$INSTALL_DIR/.git" ]]; then
+    echo "install directory exists but is not a git checkout: $INSTALL_DIR" >&2
+    echo "Choose a different --dir or remove that directory first." >&2
+    exit 1
+  fi
+
+  echo "==> Reusing existing checkout at $INSTALL_DIR"
+  if [[ "$UPDATE" == "1" ]]; then
+    echo "==> Updating checkout to $REF"
+    (
+      cd "$INSTALL_DIR"
+      git fetch origin "$REF"
+      git checkout "$REF"
+      if git show-ref --verify --quiet "refs/remotes/origin/$REF"; then
+        git pull --ff-only origin "$REF"
+      else
+        echo "==> Checked out non-branch ref $REF; skipping fast-forward pull"
+      fi
+    )
+  fi
+}
+
+warn_on_bun_version_mismatch() {
+  local version_file="$INSTALL_DIR/.bun-version"
+  if [[ -f "$version_file" ]]; then
+    local expected current
+    expected="$(< "$version_file")"
+    current="$(bun --version)"
+    if [[ "$current" != "$expected" ]]; then
+      echo "warning: expected Bun $expected, found $current" >&2
+    fi
+  fi
+}
+
+write_wrapper() {
+  local name="$1"
+  local wrapper_path="$BIN_DIR/$name"
+  cat > "$wrapper_path" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$INSTALL_DIR"
+exec bun packages/cli/src/bin.ts "\$@"
+EOF
+  chmod +x "$wrapper_path"
+}
+
+ensure_checkout
+warn_on_bun_version_mismatch
+
+echo "==> Bootstrapping checkout"
+(
+  cd "$INSTALL_DIR"
+  bun run bootstrap
+)
+
+if [[ "$LINK_BIN" == "1" ]]; then
+  echo "==> Installing xs wrapper into $BIN_DIR"
+  mkdir -p "$BIN_DIR"
+  write_wrapper xs
+  write_wrapper xmtp-signet
+fi
+
+echo
+echo "xmtp-signet is ready."
+echo "Checkout: $INSTALL_DIR"
+if [[ "$LINK_BIN" == "1" ]]; then
+  echo "Wrappers: $BIN_DIR/xs and $BIN_DIR/xmtp-signet"
+fi
+echo
+echo "Next steps:"
+echo "  xs --help"
+echo "  xs init --env dev --label owner"
+echo "  xs daemon start"
+
+case ":$PATH:" in
+  *":$BIN_DIR:"*)
+    ;;
+  *)
+    if [[ "$LINK_BIN" == "1" ]]; then
+      echo
+      echo "If \`xs\` is not found in a new shell, add this to your shell profile:"
+      echo "  export PATH=\"$BIN_DIR:\$PATH\""
+    fi
+    ;;
+esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,12 +2,51 @@
 
 set -euo pipefail
 
-REPO_URL="${XMTP_SIGNET_REPO:-https://github.com/xmtp/xmtp-signet.git}"
+UNAME="$(uname -s)"
+DEFAULT_REPO_URL="https://github.com/galligan/xmtp-signet.git"
 REF="${XMTP_SIGNET_REF:-main}"
-INSTALL_DIR="${XMTP_SIGNET_INSTALL_DIR:-$HOME/.local/share/xmtp-signet}"
-BIN_DIR="${XMTP_SIGNET_BIN_DIR:-$HOME/.local/bin}"
 LINK_BIN=1
 UPDATE=0
+
+default_install_dir() {
+  if [[ -n "${XDG_DATA_HOME:-}" ]]; then
+    printf '%s/xmtp-signet\n' "$XDG_DATA_HOME"
+    return
+  fi
+
+  case "$UNAME" in
+    Darwin)
+      printf '%s/Library/Application Support/xmtp-signet\n' "$HOME"
+      ;;
+    *)
+      printf '%s/.local/share/xmtp-signet\n' "$HOME"
+      ;;
+  esac
+}
+
+default_bin_dir() {
+  if [[ -n "${XDG_BIN_HOME:-}" ]]; then
+    printf '%s\n' "$XDG_BIN_HOME"
+    return
+  fi
+
+  case "$UNAME" in
+    Darwin)
+      if [[ -d "$HOME/bin" && ! -d "$HOME/.local/bin" ]]; then
+        printf '%s/bin\n' "$HOME"
+      else
+        printf '%s/.local/bin\n' "$HOME"
+      fi
+      ;;
+    *)
+      printf '%s/.local/bin\n' "$HOME"
+      ;;
+  esac
+}
+
+REPO_URL="${XMTP_SIGNET_REPO:-$DEFAULT_REPO_URL}"
+INSTALL_DIR="${XMTP_SIGNET_INSTALL_DIR:-$(default_install_dir)}"
+BIN_DIR="${XMTP_SIGNET_BIN_DIR:-$(default_bin_dir)}"
 
 usage() {
   cat <<'EOF'
@@ -17,8 +56,8 @@ Usage:
   install.sh [options]
 
 Options:
-  --dir <path>       Install checkout path (default: ~/.local/share/xmtp-signet)
-  --bin-dir <path>   Wrapper install path (default: ~/.local/bin)
+  --dir <path>       Install checkout path (default: XDG-aware per-platform path)
+  --bin-dir <path>   Wrapper install path (default: XDG-aware per-platform path)
   --repo <url>       Git repository to clone (default: official GitHub repo)
   --ref <name>       Git branch, tag, or ref to clone (default: main)
   --update           Fetch and fast-forward an existing checkout before bootstrap
@@ -30,7 +69,12 @@ Environment overrides:
   XMTP_SIGNET_BIN_DIR
   XMTP_SIGNET_REPO
   XMTP_SIGNET_REF
+  XDG_DATA_HOME
+  XDG_BIN_HOME
 EOF
+  printf '\nDefault paths:\n'
+  printf '  checkout -> %s\n' "$INSTALL_DIR"
+  printf '  wrappers -> %s\n' "$BIN_DIR"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -165,6 +209,7 @@ echo "Next steps:"
 echo "  xs --help"
 echo "  xs init --env dev --label owner"
 echo "  xs daemon start"
+echo "  xs agent setup openclaw   # if this machine is for OpenClaw"
 
 case ":$PATH:" in
   *":$BIN_DIR:"*)


### PR DESCRIPTION
## Summary

This turns the earlier OpenClaw setup-doc pass into a more practical install and bootstrap story:

- keeps `xs agent setup openclaw` as the single happy-path OpenClaw provisioning command
- adds a stable `xmtp.fyi/install.sh` hosting path via a tiny Cloudflare Worker app in `apps/xmtp-fyi-install/`
- makes the installer itself XDG-aware, with sensible Linux and macOS fallback locations
- teaches the packaged `xmtp` skill to check whether `xs` is already installed before continuing

## What Changed

- adds `scripts/install.sh` as a GitHub-friendly one-shot installer around clone + bootstrap
- makes the installer default paths XDG-aware:
  - Linux / XDG: `${XDG_DATA_HOME:-~/.local/share}/xmtp-signet` and `${XDG_BIN_HOME:-~/.local/bin}`
  - macOS fallback: `~/Library/Application Support/xmtp-signet` plus `~/.local/bin` or `~/bin`
- adds `apps/xmtp-fyi-install/` with a minimal Worker that serves:
  - `/install.sh`
  - `/install/v1.sh`
  - `/healthz`
- updates `README.md` with:
  - clone + bootstrap guidance
  - the preferred `https://xmtp.fyi/install.sh` path
  - raw GitHub fallback guidance
  - safer inspect-first installer usage
- updates the packaged `xmtp` skill so agents first check whether `xs` exists and, if not, install from `xmtp.fyi` or the raw GitHub fallback
- updates the packaged `xmtp-admin` skill to explain the installer path and realistic PATH follow-up on Linux and macOS
- keeps the OpenClaw docs aligned around `xs agent setup openclaw` as the happy path, with `status` as optional verification and `doctor` as troubleshooting

## Post-Merge Deploy

Once this lands on `main`, the public installer host can be deployed with:

```bash
cd apps/xmtp-fyi-install
npx wrangler deploy
```

Then verify:

```bash
curl -i https://xmtp.fyi/healthz
curl -i https://xmtp.fyi/install.sh
curl -fsSL https://xmtp.fyi/install.sh | sed -n '1,40p'
```

## Verification

- `bash scripts/install.sh --help`
- `bash scripts/install.sh --dir /Users/mg/Developer/xmtp/xmtp-signet --bin-dir <tempdir>/bin`
- wrapper smoke: `<tempdir>/bin/xs --help`
- `qmd update`
- `qmd embed`
- `bun run docs:check`
- `bun run format:check`
- `npx wrangler deploy --dry-run -c apps/xmtp-fyi-install/wrangler.jsonc`

## Notes

The branch now uses the real GitHub repo path, `galligan/xmtp-signet`, for both the raw installer fallback and the Worker proxy target.
