### PR TITLE
docs(openclaw): add managed adapter execution plan

### DIFF
--- a/.agents/plans/openclaw-managed-adapter/README.md
+++ b/.agents/plans/openclaw-managed-adapter/README.md
@@ -1,0 +1,89 @@
+# OpenClaw Managed Adapter Plan
+
+Status: planning
+Last updated: 2026-04-25
+Parent issue: #375
+
+## Goal
+
+Make XMTP usable as a batteries-included OpenClaw channel through
+`xmtp-signet`, without requiring upstream OpenClaw core changes.
+
+The target happy path is:
+
+```bash
+xs agent setup openclaw --yes
+```
+
+That command should install or wire the adapter, write safe OpenClaw channel
+defaults, create a first owner bootstrap route, and leave the setup in a
+diagnosable `pending owner link` or ready state.
+
+## Design Thesis
+
+Use OpenClaw-native shape at the edge and signet-native enforcement at the
+core.
+
+OpenClaw should see a normal chat channel with familiar channel configuration:
+
+- `channels.xmtp.enabled`
+- `channels.xmtp.descriptor`
+- `dmPolicy`
+- `allowFrom`
+- `groupPolicy`
+- `groupActivation`
+- `groupAllowFrom`
+- `groups`
+
+Signet owns the durable and sensitive state:
+
+- operators
+- credentials
+- policies
+- contacts and contact groups
+- owner/admin roles
+- identity attestations
+- owner side channels
+- Convos ephemeral inbox bindings
+- session credentials
+- subagent delegation credentials
+- seals
+- audit, status, and doctor state
+
+The OpenClaw adapter/plugin acts as a harness projection over signet's
+canonical model. It must not become a second XMTP runtime.
+
+## Plan Docs
+
+- `architecture.md` - managed adapter boundary, selectors, contacts, events,
+  and status/doctor model.
+- `stack.md` - natural PR stack and verification checkpoints.
+- `issue-plan.md` - tracking issue and subissue bodies.
+
+## GitHub Issues
+
+- Tracking: #375
+- Setup stack: #376, #377, #378, #379
+- Channel model stack: #380, #381, #382, #384
+- Runtime/action stack: #383, #385, #386
+- Diagnostics/docs: #387, #388
+
+## Related Scratch Context
+
+- `.scratch/openclaw/05-signet-native-openclaw-proposal.md`
+- `.scratch/openclaw/06-openclaw-implementation-spec.md`
+- `.scratch/openclaw/10-managed-adapter-design.md`
+
+## Stack Invariants
+
+- Keep `xs init` signet-native. OpenClaw setup layers on top through
+  `xs agent setup openclaw`.
+- Do not require OpenClaw core changes.
+- Do not patch installed OpenClaw files in place.
+- Do not put raw XMTP signer material, raw signet private state, or broad
+  credential secrets into OpenClaw config.
+- Do not expose raw operator IDs, credential IDs, policy IDs, contact bindings,
+  or bootstrap state in OpenClaw config unless explicitly requested.
+- Do not let agents self-increase permissions.
+- Prefer additive, diagnosable slices. Every PR should either add a contract,
+  a dry-run surface, a status/doctor check, or one clear runtime capability.

--- a/.agents/plans/openclaw-managed-adapter/README.md
+++ b/.agents/plans/openclaw-managed-adapter/README.md
@@ -53,16 +53,24 @@ Signet owns the durable and sensitive state:
 The OpenClaw adapter/plugin acts as a harness projection over signet's
 canonical model. It must not become a second XMTP runtime.
 
+The shared implementation should start in `packages/adapter-kit`, not inside
+`adapters/openclaw`. OpenClaw is the first concrete harness, but Hermes-style
+agents and later harnesses should reuse the same setup, descriptor, projection,
+status, doctor, selector, event, and session credential primitives.
+
 ## Plan Docs
 
 - `architecture.md` - managed adapter boundary, selectors, contacts, events,
   and status/doctor model.
+- `adapter-kit.md` - reusable `packages/adapter-kit` boundary and
+  OpenClaw/Hermes research snapshot.
 - `stack.md` - natural PR stack and verification checkpoints.
 - `issue-plan.md` - tracking issue and subissue bodies.
 
 ## GitHub Issues
 
 - Tracking: #375
+- Adapter foundation: #390, #391
 - Setup stack: #376, #377, #378, #379
 - Channel model stack: #380, #381, #382, #384
 - Runtime/action stack: #383, #385, #386
@@ -87,3 +95,6 @@ canonical model. It must not become a second XMTP runtime.
 - Do not let agents self-increase permissions.
 - Prefer additive, diagnosable slices. Every PR should either add a contract,
   a dry-run surface, a status/doctor check, or one clear runtime capability.
+- Before adding OpenClaw-specific setup, status, doctor, selector, event, or
+  session logic, decide whether the reusable contract belongs in
+  `packages/adapter-kit`.

--- a/.agents/plans/openclaw-managed-adapter/adapter-kit.md
+++ b/.agents/plans/openclaw-managed-adapter/adapter-kit.md
@@ -1,0 +1,114 @@
+# Adapter Kit Foundation
+
+Status: planning
+Last updated: 2026-04-25
+Issues: #390, #391
+
+## Why This Exists
+
+OpenClaw should be the first consumer of a reusable adapter foundation, not the
+place where reusable harness adapter logic accumulates.
+
+The current repo already has OpenClaw-specific setup, status, doctor, artifact,
+bridge config, runtime presence, and checkpoint pieces under
+`adapters/openclaw/src`. Those slices are valuable, but the next managed setup
+work will add more logic that other harnesses will also need:
+
+- adapter descriptors
+- managed adapter state
+- artifact install/update planning
+- config projection and drift detection
+- setup dry-run/apply results
+- pending owner bootstrap state
+- selector resolution
+- normalized events
+- session credential lifecycle
+- status and doctor diagnostics
+
+Hermes-style agents exert enough second-consumer pressure that this should live
+in `packages/adapter-kit`.
+
+## Research Snapshot
+
+OpenClaw today:
+
+- `adapters/openclaw/src/setup/index.ts` provisions operators, policies, and
+  adapter artifacts.
+- `adapters/openclaw/src/bridge/config.ts` resolves adapter paths, checkpoint
+  paths, and runtime presence.
+- `adapters/openclaw/src/status/index.ts` and
+  `adapters/openclaw/src/doctor/index.ts` turn runtime inspection into
+  user-facing status/doctor results.
+- `packages/cli/src/agent/*` already treats adapters as process-backed
+  setup/status/doctor targets.
+
+Hermes reference pressure:
+
+- `.reference/convos-agents/runtime-hermes/src/server.py` exposes setup,
+  setup-status, complete, cancel, status, reset, and active-conversation
+  controls.
+- The setup flow has pending invite state, join detection, timeout cleanup, and
+  later binding to an active runtime instance.
+- `.reference/convos-agents/runtime-hermes/src/convos_adapter.py` normalizes
+  inbound messages into an agent runner and routes outbound responses, replies,
+  reactions, media, and profile side effects through its bridge.
+
+The harness shapes differ, but the lifecycle categories are the same enough to
+justify shared contracts before OpenClaw grows further.
+
+## Package Boundary
+
+`packages/adapter-kit` should export shared contracts and helpers only:
+
+- `adapterDescriptor`
+- `managedState`
+- `artifactPlan`
+- `configProjection`
+- `setupPlan`
+- `selectorResolution`
+- `ownerBootstrap`
+- `channelEvent`
+- `sessionCredential`
+- `adapterStatus`
+- `adapterDoctor`
+- `redaction`
+- `fixtures`
+
+It should avoid:
+
+- OpenClaw channel config names
+- Hermes route names
+- concrete process launch or CLI dispatch
+- raw XMTP SDK access
+- raw key, credential, or signer custody
+
+## Expected Consumers
+
+OpenClaw:
+
+- provides an OpenClaw config projection adapter for `plugins` and
+  `channels.xmtp`
+- provides OpenClaw descriptor fields and session naming
+- translates normalized signet events into OpenClaw channel events
+- renders status/doctor in OpenClaw channel language
+
+Hermes:
+
+- provides a runtime adapter for setup/status/control endpoints or equivalent
+  local process controls
+- maps pending Convos invite/setup state into shared owner bootstrap status
+- maps Hermes sessions to signet session credentials
+- translates normalized signet events into Hermes agent-runner input
+- routes Hermes reply/reaction/profile side effects through signet credentials
+
+## Issue Mapping
+
+#390 creates the package and shared contracts.
+
+#391 validates those contracts against the Hermes reference before OpenClaw
+implementation details leak into the package.
+
+OpenClaw issues #376 through #388 should consume adapter-kit primitives where
+possible. If a follow-on issue discovers a primitive that is useful to both
+OpenClaw and Hermes, it should either extend #390 or open a narrow adapter-kit
+follow-up rather than duplicating logic in `adapters/openclaw`.

