### PR TITLE
fix(installer): separate install payload from runtime data

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ curl -fsSL \
 That script:
 
 - downloads the latest `xs-<target>.tar.gz` release artifact for the current
-  platform
+  platform into an `install/` subdirectory separate from runtime data
 - verifies the adjacent `.sha256` checksum before extracting
 - installs `xs` and `xmtp-signet` wrappers into an XDG-aware bin path
 
 Default locations:
 
-- Linux / XDG: `${XDG_DATA_HOME:-~/.local/share}/xmtp-signet` and `${XDG_BIN_HOME:-~/.local/bin}`
-- macOS fallback: `~/Library/Application Support/xmtp-signet` and either `~/.local/bin` or `~/bin`
+- Linux / XDG: `${XDG_DATA_HOME:-~/.local/share}/xmtp-signet/install` and `${XDG_BIN_HOME:-~/.local/bin}`
+- macOS fallback: `~/Library/Application Support/xmtp-signet/install` and either `~/.local/bin` or `~/bin`
 
 Safer inspect-first variant:
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -305,9 +305,25 @@ sha_verify() {
   fi
 }
 
+warn_on_legacy_install() {
+  local legacy_dir
+  legacy_dir="$(dirname "$INSTALL_DIR")"
+
+  if [[ "$(basename "$INSTALL_DIR")" != "install" || ! -d "$legacy_dir" ]]; then
+    return
+  fi
+
+  if [[ -f "$legacy_dir/xs-$TARGET" || -f "$legacy_dir/xs-$TARGET.json" || -d "$legacy_dir/.git" ]]; then
+    echo "warning: found a legacy install at $legacy_dir" >&2
+    echo "The wrapper will be updated to use $INSTALL_DIR." >&2
+    echo "After verifying xs works, you can remove old binary/source install artifacts from the legacy path." >&2
+  fi
+}
+
 ensure_binary() {
   detect_target
   resolve_release_urls
+  warn_on_legacy_install
 
   if [[ -e "$INSTALL_DIR" ]]; then
     if [[ "$UPDATE" == "1" ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -194,6 +194,8 @@ require_tool() {
 }
 
 ensure_checkout() {
+  warn_on_legacy_install
+
   if [[ ! -e "$INSTALL_DIR" ]]; then
     mkdir -p "$(dirname "$INSTALL_DIR")"
     echo "==> Cloning xmtp-signet into $INSTALL_DIR"
@@ -313,7 +315,16 @@ warn_on_legacy_install() {
     return
   fi
 
-  if [[ -f "$legacy_dir/xs-$TARGET" || -f "$legacy_dir/xs-$TARGET.json" || -d "$legacy_dir/.git" ]]; then
+  local legacy_binary=0
+  local candidate
+  for candidate in "$legacy_dir"/xs-*; do
+    if [[ -e "$candidate" ]]; then
+      legacy_binary=1
+      break
+    fi
+  done
+
+  if [[ "$legacy_binary" == "1" || -d "$legacy_dir/.git" ]]; then
     echo "warning: found a legacy install at $legacy_dir" >&2
     echo "The wrapper will be updated to use $INSTALL_DIR." >&2
     echo "After verifying xs works, you can remove old binary/source install artifacts from the legacy path." >&2

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,16 +18,16 @@ REPO_EXPLICIT=0
 
 default_install_dir() {
   if [[ -n "${XDG_DATA_HOME:-}" ]]; then
-    printf '%s/xmtp-signet\n' "$XDG_DATA_HOME"
+    printf '%s/xmtp-signet/install\n' "$XDG_DATA_HOME"
     return
   fi
 
   case "$UNAME" in
     Darwin)
-      printf '%s/Library/Application Support/xmtp-signet\n' "$HOME"
+      printf '%s/Library/Application Support/xmtp-signet/install\n' "$HOME"
       ;;
     *)
-      printf '%s/.local/share/xmtp-signet\n' "$HOME"
+      printf '%s/.local/share/xmtp-signet/install\n' "$HOME"
       ;;
   esac
 }


### PR DESCRIPTION
## Context

The installer and runtime were both defaulting to the same XDG data directory (`$XDG_DATA_HOME/xmtp-signet`) when `XDG_DATA_HOME` is set. That made binary `install.sh --update` dangerous because it removes the install directory before extracting a refreshed binary, which could also remove runtime secrets/data.

## What changed

- Move the default installer payload path to an `install/` subdirectory:
  - `$XDG_DATA_HOME/xmtp-signet/install`
  - `~/.local/share/xmtp-signet/install` on Linux fallback
  - `~/Library/Application Support/xmtp-signet/install` on macOS fallback
- Keep wrappers in the same XDG-aware bin path.
- Update README default-path docs.

## Verification

- `bash -n scripts/install.sh`
- `bun test packages/cli/src/__tests__/config-paths.test.ts`
- `qmd update && qmd embed`
- Manual temp binary install with explicit XDG paths, then `xs init --env local --label xdg-test --json`; confirmed install payload lives under `data/xmtp-signet/install` while runtime data lives under `data/xmtp-signet`.
- Manual temp `--update` probe confirmed existing runtime data under `data/xmtp-signet/secrets` is preserved.
- Pre-push hook passed: format, lint/docs coverage, tests, typecheck.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/galligan/xmtp-signet/pull/372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