--- a/.agents/plans/openclaw-managed-adapter/architecture.md
+++ b/.agents/plans/openclaw-managed-adapter/architecture.md
@@ -23,6 +23,69 @@ to other harnesses later.
   credentials, seals, or subagent delegation policy.
 - Do not let agents self-increase permissions.
 
+## Adapter Kit
+
+Create a shared `packages/adapter-kit` package before deepening the OpenClaw
+implementation.
+
+The current OpenClaw adapter already has setup, status, doctor, artifact,
+bridge config, checkpoint, envelope, and runtime pieces under
+`adapters/openclaw/src`. The Hermes reference runtime under
+`.reference/convos-agents/runtime-hermes` has a different harness shape, but it
+also needs setup lifecycle, pending invite state, active conversation status,
+inbound event normalization, outbound message routing, and session-bound
+runtime control. Those common needs should not be copied into every adapter.
+
+`packages/adapter-kit` should own harness-agnostic primitives:
+
+- adapter descriptor and managed-state contracts
+- adapter artifact install/update plans and manifest checks
+- XDG adapter path resolution for `~/.local/share/xmtp-signet/adapters/<name>`
+- config projection planning, dry-run output, backups, writes, and drift
+  diagnostics
+- conflict detection for managed versus user-authored config blocks
+- setup plan/apply result shapes, including pending-or-ready setup status
+- selector parse/resolve request and result contracts
+- owner bootstrap state, code expiry, and diagnosable pending owner link state
+- session credential lifecycle hooks and revocation/reacquire contracts
+- normalized channel event classes and activation/ingestion/search decisions
+- common status and doctor result shapes
+- redaction helpers so output never leaks credential or private state
+- fixtures and test helpers for first-party adapters
+
+The kit should not own harness-specific details:
+
+- OpenClaw `plugins` and `channels.xmtp` config shape
+- Hermes HTTP routes or runtime process shape
+- concrete agent/session naming rules
+- XMTP SDK custody or raw signer access
+- CLI command dispatch or process spawning
+
+Ownership should be:
+
+```text
+packages/adapter-kit
+  Shared lifecycle, projection, descriptor, selector, event, session, and
+  diagnostic contracts.
+
+adapters/openclaw
+  OpenClaw plugin packaging, OpenClaw config projection, OpenClaw session/event
+  translation, and OpenClaw-facing status language.
+
+adapters/hermes
+  Hermes runtime integration, Convos/Hermes setup endpoints or equivalent
+  bridge control, Hermes session naming, and Hermes-facing status language.
+
+packages/cli
+  `xs agent <verb> <adapter>` registry, dispatch, config loading, output, and
+  user prompts.
+```
+
+The first implementation pass should be conservative: define contracts and
+small helpers only where OpenClaw and Hermes both exert pressure. The package
+should make duplication harder, not introduce a framework that adapters have to
+fight.
+
 ## Managed Projection
 
 OpenClaw config should be a managed projection, but editable in familiar

--- a/.agents/plans/openclaw-managed-adapter/architecture.md
+++ b/.agents/plans/openclaw-managed-adapter/architecture.md
@@ -1,0 +1,575 @@
+# OpenClaw Managed Adapter Architecture
+
+Status: planning
+Last updated: 2026-04-25
+
+## Purpose
+
+This document captures the architecture for making XMTP usable as an OpenClaw
+channel through `xmtp-signet`, without requiring upstream OpenClaw core changes.
+
+The integration should feel substantially similar to existing OpenClaw chat
+channels like Slack or Telegram, while keeping durable identity,
+authorization, credential, and audit state in signet so the pattern can apply
+to other harnesses later.
+
+## Non-Goals
+
+- Do not require OpenClaw core to add XMTP support.
+- Do not patch installed OpenClaw files in place.
+- Do not put raw XMTP signer material, raw signet private state, or broad
+  credential secrets into OpenClaw config.
+- Do not make OpenClaw the source of truth for contacts, Convos inbox churn,
+  credentials, seals, or subagent delegation policy.
+- Do not let agents self-increase permissions.
+
+## Managed Projection
+
+OpenClaw config should be a managed projection, but editable in familiar
+OpenClaw channel terms.
+
+`xs` should own generated fields and be able to diagnose drift. It should warn
+or fail rather than overwrite user-authored conflicting blocks unless `--force`
+is provided.
+
+OpenClaw should see a normal channel:
+
+```json5
+{
+  "channels": {
+    "xmtp": {
+      "enabled": true,
+      "descriptor": "/path/to/openclaw-account.json",
+      "dmPolicy": "allowlist",
+      "allowFrom": ["@owner"],
+      "groupPolicy": "allowlist",
+      "groupActivation": "owner-side-channel",
+      "groupAllowFrom": ["@participants"],
+      "groups": {}
+    }
+  }
+}
+```
+
+Plugin projection should include only non-sensitive adapter references:
+
+```json5
+{
+  "plugins": {
+    "load": {
+      "paths": [
+        "~/.local/share/xmtp-signet/adapters/openclaw/plugin"
+      ]
+    },
+    "entries": {
+      "xmtp": {
+        "enabled": true
+      }
+    }
+  }
+}
+```
+
+Sensitive mappings live in signet-managed descriptor/state:
+
+```json5
+{
+  "harness": "openclaw",
+  "agents": {
+    "main": {
+      "operator": "op:...",
+      "primaryOwner": "...",
+      "defaultSessionPolicy": "policy:...",
+      "subagentDelegationProfile": "policy:..."
+    }
+  }
+}
+```
+
+## Packaging Model
+
+Keep one user-facing binary:
+
+```bash
+xs
+```
+
+Do not require a second top-level executable for normal users.
+
+`xs` may internally unpack or install versioned OpenClaw adapter artifacts:
+
+```text
+~/.local/share/xmtp-signet/adapters/openclaw/
+  plugin/
+  adapter.toml
+  adapter-manifest.toml
+  openclaw-account.json
+  managed-state.json
+  checkpoints/
+```
+
+If a helper process is eventually needed, ship it as an internal artifact of
+the `xs` distribution rather than a separate user-managed binary.
+
+## Happy Path Setup
+
+Default command:
+
+```bash
+xs agent setup openclaw --yes
+```
+
+Expected behavior:
+
+1. Verify signet is initialized and the daemon is reachable.
+2. Create or verify signet-side OpenClaw operators and policies.
+3. Install or update the OpenClaw XMTP plugin artifact.
+4. Locate the OpenClaw config, or accept `--openclaw-config`.
+5. Back up OpenClaw config before writing.
+6. Insert/update a managed `plugins` block for the XMTP plugin.
+7. Insert/update a managed `channels.xmtp` block with safe Slack-like
+   defaults.
+8. Create a bootstrap owner side channel if the operator has no owner route.
+9. Print the Convos invite and short bootstrap code.
+10. Return with status `pending owner link`, not block waiting for the user.
+
+Useful modes:
+
+```bash
+xs agent setup openclaw --yes
+xs agent setup openclaw --dry-run
+xs agent setup openclaw --print-config
+xs agent setup openclaw --force
+xs agent setup openclaw --openclaw-config ~/.openclaw/openclaw.json
+xs agent setup openclaw --yes --agent bob
+xs agent setup openclaw --yes --agent bob --agent alice
+xs agent setup openclaw --yes --all-agents
+xs agent setup openclaw --yes --agent bob --operator op:...
+```
+
+Default `--yes` wires only the main/default OpenClaw agent. Additional
+OpenClaw agents require explicit `--agent`, `--all-agents`, or explicit
+operator mapping.
+
+## Operator And Agent Mapping
+
+OpenClaw has a default/main agent and can have additional named agents.
+
+Signet model:
+
+- Durable OpenClaw agent maps to a durable signet operator.
+- OpenClaw session/conversation maps to an ephemeral signet credential.
+- OpenClaw subagent maps to an explicit delegated credential or explicit
+  separate signet operator.
+
+Default setup:
+
+```text
+OpenClaw main/default agent -> signet operator for @agent:main
+```
+
+Selectors:
+
+```text
+@agent:main
+@agent:bob
+@agent:alice
+```
+
+`@agent:<name>` is a derived selector resolved through the OpenClaw adapter
+descriptor. Exact signet operators use native IDs such as `op:<id>`.
+
+Avoid `@op:<name>` in v1.
+
+## Sessions And Credentials
+
+Each OpenClaw XMTP session should have its own credential.
+
+Rules:
+
+- Parent operator identity is durable.
+- Session credential is ephemeral and scoped.
+- Killing a session should revoke or expire its credential.
+- Revoking a credential should make that session reacquire authorization before
+  continuing XMTP reads/sends.
+- A parent credential defines the maximum possible delegation.
+- A subagent credential defines the actual granted delegation.
+- Permissions are granted, not inherited.
+
+Subagent modes:
+
+```text
+Scoped credential delegation
+  Bob remains the operator.
+  Subagent receives a temporary, narrower credential.
+  Best for one-off tasks in one chat/session.
+
+Separate operator delegation
+  Subagent has or maps to its own signet operator.
+  Best for recurring specialists or separate audit trails.
+```
+
+Subagent default should not include send/reply unless explicitly granted.
+
+## Contacts, Roles, And Identity
+
+Contacts are human/principal identities managed by `xs`, not OpenClaw config.
+
+Convos may generate a new inbox per chat, so a single person may have many
+conversation-scoped bindings.
+
+Identity binding must carry both identifier type and scope:
+
+```text
+contact Matt
+  global binding:
+    stable XMTP inbox, if available and explicitly trusted globally
+
+  conversation binding:
+    Convos-generated inbox in conv_abc
+    Convos-generated inbox in conv_def
+```
+
+Default identity attestation should use the narrowest safe binding. Global
+binding is an explicit promotion.
+
+Useful concepts:
+
+```text
+contact
+  human-facing identity, e.g. Matt
+
+link
+  this inbox/user id belongs to this contact
+  scoped globally or to a conversation
+
+route
+  a trusted way to ask this contact for approval/attestation
+  e.g. owner side chat, Slack DM, local CLI
+
+role
+  owner/admin role in an operator/domain context
+```
+
+Friendly CLI surface should be `contacts`, not `identity authority`.
+
+Possible commands:
+
+```bash
+xs contacts add matt
+xs contacts add matt --group patch-maintainers --phone +15551234567
+xs contacts list
+xs contacts info matt
+xs contacts attest matt --chat chat:...
+xs contacts link matt --chat chat:... --inbox inbox:...
+xs contacts group create patch-maintainers
+xs contacts group add patch-maintainers @contact:matt
+xs contacts group add patch-maintainers op:...
+```
+
+Exact command shapes should align with current `xs` grammar, which uses verbs
+such as `create`, `list`, `info`, `update`, `rm`, and nested commands such as
+`chat member add`.
+
+## Owner Bootstrap
+
+Default setup should create an operator-scoped owner route.
+
+Flow:
+
+1. `xs agent setup openclaw --yes` creates or verifies the operator.
+2. It creates a bootstrap XMTP/Convos chat.
+3. It generates a short code.
+4. It prints the Convos invite and code.
+5. It returns `pending owner link`.
+6. User joins the chat and sends the code.
+7. Signet observes the code, links the sender, and marks `@owner` ready.
+
+The bootstrap chat remains as the durable owner side channel for that operator.
+
+It can later be used for:
+
+- setup status
+- identity attestation
+- group creation
+- group activation
+- future approval requests, if explicitly enabled
+
+It should not automatically be an unlimited admin shell.
+
+Default generated config should use owner only:
+
+```json5
+{
+  "dmPolicy": "allowlist",
+  "allowFrom": ["@owner"]
+}
+```
+
+Do not include `@admin` in generated defaults.
+
+## Selector Grammar
+
+Use `@` for derived, adapter/signet-resolved selectors.
+
+Use signet-native prefixes without `@` for exact identifiers.
+
+Derived selectors:
+
+```text
+@agent:<name>
+@channel:current
+@channel:*
+@contact:<name>
+@group:<name>
+@owner
+@owner:*
+@admin
+@admin:*
+@participants
+@agents
+@contacts
+@operators
+```
+
+Exact signet-native identifiers:
+
+```text
+op:<id>
+chat:<id>
+inbox:<id>
+cred:<id>
+policy:<id>
+```
+
+Recommended v1 defaults:
+
+```json5
+{
+  "allowFrom": ["@owner"],
+  "groupAllowFrom": ["@participants"]
+}
+```
+
+`@channel:*` must not mean all chats known to the signet daemon. If supported,
+it should mean all chats in the current operator domain, and likely only in
+specific capability contexts such as search/read-history.
+
+## Access Control
+
+Contacts can participate in channel access control, but they do not grant agent
+permission escalation.
+
+Allowed:
+
+```text
+Is this sender allowed to invoke Bob?
+```
+
+Not allowed:
+
+```text
+Can this sender increase Bob's policy/credential scopes?
+```
+
+OpenClaw-facing knobs should be substantially similar to other channels:
+
+```text
+dmPolicy
+allowFrom
+groupPolicy
+groupAllowFrom
+groups.<chat>.allowFrom
+groups.<chat>.requireMention
+```
+
+Principal selectors can appear inside allowlists:
+
+```json5
+{
+  "allowFrom": ["@owner", "@contact:matt", "inbox:..."],
+  "groupAllowFrom": ["@participants", "@group:patch-maintainers"]
+}
+```
+
+Use `@participants` by default to avoid agent-to-agent loops.
+
+## Group Creation And Activation
+
+The clean happy path should be agent/signet-initiated group creation through
+the owner side channel.
+
+Flow:
+
+```text
+Owner side channel:
+  "Create a group called Project X"
+
+Signet:
+  creates the XMTP/Convos group
+  records it in the operator domain
+  applies default group policy
+  returns invite link/QR
+
+Owner:
+  shares invite with humans
+
+Group:
+  current non-agent participants can invoke the agent
+```
+
+Default:
+
+```json5
+{
+  "groupPolicy": "allowlist",
+  "groupActivation": "owner-side-channel",
+  "groupAllowFrom": ["@participants"],
+  "groups": {}
+}
+```
+
+For groups created through the trusted owner side channel, default invocation
+should be always-on for eligible user messages, because Convos does not
+currently provide a reliable mention mechanism.
+
+External group invites should be supported later, but not be the primary happy
+path. The safe default is pending/ignored/ask-owner rather than immediate
+activation.
+
+## Events And Session Ingestion
+
+Do not treat every raw XMTP envelope as an OpenClaw activation event.
+
+Signet should normalize raw XMTP into channel events:
+
+```text
+message.created
+reaction.created
+member.joined
+member.left
+profile.updated
+seal.published
+credential.revoked
+system.notice
+```
+
+Each event class has separate decisions:
+
+```text
+visible
+  may the harness see the event?
+
+activate
+  should this event invoke the agent/reply loop?
+
+ingestSession
+  should this event enter OpenClaw session context automatically?
+
+searchable
+  may an agent retrieve it later if credential scopes allow?
+```
+
+V1 defaults:
+
+```text
+message.created
+  visible: yes
+  activate: according to channel activation
+  ingestSession: yes
+
+reaction.created
+member.joined
+member.left
+profile.updated
+  visible: no by default
+  activate: no
+  ingestSession: no
+  available through signet history only if permissioned
+
+seal.*
+credential.*
+system/internal
+  audit/status only
+  activate: no
+  ingestSession: no
+```
+
+Owner side channel "always on" means always respond to eligible user-facing
+messages from `@owner`. It must not mean every raw XMTP content type can
+trigger OpenClaw.
+
+## Search And History
+
+Within a defined OpenClaw agent/operator domain, broad search can be allowed.
+This should not imply the agent can confuse live session context across chats.
+
+Recommended model:
+
+```text
+Bob durable operator domain:
+  searchable chats: chat A, chat B, chat C
+
+Bob session in chat B:
+  live context: chat B
+  session credential: scoped to chat B
+  optional search permission: Bob's operator domain, if policy allows
+```
+
+## Runtime Adapter Responsibilities
+
+The OpenClaw XMTP plugin/adapter should:
+
+- read the OpenClaw channel projection
+- read the signet adapter descriptor
+- connect to signet runtime APIs
+- normalize inbound signet events into OpenClaw channel events
+- ask signet to resolve selectors/principals
+- ask signet whether a sender may invoke the agent
+- request/refresh session credentials
+- send/reply/react through signet credentials
+- revoke/expire credentials when sessions end
+- request delegated subagent credentials when needed
+- report status/doctor diagnostics in OpenClaw terms
+
+The adapter should not:
+
+- read raw XMTP private keys
+- store raw credentials in OpenClaw config
+- implement its own durable identity database
+- grant permission expansion to itself
+- treat raw XMTP internal events as activation events
+
+## Status And Doctor
+
+`xs agent status openclaw` should report:
+
+- adapter installed/configured
+- OpenClaw plugin path present
+- OpenClaw config block present
+- signet daemon reachable
+- descriptor readable
+- operators mapped
+- owner side channel pending/active
+- bootstrap invite/code while pending
+- channel readiness
+- credential/session health if active
+- checkpoint health
+- last inbound/outbound event summary
+
+`xs agent doctor openclaw` should detect:
+
+- missing plugin install
+- disabled plugin entry
+- missing `channels.xmtp`
+- conflicting unmanaged config
+- missing owner route
+- expired bootstrap code
+- unmapped OpenClaw agent
+- missing signet operator
+- unreachable daemon/socket/WebSocket
+- credential/policy mismatch
+- checkpoint directory issues
+- unsafe selectors such as broad `*` in risky contexts
+
+OpenClaw `channels status --probe` should show XMTP in familiar channel terms.

--- a/.agents/plans/openclaw-managed-adapter/issue-plan.md
+++ b/.agents/plans/openclaw-managed-adapter/issue-plan.md
@@ -3,8 +3,9 @@
 Status: planning
 Last updated: 2026-04-25
 
-Created GitHub issues: #375 through #388. Subissues #376 through #388 are linked
-under tracking issue #375.
+Created GitHub issues: #375 through #388, plus adapter-kit issues #390 and
+#391. Subissues #376 through #388, #390, and #391 are linked under tracking
+issue #375.
 
 ## Tracking Issue
 
@@ -74,6 +75,100 @@ breakdown.
 ```
 
 ## Subissues
+
+### 0. Define shared adapter-kit foundation
+
+Issue: #390
+
+Title:
+
+```text
+adapter-kit: define shared harness adapter foundation
+```
+
+Body:
+
+```markdown
+## Summary
+
+Create `packages/adapter-kit` as the shared foundation for first-party harness
+adapters such as OpenClaw, Hermes, and future agent runtimes.
+
+OpenClaw should consume this kit instead of embedding reusable setup, config,
+identity, session, event, and diagnostic logic inside `adapters/openclaw`.
+
+## Requirements
+
+- Add workspace package `@xmtp/signet-adapter-kit` under
+  `packages/adapter-kit`.
+- Define shared contracts for:
+  - adapter descriptors
+  - managed adapter state
+  - setup plan/apply results
+  - artifact install manifests
+  - config projection operations
+  - drift diagnostics
+  - status/doctor results
+  - normalized channel events
+  - selector resolution requests/results
+  - owner bootstrap state
+  - session credential lifecycle hooks
+- Provide helpers for XDG adapter paths, atomic backup/write,
+  dry-run/print-config planning, managed block conflict detection, and
+  redacted output.
+- Keep harness-specific config shapes out of the kit; adapters provide
+  harness-specific projection adapters.
+- Keep CLI dispatch in `packages/cli`, not the kit.
+- Include focused tests and a README showing how OpenClaw and Hermes should
+  consume the kit.
+
+## Acceptance Criteria
+
+- `packages/adapter-kit` exports only harness-agnostic primitives.
+- OpenClaw setup/status/doctor follow-on issues can depend on the kit rather
+  than duplicating lifecycle logic.
+- A Hermes adapter spike can map its runtime requirements to the same contracts
+  without OpenClaw-specific names leaking into the kit.
+```
+
+### 0.1. Map Hermes runtime requirements onto adapter-kit
+
+Issue: #391
+
+Title:
+
+```text
+hermes: map runtime adapter requirements onto adapter-kit
+```
+
+Body:
+
+```markdown
+## Summary
+
+Use `.reference/convos-agents/runtime-hermes` to validate that
+`packages/adapter-kit` can support a second harness/runtime shape without
+becoming OpenClaw-specific.
+
+This is a design validation issue, not the full Hermes implementation.
+
+## Requirements
+
+- Inventory Hermes runtime setup/config/session/event expectations from
+  `.reference/convos-agents/runtime-hermes`.
+- Identify which needs are satisfied by `packages/adapter-kit` primitives.
+- Identify Hermes-specific adapter responsibilities.
+- Produce a short plan note under `.agents/plans/openclaw-managed-adapter/` or
+  a future `.agents/plans/hermes-adapter/`.
+- Do not implement full Hermes support in this issue.
+
+## Acceptance Criteria
+
+- The adapter-kit plan has at least one non-OpenClaw consumer check.
+- Any OpenClaw-specific assumptions in shared contracts are called out before
+  implementation.
+- Follow-up Hermes implementation issues can be created from the mapping.
+```
 
 ### 1. Package and install OpenClaw plugin artifacts from `xs`
 

--- a/.agents/plans/openclaw-managed-adapter/issue-plan.md
+++ b/.agents/plans/openclaw-managed-adapter/issue-plan.md
@@ -1,0 +1,566 @@
+# OpenClaw Managed Adapter Issue Plan
+
+Status: planning
+Last updated: 2026-04-25
+
+Created GitHub issues: #375 through #388. Subissues #376 through #388 are linked
+under tracking issue #375.
+
+## Tracking Issue
+
+Issue: #375
+
+Title:
+
+```text
+feat: make XMTP signet a batteries-included OpenClaw channel adapter
+```
+
+Body:
+
+```markdown
+## Summary
+
+Implement XMTP for OpenClaw as a managed harness projection over signet's
+operator/contact/credential model.
+
+`xs agent setup openclaw --yes` should wire the adapter, write safe OpenClaw
+channel defaults, create a pending owner side channel, and make XMTP feel like
+existing OpenClaw chat channels while keeping credential, identity, contact,
+and audit state in signet.
+
+## Target Experience
+
+```bash
+xs agent setup openclaw --yes
+```
+
+The command should:
+
+1. verify signet is initialized and the daemon is reachable
+2. install or update the OpenClaw XMTP plugin artifact
+3. write managed OpenClaw `plugins` and `channels.xmtp` config blocks
+4. create or verify OpenClaw operators and default policies in signet
+5. create an owner bootstrap side channel when no owner route exists
+6. print Convos invite material plus a short bootstrap code
+7. return `pending owner link` rather than blocking
+
+## Architecture
+
+OpenClaw should see a normal channel projection. Signet remains source of truth
+for operators, credentials, policies, contacts, owner/admin roles, Convos inbox
+bindings, session credentials, subagent delegation credentials, seals, and
+audit/status/doctor state.
+
+The adapter must not hold raw XMTP keys, raw signet private state, broad
+credential secrets, or direct SDK control.
+
+## Plan
+
+See `.agents/plans/openclaw-managed-adapter/` for the design, stack, and issue
+breakdown.
+
+## Done When
+
+- `xs agent setup openclaw --yes` produces a repeatable pending-or-ready
+  managed OpenClaw XMTP setup.
+- `xs agent status openclaw` and `xs agent doctor openclaw` explain setup
+  health and drift.
+- OpenClaw can receive normalized inbound XMTP messages through signet without
+  raw XMTP custody.
+- OpenClaw can send/reply/react through signet credentials.
+- Subagent delegation is explicit and cannot self-expand permissions.
+- Docs and smoke tests cover the no-core-change setup path.
+```
+
+## Subissues
+
+### 1. Package and install OpenClaw plugin artifacts from `xs`
+
+Issue: #376
+
+Title:
+
+```text
+openclaw: package and install plugin artifacts from xs
+```
+
+Body:
+
+```markdown
+## Summary
+
+Make the `xs` distribution install or unpack the OpenClaw XMTP plugin artifact
+under the signet XDG data directory.
+
+## Requirements
+
+- Keep `xs` as the only user-facing binary.
+- Install versioned OpenClaw adapter artifacts under
+  `~/.local/share/xmtp-signet/adapters/openclaw/`.
+- Include at least:
+  - `plugin/`
+  - `adapter.toml`
+  - `adapter-manifest.toml`
+  - `openclaw-account.json` placeholder or generated path
+  - `managed-state.json` placeholder or generated path
+  - `checkpoints/`
+- Avoid relying on repo-relative `adapters/openclaw` paths at runtime from the
+  compiled binary.
+
+## Acceptance Criteria
+
+- Binary-installed `xs agent setup openclaw --dry-run` can resolve the packaged
+  adapter artifact.
+- Missing/corrupt artifact state is diagnosed by `xs agent doctor openclaw`.
+- No second top-level executable is required for normal users.
+```
+
+### 2. Write managed OpenClaw config projection
+
+Issue: #377
+
+Title:
+
+```text
+openclaw: write managed channel config projection
+```
+
+Body:
+
+```markdown
+## Summary
+
+Teach `xs agent setup openclaw` to locate, back up, and update OpenClaw config
+with managed XMTP plugin and channel blocks.
+
+## Requirements
+
+- Support `--dry-run`, `--print-config`, `--force`, and `--openclaw-config`.
+- Back up OpenClaw config before writing.
+- Insert/update a managed `plugins` block for the XMTP plugin.
+- Insert/update a managed `channels.xmtp` block with safe defaults.
+- Warn or fail on conflicting unmanaged blocks unless `--force` is provided.
+- Keep sensitive signet mappings out of OpenClaw config.
+
+## Acceptance Criteria
+
+- `xs agent setup openclaw --dry-run` reports exact intended changes.
+- `xs agent setup openclaw --print-config` prints projected config.
+- Generated defaults use `allowFrom: ["@owner"]` and
+  `groupAllowFrom: ["@participants"]`.
+- Generated defaults do not include `@admin` or `@channel:*`.
+```
+
+### 3. Add signet-managed OpenClaw descriptor and state
+
+Issue: #378
+
+Title:
+
+```text
+openclaw: add adapter descriptor and managed state
+```
+
+Body:
+
+```markdown
+## Summary
+
+Define the signet-owned descriptor/state files that map OpenClaw agents to
+signet operators and policies without exposing sensitive IDs in OpenClaw config.
+
+## Requirements
+
+- Add schemas for `openclaw-account.json` and `managed-state.json`.
+- Represent default/main and named OpenClaw agents.
+- Store agent-to-operator mapping, primary owner reference, default session
+  policy, and subagent delegation profile.
+- Keep OpenClaw config as a projection, not source of truth.
+
+## Acceptance Criteria
+
+- Descriptor/state validation rejects malformed or unsafe records.
+- `xs agent status openclaw` can read and summarize descriptor state.
+- OpenClaw config references descriptor path only.
+```
+
+### 4. Implement owner bootstrap side channel
+
+Issue: #379
+
+Title:
+
+```text
+openclaw: implement owner bootstrap side channel
+```
+
+Body:
+
+```markdown
+## Summary
+
+Create the default owner route for a new OpenClaw adapter setup.
+
+## Requirements
+
+- `xs agent setup openclaw --yes` creates or verifies the OpenClaw operator.
+- If no owner route exists, create a bootstrap XMTP/Convos chat.
+- Generate a short bootstrap code.
+- Print the Convos invite and code.
+- Return `pending owner link`.
+- Observe the code, link the sender, and mark `@owner` ready.
+
+## Acceptance Criteria
+
+- Pending setup is visible in `xs agent status openclaw`.
+- Expired/missing bootstrap code is detected by `xs agent doctor openclaw`.
+- The owner side channel is not treated as an unlimited admin shell.
+```
+
+### 5. Add OpenClaw selector grammar and resolution
+
+Issue: #380
+
+Title:
+
+```text
+openclaw: resolve adapter principal selectors
+```
+
+Body:
+
+```markdown
+## Summary
+
+Implement selector resolution for OpenClaw channel access control and adapter
+state.
+
+## Requirements
+
+- Support derived selectors:
+  - `@owner`
+  - `@owner:*`
+  - `@admin`
+  - `@admin:*`
+  - `@agent:<name>`
+  - `@contact:<name>`
+  - `@group:<name>`
+  - `@participants`
+  - `@agents`
+- Support exact signet identifiers such as `op:<id>`, `chat:<id>`,
+  `inbox:<id>`, `cred:<id>`, and `policy:<id>`.
+- Reserve `@channel:*` until its scope is safely bounded.
+- Error on ambiguous singleton selectors.
+
+## Acceptance Criteria
+
+- Generated defaults use only safe selectors.
+- `@owner` errors if no primary owner or multiple primary owners exist.
+- `@channel:*` is not emitted in generated defaults.
+- Unsafe broad selectors produce doctor warnings in risky contexts.
+```
+
+### 6. Add contacts, links, groups, and scoped attestations
+
+Issue: #381
+
+Title:
+
+```text
+contacts: add scoped contact links for OpenClaw identity
+```
+
+Body:
+
+```markdown
+## Summary
+
+Add the contact model needed for Convos-style ephemeral inbox churn and
+OpenClaw channel access control.
+
+## Requirements
+
+- Model contacts as human/principal identities managed by `xs`.
+- Model links as scoped bindings between contacts and inbox/user IDs.
+- Support global and conversation-scoped bindings.
+- Model contact groups.
+- Support attestation routes such as owner side chat, Slack DM, or local CLI.
+- Prefer friendly `xs contacts ...` command naming.
+
+## Acceptance Criteria
+
+- A single contact can have multiple conversation-scoped Convos inbox bindings.
+- Global binding is an explicit promotion.
+- Contact/group selectors can be resolved for OpenClaw allowlists.
+- Command grammar aligns with existing `xs` verbs.
+```
+
+### 7. Implement session-scoped OpenClaw credentials
+
+Issue: #382
+
+Title:
+
+```text
+openclaw: issue session-scoped credentials
+```
+
+Body:
+
+```markdown
+## Summary
+
+Map each OpenClaw XMTP session/conversation to its own signet credential.
+
+## Requirements
+
+- Parent OpenClaw operator identity remains durable.
+- Session credential is ephemeral and scoped to the session/conversation.
+- Killing a session revokes or expires its credential.
+- Revoking a credential forces the session to reacquire authorization.
+- Parent credential defines maximum possible delegation.
+- Actual subagent grant is explicit and narrower.
+
+## Acceptance Criteria
+
+- Session credential lifecycle is covered by tests.
+- Revocation prevents continued reads/sends until reacquired.
+- Credentials do not grant permissions by inheritance alone.
+```
+
+### 8. Implement explicit subagent delegation
+
+Issue: #383
+
+Title:
+
+```text
+openclaw: implement explicit subagent delegation
+```
+
+Body:
+
+```markdown
+## Summary
+
+Allow OpenClaw to delegate work to subagents through explicit signet
+credentials or explicit separate operators.
+
+## Requirements
+
+- Support scoped credential delegation for one-off chat/session tasks.
+- Support separate operator delegation for recurring specialists or separate
+  audit trails.
+- Default subagent delegation must not include send/reply unless explicitly
+  granted.
+- Agents must not self-increase permissions.
+
+## Acceptance Criteria
+
+- Delegated credential scopes are narrower than or equal to parent grant.
+- Attempted permission expansion fails.
+- Audit/status distinguishes scoped credential delegation from separate
+  operator delegation.
+```
+
+### 9. Normalize signet events for OpenClaw channel ingestion
+
+Issue: #384
+
+Title:
+
+```text
+openclaw: normalize signet events for channel ingestion
+```
+
+Body:
+
+```markdown
+## Summary
+
+Normalize raw XMTP/signet activity into OpenClaw-facing channel events with
+separate visibility, activation, ingestion, and search decisions.
+
+## Requirements
+
+- Define normalized events such as:
+  - `message.created`
+  - `reaction.created`
+  - `member.joined`
+  - `member.left`
+  - `profile.updated`
+  - `seal.published`
+  - `credential.revoked`
+  - `system.notice`
+- Do not treat every raw XMTP envelope as an OpenClaw activation event.
+- Default `message.created` to visible and session-ingested when channel policy
+  allows activation.
+- Default reactions/membership/profile/seal/credential/system events to
+  non-activating.
+
+## Acceptance Criteria
+
+- Event classification is covered by tests.
+- Owner side channel "always on" only means eligible user-facing messages from
+  `@owner`.
+- Setup/control events stay in signet status/audit unless signet intentionally
+  sends a normal human-facing text message.
+```
+
+### 10. Implement owner-side-channel group creation and activation
+
+Issue: #385
+
+Title:
+
+```text
+openclaw: create and activate groups through owner side channel
+```
+
+Body:
+
+```markdown
+## Summary
+
+Support the clean happy path where the owner asks signet to create an
+XMTP/Convos group through the trusted owner side channel.
+
+## Requirements
+
+- Owner side channel can request group creation.
+- Signet creates the XMTP/Convos group.
+- Signet records the group in the operator domain.
+- Signet applies default group policy.
+- Signet returns invite link/QR material.
+- Groups created through the trusted owner route default to eligible
+  user-message activation with `@participants`.
+
+## Acceptance Criteria
+
+- Generated group policy uses `groupActivation: owner-side-channel`.
+- Generated group allowlist uses `@participants`.
+- External group invites are pending/ignored/ask-owner by default.
+```
+
+### 11. Implement outbound send/reply/react through signet credentials
+
+Issue: #386
+
+Title:
+
+```text
+openclaw: send through signet credentialed ingress
+```
+
+Body:
+
+```markdown
+## Summary
+
+Route OpenClaw outbound XMTP actions through signet credentials rather than
+raw XMTP SDK access.
+
+## Requirements
+
+- Support send, reply, and react.
+- Use session or delegated credentials.
+- Preserve policy checks and audit trail.
+- Do not put raw XMTP keys or raw credential secrets in OpenClaw config.
+
+## Acceptance Criteria
+
+- OpenClaw can send/reply/react through signet in a smoke flow.
+- Missing/expired credentials fail loudly and can be reacquired.
+- Outbound attempts without required scopes are denied.
+```
+
+### 12. Expand OpenClaw status and doctor
+
+Issue: #387
+
+Title:
+
+```text
+openclaw: expand adapter status and doctor
+```
+
+Body:
+
+```markdown
+## Summary
+
+Make the OpenClaw adapter setup diagnosable from `xs`.
+
+## Requirements
+
+`xs agent status openclaw` should report:
+
+- adapter installed/configured
+- plugin path present
+- OpenClaw config block present
+- signet daemon reachable
+- descriptor readable
+- operators mapped
+- owner side channel pending/active
+- bootstrap invite/code while pending
+- channel readiness
+- credential/session health if active
+- checkpoint health
+- last inbound/outbound event summary
+
+`xs agent doctor openclaw` should detect:
+
+- missing plugin install
+- disabled plugin entry
+- missing `channels.xmtp`
+- conflicting unmanaged config
+- missing owner route
+- expired bootstrap code
+- unmapped OpenClaw agent
+- missing signet operator
+- unreachable daemon/socket/WebSocket
+- credential/policy mismatch
+- checkpoint directory issues
+- unsafe selectors such as broad `*` in risky contexts
+
+## Acceptance Criteria
+
+- Common partial setup states have actionable diagnostics.
+- Doctor distinguishes warnings from hard failures.
+- Output includes enough context for OpenClaw `channels status --probe` to show
+  XMTP in familiar channel terms.
+```
+
+### 13. Add docs and smoke tests for no-core-change setup
+
+Issue: #388
+
+Title:
+
+```text
+docs: add OpenClaw managed adapter setup guide and smoke tests
+```
+
+Body:
+
+```markdown
+## Summary
+
+Document and smoke-test the no-core-change OpenClaw setup flow.
+
+## Requirements
+
+- Document binary install plus `xs agent setup openclaw --yes`.
+- Document pending owner link, Convos invite/code, and ready state.
+- Document safe defaults and how to inspect status/doctor.
+- Add smoke coverage for setup/dry-run/status/doctor.
+- Tie the guide back to the managed adapter plan.
+
+## Acceptance Criteria
+
+- A new user can follow the guide without patching OpenClaw core.
+- Smoke tests cover the happy path and common partial states.
+- Docs clarify that signet owns credentials, contacts, policies, and audit
+  state.
+```

--- a/.agents/plans/openclaw-managed-adapter/stack.md
+++ b/.agents/plans/openclaw-managed-adapter/stack.md
@@ -7,9 +7,10 @@ Parent issue: #375
 ## Goal
 
 Build the managed OpenClaw adapter in a natural stacked sequence. The first
-stack should get to a diagnosable setup flow. The second stack should get to a
-working read-only channel. Later stacks add outbound actions, contacts, and
-delegation.
+stack should establish `packages/adapter-kit` as the reusable foundation. The
+second stack should get to a diagnosable OpenClaw setup flow. The third stack
+should get to a working read-only channel. Later stacks add outbound actions,
+contacts, and delegation.
 
 ## Stack Invariants
 
@@ -20,6 +21,9 @@ delegation.
 - Never place raw keys, raw signet private state, or broad credential secrets
   into OpenClaw config.
 - Generated OpenClaw config is a projection. Signet remains source of truth.
+- Shared lifecycle, descriptor, config projection, selector, event, session,
+  status, and doctor contracts belong in `packages/adapter-kit` unless they are
+  truly OpenClaw-specific.
 - Every runtime slice must have at least one status or doctor hook so partial
   setup is explainable.
 
@@ -28,19 +32,46 @@ delegation.
 | Order | Issue | Slice | PR title |
 |---:|---:|---|---|
 | 0 | #375 | Plan packet | `docs(openclaw): add managed adapter execution plan` |
-| 1 | #376 | Plugin artifact install | `feat(adapter): install OpenClaw plugin artifacts from xs` |
-| 2 | #377 | Managed config projection | `feat(cli): write managed OpenClaw channel config` |
-| 3 | #378 | Descriptor schemas/state | `feat(schemas): define OpenClaw adapter descriptor state` |
-| 4 | #379 | Owner bootstrap | `feat(adapter): add OpenClaw owner bootstrap flow` |
-| 5 | #380 | Selector resolution | `feat(policy): resolve OpenClaw adapter selectors` |
-| 6 | #381 | Contacts primitives | `feat(contacts): model scoped contact links and groups` |
-| 7 | #382 | Session credentials | `feat(adapter): issue OpenClaw session-scoped credentials` |
-| 8 | #384 | Normalized events | `feat(adapter): normalize signet events for OpenClaw` |
-| 9 | #386 | Outbound actions | `feat(openclaw): send through signet credentials` |
-| 10 | #383 | Delegation | `feat(openclaw): delegate subagent credentials explicitly` |
-| 11 | #385 | Group creation | `feat(openclaw): create groups through owner side channel` |
-| 12 | #387 | Full status/doctor | `feat(cli): expand OpenClaw adapter status and doctor` |
-| 13 | #388 | Docs and smoke | `docs(openclaw): document managed setup and smoke flow` |
+| 1 | #390 | Adapter kit foundation | `feat(adapter-kit): add shared harness adapter foundation` |
+| 2 | #391 | Hermes consumer check | `docs(adapter-kit): map Hermes requirements to shared adapter contracts` |
+| 3 | #376 | Plugin artifact install | `feat(adapter): install OpenClaw plugin artifacts from xs` |
+| 4 | #377 | Managed config projection | `feat(cli): write managed OpenClaw channel config` |
+| 5 | #378 | Descriptor schemas/state | `feat(schemas): define OpenClaw adapter descriptor state` |
+| 6 | #379 | Owner bootstrap | `feat(adapter): add OpenClaw owner bootstrap flow` |
+| 7 | #380 | Selector resolution | `feat(policy): resolve OpenClaw adapter selectors` |
+| 8 | #381 | Contacts primitives | `feat(contacts): model scoped contact links and groups` |
+| 9 | #382 | Session credentials | `feat(adapter): issue OpenClaw session-scoped credentials` |
+| 10 | #384 | Normalized events | `feat(adapter): normalize signet events for OpenClaw` |
+| 11 | #386 | Outbound actions | `feat(openclaw): send through signet credentials` |
+| 12 | #383 | Delegation | `feat(openclaw): delegate subagent credentials explicitly` |
+| 13 | #385 | Group creation | `feat(openclaw): create groups through owner side channel` |
+| 14 | #387 | Full status/doctor | `feat(cli): expand OpenClaw adapter status and doctor` |
+| 15 | #388 | Docs and smoke | `docs(openclaw): document managed setup and smoke flow` |
+
+## Phase 0: Adapter Kit Stack
+
+Purpose: make OpenClaw the first consumer of a reusable adapter foundation, not
+the place where reusable harness logic becomes trapped.
+
+Includes:
+
+- `packages/adapter-kit` workspace package
+- shared descriptor and managed-state contracts
+- shared artifact path, install plan, and manifest helpers
+- shared config projection operations for dry-run, backup, write, drift, and
+  redacted output
+- shared setup/status/doctor result contracts
+- shared selector resolution request/result contracts
+- shared normalized event and session credential lifecycle contracts
+- a Hermes requirements mapping to validate the kit against a second harness
+
+Exit criteria:
+
+- OpenClaw follow-on issues can depend on adapter-kit primitives instead of
+  duplicating setup/config/status/doctor logic.
+- The kit exports harness-agnostic primitives only.
+- Hermes mapping calls out any OpenClaw-specific assumptions before package
+  implementation proceeds too far.
 
 ## Phase 1: Setup Stack
 
@@ -110,6 +141,14 @@ Exit criteria:
   returns invite material.
 
 ## Verification Checkpoints
+
+After phase 0:
+
+- adapter-kit package tests
+- OpenClaw fixture tests for projection/diagnostics
+- Hermes mapping note reviewed against `.reference/convos-agents/runtime-hermes`
+- `bun run typecheck`
+- `bun run docs:check`
 
 After phase 1:
 

--- a/.agents/plans/openclaw-managed-adapter/stack.md
+++ b/.agents/plans/openclaw-managed-adapter/stack.md
@@ -1,0 +1,145 @@
+# OpenClaw Managed Adapter Stack
+
+Status: planning
+Last updated: 2026-04-25
+Parent issue: #375
+
+## Goal
+
+Build the managed OpenClaw adapter in a natural stacked sequence. The first
+stack should get to a diagnosable setup flow. The second stack should get to a
+working read-only channel. Later stacks add outbound actions, contacts, and
+delegation.
+
+## Stack Invariants
+
+- One branch per issue where possible.
+- Keep `xs init` signet-native; OpenClaw-specific setup lives under
+  `xs agent setup openclaw`.
+- Prefer dry-run and status/doctor surfaces before writes.
+- Never place raw keys, raw signet private state, or broad credential secrets
+  into OpenClaw config.
+- Generated OpenClaw config is a projection. Signet remains source of truth.
+- Every runtime slice must have at least one status or doctor hook so partial
+  setup is explainable.
+
+## Execution Order
+
+| Order | Issue | Slice | PR title |
+|---:|---:|---|---|
+| 0 | #375 | Plan packet | `docs(openclaw): add managed adapter execution plan` |
+| 1 | #376 | Plugin artifact install | `feat(adapter): install OpenClaw plugin artifacts from xs` |
+| 2 | #377 | Managed config projection | `feat(cli): write managed OpenClaw channel config` |
+| 3 | #378 | Descriptor schemas/state | `feat(schemas): define OpenClaw adapter descriptor state` |
+| 4 | #379 | Owner bootstrap | `feat(adapter): add OpenClaw owner bootstrap flow` |
+| 5 | #380 | Selector resolution | `feat(policy): resolve OpenClaw adapter selectors` |
+| 6 | #381 | Contacts primitives | `feat(contacts): model scoped contact links and groups` |
+| 7 | #382 | Session credentials | `feat(adapter): issue OpenClaw session-scoped credentials` |
+| 8 | #384 | Normalized events | `feat(adapter): normalize signet events for OpenClaw` |
+| 9 | #386 | Outbound actions | `feat(openclaw): send through signet credentials` |
+| 10 | #383 | Delegation | `feat(openclaw): delegate subagent credentials explicitly` |
+| 11 | #385 | Group creation | `feat(openclaw): create groups through owner side channel` |
+| 12 | #387 | Full status/doctor | `feat(cli): expand OpenClaw adapter status and doctor` |
+| 13 | #388 | Docs and smoke | `docs(openclaw): document managed setup and smoke flow` |
+
+## Phase 1: Setup Stack
+
+Purpose: make `xs agent setup openclaw --yes` safe, repeatable, and
+diagnosable, even before real message delivery is complete.
+
+Includes:
+
+- OpenClaw config backup/merge/write
+- plugin artifact install under XDG data paths
+- descriptor and managed-state schemas
+- main/default agent to operator mapping
+- default policies
+- owner bootstrap side channel with pending status
+
+Exit criteria:
+
+- `xs agent setup openclaw --dry-run` explains intended changes.
+- `xs agent setup openclaw --print-config` prints the projected OpenClaw
+  config blocks.
+- `xs agent setup openclaw --yes` writes adapter artifacts and safe config
+  defaults.
+- Setup returns `pending owner link` when no owner route is linked.
+- `xs agent status openclaw` reports pending/ready state.
+- `xs agent doctor openclaw` catches missing plugin/config/daemon/descriptor
+  basics.
+
+## Phase 2: Channel Works Stack
+
+Purpose: make OpenClaw receive normalized XMTP messages through signet without
+raw XMTP custody.
+
+Includes:
+
+- selector resolution for `@owner`, `@participants`, `@agent:<name>`,
+  `@contact:<name>`, `@group:<name>`, and exact signet IDs
+- scoped contacts and conversation-specific links
+- session-scoped credentials
+- normalized channel events
+- read-only inbound bridge
+
+Exit criteria:
+
+- A linked owner can invoke the default OpenClaw XMTP channel.
+- A read-only inbound tracer bullet can route `message.created` into the
+  OpenClaw session shape.
+- Reaction/member/profile/seal/credential events are non-activating by default.
+- Session credential revocation forces reacquire before continued reads/sends.
+
+## Phase 3: Outbound And Delegation Stack
+
+Purpose: allow OpenClaw agents to send/reply/react and delegate to subagents
+through explicit signet credentials.
+
+Includes:
+
+- outbound send/reply/react through signet credentialed ingress
+- scoped credential delegation
+- separate-operator delegation for recurring specialists
+- owner-side-channel group creation and activation
+
+Exit criteria:
+
+- OpenClaw outbound actions do not require raw XMTP keys or direct SDK access.
+- Subagent default does not include send/reply unless explicitly granted.
+- Group creation through owner side channel records operator-domain policy and
+  returns invite material.
+
+## Verification Checkpoints
+
+After phase 1:
+
+- targeted adapter/CLI tests
+- `bun run typecheck`
+- `bun run lint`
+- `bun run docs:check`
+- manual dry-run against a temp OpenClaw config fixture
+
+After phase 2:
+
+- inbound read-only tracer bullet
+- session credential revocation/reacquire test
+- selector ambiguity tests
+- top-branch `bun run check`
+
+After phase 3:
+
+- outbound send/reply/react tests
+- delegation narrowing tests
+- owner-side-channel group creation smoke
+- top-branch `bun run check`
+
+## Guardrails
+
+- Do not use `@channel:*` in generated defaults.
+- Do not include `@admin` in generated defaults.
+- Do not make owner side channel an unlimited admin shell.
+- Do not treat every raw XMTP envelope as an activation event.
+- Do not silently overwrite unmanaged OpenClaw config conflicts without
+  `--force`.
+- Do not expose raw operator IDs, credential IDs, policy IDs, contact bindings,
+  or bootstrap state in OpenClaw config unless explicitly requested.


### PR DESCRIPTION
## Context

This adds the durable planning packet for the managed OpenClaw adapter work and ties it to the GitHub tracking issue stack.

Tracking issue: #375
Subissues: #376-#388 plus adapter-kit foundation issues #390 and #391

## What changed

- Added `.agents/plans/openclaw-managed-adapter/README.md` with the high-level goal, invariants, and issue map.
- Added `architecture.md` with the managed projection design: OpenClaw-native config at the edge, signet-owned enforcement/state at the core.
- Added `adapter-kit.md` with the `packages/adapter-kit` boundary and OpenClaw/Hermes research snapshot.
- Added `stack.md` with the natural PR stack and phase checkpoints, now starting with adapter-kit.
- Added `issue-plan.md` with the tracking issue and subissue bodies, now annotated with the created issue numbers.

## Issue setup

Created and linked GitHub subissues under #375:

- #390 adapter-kit shared harness foundation
- #391 Hermes runtime requirements mapping
- #376 plugin artifact install
- #377 managed config projection
- #378 descriptor/state
- #379 owner bootstrap
- #380 selector resolution
- #381 contacts/links/groups
- #382 session credentials
- #383 subagent delegation
- #384 normalized events
- #385 owner-side-channel group creation
- #386 outbound actions
- #387 status/doctor
- #388 docs and smoke tests

## Verification

- `git diff --check`
- `bun run docs:check`
- `qmd update`
- `qmd embed`
- GraphQL verification that #390 and #391 are native subissues of #375
- Pre-push hook via `git push`:
  - format
  - lint + docs coverage
  - test
  - typecheck
